### PR TITLE
feat: websocket live updates for devices and agents

### DIFF
--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -1,18 +1,24 @@
 import { Sidebar } from "@/components/layout/Sidebar";
 import { TopBar } from "@/components/layout/TopBar";
+import { WebSocketProvider } from "@/components/providers/WebSocketProvider";
 
 /**
  * Authenticated app layout with sidebar + topbar.
  * Login page uses the root layout directly (no chrome).
+ *
+ * WebSocketProvider keeps a persistent WS connection so all child pages
+ * receive live updates (device/agent state changes) without polling.
  */
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <TopBar />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+    <WebSocketProvider>
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <TopBar />
+          <main className="flex-1 overflow-y-auto p-6">{children}</main>
+        </div>
       </div>
-    </div>
+    </WebSocketProvider>
   );
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useWsConnected } from "@/components/providers/WebSocketProvider";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -35,6 +36,7 @@ const navItems = [
 export function Sidebar() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
+  const wsConnected = useWsConnected();
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -108,10 +110,39 @@ export function Sidebar() {
               </>
             )}
           </button>
-          {!collapsed && (
-            <p className="mt-1 px-3 text-[10px] text-gray-700">
-              Panoptikon v0.1.0
-            </p>
+          {!collapsed ? (
+            <div className="mt-1 flex items-center gap-1.5 px-3">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={cn(
+                      "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
+                      wsConnected ? "bg-green-500" : "bg-gray-600"
+                    )}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="border-[#2a2a3a] bg-[#16161f]">
+                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
+                </TooltipContent>
+              </Tooltip>
+              <p className="text-[10px] text-gray-700">Panoptikon v0.1.0</p>
+            </div>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="mt-1 flex justify-center">
+                  <span
+                    className={cn(
+                      "inline-block h-1.5 w-1.5 rounded-full",
+                      wsConnected ? "bg-green-500" : "bg-gray-600"
+                    )}
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="border-[#2a2a3a] bg-[#16161f]">
+                <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </aside>

--- a/web/src/components/providers/WebSocketProvider.tsx
+++ b/web/src/components/providers/WebSocketProvider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { useWebSocket } from "@/lib/ws";
+
+interface WebSocketContextValue {
+  /** Whether the WebSocket is currently connected to the server. */
+  connected: boolean;
+}
+
+const WebSocketContext = createContext<WebSocketContextValue>({
+  connected: false,
+});
+
+/**
+ * Provides a live WebSocket connection to the Panoptikon backend.
+ *
+ * Place this high in the component tree (e.g. app layout) so the connection
+ * persists across page navigations. Child components can:
+ *
+ * 1. Read connection status via `useWsConnected()`
+ * 2. Subscribe to specific events via `useWsEvent()`
+ */
+export function WebSocketProvider({ children }: { children: React.ReactNode }) {
+  const { connected } = useWebSocket();
+
+  return (
+    <WebSocketContext.Provider value={{ connected }}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+}
+
+/** Returns whether the WebSocket is currently connected. */
+export function useWsConnected(): boolean {
+  return useContext(WebSocketContext).connected;
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -2,87 +2,177 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 
-interface WsMessage {
+// ─── Types ──────────────────────────────────────────────
+
+export interface WsMessage {
   event: string;
-  payload: unknown;
+  data: unknown;
 }
 
+/** All event types the backend may broadcast to UI clients. */
+export type WsEventType =
+  | "device_online"
+  | "device_offline"
+  | "new_device"
+  | "agent_online"
+  | "agent_offline"
+  | "agent_report";
+
+// ─── Custom DOM event for decoupled pub/sub ─────────────
+
+const WS_EVENT_NAME = "panoptikon:ws";
+
+/** Dispatch a WebSocket message as a DOM CustomEvent so any component can listen. */
+function dispatchWsEvent(msg: WsMessage) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(WS_EVENT_NAME, { detail: msg }));
+  }
+}
+
+// ─── useWsEvent — subscribe to specific WS events ──────
+
+/**
+ * Subscribe to one or more WebSocket event types.
+ * Calls `handler` whenever a matching event arrives.
+ *
+ * ```tsx
+ * useWsEvent(["device_online", "device_offline", "new_device"], () => {
+ *   refetchDevices();
+ * });
+ * ```
+ */
+export function useWsEvent(
+  events: WsEventType | WsEventType[],
+  handler: (msg: WsMessage) => void
+) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const eventList = Array.isArray(events) ? events : [events];
+  // Stable key so useEffect doesn't re-run on every render
+  const eventsKey = eventList.join(",");
+
+  useEffect(() => {
+    const listener = (e: Event) => {
+      const msg = (e as CustomEvent<WsMessage>).detail;
+      if (eventList.includes(msg.event as WsEventType)) {
+        handlerRef.current(msg);
+      }
+    };
+
+    window.addEventListener(WS_EVENT_NAME, listener);
+    return () => window.removeEventListener(WS_EVENT_NAME, listener);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventsKey]);
+}
+
+// ─── useWebSocket — main hook ───────────────────────────
+
 interface UseWebSocketOptions {
-  /** WebSocket URL (defaults to the current host with /api/v1/ws). */
+  /** Override the WebSocket URL. Auto-detected from window.location by default. */
   url?: string;
   /** Auto-reconnect on disconnect. Default: true. */
   reconnect?: boolean;
-  /** Reconnect interval in ms. Default: 3000. */
-  reconnectInterval?: number;
+  /** Initial reconnect delay in ms. Default: 1000. */
+  initialDelay?: number;
+  /** Maximum reconnect delay in ms. Default: 30000. */
+  maxDelay?: number;
 }
 
 /**
  * React hook for live WebSocket updates from the Panoptikon server.
  *
+ * - Connects to the `/api/v1/ws` endpoint (auto-detects ws/wss from page protocol).
+ * - Reconnects with exponential backoff on disconnect (1s → 30s).
+ * - Dispatches incoming messages as DOM CustomEvents (`panoptikon:ws`).
+ * - Returns `connected` boolean for UI indicators.
+ *
  * Usage:
  * ```tsx
- * const { lastMessage, connected } = useWebSocket();
+ * const { connected } = useWebSocket();
  * ```
  */
 export function useWebSocket(options: UseWebSocketOptions = {}) {
   const {
-    url = `ws://${typeof window !== "undefined" ? window.location.host : "localhost:8080"}/api/v1/ws`,
     reconnect = true,
-    reconnectInterval = 3000,
+    initialDelay = 1000,
+    maxDelay = 30000,
   } = options;
 
   const [connected, setConnected] = useState(false);
-  const [lastMessage, setLastMessage] = useState<WsMessage | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const delayRef = useRef(initialDelay);
+  const mountedRef = useRef(true);
+
+  // Build WS URL from window.location (works for both dev proxy and production)
+  const getUrl = useCallback(() => {
+    if (options.url) return options.url;
+    if (typeof window === "undefined") return "ws://localhost:8080/api/v1/ws";
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return `${proto}//${window.location.host}/api/v1/ws`;
+  }, [options.url]);
 
   const connect = useCallback(() => {
+    if (!mountedRef.current) return;
+
     try {
-      const ws = new WebSocket(url);
+      const ws = new WebSocket(getUrl());
 
       ws.onopen = () => {
+        if (!mountedRef.current) { ws.close(); return; }
         setConnected(true);
+        delayRef.current = initialDelay; // Reset backoff on successful connection
       };
 
       ws.onmessage = (event) => {
         try {
           const data: WsMessage = JSON.parse(event.data);
-          setLastMessage(data);
+          dispatchWsEvent(data);
         } catch {
-          // Non-JSON message, ignore.
+          // Non-JSON message — ignore.
         }
       };
 
       ws.onclose = () => {
+        if (!mountedRef.current) return;
         setConnected(false);
         wsRef.current = null;
 
         if (reconnect) {
-          reconnectTimerRef.current = setTimeout(connect, reconnectInterval);
+          const delay = delayRef.current;
+          // Exponential backoff: double the delay, cap at maxDelay
+          delayRef.current = Math.min(delay * 2, maxDelay);
+          reconnectTimerRef.current = setTimeout(connect, delay);
         }
       };
 
       ws.onerror = () => {
+        // onclose will fire after onerror — it handles reconnection.
         ws.close();
       };
 
       wsRef.current = ws;
     } catch {
-      // Connection failed, retry.
-      if (reconnect) {
-        reconnectTimerRef.current = setTimeout(connect, reconnectInterval);
+      // Connection creation failed — schedule retry.
+      if (reconnect && mountedRef.current) {
+        const delay = delayRef.current;
+        delayRef.current = Math.min(delay * 2, maxDelay);
+        reconnectTimerRef.current = setTimeout(connect, delay);
       }
     }
-  }, [url, reconnect, reconnectInterval]);
+  }, [getUrl, reconnect, initialDelay, maxDelay]);
 
   useEffect(() => {
+    mountedRef.current = true;
     connect();
 
     return () => {
+      mountedRef.current = false;
       clearTimeout(reconnectTimerRef.current);
       wsRef.current?.close();
     };
   }, [connect]);
 
-  return { connected, lastMessage };
+  return { connected };
 }


### PR DESCRIPTION
Wires up the frontend to receive real-time push events over WebSocket. When device/agent state changes occur (online/offline, new device), the UI updates instantly without page refresh. Adds useWebSocket hook with exponential backoff reconnection and a connection status indicator in the nav.

## Changes

- **web/src/lib/ws.ts**: Rewrote useWebSocket hook with exponential backoff reconnection (1s → 30s), auto-detect ws/wss protocol, and DOM CustomEvent dispatch for decoupled pub/sub. Added useWsEvent helper hook for pages to subscribe to specific event types.
- **web/src/components/providers/WebSocketProvider.tsx**: New React context provider that maintains the WS connection and exposes useWsConnected() for connection status.
- **web/src/app/(app)/layout.tsx**: Wrapped app layout with WebSocketProvider so WS persists across page navigations.
- **web/src/components/layout/Sidebar.tsx**: Added green/grey connection indicator dot at the bottom of the sidebar with tooltip.
- **Devices/Agents/Dashboard pages**: Subscribe to relevant WS events for instant refetch.

## Event types handled
device_online, device_offline, new_device, agent_online, agent_offline, agent_report

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented real-time WebSocket push notifications for device and agent state changes (online/offline, new device, agent reports). The UI now updates instantly without polling by using a custom DOM event system for decoupled pub/sub and exponential backoff reconnection (1s → 30s).

**Key changes:**
- Rewrote `useWebSocket` hook with auto-detect ws/wss protocol, exponential backoff reconnection, and DOM CustomEvent dispatch
- Added `useWsEvent` helper for components to subscribe to specific event types
- Created `WebSocketProvider` context to maintain persistent connection across page navigations
- Added connection status indicator in sidebar (green dot when live)
- Updated devices, agents, and dashboard pages to refetch on relevant WS events

**Issues found:**
- One critical logic issue in `web/src/lib/ws.ts` where useEffect dependency on `connect` callback will cause reconnection loops on component re-renders

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the reconnection loop bug
- The implementation is solid and well-architected with proper cleanup, exponential backoff, and decoupled event handling. However, the useEffect dependency issue in ws.ts will cause unnecessary reconnections and should be fixed before merging.
- web/src/lib/ws.ts requires attention to fix the reconnection loop issue

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/ws.ts | Rewrote WebSocket hook with exponential backoff, DOM event dispatch, and useWsEvent helper. Has a useEffect dependency issue that could cause reconnection loops. |
| web/src/components/providers/WebSocketProvider.tsx | Simple React context wrapper for WebSocket connection, provides connection status to child components. Clean implementation. |
| web/src/app/(app)/layout.tsx | Wrapped app layout with WebSocketProvider for persistent connection. Implementation is correct. |
| web/src/components/layout/Sidebar.tsx | Added connection status indicator dot with tooltip in both collapsed and expanded states. Clean implementation. |
| web/src/app/(app)/devices/page.tsx | Converted load function to useCallback and added WebSocket event subscriptions for instant refetch on device/agent state changes. |
| web/src/app/(app)/agents/page.tsx | Converted load function to useCallback and added WebSocket event subscriptions for agent state changes. |
| web/src/app/(app)/dashboard/page.tsx | Converted load function to useCallback and added WebSocket event subscriptions for comprehensive state changes. |

</details>



<sub>Last reviewed commit: 0e5f0f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->