### PR TITLE
feat: alert management — acknowledge, mute, severity

### DIFF
--- a/server/src/api/alerts.rs
+++ b/server/src/api/alerts.rs
@@ -19,6 +19,9 @@ pub struct Alert {
     pub message: String,
     pub details: Option<String>,
     pub is_read: bool,
+    pub severity: String,
+    pub acknowledged_at: Option<String>,
+    pub acknowledged_by: Option<String>,
     pub created_at: String,
 }
 
@@ -29,6 +32,16 @@ pub struct ListAlertsQuery {
     pub unread_only: Option<bool>,
     /// Maximum number of alerts to return.
     pub limit: Option<i64>,
+    /// Filter by status: active, acknowledged, all (default: all).
+    pub status: Option<String>,
+    /// Filter by severity: INFO, WARNING, CRITICAL.
+    pub severity: Option<String>,
+}
+
+/// Request body for acknowledging an alert.
+#[derive(Debug, Deserialize)]
+pub struct AcknowledgeBody {
+    pub note: Option<String>,
 }
 
 impl Alert {
@@ -41,6 +54,11 @@ impl Alert {
             message: row.try_get("message")?,
             details: row.try_get("details")?,
             is_read: row.try_get::<i32, _>("is_read").unwrap_or(0) != 0,
+            severity: row
+                .try_get::<String, _>("severity")
+                .unwrap_or_else(|_| "WARNING".to_string()),
+            acknowledged_at: row.try_get("acknowledged_at").unwrap_or(None),
+            acknowledged_by: row.try_get("acknowledged_by").unwrap_or(None),
             created_at: row.try_get("created_at")?,
         })
     }
@@ -54,27 +72,47 @@ pub async fn list(
     let limit = params.limit.unwrap_or(50);
     let unread_only = params.unread_only.unwrap_or(false);
 
-    let rows = if unread_only {
-        sqlx::query(
-            "SELECT id, type, device_id, agent_id, message, details, is_read, created_at \
-             FROM alerts WHERE is_read = 0 ORDER BY created_at DESC LIMIT ?",
-        )
-        .bind(limit)
-        .fetch_all(&state.db)
-        .await
-    } else {
-        sqlx::query(
-            "SELECT id, type, device_id, agent_id, message, details, is_read, created_at \
-             FROM alerts ORDER BY created_at DESC LIMIT ?",
-        )
-        .bind(limit)
-        .fetch_all(&state.db)
-        .await
+    // Build dynamic query with filters
+    let mut conditions: Vec<String> = Vec::new();
+
+    if unread_only {
+        conditions.push("is_read = 0".to_string());
     }
-    .map_err(|e| {
-        tracing::error!("Failed to list alerts: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+
+    // Status filter
+    match params.status.as_deref() {
+        Some("active") => conditions.push("acknowledged_at IS NULL".to_string()),
+        Some("acknowledged") => conditions.push("acknowledged_at IS NOT NULL".to_string()),
+        _ => {} // "all" or default — no filter
+    }
+
+    // Severity filter
+    if let Some(ref sev) = params.severity {
+        let sev_upper = sev.to_uppercase();
+        if matches!(sev_upper.as_str(), "INFO" | "WARNING" | "CRITICAL") {
+            conditions.push(format!("severity = '{sev_upper}'"));
+        }
+    }
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let query_str = format!(
+        r#"SELECT id, type, device_id, agent_id, message, details, is_read, severity, acknowledged_at, acknowledged_by, created_at
+         FROM alerts {where_clause} ORDER BY created_at DESC LIMIT ?"#
+    );
+
+    let rows = sqlx::query(&query_str)
+        .bind(limit)
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list alerts: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     let alerts: Vec<Alert> = rows
         .into_iter()
@@ -103,4 +141,290 @@ pub async fn mark_read(
     }
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// POST /api/v1/alerts/:id/acknowledge — acknowledge an alert with an optional note.
+pub async fn acknowledge(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<AcknowledgeBody>,
+) -> Result<StatusCode, StatusCode> {
+    let result = sqlx::query(
+        r#"UPDATE alerts SET acknowledged_at = datetime('now'), acknowledged_by = ?, is_read = 1 WHERE id = ?"#,
+    )
+    .bind(&body.note)
+    .bind(&id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to acknowledge alert {id}: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if result.rows_affected() == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Query parameters for muting a device.
+#[derive(Debug, Deserialize)]
+pub struct MuteQuery {
+    /// Hours to mute: 1, 8, 24, or 0 to unmute.
+    pub hours: Option<i64>,
+}
+
+/// POST /api/v1/devices/:id/mute?hours=N — mute a device for N hours (0 to unmute).
+pub async fn mute_device(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(params): Query<MuteQuery>,
+) -> Result<StatusCode, StatusCode> {
+    let hours = params.hours.unwrap_or(1);
+
+    let result = if hours <= 0 {
+        // Unmute
+        sqlx::query(r#"UPDATE devices SET muted_until = NULL WHERE id = ?"#)
+            .bind(&id)
+            .execute(&state.db)
+            .await
+    } else {
+        sqlx::query(
+            r#"UPDATE devices SET muted_until = datetime('now', '+' || ? || ' hours') WHERE id = ?"#,
+        )
+        .bind(hours)
+        .bind(&id)
+        .execute(&state.db)
+        .await
+    }
+    .map_err(|e| {
+        tracing::error!("Failed to mute device {id}: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if result.rows_affected() == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Check if a device is currently muted (muted_until > now).
+/// Returns true if the device is muted and alerts should be suppressed.
+pub async fn is_device_muted(db: &sqlx::SqlitePool, device_id: &str) -> bool {
+    let result: Option<i64> = sqlx::query_scalar(
+        r#"SELECT 1 FROM devices WHERE id = ? AND muted_until IS NOT NULL AND muted_until > datetime('now')"#,
+    )
+    .bind(device_id)
+    .fetch_optional(db)
+    .await
+    .unwrap_or(None);
+
+    result.is_some()
+}
+
+/// Determine the severity level for an alert type.
+pub fn severity_for_alert_type(alert_type: &str) -> &'static str {
+    match alert_type {
+        "new_device" => "INFO",
+        "device_online" => "INFO",
+        "device_offline" | "agent_offline" | "high_bandwidth" => "WARNING",
+        _ => "WARNING",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    /// Helper: create a fresh in-memory database with all migrations applied.
+    async fn test_db() -> sqlx::SqlitePool {
+        db::init(":memory:")
+            .await
+            .expect("in-memory DB init failed")
+    }
+
+    /// Helper: insert a test device and return its id.
+    async fn insert_test_device(pool: &sqlx::SqlitePool, mac: &str) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"INSERT INTO devices (id, mac, name, first_seen_at, last_seen_at)
+               VALUES (?, ?, 'test-device', ?, ?)"#,
+        )
+        .bind(&id)
+        .bind(mac)
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Helper: insert a test alert and return its id.
+    async fn insert_test_alert(
+        pool: &sqlx::SqlitePool,
+        device_id: &str,
+        alert_type: &str,
+        severity: &str,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO alerts (id, type, device_id, message, severity, created_at)
+               VALUES (?, ?, ?, 'Test alert', ?, datetime('now'))"#,
+        )
+        .bind(&id)
+        .bind(alert_type)
+        .bind(device_id)
+        .bind(severity)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_acknowledge_alert() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:01").await;
+        let alert_id = insert_test_alert(&pool, &device_id, "device_offline", "WARNING").await;
+
+        // Acknowledge the alert
+        sqlx::query(
+            r#"UPDATE alerts SET acknowledged_at = datetime('now'), acknowledged_by = ? WHERE id = ?"#,
+        )
+        .bind("Fixed the issue")
+        .bind(&alert_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Verify
+        let row =
+            sqlx::query(r#"SELECT acknowledged_at, acknowledged_by FROM alerts WHERE id = ?"#)
+                .bind(&alert_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let ack_at: Option<String> = row.try_get("acknowledged_at").unwrap();
+        let ack_by: Option<String> = row.try_get("acknowledged_by").unwrap();
+
+        assert!(
+            ack_at.is_some(),
+            "acknowledged_at should be set after acknowledge"
+        );
+        assert_eq!(
+            ack_by.as_deref(),
+            Some("Fixed the issue"),
+            "acknowledged_by should contain the note"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mute_device_suppresses_alerts() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:02").await;
+
+        // Mute the device for 1 hour
+        sqlx::query(r#"UPDATE devices SET muted_until = datetime('now', '+1 hours') WHERE id = ?"#)
+            .bind(&device_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Check if device is muted
+        let muted = is_device_muted(&pool, &device_id).await;
+        assert!(
+            muted,
+            "Device should be muted after setting muted_until in the future"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mute_expired_allows_alerts() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:03").await;
+
+        // Set muted_until in the past (expired)
+        sqlx::query(r#"UPDATE devices SET muted_until = datetime('now', '-1 hours') WHERE id = ?"#)
+            .bind(&device_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Check if device is muted — should NOT be
+        let muted = is_device_muted(&pool, &device_id).await;
+        assert!(
+            !muted,
+            "Device should NOT be muted when muted_until is in the past"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alert_severity_default() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:04").await;
+
+        // Insert alert without specifying severity (uses DB default)
+        let alert_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO alerts (id, type, device_id, message, created_at)
+               VALUES (?, 'device_offline', ?, 'Test', datetime('now'))"#,
+        )
+        .bind(&alert_id)
+        .bind(&device_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let severity: String = sqlx::query_scalar(r#"SELECT severity FROM alerts WHERE id = ?"#)
+            .bind(&alert_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(severity, "WARNING", "Default severity should be 'WARNING'");
+    }
+
+    #[tokio::test]
+    async fn test_filter_active_alerts() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:05").await;
+
+        // Create two alerts
+        let alert1 = insert_test_alert(&pool, &device_id, "device_offline", "WARNING").await;
+        let _alert2 = insert_test_alert(&pool, &device_id, "new_device", "INFO").await;
+
+        // Acknowledge alert1
+        sqlx::query(
+            r#"UPDATE alerts SET acknowledged_at = datetime('now'), acknowledged_by = 'test' WHERE id = ?"#,
+        )
+        .bind(&alert1)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Query active alerts (not acknowledged)
+        let rows =
+            sqlx::query(r#"SELECT id FROM alerts WHERE acknowledged_at IS NULL AND device_id = ?"#)
+                .bind(&device_id)
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "Only one active (unacknowledged) alert should remain"
+        );
+        let active_id: String = rows[0].try_get("id").unwrap();
+        assert_ne!(
+            active_id, alert1,
+            "The acknowledged alert should not appear in active filter"
+        );
+    }
 }

--- a/server/src/api/devices.rs
+++ b/server/src/api/devices.rs
@@ -43,6 +43,9 @@ pub struct Device {
     /// Linked agent summary (if any)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent: Option<AgentSummary>,
+    /// Muted until timestamp (if device is muted)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub muted_until: Option<String>,
 }
 
 /// Request body for creating a device.
@@ -94,6 +97,7 @@ impl Device {
             ips: vec![], // populated after query
             mdns_services: row.try_get("mdns_services").unwrap_or(None),
             agent,
+            muted_until: row.try_get("muted_until").unwrap_or(None),
         })
     }
 }
@@ -104,7 +108,7 @@ pub async fn list(State(state): State<AppState>) -> Result<Json<Vec<Device>>, St
         r#"
         SELECT d.id, d.mac, d.name, d.hostname, d.vendor, d.icon, d.notes,
                d.is_known, d.is_favorite, d.first_seen_at, d.last_seen_at, d.is_online,
-               d.mdns_services,
+               d.mdns_services, d.muted_until,
                a.id AS agent_id,
                a.name AS agent_name,
                r.cpu_percent AS agent_cpu_percent,
@@ -165,7 +169,7 @@ pub async fn get_one(
         r#"
         SELECT d.id, d.mac, d.name, d.hostname, d.vendor, d.icon, d.notes,
                d.is_known, d.is_favorite, d.first_seen_at, d.last_seen_at, d.is_online,
-               d.mdns_services,
+               d.mdns_services, d.muted_until,
                a.id AS agent_id,
                a.name AS agent_name,
                r.cpu_percent AS agent_cpu_percent,
@@ -254,6 +258,7 @@ pub async fn create(
         ips: vec![],
         mdns_services: None,
         agent: None,
+        muted_until: None,
     };
 
     Ok((StatusCode::CREATED, Json(device)))
@@ -898,7 +903,7 @@ mod tests {
             r#"
             SELECT d.id, d.mac, d.name, d.hostname, d.vendor, d.icon, d.notes,
                    d.is_known, d.is_favorite, d.first_seen_at, d.last_seen_at, d.is_online,
-                   d.mdns_services,
+                   d.mdns_services, d.muted_until,
                    a.id AS agent_id,
                    a.name AS agent_name,
                    r.cpu_percent AS agent_cpu_percent,

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -94,6 +94,9 @@ pub fn router(state: AppState) -> Router {
         // Alerts
         .route("/alerts", get(alerts::list))
         .route("/alerts/:id/read", post(alerts::mark_read))
+        .route("/alerts/:id/acknowledge", post(alerts::acknowledge))
+        // Device mute
+        .route("/devices/:id/mute", post(alerts::mute_device))
         // Settings
         .route("/settings", get(settings::get_settings))
         .route("/settings", patch(settings::update_settings))

--- a/server/src/db/migrations/007_alert_management.sql
+++ b/server/src/db/migrations/007_alert_management.sql
@@ -1,0 +1,9 @@
+-- Migration 007: Alert management — acknowledge, mute, severity levels
+-- Add acknowledged_at, acknowledged_by, severity to alerts
+-- Add muted_until to devices
+
+ALTER TABLE alerts ADD COLUMN acknowledged_at TEXT;
+ALTER TABLE alerts ADD COLUMN acknowledged_by TEXT;
+ALTER TABLE alerts ADD COLUMN severity TEXT NOT NULL DEFAULT 'WARNING' CHECK (severity IN ('INFO','WARNING','CRITICAL'));
+
+ALTER TABLE devices ADD COLUMN muted_until TEXT;

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -6,16 +6,33 @@ import {
   AlertTriangle,
   Bell,
   BellOff,
+  Check,
   CheckCheck,
+  Clock,
   MonitorSmartphone,
   Shield,
+  VolumeX,
   Wifi,
 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { fetchAlerts, markAlertRead } from "@/lib/api";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  fetchAlerts,
+  markAlertRead,
+  acknowledgeAlert,
+  muteDevice,
+} from "@/lib/api";
 import type { Alert } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 
@@ -53,18 +70,51 @@ function alertTypeLabel(type: Alert["type"]): string {
   }
 }
 
+function severityBadge(severity: Alert["severity"]) {
+  switch (severity) {
+    case "CRITICAL":
+      return (
+        <Badge className="bg-red-500/20 text-red-400 border-red-500/30 text-[10px] px-1.5 py-0">
+          CRITICAL
+        </Badge>
+      );
+    case "WARNING":
+      return (
+        <Badge className="bg-amber-500/20 text-amber-400 border-amber-500/30 text-[10px] px-1.5 py-0">
+          WARNING
+        </Badge>
+      );
+    case "INFO":
+      return (
+        <Badge className="bg-blue-500/20 text-blue-400 border-blue-500/30 text-[10px] px-1.5 py-0">
+          INFO
+        </Badge>
+      );
+    default:
+      return null;
+  }
+}
+
+type StatusFilter = "all" | "active" | "acknowledged";
+
 export default function AlertsPage() {
   const [alerts, setAlerts] = useState<Alert[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [ackDialogOpen, setAckDialogOpen] = useState(false);
+  const [ackAlertId, setAckAlertId] = useState<string | null>(null);
+  const [ackNote, setAckNote] = useState("");
+  const [muteDropdownId, setMuteDropdownId] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const data = await fetchAlerts(100);
+      const status = statusFilter === "all" ? undefined : statusFilter;
+      const data = await fetchAlerts(100, status);
       setAlerts(Array.isArray(data) ? data : []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load alerts");
     }
-  }, []);
+  }, [statusFilter]);
 
   useEffect(() => {
     load();
@@ -79,7 +129,44 @@ export default function AlertsPage() {
         (prev ?? []).map((a) => (a.id === id ? { ...a, is_read: true } : a))
       );
     } catch {
-      // silently ignore — next refresh will sync
+      // silently ignore
+    }
+  }
+
+  function openAckDialog(alertId: string) {
+    setAckAlertId(alertId);
+    setAckNote("");
+    setAckDialogOpen(true);
+  }
+
+  async function handleAcknowledge() {
+    if (!ackAlertId) return;
+    try {
+      await acknowledgeAlert(ackAlertId, ackNote || undefined);
+      setAlerts((prev) =>
+        (prev ?? []).map((a) =>
+          a.id === ackAlertId
+            ? {
+                ...a,
+                acknowledged_at: new Date().toISOString(),
+                acknowledged_by: ackNote || null,
+                is_read: true,
+              }
+            : a
+        )
+      );
+      setAckDialogOpen(false);
+    } catch {
+      // silently ignore
+    }
+  }
+
+  async function handleMute(deviceId: string, hours: number) {
+    try {
+      await muteDevice(deviceId, hours);
+      setMuteDropdownId(null);
+    } catch {
+      // silently ignore
     }
   }
 
@@ -91,7 +178,8 @@ export default function AlertsPage() {
     );
   }
 
-  const unreadCount = (alerts ?? []).filter((a) => !a.is_read).length;
+  const activeCount = (alerts ?? []).filter((a) => !a.acknowledged_at).length;
+  const acknowledgedCount = (alerts ?? []).filter((a) => !!a.acknowledged_at).length;
 
   return (
     <div className="space-y-6">
@@ -99,13 +187,38 @@ export default function AlertsPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-semibold text-white">Alerts</h1>
-          {unreadCount > 0 && (
+          {activeCount > 0 && (
             <Badge variant="secondary" className="gap-1">
               <Bell className="h-3 w-3" />
-              {unreadCount} unread
+              {activeCount} active
+            </Badge>
+          )}
+          {acknowledgedCount > 0 && (
+            <Badge variant="outline" className="gap-1 text-gray-400 border-gray-700">
+              <Check className="h-3 w-3" />
+              {acknowledgedCount} acknowledged
             </Badge>
           )}
         </div>
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex gap-2">
+        {(["all", "active", "acknowledged"] as StatusFilter[]).map((f) => (
+          <Button
+            key={f}
+            variant={statusFilter === f ? "default" : "outline"}
+            size="sm"
+            onClick={() => setStatusFilter(f)}
+            className={
+              statusFilter === f
+                ? ""
+                : "border-gray-700 text-gray-400 hover:text-gray-200"
+            }
+          >
+            {f === "all" ? "All" : f === "active" ? "Active" : "Acknowledged"}
+          </Button>
+        ))}
       </div>
 
       {/* Alert list */}
@@ -136,18 +249,23 @@ export default function AlertsPage() {
           {alerts.map((alert) => (
             <Card
               key={alert.id}
-              className={`cursor-pointer border-[#2a2a3a] transition-colors hover:border-blue-500/30 ${
-                !alert.is_read ? "border-l-2 border-l-blue-500 bg-[#16161f]" : "bg-[#12121a]"
+              className={`border-[#2a2a3a] transition-colors hover:border-blue-500/30 ${
+                alert.acknowledged_at
+                  ? "bg-[#12121a] opacity-70"
+                  : !alert.is_read
+                    ? "border-l-2 border-l-blue-500 bg-[#16161f]"
+                    : "bg-[#16161f]"
               }`}
-              onClick={() => {
-                if (!alert.is_read) handleMarkRead(alert.id);
-              }}
             >
               <CardContent className="flex items-center gap-4 py-4">
                 {/* Icon */}
                 <div
                   className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
-                    !alert.is_read ? "bg-blue-500/10" : "bg-gray-800"
+                    alert.acknowledged_at
+                      ? "bg-gray-800/50"
+                      : !alert.is_read
+                        ? "bg-blue-500/10"
+                        : "bg-gray-800"
                   }`}
                 >
                   {alertIcon(alert.type)}
@@ -159,17 +277,33 @@ export default function AlertsPage() {
                     <span className="text-xs font-medium uppercase tracking-wider text-gray-500">
                       {alertTypeLabel(alert.type)}
                     </span>
-                    {!alert.is_read && (
+                    {severityBadge(alert.severity)}
+                    {!alert.is_read && !alert.acknowledged_at && (
                       <span className="h-2 w-2 rounded-full bg-blue-500" />
+                    )}
+                    {alert.acknowledged_at && (
+                      <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-700 text-green-500">
+                        <CheckCheck className="mr-0.5 h-3 w-3" />
+                        ACK
+                      </Badge>
                     )}
                   </div>
                   <p
                     className={`mt-0.5 text-sm ${
-                      !alert.is_read ? "text-gray-200" : "text-gray-400"
+                      alert.acknowledged_at
+                        ? "text-gray-500"
+                        : !alert.is_read
+                          ? "text-gray-200"
+                          : "text-gray-400"
                     }`}
                   >
                     {alert.message}
                   </p>
+                  {alert.acknowledged_by && (
+                    <p className="mt-0.5 text-xs text-gray-600 italic">
+                      Note: {alert.acknowledged_by}
+                    </p>
+                  )}
                 </div>
 
                 {/* Time */}
@@ -177,15 +311,119 @@ export default function AlertsPage() {
                   {timeAgo(alert.created_at)}
                 </span>
 
-                {/* Read indicator */}
-                {alert.is_read && (
-                  <CheckCheck className="h-4 w-4 shrink-0 text-gray-700" />
-                )}
+                {/* Actions */}
+                <div className="flex items-center gap-1 shrink-0">
+                  {/* Mark read */}
+                  {!alert.is_read && !alert.acknowledged_at && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-gray-500 hover:text-gray-200"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleMarkRead(alert.id);
+                      }}
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+
+                  {/* Acknowledge */}
+                  {!alert.acknowledged_at && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-gray-500 hover:text-green-400"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openAckDialog(alert.id);
+                      }}
+                      title="Acknowledge"
+                    >
+                      <CheckCheck className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+
+                  {/* Mute device */}
+                  {alert.device_id && (
+                    <div className="relative">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-gray-500 hover:text-amber-400"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setMuteDropdownId(
+                            muteDropdownId === alert.id ? null : alert.id
+                          );
+                        }}
+                        title="Mute device"
+                      >
+                        <VolumeX className="h-3.5 w-3.5" />
+                      </Button>
+                      {muteDropdownId === alert.id && (
+                        <div className="absolute right-0 top-full z-50 mt-1 w-36 rounded-md border border-[#2a2a3a] bg-[#1a1a2a] py-1 shadow-lg">
+                          {[
+                            { label: "Mute 1h", hours: 1 },
+                            { label: "Mute 8h", hours: 8 },
+                            { label: "Mute 24h", hours: 24 },
+                            { label: "Unmute", hours: 0 },
+                          ].map((opt) => (
+                            <button
+                              key={opt.hours}
+                              className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-gray-300 hover:bg-[#2a2a3a] hover:text-white"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (alert.device_id) {
+                                  handleMute(alert.device_id, opt.hours);
+                                }
+                              }}
+                            >
+                              <Clock className="h-3 w-3" />
+                              {opt.label}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
               </CardContent>
             </Card>
           ))}
         </div>
       )}
+
+      {/* Acknowledge Dialog */}
+      <Dialog open={ackDialogOpen} onOpenChange={setAckDialogOpen}>
+        <DialogContent className="bg-[#16161f] border-[#2a2a3a]">
+          <DialogHeader>
+            <DialogTitle>Acknowledge Alert</DialogTitle>
+            <DialogDescription>
+              Optionally add a note about why this alert is being acknowledged.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            placeholder="Add a note (optional)..."
+            value={ackNote}
+            onChange={(e) => setAckNote(e.target.value)}
+            className="bg-[#12121a] border-[#2a2a3a]"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAcknowledge();
+            }}
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setAckDialogOpen(false)}
+              className="border-gray-700"
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleAcknowledge}>Acknowledge</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowDown, ArrowUp, Cpu, Loader2, LayoutGrid, List, MemoryStick, Power, Radar, Search, Wifi, WifiOff } from "lucide-react";
+import { ArrowDown, ArrowUp, Cpu, Loader2, LayoutGrid, List, MemoryStick, Power, Radar, Search, VolumeX, Wifi, WifiOff } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -582,6 +582,16 @@ function DeviceInfoTab({
       <InfoRow label="First Seen" value={timeAgo(device.first_seen_at)} />
       <InfoRow label="Last Seen" value={timeAgo(device.last_seen_at)} />
       <InfoRow label="Status" value={device.is_known ? "Known" : "Unacknowledged"} />
+
+      {/* Muted status */}
+      {device.muted_until && new Date(device.muted_until) > new Date() && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+          <VolumeX className="h-4 w-4 text-amber-400" />
+          <span className="text-sm text-amber-400">
+            Muted until {new Date(device.muted_until).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </span>
+        </div>
+      )}
 
       {/* All IPs */}
       {ips.length > 1 && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -86,12 +86,27 @@ export function fetchTopDevices(limit = 5): Promise<TopDevice[]> {
   return apiGet<TopDevice[]>(`/api/v1/dashboard/top-devices?limit=${limit}`);
 }
 
-export function fetchAlerts(limit = 50): Promise<Alert[]> {
-  return apiGet<Alert[]>(`/api/v1/alerts?limit=${limit}`);
+export function fetchAlerts(
+  limit = 50,
+  status?: "active" | "acknowledged" | "all",
+  severity?: "INFO" | "WARNING" | "CRITICAL"
+): Promise<Alert[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (status) params.set("status", status);
+  if (severity) params.set("severity", severity);
+  return apiGet<Alert[]>(`/api/v1/alerts?${params}`);
 }
 
 export function markAlertRead(id: string): Promise<void> {
   return apiPost<void>(`/api/v1/alerts/${id}/read`);
+}
+
+export function acknowledgeAlert(id: string, note?: string): Promise<void> {
+  return apiPost<void>(`/api/v1/alerts/${id}/acknowledge`, { note });
+}
+
+export function muteDevice(id: string, hours: number): Promise<void> {
+  return apiPost<void>(`/api/v1/devices/${id}/mute?hours=${hours}`);
 }
 
 // ─── Devices ────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -23,6 +23,8 @@ export interface Device {
   /** mDNS/Bonjour discovered service types (comma-separated). */
   mdns_services?: string | null;
   agent?: AgentSummary | null;
+  /** Muted until timestamp (if device is muted). */
+  muted_until?: string | null;
 }
 
 export interface AgentSummary {
@@ -71,6 +73,9 @@ export interface Alert {
   message: string;
   details: string | null;
   is_read: boolean;
+  severity: "INFO" | "WARNING" | "CRITICAL";
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
Adds alert acknowledge (with note) and device mute (1h/8h/24h) functionality. New columns: alerts.acknowledged_at/by, alerts.severity, devices.muted_until. Muted devices skip alert creation. Frontend: Acknowledge dialog, Mute dropdown, severity badges, active/acknowledged tabs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements alert management features including acknowledgement with notes, device muting (1h/8h/24h), and severity levels (INFO/WARNING/CRITICAL).

**Backend changes:**
- Added database columns: `alerts.acknowledged_at`, `alerts.acknowledged_by`, `alerts.severity`, `devices.muted_until`
- Implemented acknowledge and mute endpoints with proper validation
- Updated all alert creation points to check mute status and assign severity
- Added comprehensive unit tests covering acknowledge, mute expiration, and filtering

**Frontend changes:**
- Added acknowledge dialog with optional note input
- Implemented mute dropdown with 1h/8h/24h/unmute options
- Added severity badges (CRITICAL/WARNING/INFO) with color coding
- Implemented active/acknowledged filter tabs
- Added muted status indicator on device detail page

**Critical issue:**
- SQL injection vulnerability in severity filter (line 93 of `server/src/api/alerts.rs`) using string interpolation instead of parameterized query

<h3>Confidence Score: 2/5</h3>

- Critical SQL injection vulnerability must be fixed before merge
- The PR has solid functionality, comprehensive tests, and well-structured frontend implementation, but contains a SQL injection vulnerability in the alerts list endpoint where the severity filter uses string interpolation instead of parameterized binding. This creates a security risk that must be resolved.
- `server/src/api/alerts.rs` requires immediate attention to fix SQL injection vulnerability on line 93

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/db/migrations/007_alert_management.sql | Added schema columns for alert acknowledgement, severity levels, and device muting - clean migration |
| server/src/api/alerts.rs | Added acknowledge/mute endpoints and filtering logic with comprehensive tests, but contains SQL injection vulnerability in severity filter |
| server/src/scanner/mod.rs | Updated device online/offline/new alert creation to respect mute status and include severity - consistent implementation |
| web/src/app/(app)/alerts/page.tsx | Added acknowledge dialog, mute dropdown, severity badges, and active/acknowledged filter tabs - well-structured UI implementation |

</details>



<sub>Last reviewed commit: fdd40d1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->