### PR TITLE
feat: traffic history chart with inbound/outbound areas

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod dashboard;
 pub mod devices;
 pub mod settings;
+pub mod traffic;
 pub mod vyos;
 
 /// Shared application state available to all handlers.
@@ -94,6 +95,8 @@ pub fn router(state: AppState) -> Router {
         .route("/vyos/routes", get(vyos::routes))
         .route("/vyos/dhcp-leases", get(vyos::dhcp_leases))
         .route("/vyos/firewall", get(vyos::firewall))
+        // Traffic
+        .route("/traffic/history", get(traffic::history))
         // WebSocket for UI live updates
         .route("/ws", get(agents::ui_ws_handler))
         .route_layer(middleware::from_fn_with_state(

--- a/server/src/api/traffic.rs
+++ b/server/src/api/traffic.rs
@@ -1,0 +1,194 @@
+use crate::api::AppState;
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct TrafficHistoryPoint {
+    pub minute: String,
+    pub rx_bps: i64,
+    pub tx_bps: i64,
+}
+
+#[derive(Deserialize)]
+pub struct HistoryQuery {
+    pub minutes: Option<i64>,
+}
+
+/// GET /api/v1/traffic/history?minutes=60
+///
+/// Returns per-minute aggregated traffic (sum of rx_bps, tx_bps) for the
+/// requested time window. Default: 60 minutes. Max: 1440 (24 hours).
+pub async fn history(
+    State(state): State<AppState>,
+    Query(q): Query<HistoryQuery>,
+) -> Json<Vec<TrafficHistoryPoint>> {
+    let minutes = q.minutes.unwrap_or(60).clamp(1, 1440);
+
+    let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+        r#"SELECT
+             strftime('%Y-%m-%dT%H:%M:00', sampled_at) AS minute,
+             COALESCE(SUM(rx_bps), 0) AS rx_bps,
+             COALESCE(SUM(tx_bps), 0) AS tx_bps
+           FROM traffic_samples
+           WHERE sampled_at >= datetime('now', '-' || CAST(? AS TEXT) || ' minutes')
+           GROUP BY minute
+           ORDER BY minute ASC"#,
+    )
+    .bind(minutes)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    Json(
+        rows.into_iter()
+            .map(|(minute, rx_bps, tx_bps)| TrafficHistoryPoint {
+                minute,
+                rx_bps,
+                tx_bps,
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use sqlx::SqlitePool;
+
+    /// Helper: create a fresh in-memory database with all migrations applied.
+    async fn test_db() -> SqlitePool {
+        db::init(":memory:")
+            .await
+            .expect("in-memory DB init failed")
+    }
+
+    /// Helper: insert a device and return its id.
+    async fn insert_test_device(pool: &SqlitePool) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO devices (id, mac, name, icon, is_known, is_favorite, first_seen_at, last_seen_at, is_online)
+               VALUES (?, '00:11:22:33:44:55', 'test-device', 'desktop', 0, 0, datetime('now'), datetime('now'), 1)"#,
+        )
+        .bind(&id)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Helper: insert a traffic sample at a given time.
+    async fn insert_sample(
+        pool: &SqlitePool,
+        device_id: &str,
+        sampled_at: &str,
+        rx_bps: i64,
+        tx_bps: i64,
+    ) {
+        sqlx::query(
+            r#"INSERT INTO traffic_samples (device_id, sampled_at, rx_bps, tx_bps, source)
+               VALUES (?, ?, ?, ?, 'test')"#,
+        )
+        .bind(device_id)
+        .bind(sampled_at)
+        .bind(rx_bps)
+        .bind(tx_bps)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_traffic_history_empty() {
+        let pool = test_db().await;
+
+        let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+            r#"SELECT
+                 strftime('%Y-%m-%dT%H:%M:00', sampled_at) AS minute,
+                 COALESCE(SUM(rx_bps), 0) AS rx_bps,
+                 COALESCE(SUM(tx_bps), 0) AS tx_bps
+               FROM traffic_samples
+               WHERE sampled_at >= datetime('now', '-60 minutes')
+               GROUP BY minute
+               ORDER BY minute ASC"#,
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert!(rows.is_empty(), "Empty DB should return no traffic history");
+    }
+
+    #[tokio::test]
+    async fn test_traffic_history_aggregates() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool).await;
+
+        // Insert two samples in the same minute — they should be summed.
+        let now = chrono::Utc::now();
+        let ts1 = now.format("%Y-%m-%dT%H:%M:10").to_string();
+        let ts2 = now.format("%Y-%m-%dT%H:%M:30").to_string();
+
+        insert_sample(&pool, &device_id, &ts1, 1000, 2000).await;
+        insert_sample(&pool, &device_id, &ts2, 3000, 4000).await;
+
+        let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+            r#"SELECT
+                 strftime('%Y-%m-%dT%H:%M:00', sampled_at) AS minute,
+                 COALESCE(SUM(rx_bps), 0) AS rx_bps,
+                 COALESCE(SUM(tx_bps), 0) AS tx_bps
+               FROM traffic_samples
+               WHERE sampled_at >= datetime('now', '-60 minutes')
+               GROUP BY minute
+               ORDER BY minute ASC"#,
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 1, "Two samples in same minute → one row");
+        assert_eq!(rows[0].1, 4000, "rx_bps should be summed: 1000 + 3000");
+        assert_eq!(rows[0].2, 6000, "tx_bps should be summed: 2000 + 4000");
+    }
+
+    #[tokio::test]
+    async fn test_traffic_history_ordering() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool).await;
+
+        let now = chrono::Utc::now();
+        // Two different minutes — insert in reverse order to test ASC sorting.
+        let earlier = (now - chrono::Duration::minutes(5))
+            .format("%Y-%m-%dT%H:%M:00")
+            .to_string();
+        let later = now.format("%Y-%m-%dT%H:%M:00").to_string();
+
+        // Insert later first, earlier second — ASC should still sort correctly.
+        insert_sample(&pool, &device_id, &later, 100, 200).await;
+        insert_sample(&pool, &device_id, &earlier, 300, 400).await;
+
+        let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+            r#"SELECT
+                 strftime('%Y-%m-%dT%H:%M:00', sampled_at) AS minute,
+                 COALESCE(SUM(rx_bps), 0) AS rx_bps,
+                 COALESCE(SUM(tx_bps), 0) AS tx_bps
+               FROM traffic_samples
+               WHERE sampled_at >= datetime('now', '-60 minutes')
+               GROUP BY minute
+               ORDER BY minute ASC"#,
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 2, "Two different minutes → two rows");
+        assert!(
+            rows[0].0 < rows[1].0,
+            "Rows should be in ascending order: {} < {}",
+            rows[0].0,
+            rows[1].0
+        );
+    }
+}

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -1,22 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 import { Activity } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { fetchTrafficHistory, fetchTopDevices } from "@/lib/api";
+import { formatBps } from "@/lib/format";
+import type { TrafficHistoryPoint, TopDevice } from "@/lib/types";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+/** Format an ISO minute string to HH:mm for the X axis. */
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
 
 export default function TrafficPage() {
+  const [history, setHistory] = useState<TrafficHistoryPoint[]>([]);
+  const [topDevices, setTopDevices] = useState<TopDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      const [h, d] = await Promise.all([
+        fetchTrafficHistory(60),
+        fetchTopDevices(10),
+      ]);
+      setHistory(h);
+      setTopDevices(d);
+    } catch {
+      // Silently ignore errors — data will remain stale until next refresh.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, 30_000);
+    return () => clearInterval(interval);
+  }, [load]);
+
   return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <Card className="w-full max-w-md border-[#2a2a3a] bg-[#16161f]">
-        <CardContent className="flex flex-col items-center gap-4 py-12">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-500/10">
-            <Activity className="h-8 w-8 text-blue-400" />
+    <div className="space-y-6">
+      {/* Traffic History Chart */}
+      <div className="rounded-lg border border-[#2a2a3a] bg-[#16161f] p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Activity className="h-4 w-4 text-blue-400" />
+          <h2 className="text-sm font-medium text-gray-400">
+            Traffic — Last 60 minutes
+          </h2>
+        </div>
+
+        {history.length > 0 ? (
+          <div className="h-[200px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={history}>
+                <defs>
+                  <linearGradient id="colorRx" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="colorTx" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#2a2a3a" />
+                <XAxis
+                  dataKey="minute"
+                  tickFormatter={formatTime}
+                  tick={{ fill: "#6b7280", fontSize: 11 }}
+                  stroke="#2a2a3a"
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tickFormatter={(v: number) => formatBps(v)}
+                  tick={{ fill: "#6b7280", fontSize: 11 }}
+                  stroke="#2a2a3a"
+                  width={70}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "#16161f",
+                    border: "1px solid #2a2a3a",
+                    borderRadius: "6px",
+                    color: "#fff",
+                    fontSize: "12px",
+                  }}
+                  labelFormatter={formatTime}
+                  formatter={(value: number, name: string) => [
+                    formatBps(value),
+                    name === "rx_bps" ? "Inbound" : "Outbound",
+                  ]}
+                />
+                <Legend
+                  formatter={(value: string) =>
+                    value === "rx_bps" ? "Inbound" : "Outbound"
+                  }
+                  wrapperStyle={{ fontSize: "12px", color: "#9ca3af" }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="rx_bps"
+                  stroke="#3b82f6"
+                  fillOpacity={1}
+                  fill="url(#colorRx)"
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="tx_bps"
+                  stroke="#22c55e"
+                  fillOpacity={1}
+                  fill="url(#colorTx)"
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
           </div>
-          <h1 className="text-xl font-semibold text-white">Traffic Monitor</h1>
-          <p className="text-center text-sm text-gray-500">
-            Real-time bandwidth monitoring and traffic analytics.
-            <br />
-            Coming in v0.2
-          </p>
-        </CardContent>
-      </Card>
+        ) : (
+          <div className="flex h-[200px] items-center justify-center">
+            <p className="text-sm text-gray-500">
+              {loading ? "Loading traffic data…" : "No traffic data available yet."}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Top Devices by Bandwidth */}
+      <div className="rounded-lg border border-[#2a2a3a] bg-[#16161f]">
+        <div className="border-b border-[#2a2a3a] px-4 py-3">
+          <h2 className="text-sm font-medium text-gray-400">
+            Top Devices by Bandwidth
+          </h2>
+        </div>
+        {topDevices.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">
+            {loading ? "Loading…" : "No active devices."}
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow className="border-[#2a2a3a] hover:bg-transparent">
+                <TableHead className="text-gray-500">Device</TableHead>
+                <TableHead className="text-gray-500">IP</TableHead>
+                <TableHead className="text-right text-gray-500">
+                  Download
+                </TableHead>
+                <TableHead className="text-right text-gray-500">
+                  Upload
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {topDevices.map((d) => (
+                <TableRow key={d.id} className="border-[#2a2a3a]">
+                  <TableCell className="text-white">
+                    {d.name ?? d.hostname ?? d.id.slice(0, 8)}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-gray-400">
+                    {d.ip ?? "—"}
+                  </TableCell>
+                  <TableCell className="text-right text-blue-400">
+                    {formatBps(d.rx_bps)}
+                  </TableCell>
+                  <TableCell className="text-right text-green-400">
+                    {formatBps(d.tx_bps)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   Device,
   LoginResponse,
   TopDevice,
+  TrafficHistoryPoint,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -115,6 +116,12 @@ export function fetchAgent(id: string): Promise<Agent> {
 
 export function fetchAgentReports(id: string, limit = 100): Promise<AgentReport[]> {
   return apiGet<AgentReport[]>(`/api/v1/agents/${id}/reports?limit=${limit}`);
+}
+
+// ─── Traffic ────────────────────────────────────────────
+
+export function fetchTrafficHistory(minutes = 60): Promise<TrafficHistoryPoint[]> {
+  return apiGet<TrafficHistoryPoint[]>(`/api/v1/traffic/history?minutes=${minutes}`);
 }
 
 // ─── Auth ───────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -94,6 +94,14 @@ export interface TopDevice {
   tx_bps: number;
 }
 
+// ─── Traffic ────────────────────────────────────────────
+
+export interface TrafficHistoryPoint {
+  minute: string;
+  rx_bps: number;
+  tx_bps: number;
+}
+
 // ─── Auth ───────────────────────────────────────────────
 
 export interface AuthStatus {


### PR DESCRIPTION
Adds a time-series AreaChart to the Traffic page showing inbound/outbound bandwidth over the last 60 minutes. New GET /api/v1/traffic/history endpoint aggregates traffic_samples by minute bucket. Uses recharts with formatted bandwidth axis labels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added traffic history visualization with time-series area chart showing inbound/outbound bandwidth over the last 60 minutes. New backend endpoint `/api/v1/traffic/history` aggregates `traffic_samples` by minute bucket using SQLite's `strftime` function. Frontend uses recharts `AreaChart` component with gradient fills and formatted bandwidth axis labels.

- Created new `server/src/api/traffic.rs` module with `history` endpoint
- Endpoint properly uses parameterized queries to prevent SQL injection
- Includes comprehensive unit tests for aggregation, ordering, and empty state
- Frontend fetches data every 30 seconds with error handling
- Reuses existing `formatBps` utility for consistent bandwidth formatting
- One minor style issue: unused `Card` and `CardContent` imports in `page.tsx`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested feature with proper parameterization and error handling
- The implementation follows best practices with parameterized SQL queries preventing injection, comprehensive unit tests covering edge cases, proper error handling on both frontend and backend, and consistent patterns with the existing codebase. The only issue is a minor unused import.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Adds traffic module and registers `/traffic/history` endpoint |
| server/src/api/traffic.rs | New endpoint with per-minute traffic aggregation, parameter binding prevents SQL injection, includes comprehensive tests |
| web/src/app/(app)/traffic/page.tsx | Implements traffic history chart with AreaChart and top devices table; unused Card imports should be removed |
| web/src/lib/api.ts | Adds `fetchTrafficHistory` function with minutes parameter |
| web/src/lib/types.ts | Adds `TrafficHistoryPoint` interface matching backend response structure |

</details>



<sub>Last reviewed commit: 20dfa59</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->