### PR TITLE
feat: bulk delete agents endpoint + clean up dev test agents

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -76,6 +76,7 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/:id", get(agents::get_one))
         .route("/agents/:id", patch(agents::update))
         .route("/agents/:id", delete(agents::delete))
+        .route("/agents/bulk-delete", post(agents::bulk_delete))
         // Dashboard
         .route("/dashboard/stats", get(dashboard::stats))
         .route("/dashboard/top-devices", get(dashboard::top_devices))

--- a/server/src/db/migrations/003_cleanup_test_agents.sql
+++ b/server/src/db/migrations/003_cleanup_test_agents.sql
@@ -1,0 +1,7 @@
+-- Migration 003: Clean up leftover test/dev agents.
+-- These agents were created during development and e2e testing.
+-- Real agents (e.g. mac-mini) do not match these patterns.
+DELETE FROM agent_reports WHERE agent_id IN (
+    SELECT id FROM agents WHERE name LIKE 'e2e-%' OR name IN ('fixtest', 'sdf', 'dimtest')
+);
+DELETE FROM agents WHERE name LIKE 'e2e-%' OR name IN ('fixtest', 'sdf', 'dimtest');


### PR DESCRIPTION
## Summary

Adds **POST /api/v1/agents/bulk-delete** endpoint for reusable bulk agent cleanup.

### New Endpoint

`POST /api/v1/agents/bulk-delete` accepts a JSON body with:
- `ids`: array of agent UUIDs to delete
- `name_pattern`: SQL LIKE pattern to match agent names (e.g. `e2e-%`)

Both fields are optional but at least one must be provided. Returns `{"deleted": N}` with the count of removed agents. Related `agent_reports` rows are cleaned up automatically.

### Example

```bash
# Delete by IDs
curl -X POST /api/v1/agents/bulk-delete -d '{"ids": ["abc", "def"]}'

# Delete by name pattern  
curl -X POST /api/v1/agents/bulk-delete -d '{"name_pattern": "e2e-%"}'

# Both
curl -X POST /api/v1/agents/bulk-delete -d '{"ids": ["abc"], "name_pattern": "test-%"}'
```

### Migration 003

Adds migration `003_cleanup_test_agents.sql` that removes leftover dev/test agents matching:
- `name LIKE 'e2e-%'`
- `name IN ('fixtest', 'sdf', 'dimtest')`

Real agents (e.g. mac-mini) are unaffected.