### PR TITLE
feat: Wake-on-LAN — send magic packet to offline devices

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -74,6 +74,7 @@ pub fn router(state: AppState) -> Router {
         .route("/devices/:id", patch(devices::update))
         .route("/devices/:id/events", get(devices::events))
         .route("/devices/:id/uptime", get(devices::uptime))
+        .route("/devices/:id/wake", post(devices::wake))
         // Agents
         .route("/agents", get(agents::list))
         .route("/agents", post(agents::register))

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -21,6 +21,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^2.15.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.2.0",
       },
       "devDependencies": {
@@ -890,6 +891,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const inter = Inter({
@@ -29,6 +30,7 @@ export default function RootLayout({
         style={{ backgroundColor: "#0a0a0f", color: "#f2f2f2" }}
       >
         {children}
+        <Toaster theme="dark" position="bottom-right" richColors />
       </body>
     </html>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -123,6 +123,10 @@ export function fetchDeviceUptime(id: string, days = 7): Promise<UptimeStats> {
   return apiGet<UptimeStats>(`/api/v1/devices/${id}/uptime?days=${days}`);
 }
 
+export function wakeDevice(id: string): Promise<void> {
+  return apiPost<void>(`/api/v1/devices/${id}/wake`);
+}
+
 // ─── Agents ─────────────────────────────────────────────
 
 export function fetchAgents(): Promise<Agent[]> {


### PR DESCRIPTION
Adds POST /api/v1/devices/:id/wake endpoint that constructs a WoL magic packet (6x 0xFF + MAC*16 = 102 bytes) and broadcasts it over UDP to 255.255.255.255:9. Frontend adds a Wake button in device detail (active only when device is offline) with a toast on success.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Wake-on-LAN functionality by adding a new endpoint that constructs and broadcasts magic packets to wake offline devices. The implementation includes comprehensive unit tests for magic packet construction and proper UI integration with toast notifications.

- Added `POST /api/v1/devices/:id/wake` endpoint that builds a standard 102-byte WoL magic packet (6×0xFF + MAC×16) and broadcasts it via UDP to 255.255.255.255:9
- Frontend displays a Wake button only when devices are offline, with loading states and user-friendly error messages
- Added sonner library for toast notifications
- Includes 5 unit tests covering magic packet construction with valid/invalid MAC addresses

**Critical Issue**: The backend uses `std::net::UdpSocket` (synchronous blocking I/O) inside an async function running on Tokio runtime. This blocks the async executor thread and degrades performance. Should use `tokio::net::UdpSocket` with `.await` on bind and send_to operations instead.

<h3>Confidence Score: 3/5</h3>

- PR has a critical performance issue but is otherwise well-implemented
- The blocking I/O in async context is a significant runtime performance issue that must be fixed. However, the feature itself is well-designed with proper error handling, comprehensive tests, and good UX. Once the async/await fix is applied, this would be safe to merge.
- `server/src/api/devices.rs` needs the UdpSocket changed from std to tokio

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/devices.rs | Added Wake-on-LAN endpoint with magic packet construction; uses blocking UDP socket in async context which could impact runtime performance |
| web/src/lib/api.ts | Added wakeDevice API client function |
| web/src/app/(app)/devices/page.tsx | Added Wake button UI component with loading state and error handling for offline devices |

</details>



<sub>Last reviewed commit: 490196c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->