### PR TITLE
feat(vyos): Router Firewall tab — structured rules tables with action badges

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   AuthStatus,
   DashboardStats,
   Device,
+  FirewallConfig,
   LoginResponse,
   NetflowStatus,
   RouterStatus,
@@ -229,8 +230,8 @@ export function fetchRouterDhcpLeases(): Promise<VyosDhcpLease[]> {
   return apiGet<VyosDhcpLease[]>("/api/v1/vyos/dhcp-leases");
 }
 
-export function fetchRouterFirewall(): Promise<Record<string, unknown>> {
-  return apiGet<Record<string, unknown>>("/api/v1/vyos/firewall");
+export function fetchRouterFirewall(): Promise<FirewallConfig> {
+  return apiGet<FirewallConfig>("/api/v1/vyos/firewall");
 }
 
 export function runSpeedTest(): Promise<SpeedTestResult> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -166,6 +166,28 @@ export interface VyosDhcpLease {
   pool: string | null;
 }
 
+// ─── Firewall ───────────────────────────────────────────
+
+export interface FirewallRule {
+  number: number;
+  action: string;
+  source: string | null;
+  destination: string | null;
+  protocol: string | null;
+  state: string | null;
+  description: string | null;
+}
+
+export interface FirewallChain {
+  name: string;
+  default_action: string;
+  rules: FirewallRule[];
+}
+
+export interface FirewallConfig {
+  chains: FirewallChain[];
+}
+
 export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;


### PR DESCRIPTION
Replaces raw JSON display with parsed firewall chain/rule tables. Server parses VyOS firewall config into FirewallConfig struct with chains and rules. Frontend renders one Card per chain with rules table, colored action badges (ACCEPT=green, DROP=red, REJECT=orange), and default-action badge per chain.

## Changes

### Server (Rust)
- New structs: `FirewallRule`, `FirewallChain`, `FirewallConfig`
- `parse_firewall_config()` function parses VyOS JSON config structure (ipv4/ipv6 → forward/input/output → filter chains)
- Handles source/destination with address, network, port, and group types
- Handles state objects (established, related, new)
- `GET /api/v1/vyos/firewall` now returns structured `FirewallConfig` instead of raw JSON
- 3 new unit tests: `test_parse_firewall_with_rules`, `test_parse_firewall_empty`, `test_parse_firewall_with_groups_and_network`

### Frontend (TypeScript/Next.js)
- New types: `FirewallRule`, `FirewallChain`, `FirewallConfig`
- `FirewallPanel` component with per-chain Cards
- `FirewallChainCard` with rules table (#, Action badge, Source, Destination, Protocol, Description)
- Action badges: ACCEPT=green, DROP=red, REJECT=orange
- Default action badge per chain header
- Empty state: centered icon + 'No firewall rules configured'
- Removed unused `OutputPanel` and `JsonPanel` components

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces raw JSON display of VyOS firewall config with parsed, structured chain/rule tables. The server-side parser walks the VyOS firewall JSON tree (ipv4/ipv6 → direction → filter type) to produce `FirewallChain` and `FirewallRule` structs. The frontend renders one Card per chain with a rules table, colored action badges, and default-action indicators. Unused `OutputPanel` and `JsonPanel` components are cleanly removed.

- **Bug**: `parse_firewall_config()` iterates all top-level keys and relies on type-checking to skip non-IP-version keys like `"group"`. Since VyOS `group` objects contain nested objects, they pass the type check and produce phantom chains in the output. Needs an explicit allowlist for `ipv4`/`ipv6`.
- The server parses `FirewallRule.state` (e.g., "established, related") but the frontend table does not display it — this is useful context for stateful rules.
- Types, API client, and test coverage are well aligned across the stack.

<h3>Confidence Score: 3/5</h3>

- Functional bug in firewall parser will produce phantom chains for any VyOS config with firewall groups defined.
- The core parsing logic has a bug where top-level non-IP keys (notably `group`) are not properly filtered, causing bogus chain entries in production. The fix is straightforward (add an allowlist), but the issue will affect real deployments since firewall groups are commonly used in VyOS. The frontend and types are clean.
- `server/src/api/vyos.rs` — the `parse_firewall_config` function needs to explicitly filter top-level keys to only `ipv4` and `ipv6`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | New firewall parsing logic is well-structured, but the top-level key iteration will produce phantom chains when VyOS has a `group` key configured (which is common). Needs explicit allowlist for `ipv4`/`ipv6`. |
| web/src/app/(app)/router/page.tsx | Clean replacement of raw JSON display with structured firewall chain cards. Badge components and table rendering are well done. Minor gap: parsed `state` field is not rendered in the table. |
| web/src/lib/api.ts | Straightforward type change from `Record<string, unknown>` to `FirewallConfig`. No issues. |
| web/src/lib/types.ts | New `FirewallRule`, `FirewallChain`, and `FirewallConfig` interfaces correctly mirror the Rust server structs. No issues. |

</details>



<sub>Last reviewed commit: 2cc62e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->