### PR TITLE
feat: network speed test via VyOS iperf3

### DIFF
--- a/server/src/vyos/client.rs
+++ b/server/src/vyos/client.rs
@@ -118,6 +118,70 @@ impl VyosClient {
         }
     }
 
+    /// Run an iperf3 client command on VyOS targeting the given server IP.
+    ///
+    /// Uses the VyOS `/show` endpoint with iperf3 arguments.
+    /// `reverse` controls the `--reverse` flag (upload measurement).
+    /// Returns the raw iperf3 JSON output as a string.
+    pub async fn run_iperf3(&self, server_ip: &str, reverse: bool) -> Result<String> {
+        // Build a client with a longer timeout (iperf3 --time 5 + overhead)
+        let iperf_http = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to build iperf3 reqwest client")?;
+
+        let mut path = vec!["iperf3", "--client", server_ip, "--time", "5", "--json"];
+        if reverse {
+            path.push("--reverse");
+        }
+
+        let data = serde_json::json!({
+            "op": "show",
+            "path": path,
+        });
+
+        let url = format!("{}/show", self.base_url);
+        let data_str = serde_json::to_string(&data)?;
+
+        let form = reqwest::multipart::Form::new()
+            .text("data", data_str)
+            .text("key", self.api_key.clone());
+
+        let resp = iperf_http
+            .post(&url)
+            .multipart(form)
+            .send()
+            .await
+            .context("VyOS iperf3 request failed")?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .context("failed to read VyOS iperf3 response body")?;
+
+        if !status.is_success() {
+            anyhow::bail!("VyOS iperf3 returned HTTP {status}: {body}");
+        }
+
+        let parsed: VyosResponse =
+            serde_json::from_str(&body).context("failed to parse VyOS iperf3 response JSON")?;
+
+        if parsed.success {
+            Ok(parsed
+                .data
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .unwrap_or_default())
+        } else {
+            let err_msg = parsed
+                .error
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown error".to_string());
+            anyhow::bail!("VyOS iperf3 error: {err_msg}");
+        }
+    }
+
     /// Low-level helper: send a multipart form POST to the VyOS API.
     async fn post_form(&self, endpoint: &str, data: &Value) -> Result<Value> {
         let url = format!("{}{endpoint}", self.base_url);

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -10,6 +10,11 @@ import {
   Loader2,
   AlertCircle,
   Settings,
+  Gauge,
+  ArrowDown,
+  ArrowUp,
+  Clock,
+  AlertTriangle,
 } from "lucide-react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -24,8 +29,10 @@ import {
   fetchRouterDhcpLeases,
   fetchRouterFirewall,
   fetchRouterConfigInterfaces,
+  runSpeedTest,
 } from "@/lib/api";
-import type { RouterStatus } from "@/lib/types";
+import type { RouterStatus, SpeedTestResult } from "@/lib/types";
+import { Progress } from "@/components/ui/progress";
 
 // ── Not Configured state ────────────────────────────────
 
@@ -228,6 +235,184 @@ function useAsyncData<T>(
   return { data, loading, error, reload: load };
 }
 
+// ── Speed Test Section ──────────────────────────────────
+
+function SpeedTestSection() {
+  const [result, setResult] = useState<SpeedTestResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+
+  const handleRunTest = async () => {
+    setRunning(true);
+    setError(null);
+    setProgress(0);
+
+    // Animate progress bar over ~12 seconds (download 5s + upload 5s + overhead)
+    const totalMs = 12000;
+    const intervalMs = 100;
+    const steps = totalMs / intervalMs;
+    let step = 0;
+
+    const timer = setInterval(() => {
+      step++;
+      // Ease-out progress: fast at first, slows near end
+      const pct = Math.min((step / steps) * 95, 95);
+      setProgress(pct);
+    }, intervalMs);
+
+    try {
+      const res = await runSpeedTest();
+      setResult(res);
+      setProgress(100);
+    } catch (e) {
+      if (e instanceof Error) {
+        // Extract error message from API response if possible
+        if (e.message.includes("429")) {
+          setError("Rate limited — please wait 60 seconds between tests.");
+        } else if (e.message.includes("503")) {
+          setError("iperf3 not available or VyOS not configured.");
+        } else {
+          setError(e.message);
+        }
+      } else {
+        setError("Speed test failed.");
+      }
+    } finally {
+      clearInterval(timer);
+      setRunning(false);
+      // Reset progress after a brief pause showing 100%
+      setTimeout(() => setProgress(0), 500);
+    }
+  };
+
+  const timeAgo = (dateStr: string) => {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "just now";
+    if (mins === 1) return "1 minute ago";
+    if (mins < 60) return `${mins} minutes ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs === 1) return "1 hour ago";
+    return `${hrs} hours ago`;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Action row */}
+      <Card className="border-[#2a2a3a] bg-[#16161f]">
+        <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h3 className="flex items-center gap-2 text-base font-medium text-white">
+              <Gauge className="h-4 w-4 text-blue-400" />
+              LAN Speed Test
+            </h3>
+            <p className="text-xs text-gray-500">
+              Measures throughput between VyOS router and Panoptikon server using
+              iperf3.
+            </p>
+          </div>
+          <Button
+            onClick={handleRunTest}
+            disabled={running}
+            className="shrink-0 bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {running ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Testing…
+              </>
+            ) : (
+              <>
+                <Gauge className="mr-2 h-4 w-4" />
+                Run Speed Test
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Progress bar while running */}
+      {running && (
+        <div className="space-y-2">
+          <Progress value={progress} />
+          <p className="text-center text-xs text-gray-500">
+            Running iperf3 test… download + upload (~12 seconds)
+          </p>
+        </div>
+      )}
+
+      {/* Error display */}
+      {error && (
+        <div className="flex items-center gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-4 py-3">
+          <AlertCircle className="h-4 w-4 shrink-0 text-red-400" />
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {/* Result cards */}
+      {result && !running && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {/* Download */}
+            <Card className="border-[#2a2a3a] bg-[#16161f]">
+              <CardContent className="flex items-center gap-4 py-6">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-green-500/10">
+                  <ArrowDown className="h-6 w-6 text-green-400" />
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Download</p>
+                  <p className="text-2xl font-bold text-white">
+                    {result.download_mbps.toFixed(1)}{" "}
+                    <span className="text-sm font-normal text-gray-500">
+                      Mbps
+                    </span>
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Upload */}
+            <Card className="border-[#2a2a3a] bg-[#16161f]">
+              <CardContent className="flex items-center gap-4 py-6">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-blue-500/10">
+                  <ArrowUp className="h-6 w-6 text-blue-400" />
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Upload</p>
+                  <p className="text-2xl font-bold text-white">
+                    {result.upload_mbps.toFixed(1)}{" "}
+                    <span className="text-sm font-normal text-gray-500">
+                      Mbps
+                    </span>
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Metadata */}
+          <div className="flex items-center justify-between px-1">
+            <p className="flex items-center gap-1 text-xs text-gray-500">
+              <Clock className="h-3 w-3" />
+              Last tested: {timeAgo(result.tested_at)}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Traffic warning */}
+      <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/5 px-4 py-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+        <p className="text-xs text-amber-400/80">
+          Speed test generates ~50 MB of traffic per run. Tests are rate limited
+          to once per 60 seconds.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // ── Main Page ───────────────────────────────────────────
 
 export default function RouterPage() {
@@ -329,6 +514,13 @@ function RouterTabs({ status }: { status: RouterStatus }) {
             <Shield className="mr-1.5 h-3.5 w-3.5" />
             Firewall
           </TabsTrigger>
+          <TabsTrigger
+            value="speedtest"
+            className="data-[state=active]:bg-[#1e1e2e] data-[state=active]:text-white"
+          >
+            <Gauge className="mr-1.5 h-3.5 w-3.5" />
+            Speed Test
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="interfaces" className="space-y-4">
@@ -425,6 +617,10 @@ function RouterTabs({ status }: { status: RouterStatus }) {
               />
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="speedtest">
+          <SpeedTestSection />
         </TabsContent>
       </Tabs>
     </div>

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+  max?: number;
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, ...props }, ref) => {
+    const percentage = Math.min(Math.max((value / max) * 100, 0), 100);
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        className={cn(
+          "relative h-2 w-full overflow-hidden rounded-full bg-[#1e1e2e]",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-300 ease-in-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    );
+  },
+);
+Progress.displayName = "Progress";
+
+export { Progress };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   NetflowStatus,
   RouterStatus,
   SettingsData,
+  SpeedTestResult,
   TopDevice,
   TrafficHistoryPoint,
 } from "./types";
@@ -211,6 +212,10 @@ export function fetchRouterDhcpLeases(): Promise<string> {
 
 export function fetchRouterFirewall(): Promise<Record<string, unknown>> {
   return apiGet<Record<string, unknown>>("/api/v1/vyos/firewall");
+}
+
+export function runSpeedTest(): Promise<SpeedTestResult> {
+  return apiPost<SpeedTestResult>("/api/v1/router/speedtest");
 }
 
 // ─── NetFlow ────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -120,6 +120,13 @@ export interface RouterStatus {
   hostname: string | null;
 }
 
+export interface SpeedTestResult {
+  download_mbps: number;
+  upload_mbps: number;
+  latency_ms: number;
+  tested_at: string;
+}
+
 export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;


### PR DESCRIPTION
Adds POST /api/v1/router/speedtest endpoint that spawns an iperf3 server locally, triggers VyOS iperf3 client, parses JSON result. Rate limited 60s. Frontend: Speed Test tab on Router page with progress and result cards.

## Changes
- **Backend**: New `POST /api/v1/router/speedtest` handler in `server/src/api/vyos.rs`
  - Spawns local iperf3 server (`--server --one-off --port 5201`)
  - Triggers VyOS iperf3 client via `/show` API (download + upload with `--reverse`)
  - Parses iperf3 JSON output (`.end.sum_received.bits_per_second`)
  - Rate limited: 60s between tests (429 if too frequent)
  - Checks iperf3 binary availability (503 if missing)
  - Auto-detects local IP for VyOS to connect back
  - Caches last result in `AppState`
- **VyOS client**: New `run_iperf3()` method with 30s timeout
- **Frontend**: Speed Test tab on Router page
  - Run Speed Test button with animated progress bar (~12s)
  - Download/Upload result cards (Mbps)
  - Last tested timestamp
  - Traffic warning (~50MB per run)
- **Tests**: 3 unit tests (parse JSON, missing fields, rate limit)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds network speed testing functionality using iperf3 to measure LAN throughput between VyOS router and Panoptikon server.

**Key Changes:**
- Backend: `/api/v1/router/speedtest` endpoint spawns local iperf3 server, triggers VyOS client, parses JSON results
- Frontend: New Speed Test tab with progress animation, download/upload cards, and rate limit warnings
- Rate limiting: 60-second cooldown between tests enforced server-side
- Security: Endpoint protected by existing auth middleware

**Issues Found:**
- **Critical**: Race condition on concurrent requests - both can pass rate limit check and attempt to bind port 5201 simultaneously
- **Moderate**: Memory leak if Speed Test component unmounts during active test (interval not cleaned up)
- Minor: Hardcoded `latency_ms: 0.0` field in response; non-idiomatic error checking pattern

<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes recommended for race condition and memory leak
- Score reflects two logic issues that should be addressed: (1) race condition allowing concurrent port binding attempts, and (2) memory leak from uncleaned interval on unmount. Both are fixable but could cause production issues under load.
- Pay close attention to `server/src/api/vyos.rs` (race condition) and `web/src/app/(app)/router/page.tsx` (memory leak)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Speed test endpoint with iperf3 integration; potential race condition on port binding with concurrent requests |
| server/src/vyos/client.rs | VyOS iperf3 client method with proper timeout handling and error propagation |
| web/src/app/(app)/router/page.tsx | Speed test UI with progress animation and proper error handling |

</details>



<sub>Last reviewed commit: 68fccf4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->