### PR TITLE
feat: on-demand port scan via VyOS nmap

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -75,6 +75,8 @@ pub fn router(state: AppState) -> Router {
         .route("/devices/:id/events", get(devices::events))
         .route("/devices/:id/uptime", get(devices::uptime))
         .route("/devices/:id/wake", post(devices::wake))
+        .route("/devices/:id/scan", get(devices::get_scan))
+        .route("/devices/:id/scan", post(devices::trigger_scan))
         // Agents
         .route("/agents", get(agents::list))
         .route("/agents", post(agents::register))

--- a/server/src/db/migrations/005_port_scans.sql
+++ b/server/src/db/migrations/005_port_scans.sql
@@ -1,0 +1,10 @@
+-- Migration 005: port_scans table for caching nmap scan results per device.
+CREATE TABLE IF NOT EXISTS port_scans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id TEXT NOT NULL,
+    scanned_at TEXT NOT NULL DEFAULT (datetime('now')),
+    result_json TEXT NOT NULL,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_port_scans_device_id ON port_scans(device_id);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -127,6 +127,28 @@ export function wakeDevice(id: string): Promise<void> {
   return apiPost<void>(`/api/v1/devices/${id}/wake`);
 }
 
+export interface PortEntry {
+  port: number;
+  protocol: string;
+  state: string;
+  service: string;
+  version: string;
+}
+
+export interface PortScanResult {
+  device_id: string;
+  scanned_at: string;
+  ports: PortEntry[];
+}
+
+export function triggerPortScan(id: string): Promise<PortScanResult> {
+  return apiPost<PortScanResult>(`/api/v1/devices/${id}/scan`);
+}
+
+export function fetchPortScan(id: string): Promise<PortScanResult> {
+  return apiGet<PortScanResult>(`/api/v1/devices/${id}/scan`);
+}
+
 // ─── Agents ─────────────────────────────────────────────
 
 export function fetchAgents(): Promise<Agent[]> {


### PR DESCRIPTION
Adds POST /devices/:id/scan (triggers nmap via VyOS HTTP API) and GET /devices/:id/scan (latest cached result). New port_scans table caches results. Rate limited to 1 scan/device/60s. Frontend shows Ports tab in device detail with scan button and port table.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds on-demand port scanning via VyOS nmap integration with result caching and rate limiting. The implementation includes a new `port_scans` table, POST/GET endpoints at `/devices/:id/scan`, and a frontend Ports tab with scan button and results table.

**Key changes:**
- Backend routes trigger nmap via VyOS HTTP API with `-sV` flag for service detection
- Results cached in SQLite with 60s rate limit per device
- Frontend displays scan results with loading/error states and user-friendly error messages
- Comprehensive test coverage for nmap output parsing and database operations

**Issues found:**
- Rate limiting has a race condition where concurrent requests can bypass the 60s limit
- Database errors in rate limit check are silently ignored, allowing scans to proceed on query failure

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor race condition in rate limiting that could allow concurrent scans
- Well-structured implementation with proper error handling, comprehensive tests, and security-conscious design (parameterized queries, no command injection risk). The two logic issues found are edge cases that won't cause critical failures - the race condition allows extra scans but doesn't break functionality, and error swallowing in rate limit check fails open safely. Code quality is high with good separation of concerns.
- Pay attention to `server/src/api/devices.rs` rate limiting logic (lines 691-715) for the race condition issue

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/devices.rs | Adds port scan endpoints with nmap parsing, rate limiting (60s), and result caching - implementation looks solid with proper error handling |
| server/src/vyos/client.rs | Added `run_nmap` method with 30s timeout and proper error handling - IP passed safely as JSON array element |
| web/src/app/(app)/devices/page.tsx | Adds Ports tab with scan button and port table display - UI properly handles loading, scanning, and error states |

</details>



<sub>Last reviewed commit: a3352cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->