### PR TITLE
fix(build): add build-prod pipeline — enforce web→cargo build order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,21 @@
-.PHONY: build dev clean
+.PHONY: build build-prod dev clean deploy
 
+# Default build: web + Rust binary (correct order for rust-embed)
 build: ## Build production binary with embedded frontend
-	cd web && ~/.bun/bin/bun run build
+	cd web && ~/.bun/bin/bun install --frozen-lockfile && ~/.bun/bin/bun run build
 	~/.cargo/bin/cargo build --release -p panoptikon-server
+
+# Alias — explicit name for CI/deploy scripts
+build-prod: build ## Alias for 'build' — guaranteed correct order for production
 
 dev: ## Run in development mode
 	~/.cargo/bin/cargo run -p panoptikon-server
 
-clean:
+clean: ## Clean all build artifacts
 	~/.cargo/bin/cargo clean
-	rm -rf web/.next
+	rm -rf web/.next web/node_modules/.cache
+
+deploy: build ## Build and deploy to LXC 115 (10.10.0.22)
+	scp target/release/panoptikon-server root@10.10.0.22:/usr/local/bin/panoptikon-server.new
+	ssh root@10.10.0.22 "systemctl stop panoptikon.service && mv /usr/local/bin/panoptikon-server.new /usr/local/bin/panoptikon-server && chmod 755 /usr/local/bin/panoptikon-server && systemctl start panoptikon.service"
+	@echo "✅ Deployed to 10.10.0.22:8080"

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# build-prod.sh — Build Panoptikon production binary with embedded frontend.
+#
+# rust-embed bakes web/.next/static/ into the binary at compile time.
+# Order matters: web MUST be built BEFORE cargo build.
+# Running cargo build alone produces a binary with STALE frontend.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BUN="${BUN:-$HOME/.bun/bin/bun}"
+CARGO="${CARGO:-$HOME/.cargo/bin/cargo}"
+
+echo "=== Step 1/2: Building web frontend ==="
+cd web
+"$BUN" install --frozen-lockfile
+"$BUN" run build
+cd "$REPO_ROOT"
+
+echo "=== Step 2/2: Building Rust server (embeds frontend via rust-embed) ==="
+"$CARGO" build --release -p panoptikon-server
+
+echo ""
+echo "✅ Production binary ready: target/release/panoptikon-server"
+echo "   Frontend embedded from: web/.next/static/"
+ls -lh target/release/panoptikon-server


### PR DESCRIPTION
## Problem

rust-embed bakes `web/.next/static/` into the binary at compile time. When autodev runs `cargo build --release` without first running `bun run build`, the deployed binary contains **stale frontend assets** → `Application error: a client-side exception has occurred` in production.

This has happened multiple times because the autodev deploy pipeline didn't enforce the correct build order.

## Changes

- **Makefile**: Updated `build` target to include `bun install --frozen-lockfile` before `bun run build`. Added `build-prod` alias and `deploy` target for LXC 115.
- **scripts/build-prod.sh**: Standalone build script with clear step-by-step comments explaining WHY order matters.

## Correct build order (enforced)

1. `cd web && bun install && bun run build` (generates .next/static/)
2. `cargo build --release` (rust-embed embeds .next/static/ into binary)

## Testing

`make build` or `scripts/build-prod.sh` — both produce a binary with fresh frontend.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents stale frontend assets in production by enforcing the correct build order (web → cargo) required for rust-embed. The changes ensure `bun run build` generates `.next/static/` before `cargo build --release` embeds it into the binary.

- Added `bun install --frozen-lockfile` to Makefile `build` target for reproducible builds
- Created `scripts/build-prod.sh` standalone script with clear documentation and configurable paths
- Added `build-prod` Makefile alias for explicit CI/deploy usage
- Added `deploy` target with LXC 115 deployment automation

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor deployment robustness issue to address
- The build order fix is correct and solves the stated problem. The new build script is well-documented with proper error handling (`set -euo pipefail`). However, the deploy target has a minor issue where `systemctl stop` failure would abort the entire deployment chain, which should use `|| true` to continue even if the service is already stopped.
- The `deploy` target in Makefile needs a small fix to handle the case where the service is already stopped

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Makefile | Enforces correct web→cargo build order with `bun install --frozen-lockfile`. Adds `build-prod` alias and `deploy` target for LXC deployment. |
| scripts/build-prod.sh | Standalone build script with clear documentation and configurable BUN/CARGO paths. Enforces correct build order with `set -euo pipefail`. |

</details>



<sub>Last reviewed commit: 9eeeb85</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->