### PR TITLE
feat: device type icons — visual identity per vendor/OUI

### DIFF
--- a/web/src/lib/device-icons.ts
+++ b/web/src/lib/device-icons.ts
@@ -1,0 +1,65 @@
+/**
+ * Convenience wrapper around device-type inference.
+ * Returns a Lucide icon component + human label for a device,
+ * derived from vendor string and hostname.
+ */
+
+import type { LucideIcon } from "lucide-react";
+import {
+  CircuitBoard,
+  Gamepad2,
+  HelpCircle,
+  Laptop,
+  Monitor,
+  Printer,
+  Router,
+  Server,
+  Smartphone,
+  Tablet,
+  Tv,
+} from "lucide-react";
+import { inferDeviceType, type DeviceType } from "./device-type";
+
+const ICON_MAP: Record<DeviceType, LucideIcon> = {
+  router: Router,
+  laptop: Laptop,
+  desktop: Monitor,
+  phone: Smartphone,
+  tablet: Tablet,
+  tv: Tv,
+  server: Server,
+  printer: Printer,
+  iot: CircuitBoard,
+  gaming: Gamepad2,
+  unknown: HelpCircle,
+};
+
+const LABEL_MAP: Record<DeviceType, string> = {
+  router: "Router",
+  laptop: "Laptop",
+  desktop: "Desktop",
+  phone: "Phone",
+  tablet: "Tablet",
+  tv: "TV",
+  server: "Server",
+  printer: "Printer",
+  iot: "IoT",
+  gaming: "Gaming",
+  unknown: "Device",
+};
+
+/**
+ * Get device icon and label from vendor/hostname/mdns data.
+ */
+export function getDeviceIcon(
+  vendor?: string | null,
+  hostname?: string | null,
+  mdnsServices?: string | null
+): { icon: LucideIcon; label: string; type: DeviceType } {
+  const type = inferDeviceType(vendor, hostname, mdnsServices);
+  return {
+    icon: ICON_MAP[type],
+    label: LABEL_MAP[type],
+    type,
+  };
+}


### PR DESCRIPTION
## Device Type Icons

Adds visual device-type identification to all device views:

- **New**: `web/src/lib/device-icons.ts` — `getDeviceIcon(vendor, hostname, mdns)` convenience wrapper around existing `inferDeviceType`
- **Vendor mapping**: Apple→Smartphone/Laptop, Ubiquiti/Cisco→Router, Synology/QNAP/TrueNAS→Server, Raspberry→IoT, Samsung/LG→TV, etc. (via existing comprehensive `device-type.ts`)
- **Hostname fallback**: 'macbook'→Laptop, 'iphone'→Phone, 'nas'→Server, 'printer'→Printer
- **Device cards**: 40×40 slate-800 rounded-xl icon container, status-colored icon (emerald online, slate offline)
- **Table rows**: 32×32 icon column as first column before status dot
- **Vendor badge**: small slate-400 text below device name (truncated to 20 chars)
- **Agent badge**: blue pill badge when device has active telemetry agent (card, table, slide-over)
- **Slide-over header**: icon container + device type label + vendor + agent badge

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhances device identification with visual icons mapped from vendor/hostname/mDNS data. New `device-icons.ts` wraps existing `inferDeviceType` logic with Lucide icon components. All device views (cards, table rows, slide-over) now display 40×40 or 32×32 icon containers with status-colored icons. Vendor names are truncated to 20 characters, and active telemetry agents get blue pill badges across all views. The implementation is clean and leverages existing device type inference infrastructure.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor layout refinement recommended
- Implementation is solid and reuses existing device type inference logic. New module is well-structured with clear mappings. Only minor issue is badge layout when both Agent and NEW badges appear together - both use `ml-auto` which may cause stacking instead of proper spacing
- No files require special attention - the layout suggestion is optional

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/device-icons.ts | Clean wrapper around existing inferDeviceType, provides Lucide icons and labels for each device type |
| web/src/app/(app)/devices/page.tsx | Added device type icons to cards/table/slide-over, vendor display truncation, and agent badges throughout UI |

</details>



<sub>Last reviewed commit: 8f3b423</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->