### PR TITLE
fix: speed test uses local iperf3 against public WAN servers

### DIFF
--- a/server/src/vyos/iperf3.rs
+++ b/server/src/vyos/iperf3.rs
@@ -1,0 +1,100 @@
+//! Standalone iperf3 speed test — runs iperf3 client locally against public servers.
+
+use anyhow::{Context, Result};
+use std::time::Duration;
+use tokio::process::Command;
+
+/// A public iperf3 server endpoint.
+struct Iperf3Server {
+    host: &'static str,
+    port: u16,
+}
+
+/// Public iperf3 servers to try, in order of preference.
+const PUBLIC_SERVERS: &[Iperf3Server] = &[
+    Iperf3Server {
+        host: "iperf.he.net",
+        port: 5201,
+    },
+    Iperf3Server {
+        host: "speedtest.wtnet.de",
+        port: 5200,
+    },
+    Iperf3Server {
+        host: "bouygues.testdebit.info",
+        port: 5200,
+    },
+];
+
+/// Run an iperf3 client test against public servers.
+///
+/// Tries each server in order until one succeeds.
+/// `reverse` controls the `--reverse` flag (measures upload when true).
+/// Returns `(json_output, server_used)`.
+pub async fn run_iperf3_local(reverse: bool) -> Result<(String, String)> {
+    let mut last_error = String::new();
+
+    for server in PUBLIC_SERVERS {
+        tracing::info!(
+            "Trying iperf3 server {}:{} (reverse={})",
+            server.host,
+            server.port,
+            reverse
+        );
+
+        let mut args = vec![
+            "--client".to_string(),
+            server.host.to_string(),
+            "--port".to_string(),
+            server.port.to_string(),
+            "--time".to_string(),
+            "5".to_string(),
+            "--json".to_string(),
+        ];
+        if reverse {
+            args.push("--reverse".to_string());
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(20), async {
+            Command::new("iperf3")
+                .args(&args)
+                .output()
+                .await
+                .context("failed to execute iperf3")
+        })
+        .await;
+
+        match result {
+            Ok(Ok(output)) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                // Verify it's valid JSON with an "end" section
+                if stdout.contains("\"end\"") {
+                    let server_name = format!("{}:{}", server.host, server.port);
+                    tracing::info!("iperf3 succeeded with server {server_name}");
+                    return Ok((stdout, server_name));
+                } else {
+                    last_error = format!(
+                        "{}:{} returned invalid iperf3 output",
+                        server.host, server.port
+                    );
+                    tracing::warn!("{last_error}");
+                }
+            }
+            Ok(Ok(output)) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                last_error = format!("{}:{} failed: {}", server.host, server.port, stderr.trim());
+                tracing::warn!("{last_error}");
+            }
+            Ok(Err(e)) => {
+                last_error = format!("{}:{} exec error: {e}", server.host, server.port);
+                tracing::warn!("{last_error}");
+            }
+            Err(_) => {
+                last_error = format!("{}:{} timed out (20s)", server.host, server.port);
+                tracing::warn!("{last_error}");
+            }
+        }
+    }
+
+    anyhow::bail!("All public iperf3 servers failed. Last error: {last_error}")
+}

--- a/server/src/vyos/mod.rs
+++ b/server/src/vyos/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod iperf3;

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -248,8 +248,8 @@ function SpeedTestSection() {
     setError(null);
     setProgress(0);
 
-    // Animate progress bar over ~12 seconds (download 5s + upload 5s + overhead)
-    const totalMs = 12000;
+    // Animate progress bar over ~15 seconds (download 5s + upload 5s + connection overhead)
+    const totalMs = 15000;
     const intervalMs = 100;
     const steps = totalMs / intervalMs;
     let step = 0;
@@ -271,7 +271,7 @@ function SpeedTestSection() {
         if (e.message.includes("429")) {
           setError("Rate limited — please wait 60 seconds between tests.");
         } else if (e.message.includes("503")) {
-          setError("iperf3 not available or VyOS not configured.");
+          setError("iperf3 not available on the server.");
         } else {
           setError(e.message);
         }
@@ -305,10 +305,10 @@ function SpeedTestSection() {
           <div className="space-y-1">
             <h3 className="flex items-center gap-2 text-base font-medium text-white">
               <Gauge className="h-4 w-4 text-blue-400" />
-              LAN Speed Test
+              Speed Test
             </h3>
             <p className="text-xs text-gray-500">
-              Measures throughput between VyOS router and Panoptikon server using
+              Measures internet throughput from the Panoptikon server using
               iperf3.
             </p>
           </div>
@@ -337,7 +337,7 @@ function SpeedTestSection() {
         <div className="space-y-2">
           <Progress value={progress} />
           <p className="text-center text-xs text-gray-500">
-            Running iperf3 test… download + upload (~12 seconds)
+            Running speed test… download + upload (~15 seconds)
           </p>
         </div>
       )}
@@ -405,8 +405,8 @@ function SpeedTestSection() {
       <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/5 px-4 py-3">
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         <p className="text-xs text-amber-400/80">
-          Speed test generates ~50 MB of traffic per run. Tests are rate limited
-          to once per 60 seconds.
+          Speed test measures WAN throughput to public iperf3 servers. Tests are
+          rate limited to once per 60 seconds.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Problem

Speed test endpoint called VyOS HTTP API with `show iperf3 --client ...` but VyOS doesn't have `show iperf3` as a CLI command, resulting in: **"Invalid command: show [iperf3]"**

## Fix

Replaced the broken VyOS-dependent approach with direct iperf3 execution on the Panoptikon server against public iperf3 servers.

### Changes

- **New `vyos::iperf3` module** — `run_iperf3_local()` tries public servers in order with fallback:
  1. `iperf.he.net:5201`
  2. `speedtest.wtnet.de:5200`
  3. `bouygues.testdebit.info:5200`
- **Rewritten speedtest handler** — no longer requires VyOS to be configured; runs iperf3 locally
- **Deprecated `VyosClient::run_iperf3()`** — now returns an error directing to the new function
- **Updated UI** — "LAN Speed Test" → "Speed Test", updated description and timing estimates
- Download test uses `--reverse` (server sends to us), upload test sends to server

### Benefits
- Works without VyOS configuration
- Measures actual WAN/internet throughput (more useful than LAN to VyOS VM)
- Automatic fallback between multiple public servers

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the broken VyOS HTTP API-based speed test (which used a nonexistent `show iperf3` command) with direct iperf3 execution on the Panoptikon server against public iperf3 endpoints, with automatic fallback across three servers.

- New `vyos::iperf3` module runs iperf3 locally with a 20s timeout per server and tries up to three public servers in sequence
- Speedtest handler no longer depends on VyOS being configured — only requires iperf3 installed on the host
- Old `VyosClient::run_iperf3()` is deprecated and now returns an error directing callers to the new function
- UI updated to reflect the change: "LAN Speed Test" → "Speed Test", timing estimate increased from 12s to 15s, VyOS-specific messaging removed
- Minor doc inaccuracy: `run_iperf3_local` doc comment reverses the meaning of the `reverse` parameter

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a fundamentally broken feature with a straightforward approach and has no regressions.
- The changes correctly fix a non-functional speed test endpoint by replacing VyOS API calls with local iperf3 execution. The fallback logic, timeout handling, and error reporting are solid. Two minor issues were found: an incorrect doc comment on the `reverse` parameter, and the upload test reads `sum_received` instead of the more semantically correct `sum_sent` (though this has negligible practical impact). No security concerns — the code only executes `iperf3` with safe, hardcoded arguments.
- `server/src/vyos/iperf3.rs` has a misleading doc comment on the `reverse` parameter.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/vyos/iperf3.rs | New module for local iperf3 execution against public servers with fallback; doc comment incorrectly describes the `reverse` parameter direction. |
| server/src/api/vyos.rs | Speedtest handler rewritten to use local iperf3 against public servers instead of VyOS API; upload test reads `sum_received` instead of the more correct `sum_sent`. |
| server/src/vyos/client.rs | Deprecated `run_iperf3` method replaced with a bail directing callers to the new function. Clean removal of dead code. |
| server/src/vyos/mod.rs | Added `pub mod iperf3` to expose the new module. Trivial change. |
| web/src/app/(app)/router/page.tsx | UI copy updated from "LAN Speed Test" to "Speed Test", timing estimate adjusted from 12s to 15s, and VyOS-specific messaging removed. All changes are cosmetic and correct. |

</details>



<sub>Last reviewed commit: bdf3486</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->