### PR TITLE
perf(agent): incremental sysinfo refresh — hold System struct across report cycles

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -21,6 +21,5 @@ toml = "0.8"
 sysinfo = "0.30"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-dirs = "5"
 futures-util = "0.3"
 http = "1"

--- a/agent/src/collectors/disk.rs
+++ b/agent/src/collectors/disk.rs
@@ -10,10 +10,8 @@ pub struct DiskInfo {
     pub used_bytes: u64,
 }
 
-/// Collect disk usage for all mounted filesystems.
-pub fn collect() -> Vec<DiskInfo> {
-    let disks = Disks::new_with_refreshed_list();
-
+/// Collect disk usage from a pre-refreshed `Disks` instance.
+pub fn collect_from(disks: &Disks) -> Vec<DiskInfo> {
     disks
         .iter()
         .filter(|d| {

--- a/agent/src/collectors/mod.rs
+++ b/agent/src/collectors/mod.rs
@@ -4,7 +4,10 @@ pub mod memory;
 pub mod network;
 pub mod os;
 
+use std::collections::HashMap;
+
 use serde::Serialize;
+use sysinfo::{Disks, Networks, System};
 
 use crate::config::AgentConfig;
 
@@ -23,20 +26,105 @@ pub struct AgentReport {
     pub network_interfaces: Vec<network::NetworkInterface>,
 }
 
-/// Collect all system metrics into a single report.
-pub fn collect_all(config: &AgentConfig) -> AgentReport {
-    let sys = sysinfo::System::new_all();
+/// Long-lived system metrics collector.
+///
+/// Holds `sysinfo` structs across report cycles to avoid re-enumerating
+/// processes, disks, and interfaces on every 30-second report.
+/// CPU and memory are refreshed every cycle; disks and network only
+/// every 5th cycle (~2.5 minutes at default 30 s interval).
+pub struct SystemCollector {
+    sys: System,
+    disks: Disks,
+    networks: Networks,
+    report_count: u64,
+    prev_net_counters: HashMap<String, (u64, u64)>,
+}
 
-    AgentReport {
-        agent_id: config.agent_id.clone(),
-        timestamp: chrono::Utc::now().to_rfc3339(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        hostname: sysinfo::System::host_name().unwrap_or_else(|| "unknown".to_string()),
-        os: os::collect(),
-        uptime_seconds: sysinfo::System::uptime(),
-        cpu: cpu::collect(&sys),
-        memory: memory::collect(&sys),
-        disks: disk::collect(),
-        network_interfaces: network::collect(),
+impl SystemCollector {
+    /// Create a new collector, performing an initial full enumeration.
+    ///
+    /// Sleeps 200 ms after `System::new_all()` so that the first
+    /// `refresh_cpu_all()` returns meaningful usage percentages
+    /// (sysinfo needs two measurements to compute delta-based CPU %).
+    pub fn new() -> Self {
+        let mut sys = System::new_all();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        sys.refresh_cpu_usage();
+
+        let disks = Disks::new_with_refreshed_list();
+        let networks = Networks::new_with_refreshed_list();
+
+        Self {
+            sys,
+            disks,
+            networks,
+            report_count: 0,
+            prev_net_counters: HashMap::new(),
+        }
+    }
+
+    /// Collect a full system report using incremental refresh.
+    ///
+    /// CPU and memory are refreshed on every call (lightweight).
+    /// Disks and network interfaces are refreshed only every 5th call
+    /// to avoid the heavier enumeration cost.
+    pub fn collect(&mut self, config: &AgentConfig) -> AgentReport {
+        // Always refresh CPU and memory (lightweight).
+        self.sys.refresh_cpu_usage();
+        self.sys.refresh_memory();
+
+        // Heavy refresh (disks, networks) only every 5th cycle.
+        if self.report_count.is_multiple_of(5) {
+            self.disks.refresh_list();
+            self.networks.refresh_list();
+        }
+
+        let network_interfaces = network::collect_from(&self.networks, &mut self.prev_net_counters);
+
+        self.report_count += 1;
+
+        AgentReport {
+            agent_id: config.agent_id.clone(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            hostname: System::host_name().unwrap_or_else(|| "unknown".to_string()),
+            os: os::collect(),
+            uptime_seconds: System::uptime(),
+            cpu: cpu::collect(&self.sys),
+            memory: memory::collect(&self.sys),
+            disks: disk::collect_from(&self.disks),
+            network_interfaces,
+        }
+    }
+
+    /// Returns the current report count (useful for testing).
+    #[cfg(test)]
+    pub fn report_count(&self) -> u64 {
+        self.report_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collector_new_returns_valid() {
+        let collector = SystemCollector::new();
+        assert_eq!(collector.report_count(), 0);
+    }
+
+    #[test]
+    fn test_collector_increments_count() {
+        let mut collector = SystemCollector::new();
+        let config = AgentConfig {
+            server_url: "ws://localhost:8080".to_string(),
+            api_key: "test-key".to_string(),
+            agent_id: "test-agent".to_string(),
+            report_interval_secs: 30,
+        };
+        let report = collector.collect(&config);
+        assert_eq!(collector.report_count(), 1);
+        assert_eq!(report.agent_id, "test-agent");
     }
 }

--- a/agent/src/collectors/network.rs
+++ b/agent/src/collectors/network.rs
@@ -1,8 +1,6 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use sysinfo::Networks;
-use tracing::warn;
 
 /// Network interface information.
 #[derive(Debug, Serialize)]
@@ -16,78 +14,17 @@ pub struct NetworkInterface {
     pub state: String,
 }
 
-/// Per-interface cumulative counter state persisted between reports.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct InterfaceCounters {
-    tx: u64,
-    rx: u64,
-}
-
-/// Returns the path to the network counters state file.
+/// Collect network interface statistics with in-memory delta tracking.
 ///
-/// On Linux: `~/.local/share/panoptikon-agent/net-counters.json`
-/// On macOS: `~/Library/Application Support/panoptikon-agent/net-counters.json`
-fn state_file_path() -> Option<PathBuf> {
-    dirs::data_local_dir().map(|d| d.join("panoptikon-agent").join("net-counters.json"))
-}
-
-/// Load previous counters from the state file. Returns None if file doesn't exist or is invalid.
-fn load_previous_counters() -> Option<HashMap<String, InterfaceCounters>> {
-    let path = state_file_path()?;
-    let data = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&data).ok()
-}
-
-/// Save current counters to the state file atomically (write to temp, rename).
-fn save_counters(counters: &HashMap<String, InterfaceCounters>) {
-    let Some(path) = state_file_path() else {
-        warn!("Could not determine data_local_dir for counter state file");
-        return;
-    };
-
-    // Ensure parent directory exists.
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            warn!("Failed to create state dir {}: {e}", parent.display());
-            return;
-        }
-    }
-
-    // Write to a temp file in the same directory, then rename for atomicity.
-    let tmp_path = path.with_extension("json.tmp");
-    match serde_json::to_string(counters) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(&tmp_path, &json) {
-                warn!("Failed to write temp state file: {e}");
-                return;
-            }
-            if let Err(e) = std::fs::rename(&tmp_path, &path) {
-                warn!("Failed to rename temp state file: {e}");
-                // Try to clean up temp file
-                let _ = std::fs::remove_file(&tmp_path);
-            }
-        }
-        Err(e) => {
-            warn!("Failed to serialize counters: {e}");
-        }
-    }
-}
-
-/// Collect network interface statistics with proper delta tracking.
-///
-/// Uses a persistent state file to store cumulative counters between reports.
-/// On first call (no state file), deltas are 0. Subsequent calls compute
-/// real deltas from the difference in cumulative counters.
-pub fn collect() -> Vec<NetworkInterface> {
-    let networks = Networks::new_with_refreshed_list();
-
-    // Load previous counters (None on first boot).
-    let previous = load_previous_counters();
-
-    // Build current counters and compute deltas.
-    let mut current_counters: HashMap<String, InterfaceCounters> = HashMap::new();
-
-    let interfaces: Vec<NetworkInterface> = networks
+/// `prev_counters` maps interface name → `(tx_cumulative, rx_cumulative)`.
+/// On each call, deltas are computed from the previous values and the
+/// map is updated with current counters.  On the first call (or for
+/// newly-appeared interfaces) deltas are 0.
+pub fn collect_from(
+    networks: &Networks,
+    prev_counters: &mut HashMap<String, (u64, u64)>,
+) -> Vec<NetworkInterface> {
+    networks
         .iter()
         .filter(|(name, _)| {
             // Filter out loopback and virtual interfaces.
@@ -97,28 +34,19 @@ pub fn collect() -> Vec<NetworkInterface> {
             let current_tx = data.total_transmitted();
             let current_rx = data.total_received();
 
-            // Store current cumulative counters for next report.
-            current_counters.insert(
-                name.clone(),
-                InterfaceCounters {
-                    tx: current_tx,
-                    rx: current_rx,
-                },
-            );
-
             // Compute deltas from previous counters.
-            let (tx_delta, rx_delta) = match previous.as_ref().and_then(|p| p.get(name.as_str())) {
-                Some(prev) => {
-                    // Handle counter reset/overflow: if current < previous, treat as 0.
-                    let tx_d = current_tx.saturating_sub(prev.tx);
-                    let rx_d = current_rx.saturating_sub(prev.rx);
+            let (tx_delta, rx_delta) = match prev_counters.get(name.as_str()) {
+                Some(&(prev_tx, prev_rx)) => {
+                    // Handle counter reset/overflow: if current < previous, delta is 0.
+                    let tx_d = current_tx.saturating_sub(prev_tx);
+                    let rx_d = current_rx.saturating_sub(prev_rx);
                     (tx_d, rx_d)
                 }
-                None => {
-                    // No previous state for this interface — first boot or new interface.
-                    (0, 0)
-                }
+                None => (0, 0),
             };
+
+            // Update counters for next report.
+            prev_counters.insert(name.clone(), (current_tx, current_rx));
 
             NetworkInterface {
                 name: name.clone(),
@@ -130,12 +58,7 @@ pub fn collect() -> Vec<NetworkInterface> {
                 state: "up".to_string(),
             }
         })
-        .collect();
-
-    // Persist current counters for next report.
-    save_counters(&current_counters);
-
-    interfaces
+        .collect()
 }
 
 #[cfg(test)]
@@ -143,101 +66,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_delta_computation_no_previous() {
-        // When there's no previous state, deltas should be 0.
-        let previous: Option<HashMap<String, InterfaceCounters>> = None;
-        let current_tx = 12345u64;
-        let current_rx = 67890u64;
-        let name = "eth0";
+    fn test_delta_no_previous() {
+        let mut prev: HashMap<String, (u64, u64)> = HashMap::new();
 
-        let (tx_delta, rx_delta) = match previous.as_ref().and_then(|p| p.get(name)) {
-            Some(prev) => {
-                let tx_d = current_tx.saturating_sub(prev.tx);
-                let rx_d = current_rx.saturating_sub(prev.rx);
-                (tx_d, rx_d)
-            }
+        let (tx_delta, rx_delta) = match prev.get("eth0") {
+            Some(&(prev_tx, prev_rx)) => (
+                100u64.saturating_sub(prev_tx),
+                200u64.saturating_sub(prev_rx),
+            ),
             None => (0, 0),
         };
 
         assert_eq!(tx_delta, 0);
         assert_eq!(rx_delta, 0);
+
+        // Store counters for next cycle.
+        prev.insert("eth0".to_string(), (100, 200));
+        assert_eq!(prev["eth0"], (100, 200));
     }
 
     #[test]
-    fn test_delta_computation_with_previous() {
-        let mut previous = HashMap::new();
-        previous.insert(
-            "eth0".to_string(),
-            InterfaceCounters {
-                tx: 10000,
-                rx: 20000,
-            },
-        );
+    fn test_delta_with_previous() {
+        let mut prev: HashMap<String, (u64, u64)> = HashMap::new();
+        prev.insert("eth0".to_string(), (10_000, 20_000));
 
-        let current_tx = 15000u64;
-        let current_rx = 25000u64;
-        let name = "eth0";
+        let current_tx = 15_000u64;
+        let current_rx = 25_000u64;
 
-        let (tx_delta, rx_delta) = match previous.get(name) {
-            Some(prev) => {
-                let tx_d = current_tx.saturating_sub(prev.tx);
-                let rx_d = current_rx.saturating_sub(prev.rx);
-                (tx_d, rx_d)
-            }
+        let (tx_delta, rx_delta) = match prev.get("eth0") {
+            Some(&(prev_tx, prev_rx)) => (
+                current_tx.saturating_sub(prev_tx),
+                current_rx.saturating_sub(prev_rx),
+            ),
             None => (0, 0),
         };
 
-        assert_eq!(tx_delta, 5000);
-        assert_eq!(rx_delta, 5000);
+        assert_eq!(tx_delta, 5_000);
+        assert_eq!(rx_delta, 5_000);
     }
 
     #[test]
-    fn test_delta_computation_counter_reset() {
-        // If current < previous (counter reset), delta should be 0.
-        let mut previous = HashMap::new();
-        previous.insert(
-            "eth0".to_string(),
-            InterfaceCounters {
-                tx: 99999,
-                rx: 88888,
-            },
-        );
+    fn test_delta_counter_reset() {
+        let mut prev: HashMap<String, (u64, u64)> = HashMap::new();
+        prev.insert("eth0".to_string(), (99_999, 88_888));
 
-        let current_tx = 100u64; // Reset happened
+        let current_tx = 100u64;
         let current_rx = 200u64;
-        let name = "eth0";
 
-        let (tx_delta, rx_delta) = match previous.get(name) {
-            Some(prev) => {
-                let tx_d = current_tx.saturating_sub(prev.tx);
-                let rx_d = current_rx.saturating_sub(prev.rx);
-                (tx_d, rx_d)
-            }
+        let (tx_delta, rx_delta) = match prev.get("eth0") {
+            Some(&(prev_tx, prev_rx)) => (
+                current_tx.saturating_sub(prev_tx),
+                current_rx.saturating_sub(prev_rx),
+            ),
             None => (0, 0),
         };
 
         assert_eq!(tx_delta, 0);
         assert_eq!(rx_delta, 0);
-    }
-
-    #[test]
-    fn test_counters_serialization_roundtrip() {
-        let mut counters = HashMap::new();
-        counters.insert(
-            "eth0".to_string(),
-            InterfaceCounters {
-                tx: 12345,
-                rx: 67890,
-            },
-        );
-        counters.insert("wlan0".to_string(), InterfaceCounters { tx: 100, rx: 200 });
-
-        let json = serde_json::to_string(&counters).unwrap();
-        let deserialized: HashMap<String, InterfaceCounters> = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized["eth0"].tx, 12345);
-        assert_eq!(deserialized["eth0"].rx, 67890);
-        assert_eq!(deserialized["wlan0"].tx, 100);
-        assert_eq!(deserialized["wlan0"].rx, 200);
     }
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -58,6 +58,11 @@ async fn main() -> Result<()> {
         "Configuration loaded"
     );
 
+    // Create the system collector once — it holds sysinfo structs across
+    // reconnections, avoiding expensive re-enumeration on every cycle.
+    let mut collector = collectors::SystemCollector::new();
+    info!("System collector initialised");
+
     // Main loop: connect, report, reconnect on failure.
     let mut backoff_secs = 1u64;
     let max_backoff = 60u64;
@@ -65,7 +70,7 @@ async fn main() -> Result<()> {
     loop {
         info!("Connecting to server...");
 
-        match ws::run_session(&cfg).await {
+        match ws::run_session(&cfg, &mut collector).await {
             Ok(()) => {
                 info!("Session ended gracefully");
                 backoff_secs = 1; // Reset backoff on clean disconnect.

--- a/docs/GUI_IMPROVEMENTS.md
+++ b/docs/GUI_IMPROVEMENTS.md
@@ -1,0 +1,70 @@
+# Panoptikon GUI & UX Modernization Plan
+
+**Date:** 2026-02-21
+**Inspirations:** Ubiquiti UniFi Web Console & Fing App Dashboard
+**Objective:** Evolve Panoptikon's interface into a "Premium Command Center" that merges the highly technical, space-grade aesthetic of UniFi with the intuitive, device-centric visual language of Fing.
+
+---
+
+## 1. Visual Language & Core Aesthetic
+
+### The "UniFi Foundation" (Technical Polish)
+- **Deep Dark Mode:** Expand beyond standard `bg-black`. Use deep slate or charcoal backgrounds (e.g., `#1e293b` or `#0f172a`) combined with surface cards (`#1e293b` or `#334155`).
+- **Gradients & Neon Accents:** Use subtle, colored gradients for network traffic charts (WAN Rx/Tx). Use sharp, high-contrast neon colors for status indicators (Emerald Green for online, Rose Red for critical offline).
+- **Tabular Data Presentation:** Dense but highly legible tables with monospaced (`tabular-nums`) fonts for IP addresses, MAC addresses, and active bandwidth to prevent horizontal layout shift.
+
+### The "Fing Overlay" (Device Intelligence)
+- **Visual Identity:** Heavy emphasis on universally recognizable device icons (Laptops, Smart TVs, Phones, IoT Hubs) rather than generic dots.
+- **Brand Recognition:** Display manufacturer/vendor names prominently below the device name (e.g., "Apple", "Ubiquiti", "Sonos").
+- **Health & Security Scoring:** Visual circles or progress rings indicating network health, device trust score, or open port vulnerabilities.
+
+---
+
+## 2. Key View Redesigns & Upgrades
+
+### A. The Dashboard (The Command Center)
+A high-level "single pane of glass" widget layout, avoiding vertical-only scrolling.
+- **Top Bar (UniFi style):** "System Health: 99%" with a circular or semi-circular progress bar, active WAN speed test metrics, and total devices online/offline.
+- **Traffic sparklines:** A prominent, wide Area Chart (using `Recharts` with `<linearGradient>`) showing WAN traffic over the last 1h/24h.
+- **Device Breakdown (Fing style):** A donut chart or bar indicating device categories on the network (e.g., 10 Phones, 5 Computers, 15 IoT devices).
+- **Alert Feed Sidebar:** A compact widget on the right displaying the latest network events (Devices dropping offline, new agents reporting).
+
+### B. Device Discovery & List (The Roster)
+- **Card vs. List Toggle:** Allow users to switch between a dense UniFi-style data table (ideal for massive homelabs) and a Fing-style rich card grid (better for quick visual scanning).
+- **Rich Rows:** Each row should feature:
+  - An icon correlating to the vendor/type.
+  - Device Name & Vendor.
+  - A subtle `[Agent]` badge if telemetery is active.
+  - A real-time traffic sparkline for the specific device (if NetFlow data is available).
+- **Status Indicators:** Glowing inner rings or pulsing dots (green=online, gray=offline, yellow=warning/high-cpu).
+
+### C. Device Slide-over (Deep Dive)
+Instead of navigating away from the list, clicking a device opens a sleek side-drawer (Slide-over component).
+- **Header:** Large device icon, editable name, and quick-actions (Wake-on-LAN, Mute Alerts, Copy Install Script).
+- **Vulnerability/Scan Tab (Fing style):** A dedicated section highlighting open ports discovered via Nmap, rendered with risk colors (e.g., Port 22 SSH in Yellow, 80 HTTP in Red).
+- **Telemetry Tab:** Real-time Agent CPU/Memory graphs mirroring UniFi's "Experience" telemetry graphs.
+- **Events Timeline:** A chronological list of when the device joined, went offline, or triggered a high-bandwidth alert.
+
+### D. Interactive Topology Map (The Missing Centerpiece)
+- Implement a force-directed graph (via React Flow) showing the central VyOS router connecting out to various switches/subnets and terminal devices.
+- **UniFi Experience:** Links (lines) between nodes should be animatable, showing little glowing pulses traveling from the router to the device when bandwidth exceeds a certain threshold.
+
+---
+
+## 3. UI Interactions & Quality of Life
+
+- **Fluid Animations:** Use `framer-motion` to smoothly sequence page loads. Cards shouldn't just appear; they should gently slide up into place with a staggered fade-in.
+- **Cmd+K Command Palette:** A global search overlay that blurs the background. Searching "10.0" instantly renders matching IPs, devices, and open alerts with arrow-key navigation.
+- **Skeletons, No Spinners:** Content loaders should trace the exact geometric shape of the eventual data (shimmering table rows, skeleton sparklines) rather than utilizing generic loading spinners.
+- **Hover Ergonomics:** Cards and list rows should subtly elevate and lighten on cursor hover, indicating interactivity. 
+
+---
+
+## 4. Proposed Technical Stack Alignments (Frontend)
+
+To execute this aesthetic, the following stack additions/updates are recommended:
+- **Charting:** `recharts` for fluid, SVG-gradient traffic and CPU/Mem area charts.
+- **Topology:** `reactflow` for the interactive, node-based network map.
+- **Micro-interactions:** `framer-motion` for staggering list renders and shared-layout transitions.
+- **Icons:** `lucide-react` (already present) but supplemented with a custom SVG icon set specifically for distinct device classes (Server, Mobile, Console, IoT).
+- **Components:** Deep styling of `shadcn/ui` focusing on `bg-slate-900`/`bg-slate-950` layering, `border-slate-800` borders, and `backdrop-blur-md` for floating elements.


### PR DESCRIPTION
Replaces System::new_all() on every 30s cycle with a long-lived SystemCollector struct. CPU and memory are refreshed incrementally every cycle; disks and network only every 5th cycle (~2.5 minutes). Network counters stored in-memory instead of file. Expected: ~10x less CPU/allocation overhead per report.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors system metrics collection to hold `System`, `Disks`, and `Networks` structs across report cycles instead of recreating them every 30 seconds. CPU and memory refresh every cycle, while disks and networks refresh only every 5th cycle. Network counters moved from file persistence to in-memory HashMap.

**Critical issue found:**
- Network delta tracking is broken when networks aren't refreshed (cycles 1-4). The `Networks` struct holds stale counter values, causing `collect_from` to compute delta=0 for intermediate cycles and accumulated deltas on refresh cycles.

**Other observations:**
- The optimization approach is sound for CPU, memory, and disk collection
- Removed `dirs` dependency (network counters no longer persisted to file)
- Added unit tests for the new `SystemCollector`
- Unrelated GUI documentation file included in PR

<h3>Confidence Score: 1/5</h3>

- This PR has a critical logic bug that will cause incorrect network metrics
- The network delta computation relies on fresh counter values from `Networks`, but the optimization skips refreshing networks for 4 out of 5 cycles. This will report zero deltas for most cycles and accumulated deltas on refresh cycles, making network traffic metrics unreliable
- Pay close attention to `agent/src/collectors/mod.rs` lines 76-82

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| agent/src/collectors/mod.rs | Introduces `SystemCollector` struct with incremental refresh, but network delta tracking is broken when networks aren't refreshed |
| agent/src/collectors/network.rs | Replaces file-based counter persistence with in-memory HashMap, cleaner implementation but relies on fresh network data |
| agent/src/collectors/disk.rs | Simple refactor to accept pre-refreshed `Disks` reference instead of creating new instance |

</details>



<sub>Last reviewed commit: a803baa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->