### PR TITLE
feat(deploy): multi-stage Dockerfile + docker-compose for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+node_modules/
+.git/
+*.db
+*.db-wal
+*.db-shm
+web/.next/
+web/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: Build Rust server ─────────────────────────────────────────────
+FROM rust:1.83-slim AS rust-builder
+WORKDIR /app
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY Cargo.toml Cargo.lock ./
+COPY server ./server
+COPY agent ./agent
+RUN cargo build --release --bin panoptikon-server
+
+# ── Stage 2: Build Next.js frontend ────────────────────────────────────────
+FROM node:22-slim AS frontend-builder
+RUN npm install -g bun@latest
+WORKDIR /app/web
+COPY web/package.json web/bun.lock* web/bun.lockb* ./
+RUN bun install --frozen-lockfile
+COPY web/ ./
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN bun run build
+
+# ── Stage 3: Runtime ────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    nmap \
+    iperf3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rust-builder /app/target/release/panoptikon-server /usr/local/bin/panoptikon-server
+COPY --from=frontend-builder /app/web/.next /opt/panoptikon/web/.next
+COPY --from=frontend-builder /app/web/public /opt/panoptikon/web/public
+
+WORKDIR /data
+ENV PANOPTIKON_DATA_DIR=/data
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/api/v1/auth/status || exit 1
+
+ENTRYPOINT ["/usr/local/bin/panoptikon-server"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ scrape_configs:
       - targets: ['localhost:8080']
 ```
 
+## Docker Deployment
+
+Build and run Panoptikon in a container:
+
+```bash
+# Build the image
+docker build -t panoptikon .
+
+# Run with docker-compose (recommended)
+docker-compose up -d
+```
+
+The multi-stage Dockerfile builds the Rust server, Next.js frontend, and packages them into a minimal `debian:bookworm-slim` runtime image with `nmap` and `iperf3` pre-installed.
+
+**Important notes:**
+
+- **`network_mode: host`** is required for ARP scanning and receiving NetFlow UDP packets on the host network.
+- **`NET_RAW` capability** is required for nmap raw socket scanning.
+- **`NET_ADMIN` capability** is required for ARP table access and network administration.
+- Data (SQLite database) is persisted in a Docker volume mounted at `/data`.
+
 ## License
 
 MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  panoptikon:
+    build: .
+    image: panoptikon:latest
+    container_name: panoptikon
+    restart: unless-stopped
+    network_mode: host          # needed for ARP scanning + NetFlow UDP
+    volumes:
+      - panoptikon-data:/data
+    environment:
+      - PANOPTIKON_URL=http://localhost:8080
+    cap_add:
+      - NET_RAW                 # required for nmap raw socket scanning
+      - NET_ADMIN
+
+volumes:
+  panoptikon-data:


### PR DESCRIPTION
Adds multi-stage Docker build: Stage 1 builds Rust server, Stage 2 builds Next.js frontend, Stage 3 creates minimal debian:bookworm-slim runtime. Includes docker-compose.yml with network_mode: host (for ARP scanning) and NET_RAW capability (for nmap). Volume for DB persistence.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds containerized deployment with multi-stage Docker build and docker-compose configuration. The approach is architecturally sound - using host networking and elevated capabilities (NET_RAW, NET_ADMIN) for ARP scanning and nmap operations.

**Critical issues:**
- Dockerfile copies from `.next` instead of `out` - Next.js static export (configured in `next.config.ts`) outputs to `web/out`, but the Dockerfile copies from `web/.next` which is the development/SSR build directory
- Dockerfile attempts to copy non-existent `web/public` directory, which will fail the build

**Minor issues:**
- `PANOPTIKON_DATA_DIR` env var is set but unused by the server
- `PANOPTIKON_URL` in docker-compose is only used by Playwright tests, not runtime
- Lockfile pattern in Dockerfile is overly broad (`bun.lock*` and `bun.lockb*` when only `bun.lock` exists)

<h3>Confidence Score: 1/5</h3>

- This PR cannot be merged - the Docker build will fail due to incorrect paths
- Two critical logic errors in the Dockerfile will cause the build to fail: copying from `.next` instead of `out` means the built static files won't be available, and attempting to copy a non-existent `public` directory will terminate the build
- Dockerfile requires immediate attention - lines 32-33 have critical path errors that will prevent successful builds

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Dockerfile | Multi-stage build for Rust + Next.js, but copies from wrong Next.js output directory (.next instead of out) and attempts to copy non-existent public directory - build will fail |
| docker-compose.yml | Container config with host networking and NET_RAW/NET_ADMIN caps for ARP/nmap scanning - architecture is sound, minor style improvements possible |
| .dockerignore | Excludes build artifacts, node_modules, and database files appropriately |
| README.md | Added Docker deployment section with clear explanation of network requirements and capabilities |

</details>



<sub>Last reviewed commit: 8322148</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->