### PR TITLE
feat(vyos): Router Routes tab — structured table with protocol badges

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   TopDevice,
   TrafficHistoryPoint,
   VyosInterface,
+  VyosRoute,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -219,8 +220,8 @@ export function fetchRouterConfigInterfaces(): Promise<Record<string, unknown>> 
   return apiGet<Record<string, unknown>>("/api/v1/vyos/config-interfaces");
 }
 
-export function fetchRouterRoutes(): Promise<string> {
-  return apiGet<string>("/api/v1/vyos/routes");
+export function fetchRouterRoutes(): Promise<VyosRoute[]> {
+  return apiGet<VyosRoute[]>("/api/v1/vyos/routes");
 }
 
 export function fetchRouterDhcpLeases(): Promise<string> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -145,6 +145,16 @@ export interface VyosInterface {
   description: string | null;
 }
 
+export interface VyosRoute {
+  protocol: string;
+  destination: string;
+  gateway: string | null;
+  interface: string | null;
+  metric: string | null;
+  uptime: string | null;
+  selected: boolean;
+}
+
 export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;


### PR DESCRIPTION
Replaces raw VyOS 'show ip route' text with parsed structured JSON. Server parses route protocol codes, destinations, gateways. Frontend renders as sortable table with colored protocol badges (C=connected, S=static, K=kernel, etc.).

## Changes

### Server (server/src/api/vyos.rs)
- New `VyosRoute` struct with protocol, destination, gateway, interface, metric, uptime, selected fields
- New `parse_routes_text()` function — parses VyOS `show ip route` text output
- `GET /api/v1/vyos/routes` now returns `Vec<VyosRoute>` instead of raw text string
- 6 unit tests for the parser (static, connected, local, empty, full output, not-selected)

### Frontend (web/src/app/(app)/router/page.tsx)
- New `RoutesTable` component replaces raw `<pre>` output
- Protocol badges with colored styling (C=green, S=blue, K=gray, L=teal, O=orange, B=purple)
- Table columns: Protocol, Destination, Gateway, Interface, Metric, Uptime
- Selected/best route indicator (✓)
- `VyosRoute` TypeScript type added

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces raw VyOS routing table text output with structured JSON parsing and a styled table UI. The server-side parser extracts protocol codes, destinations, gateways, interfaces, metrics, and uptime from `show ip route` text. The frontend renders this data as a sortable table with colored protocol badges (C=Connected, S=Static, K=Kernel, etc.) and a checkmark for selected routes.

- Parser handles multiple route types (static, connected, local, kernel, OSPF, BGP) with 6 unit tests
- Frontend replaces `<pre>` tag with `RoutesTable` component featuring protocol color coding
- Type definitions synchronized between Rust backend and TypeScript frontend
- Comprehensive test coverage for common route formats

One minor concern: the parser skips all indented lines (server/src/api/vyos.rs:60-61), which could potentially drop multi-line route entries if VyOS outputs them, though current test cases only show single-line routes.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor risk around edge case handling
- The implementation is well-tested with 6 unit tests covering various route types, and the changes follow the established pattern from the interfaces PR (#37). The parser logic is straightforward and handles the common cases properly. Confidence reduced from 5 to 4 due to the indented line skipping logic that could potentially miss multi-line route entries if they exist in VyOS output.
- server/src/api/vyos.rs — verify the indented line skip logic doesn't miss legitimate route data

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Added VyosRoute struct and parse_routes_text() parser with comprehensive test coverage; potential issue with indented line handling |
| web/src/app/(app)/router/page.tsx | Replaced raw text output with RoutesTable component featuring protocol badges and structured display |

</details>



<sub>Last reviewed commit: 74c3a16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->