### PR TITLE
feat: search and status filter on devices page

### DIFF
--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -75,6 +75,7 @@ export default function DevicesPage() {
           (d.name ?? "").toLowerCase().includes(q) ||
           (d.hostname ?? "").toLowerCase().includes(q) ||
           (d.mac ?? "").toLowerCase().includes(q) ||
+          (d.vendor ?? "").toLowerCase().includes(q) ||
           (d.ips ?? []).some((ip) => ip.includes(q))
       );
     }
@@ -131,7 +132,7 @@ export default function DevicesPage() {
         <div className="relative ml-auto w-full max-w-xs">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
           <Input
-            placeholder="Search name, IP, MAC…"
+            placeholder="Search name, IP, MAC, vendor…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"


### PR DESCRIPTION
Adds vendor to the client-side search filter on the Devices page. The page already had search (by name, hostname, IP, MAC) and status filtering (All/Online/Offline/Unknown) with useMemo — this PR completes the feature by including vendor in the search. Updated placeholder text to reflect the new field. No backend changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added vendor field to the client-side search filter on the Devices page, completing the existing search functionality.

- Extended search to include `vendor` field alongside existing name, hostname, IP, and MAC filters
- Updated placeholder text to reflect the new searchable field
- Proper null handling matches existing pattern for optional fields
- No backend changes required

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal, follows existing patterns precisely, includes proper null handling, and only extends existing functionality without modifying logic or introducing side effects
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Added `vendor` field to search filter and updated placeholder text - simple, safe change with proper null handling |

</details>



<sub>Last reviewed commit: 09620aa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->