### PR TITLE
fix: remove hardcoded values — dynamic server URL, badge count, version env

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -125,7 +125,7 @@ export function Sidebar() {
                   <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
                 </TooltipContent>
               </Tooltip>
-              <p className="text-[10px] text-slate-700">Panoptikon v0.1.0</p>
+              <p className="text-[10px] text-slate-700">Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.1.0"}</p>
             </div>
           ) : (
             <Tooltip>

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -253,10 +253,6 @@ export function TopBar() {
         {/* Alerts bell */}
         <button className="relative text-slate-400 hover:text-white transition-colors">
           <span className="text-xl">🔔</span>
-          {/* Unread badge */}
-          <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-rose-500 text-[10px] font-bold text-white">
-            2
-          </span>
         </button>
 
         {/* User avatar */}


### PR DESCRIPTION
## Changes

- **agents.rs**: Replace hardcoded `10.10.0.14` IP with dynamic `Host` header from the incoming HTTP request. Fallback to config listen address.
- **TopBar.tsx**: Remove hardcoded badge count `2` from notification bell (no API for unread count yet).
- **Sidebar.tsx**: Version string reads from `NEXT_PUBLIC_VERSION` env var with `v0.1.0` fallback.
- **ws.ts**: Already had correct `wss://` auto-detection — no change needed.

All changes pass `cargo clippy -D warnings` and `bun run build`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes hardcoded values across the stack: the server now uses the Host header to generate dynamic install scripts (replacing `10.10.0.14`), the UI removed a placeholder notification badge, and the version string reads from an environment variable.

- Replaced hardcoded server IP with dynamic Host header detection in `install_script` endpoint
- Removed hardcoded notification badge count `2` from TopBar
- Version string now configurable via `NEXT_PUBLIC_VERSION` env var

The Host header approach is better than the hardcoded IP, but the fallback to `0.0.0.0:8080` when Host is missing will generate unusable install scripts. Consider adding a dedicated config field for the public server URL.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical issue that affects the install script fallback behavior
- The changes correctly remove hardcoded values and the implementation is mostly sound. However, the fallback path in `agents.rs` will generate broken install scripts when the Host header is missing, as `0.0.0.0` is not a routable address. The UI changes are straightforward and safe.
- Pay attention to `server/src/api/agents.rs` — verify the Host header is always present in your deployment, or add a public URL config field

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/agents.rs | Replaced hardcoded IP with Host header for dynamic server URL detection; fallback to `0.0.0.0` may cause agent connection issues |
| web/src/components/layout/TopBar.tsx | Removed hardcoded badge count from notification bell |
| web/src/components/layout/Sidebar.tsx | Version string now reads from `NEXT_PUBLIC_VERSION` env var with fallback |

</details>



<sub>Last reviewed commit: 3e31358</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->