### PR TITLE
feat(vyos): Router Interfaces tab — structured UI with status badges

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   SpeedTestResult,
   TopDevice,
   TrafficHistoryPoint,
+  VyosInterface,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -210,8 +211,8 @@ export function fetchRouterStatus(): Promise<RouterStatus> {
   return apiGet<RouterStatus>("/api/v1/vyos/status");
 }
 
-export function fetchRouterInterfaces(): Promise<string> {
-  return apiGet<string>("/api/v1/vyos/interfaces");
+export function fetchRouterInterfaces(): Promise<VyosInterface[]> {
+  return apiGet<VyosInterface[]>("/api/v1/vyos/interfaces");
 }
 
 export function fetchRouterConfigInterfaces(): Promise<Record<string, unknown>> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -134,6 +134,17 @@ export interface SpeedTestResult {
   tested_at: string;
 }
 
+export interface VyosInterface {
+  name: string;
+  ip_address: string | null;
+  mac: string | null;
+  vrf: string | null;
+  mtu: number;
+  admin_state: string;
+  link_state: string;
+  description: string | null;
+}
+
 export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;


### PR DESCRIPTION
## Summary

Replaces raw VyOS CLI text with parsed structured JSON from server. Frontend renders as a clean table with colored status dots, IP, MAC, MTU columns.

### Server Changes
- New `VyosInterface` struct: name, ip_address, mac, vrf, mtu, admin_state, link_state, description
- `parse_interfaces_text()` parses VyOS `show interfaces` tabular text output
- `parse_state_field()` converts S/L codes (`u/u`, `D/D`, `A/D`) → human-readable states
- `GET /api/v1/vyos/interfaces` now returns `Vec<VyosInterface>` JSON instead of raw text
- 5 unit tests for the parser (up, down, admin-down, empty input, state field parsing)

### Frontend Changes
- New `VyosInterface` TypeScript type
- `InterfacesTable` component with:
  - Green dot + "Up" badge for admin=up AND link=up
  - Red dot + "Down" badge otherwise
  - Columns: Status, Interface, IP Address, MAC, MTU, Description
- Merged "Interface Configuration" config data into Description column (removed separate JSON panel)
- All 100 server tests pass, frontend builds clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Transformed VyOS interface display from raw CLI text to a structured table with visual status indicators. Server-side parser converts whitespace-delimited text into typed JSON objects, frontend renders with color-coded up/down badges.

- Replaced text parsing with structured `VyosInterface` type containing name, IP, MAC, VRF, MTU, admin/link states
- Parser handles state codes (`u/u`, `D/D`, `A/D`) → human-readable states (`up`, `down`, `admin-down`)
- Table displays green dot + "Up" badge when both admin and link are up, red "Down" badge otherwise
- Merged separate "Interface Configuration" card into Description column
- 5 comprehensive unit tests cover up/down states, empty input, and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured changes with comprehensive test coverage (5 unit tests), clear separation of concerns between parsing and rendering, type-safe implementation across server and frontend
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Added robust parser for VyOS interface text with comprehensive unit tests covering all state variations |
| web/src/app/(app)/router/page.tsx | Replaced raw text with structured table UI, merged config descriptions into single view |
| web/src/lib/api.ts | Updated return type from string to VyosInterface[] for fetchRouterInterfaces |
| web/src/lib/types.ts | Added VyosInterface type matching server-side struct |

</details>



<sub>Last reviewed commit: 4e9cca4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->