### PR TITLE
feat: deep dark mode — slate/charcoal palette with neon status accents

### DIFF
--- a/web/src/app/(app)/agents/detail/content.tsx
+++ b/web/src/app/(app)/agents/detail/content.tsx
@@ -126,7 +126,9 @@ export default function AgentDetailContent() {
           >
             <span
               className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full ${
-                agent.is_online ? "bg-emerald-500 status-glow-online" : "bg-rose-500"
+                agent.is_online
+                  ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                  : "bg-rose-400 ring-2 ring-rose-400/30 status-glow-offline"
               }`}
             />
             {agent.is_online ? "Online" : "Offline"}
@@ -256,7 +258,7 @@ export default function AgentDetailContent() {
             <TableBody>
               {reports.map((report) => (
                 <TableRow key={report.id} className="border-slate-800">
-                  <TableCell className="text-slate-400 font-mono text-xs">
+                  <TableCell className="text-slate-400 font-mono tabular-nums text-xs">
                     {new Date(report.reported_at).toLocaleString()}
                   </TableCell>
                   <TableCell className="text-white">

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -191,7 +191,7 @@ export default function AgentsPage() {
                             onChange={(e) => setRenameValue(e.target.value)}
                             className="h-7 w-40 bg-slate-950 border-blue-500 text-white text-sm px-2"
                           />
-                          <button type="submit" className="text-emerald-400 hover:text-green-300">
+                          <button type="submit" className="text-emerald-400 hover:text-emerald-300 transition-colors">
                             <Check size={14} />
                           </button>
                           <button
@@ -228,7 +228,7 @@ export default function AgentsPage() {
                       </span>
                     )}
                   </TableCell>
-                  <TableCell className="font-mono text-slate-400">
+                  <TableCell className="font-mono tabular-nums text-slate-400">
                     {agent.hostname ?? "—"}
                   </TableCell>
                   <TableCell className="text-slate-400">
@@ -237,7 +237,7 @@ export default function AgentsPage() {
                   <TableCell className="text-slate-400">
                     {agent.platform ?? "—"}
                   </TableCell>
-                  <TableCell className="font-mono text-xs text-slate-500">
+                  <TableCell className="font-mono tabular-nums text-xs text-slate-500">
                     {agent.version ?? "—"}
                   </TableCell>
                   <TableCell>
@@ -293,7 +293,7 @@ export default function AgentsPage() {
               onClick={handleDelete}
               disabled={deleting}
               autoFocus
-              className="bg-red-600 text-white hover:bg-rose-500"
+              className="bg-rose-600 text-white hover:bg-rose-500"
             >
               {deleting ? "Deleting…" : "Delete"}
             </AlertDialogAction>
@@ -318,7 +318,9 @@ function StatusBadge({ online }: { online: boolean }) {
     >
       <span
         className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full ${
-          online ? "bg-emerald-500 status-glow-online" : "bg-rose-500"
+          online
+            ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+            : "bg-rose-400 ring-2 ring-rose-400/30 status-glow-offline"
         }`}
       />
       {online ? "Online" : "Offline"}

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -249,7 +249,7 @@ export default function AlertsPage() {
           {alerts.map((alert) => (
             <Card
               key={alert.id}
-              className={`border-slate-800 transition-colors hover:border-blue-500/30 ${
+              className={`border-slate-800 transition-colors hover:bg-slate-800/60 hover:border-blue-500/30 ${
                 alert.acknowledged_at
                   ? "bg-[#12121a] opacity-70"
                   : !alert.is_read

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -49,9 +49,9 @@ function alertIcon(type: Alert["type"]) {
 
 function StatusDot({ status }: { status: "online" | "offline" | "warning" }) {
   const colors = {
-    online: "bg-emerald-500 status-glow-online",
-    offline: "bg-rose-500",
-    warning: "bg-amber-400",
+    online: "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online",
+    offline: "bg-rose-400 ring-2 ring-rose-400/30 status-glow-offline",
+    warning: "bg-amber-400 ring-2 ring-amber-400/30",
   };
   return (
     <span
@@ -78,7 +78,7 @@ function StatCard({
   href?: string;
 }) {
   const inner = (
-    <Card className="border-slate-800 bg-slate-900 transition-all hover:border-blue-500/50 hover:bg-slate-800/50 hover:shadow-lg hover:shadow-blue-500/5">
+    <Card className="border-slate-800 bg-slate-900 transition-all hover:border-blue-500/50 hover:bg-slate-800/60 hover:shadow-lg hover:shadow-blue-500/5">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-sm font-medium text-slate-400">
           {title}
@@ -318,10 +318,10 @@ export default function DashboardPage() {
                       <TableCell className="tabular-nums font-mono text-slate-400">
                         {d.ip}
                       </TableCell>
-                      <TableCell className="tabular-nums text-right text-emerald-400">
+                      <TableCell className="tabular-nums font-mono text-right text-emerald-400">
                         {formatBps(d.rx_bps)}
                       </TableCell>
-                      <TableCell className="tabular-nums text-right text-blue-400">
+                      <TableCell className="tabular-nums font-mono text-right text-blue-400">
                         {formatBps(d.tx_bps)}
                       </TableCell>
                     </TableRow>

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -364,7 +364,7 @@ function DeviceCard({
 
   return (
     <Card
-      className="cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:border-blue-500/50"
+      className="cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:bg-slate-800/60 hover:border-blue-500/50"
       onClick={onClick}
     >
       <CardContent className="p-5">
@@ -372,7 +372,9 @@ function DeviceCard({
         <div className="flex items-center gap-2">
           <span
             className={`h-2.5 w-2.5 shrink-0 rounded-full ${
-              device.is_online ? "bg-emerald-500 status-glow-online" : "bg-slate-500"
+              device.is_online
+                ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                : "bg-slate-500"
             }`}
           />
           <span className="truncate font-medium text-white">{displayName}</span>
@@ -385,8 +387,8 @@ function DeviceCard({
 
         {/* Technical info */}
         <div className="mt-3 space-y-1">
-          <p className="font-mono text-sm text-slate-400">{primaryIp}</p>
-          <p className="font-mono text-xs text-slate-600">{device.mac}</p>
+          <p className="font-mono tabular-nums text-sm text-slate-400">{primaryIp}</p>
+          <p className="font-mono tabular-nums text-xs text-slate-600">{device.mac}</p>
           {device.vendor && (
             <p className="text-xs text-slate-500">{device.vendor}</p>
           )}
@@ -496,13 +498,15 @@ function DevicesTable({
             return (
               <TableRow
                 key={device.id}
-                className="cursor-pointer border-slate-800 hover:bg-slate-800"
+                className="cursor-pointer border-slate-800 transition-colors hover:bg-slate-800/60"
                 onClick={() => onSelect(device)}
               >
                 <TableCell>
                   <span
                     className={`inline-block h-2.5 w-2.5 rounded-full ${
-                      device.is_online ? "bg-emerald-500 status-glow-online" : "bg-slate-500"
+                      device.is_online
+                        ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                        : "bg-slate-500"
                     }`}
                   />
                 </TableCell>
@@ -559,7 +563,9 @@ function DeviceDetail({ device }: { device: Device }) {
         <div className="flex items-center gap-3">
           <span
             className={`h-3 w-3 rounded-full ${
-              device.is_online ? "bg-emerald-500 status-glow-online" : "bg-slate-500"
+              device.is_online
+                ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                : "bg-slate-500"
             }`}
           />
           <SheetTitle className="text-white">{displayName}</SheetTitle>
@@ -795,11 +801,13 @@ function DeviceEventsTab({ deviceId }: { deviceId: string }) {
           {events.map((event) => (
             <div
               key={event.id}
-              className="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-slate-800"
+              className="flex items-center gap-3 rounded-md px-3 py-2 transition-colors hover:bg-slate-800/60"
             >
               <span
                 className={`h-2.5 w-2.5 shrink-0 rounded-full ${
-                  event.event_type === "online" ? "bg-emerald-500" : "bg-slate-500"
+                  event.event_type === "online"
+                    ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                    : "bg-slate-500"
                 }`}
               />
               <span className="text-sm text-slate-300 capitalize">
@@ -979,7 +987,7 @@ function InfoRow({
         {label}
       </span>
       <span
-        className={`text-sm text-slate-300 ${mono ? "font-mono" : ""}`}
+        className={`text-sm text-slate-300 ${mono ? "font-mono tabular-nums" : ""}`}
       >
         {value}
       </span>

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -280,7 +280,7 @@ function SpeedTestSection() {
                 </div>
                 <div>
                   <p className="text-sm text-slate-500">Download</p>
-                  <p className="text-2xl font-bold text-white">
+                  <p className="text-2xl font-bold tabular-nums text-white">
                     {result.download_mbps.toFixed(1)}{" "}
                     <span className="text-sm font-normal text-slate-500">
                       Mbps
@@ -298,7 +298,7 @@ function SpeedTestSection() {
                 </div>
                 <div>
                   <p className="text-sm text-slate-500">Upload</p>
-                  <p className="text-2xl font-bold text-white">
+                  <p className="text-2xl font-bold tabular-nums text-white">
                     {result.upload_mbps.toFixed(1)}{" "}
                     <span className="text-sm font-normal text-slate-500">
                       Mbps
@@ -316,7 +316,7 @@ function SpeedTestSection() {
                 <Activity className="h-5 w-5 text-purple-400" />
                 <div>
                   <p className="text-xs text-slate-500">Ping</p>
-                  <p className="text-lg font-semibold text-white">
+                  <p className="text-lg font-semibold tabular-nums text-white">
                     {result.ping_ms.toFixed(1)}{" "}
                     <span className="text-xs font-normal text-slate-500">ms</span>
                   </p>
@@ -329,7 +329,7 @@ function SpeedTestSection() {
                 <Activity className="h-5 w-5 text-yellow-400" />
                 <div>
                   <p className="text-xs text-slate-500">Jitter</p>
-                  <p className="text-lg font-semibold text-white">
+                  <p className="text-lg font-semibold tabular-nums text-white">
                     {result.jitter_ms.toFixed(2)}{" "}
                     <span className="text-xs font-normal text-slate-500">ms</span>
                   </p>
@@ -342,7 +342,7 @@ function SpeedTestSection() {
                 <Wifi className="h-5 w-5 text-cyan-400" />
                 <div>
                   <p className="text-xs text-slate-500">Packet Loss</p>
-                  <p className="text-lg font-semibold text-white">
+                  <p className="text-lg font-semibold tabular-nums text-white">
                     {result.packet_loss.toFixed(1)}
                     <span className="text-xs font-normal text-slate-500">%</span>
                   </p>
@@ -397,10 +397,12 @@ function SpeedTestSection() {
 
 function StatusDot({ admin, link }: { admin: string; link: string }) {
   const isUp = admin === "up" && link === "up";
-  const color = isUp ? "bg-emerald-500" : "bg-rose-500";
+  const cls = isUp
+    ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+    : "bg-rose-400 ring-2 ring-rose-400/30 status-glow-offline";
   return (
     <span
-      className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${color}`}
+      className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${cls}`}
       title={`Admin: ${admin}, Link: ${link}`}
     />
   );
@@ -490,7 +492,7 @@ function InterfacesTable({
             return (
               <tr
                 key={iface.name}
-                className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/50"
+                className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
               >
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
@@ -499,17 +501,17 @@ function InterfacesTable({
                   </div>
                 </td>
                 <td className="px-4 py-3">
-                  <span className="font-mono font-medium text-white">
+                  <span className="font-mono tabular-nums font-medium text-white">
                     {iface.name}
                   </span>
                 </td>
                 <td className="px-4 py-3">
-                  <span className="font-mono text-slate-300">
+                  <span className="font-mono tabular-nums text-slate-300">
                     {iface.ip_address ?? "—"}
                   </span>
                 </td>
                 <td className="px-4 py-3">
-                  <span className="font-mono text-xs text-slate-400">
+                  <span className="font-mono tabular-nums text-xs text-slate-400">
                     {iface.mac ?? "—"}
                   </span>
                 </td>
@@ -625,7 +627,7 @@ function RoutesTable({
           {routes.map((route, idx) => (
             <tr
               key={`${route.destination}-${idx}`}
-              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/50"
+              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
             >
               <td className="px-4 py-3">
                 <div className="flex items-center gap-2">
@@ -638,22 +640,22 @@ function RoutesTable({
                 </div>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono font-medium text-white">
+                <span className="font-mono tabular-nums font-medium text-white">
                   {route.destination}
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono text-slate-300">
+                <span className="font-mono tabular-nums text-slate-300">
                   {route.gateway ?? "—"}
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono text-slate-300">
+                <span className="font-mono tabular-nums text-slate-300">
                   {route.interface ?? "—"}
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono text-xs text-slate-400">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
                   {route.metric ? `[${route.metric}]` : "—"}
                 </span>
               </td>
@@ -766,15 +768,15 @@ function DhcpLeasesTable({
           {leases.map((lease, idx) => (
             <tr
               key={`${lease.ip}-${idx}`}
-              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/50"
+              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
             >
               <td className="px-4 py-3">
-                <span className="font-mono font-medium text-white">
+                <span className="font-mono tabular-nums font-medium text-white">
                   {lease.ip}
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono text-xs text-slate-400">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
                   {lease.mac}
                 </span>
               </td>
@@ -789,7 +791,7 @@ function DhcpLeasesTable({
                 </span>
               </td>
               <td className="px-4 py-3">
-                <span className="font-mono text-xs text-slate-400">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
                   {lease.lease_expiry ?? "—"}
                 </span>
               </td>
@@ -895,21 +897,21 @@ function FirewallChainCard({ chain }: { chain: FirewallChain }) {
                 {chain.rules.map((rule) => (
                   <tr
                     key={rule.number}
-                    className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/50"
+                    className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
                   >
                     <td className="px-4 py-3">
-                      <span className="font-mono text-slate-300">{rule.number}</span>
+                      <span className="font-mono tabular-nums text-slate-300">{rule.number}</span>
                     </td>
                     <td className="px-4 py-3">
                       <FirewallActionBadge action={rule.action} />
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-slate-300">
+                      <span className="font-mono tabular-nums text-xs text-slate-300">
                         {rule.source ?? "any"}
                       </span>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-slate-300">
+                      <span className="font-mono tabular-nums text-xs text-slate-300">
                         {rule.destination ?? "any"}
                       </span>
                     </td>

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -267,13 +267,13 @@ export default function TrafficPage() {
                   <TableCell className="text-white">
                     {d.name ?? d.hostname ?? d.id.slice(0, 8)}
                   </TableCell>
-                  <TableCell className="font-mono text-xs text-slate-400">
+                  <TableCell className="font-mono tabular-nums text-xs text-slate-400">
                     {d.ip ?? "—"}
                   </TableCell>
-                  <TableCell className="text-right text-blue-400">
+                  <TableCell className="font-mono tabular-nums text-right text-blue-400">
                     {formatBps(d.rx_bps)}
                   </TableCell>
-                  <TableCell className="text-right text-emerald-400">
+                  <TableCell className="font-mono tabular-nums text-right text-emerald-400">
                     {formatBps(d.tx_bps)}
                   </TableCell>
                 </TableRow>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -37,7 +37,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-slate-950 text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }
@@ -48,32 +48,42 @@
   font-feature-settings: "tnum" 1;
 }
 
-/* Status dot pulse animation */
-@keyframes pulse-dot {
-  0%, 100% {
-    opacity: 1;
-    box-shadow: 0 0 0 0 currentColor;
-  }
-  50% {
-    opacity: 0.7;
-    box-shadow: 0 0 4px 2px currentColor;
-  }
+/* ── Neon glow status dots ───────────────────────────── */
+
+/* Online: emerald neon glow */
+.status-glow-online {
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.4);
 }
 
-.status-pulse {
-  animation: pulse-dot 2s ease-in-out infinite;
+/* Offline/Critical: rose neon glow */
+.status-glow-offline {
+  box-shadow: 0 0 8px rgba(244, 63, 94, 0.4);
 }
 
-/* Glow pulse for online status indicators */
+/* Animated pulse for online status indicators */
 @keyframes glow-pulse {
   0%, 100% {
     box-shadow: 0 0 4px 1px rgba(16, 185, 129, 0.4);
   }
   50% {
-    box-shadow: 0 0 8px 3px rgba(16, 185, 129, 0.6);
+    box-shadow: 0 0 10px 3px rgba(16, 185, 129, 0.6);
   }
 }
 
-.status-glow-online {
+.status-glow-online-pulse {
   animation: glow-pulse 2s ease-in-out infinite;
+}
+
+/* Rose pulse for critical/offline dots */
+@keyframes glow-pulse-rose {
+  0%, 100% {
+    box-shadow: 0 0 4px 1px rgba(244, 63, 94, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 10px 3px rgba(244, 63, 94, 0.6);
+  }
+}
+
+.status-glow-offline-pulse {
+  animation: glow-pulse-rose 2s ease-in-out infinite;
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -26,8 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}
-        style={{ backgroundColor: "#0b1120", color: "#f0f4f8" }}
+        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased bg-slate-950 text-slate-50`}
       >
         {children}
         <Toaster theme="dark" position="bottom-right" richColors />

--- a/web/src/components/DeviceTypeIcon.tsx
+++ b/web/src/components/DeviceTypeIcon.tsx
@@ -40,7 +40,7 @@ const COLOR_MAP: Record<DeviceType, string> = {
   server: "text-emerald-400",
   printer: "text-amber-400",
   iot: "text-teal-400",
-  gaming: "text-red-400",
+  gaming: "text-rose-400",
   unknown: "text-slate-400",
 };
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -71,7 +71,7 @@ export function Sidebar() {
                   "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                   active
                     ? "bg-blue-500/10 text-blue-500"
-                    : "text-slate-400 hover:bg-slate-900 hover:text-white",
+                    : "text-slate-400 hover:bg-slate-800/60 hover:text-white transition-colors",
                   collapsed && "justify-center px-0"
                 )}
               >
@@ -99,7 +99,7 @@ export function Sidebar() {
         <div className="border-t border-slate-800 p-2">
           <button
             onClick={() => setCollapsed(!collapsed)}
-            className="flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-xs text-slate-600 transition-colors hover:bg-slate-900 hover:text-slate-400"
+            className="flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-xs text-slate-600 transition-colors hover:bg-slate-800/60 hover:text-slate-400"
           >
             {collapsed ? (
               <ChevronRight className="h-4 w-4" />
@@ -117,7 +117,9 @@ export function Sidebar() {
                   <span
                     className={cn(
                       "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
-                      wsConnected ? "bg-emerald-500" : "bg-slate-600"
+                      wsConnected
+                        ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                        : "bg-slate-600"
                     )}
                   />
                 </TooltipTrigger>
@@ -134,7 +136,9 @@ export function Sidebar() {
                   <span
                     className={cn(
                       "inline-block h-1.5 w-1.5 rounded-full",
-                      wsConnected ? "bg-emerald-500" : "bg-slate-600"
+                      wsConnected
+                        ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                        : "bg-slate-600"
                     )}
                   />
                 </div>

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -156,18 +156,20 @@ export function TopBar() {
                       return (
                         <button
                           key={d.id}
-                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-800 ${
-                            activeIndex === idx ? "bg-slate-800" : ""
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-800/60 ${
+                            activeIndex === idx ? "bg-slate-800/60" : ""
                           }`}
                           onClick={() => navigateTo("device", d.id)}
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
-                              d.is_online ? "bg-emerald-500" : "bg-slate-500"
+                              d.is_online
+                                ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                                : "bg-slate-500"
                             }`}
                           />
-                          <span className="text-white">
+                          <span className="font-mono tabular-nums text-white">
                             {d.ip_address || d.mac_address}
                           </span>
                           {d.hostname && (
@@ -193,15 +195,17 @@ export function TopBar() {
                       return (
                         <button
                           key={a.id}
-                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-800 ${
-                            activeIndex === idx ? "bg-slate-800" : ""
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-800/60 ${
+                            activeIndex === idx ? "bg-slate-800/60" : ""
                           }`}
                           onClick={() => navigateTo("agent", a.id)}
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
-                              a.is_online ? "bg-emerald-500" : "bg-slate-500"
+                              a.is_online
+                                ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                                : "bg-slate-500"
                             }`}
                           />
                           <span className="text-white">{a.name || a.id}</span>
@@ -225,8 +229,8 @@ export function TopBar() {
                       return (
                         <button
                           key={al.id}
-                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-800 ${
-                            activeIndex === idx ? "bg-slate-800" : ""
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-800/60 ${
+                            activeIndex === idx ? "bg-slate-800/60" : ""
                           }`}
                           onClick={() => navigateTo("alert", al.id)}
                           onMouseEnter={() => setActiveIndex(idx)}

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border bg-card text-card-foreground shadow-lg",
       className
     )}
     {...props}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -44,11 +44,13 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
-        // Custom Panoptikon status colors
-        "status-online": "#22c55e",
-        "status-offline": "#ef4444",
-        "status-warning": "#f59e0b",
-        "status-inactive": "#6b7280",
+        // Deep dark layered surfaces
+        surface: "#334155",
+        // Custom Panoptikon status colors (neon accents)
+        "status-online": "#10b981",   // emerald-500
+        "status-offline": "#f43f5e",  // rose-500
+        "status-warning": "#f59e0b",  // amber-500
+        "status-inactive": "#6b7280", // gray-500
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Deep Dark Theme (GUI v2 foundation)

Upgrades the visual foundation to a premium dark theme:

- **Base layer**: bg-slate-950 (#0f172a) root background
- **Cards/surfaces**: bg-slate-900 (#1e293b) with border-slate-800, rounded-xl shadow-lg
- **Status colors**: emerald-400 for online (with neon glow ring + shadow), rose-400 for offline/critical (with neon glow)
- **Typography**: font-mono tabular-nums for IPs, MACs, bandwidth figures, port numbers, route destinations
- **Interactive**: hover:bg-slate-800/60 transition-colors on rows/cards across all pages
- **TopBar/Sidebar**: updated hover states and neon glow WebSocket indicator
- **CSS utilities**: status-glow-online / status-glow-offline classes with box-shadow neon effects
- **Surface token**: added `surface` (#334155) to Tailwind config

### Files changed (14)
- tailwind.config.ts: surface color token, updated status color values
- globals.css: deep slate CSS variables, neon glow keyframes & utilities
- layout.tsx: Tailwind class instead of inline style for root bg
- Card component: rounded-xl + shadow-lg default
- Sidebar: neon glow WS dot, hover:bg-slate-800/60
- TopBar: neon glow search result dots, font-mono tabular-nums on IPs
- Dashboard: neon glow StatusDot, tabular-nums on bandwidth
- Devices: neon glow dots (card/table/detail/events), tabular-nums IP/MAC
- Agents: neon glow StatusBadge, tabular-nums hostname/version, rose-600 delete
- Agent detail: neon glow dot, tabular-nums timestamps
- Router: neon glow StatusDot, tabular-nums on all IP/MAC/metric/DHCP/firewall/speedtest
- Traffic: tabular-nums on IP/bandwidth cells
- Alerts: hover:bg-slate-800/60 on cards
- DeviceTypeIcon: gaming color text-red-400 → text-rose-400

Sets the visual tone for all subsequent GUI v2 improvements.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Comprehensive visual upgrade transitioning the entire UI to a deep dark theme with neon status accents. The changes systematically apply a new color palette (`bg-slate-950` root, `bg-slate-900` surfaces, emerald-400/rose-400 status colors) with consistent neon glow effects and improved typography using `tabular-nums` for all numeric data.

**Key changes:**
- Replaced inline styles with Tailwind utility classes for consistency
- Added neon glow CSS utilities (`status-glow-online`/`status-glow-offline`) with box-shadow effects
- Applied `ring-2` and glow effects to all status indicators across 14 files
- Added `tabular-nums` to IPs, MACs, bandwidth, timestamps, and all numeric fields for proper alignment
- Updated Card component defaults to `rounded-xl` and `shadow-lg`
- Standardized all interactive hover states to `hover:bg-slate-800/60` with `transition-colors`
- Color consistency: red → rose across the board (gaming icons, delete buttons, offline states)

The implementation is thorough, consistent, and purely cosmetic with no functional changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - purely cosmetic styling changes
- All changes are visual/cosmetic CSS and class modifications with no logic changes, no new dependencies, and consistent application across all files
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/tailwind.config.ts | Added surface color token and updated status colors to emerald/rose variants for neon theme |
| web/src/app/globals.css | Replaced inline style with bg-slate-950 utility, added neon glow keyframes and status-glow-online/offline classes |
| web/src/components/ui/card.tsx | Updated default Card styling to rounded-xl and shadow-lg for deeper elevation |
| web/src/app/(app)/dashboard/page.tsx | Applied neon glow rings to StatusDot, added tabular-nums to bandwidth values, updated card hover opacity |
| web/src/app/(app)/devices/page.tsx | Added neon glow to all status dots (card/table/detail/events), applied tabular-nums to IP/MAC addresses |
| web/src/app/(app)/router/page.tsx | Applied neon glow to StatusDot, added tabular-nums to all numeric fields (IP/MAC/metrics/speeds), updated all table row hover states |

</details>



<sub>Last reviewed commit: b6543b0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->