### PR TITLE
feat: network topology map — React Flow, dagre layout, animated edges

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "panoptikon-web",
       "dependencies": {
+        "@dagrejs/dagre": "^2.0.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -14,6 +15,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "framer-motion": "^12.34.3",
@@ -27,6 +29,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/dagre": "^0.7.53",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -44,6 +47,10 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@dagrejs/dagre": ["@dagrejs/dagre@2.0.4", "", { "dependencies": { "@dagrejs/graphlib": "3.0.4" } }, "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA=="],
+
+    "@dagrejs/graphlib": ["@dagrejs/graphlib@3.0.4", "", {}, "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -257,6 +264,8 @@
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
     "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
 
     "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
@@ -265,11 +274,19 @@
 
     "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
 
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
     "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
 
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/dagre": ["@types/dagre@0.7.53", "", {}, "sha512-f4gkWqzPZvYmKhOsDnhq/R8mO4UMcKdxZo+i5SCkOU1wvGeHJeUXGIHeE9pnwGyPMDof1Vx5ZQo4nxpeg2TTVQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -340,6 +357,10 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@xyflow/react": ["@xyflow/react@12.10.1", "", { "dependencies": { "@xyflow/system": "0.0.75", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.75", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -419,6 +440,8 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -441,6 +464,10 @@
 
     "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
 
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
     "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
 
     "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
@@ -451,6 +478,8 @@
 
     "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
 
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
     "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
 
     "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
@@ -458,6 +487,10 @@
     "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
 
     "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
@@ -1000,6 +1033,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^2.0.4",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -18,6 +19,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "framer-motion": "^12.34.3",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@types/dagre": "^0.7.53",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -1,0 +1,379 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  ReactFlow,
+  Controls,
+  MiniMap,
+  Background,
+  BackgroundVariant,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  type NodeProps,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import dagre from '@dagrejs/dagre'
+import { Network, Loader2, RefreshCw } from 'lucide-react'
+import { fetchDevices, fetchTopDevices, fetchRouterInterfaces } from '@/lib/api'
+import type { Device, TopDevice, VyosInterface } from '@/lib/types'
+import { getDeviceIcon } from '@/lib/device-icons'
+import { PageTransition } from '@/components/PageTransition'
+
+// ─── Types ──────────────────────────────────────────────
+
+type RouterNodeData = {
+  label: string
+  wanIp: string | null
+  isOnline: boolean
+}
+
+type DeviceNodeData = {
+  device: Device
+  trafficBps: number
+}
+
+type RouterNodeType = Node<RouterNodeData, 'routerNode'>
+type DeviceNodeType = Node<DeviceNodeData, 'deviceNode'>
+type TopologyNode = RouterNodeType | DeviceNodeType
+
+// ─── Dagre Layout ───────────────────────────────────────
+
+const ROUTER_WIDTH = 200
+const ROUTER_HEIGHT = 80
+const DEVICE_WIDTH = 180
+const DEVICE_HEIGHT = 68
+
+function getLayoutedElements(
+  nodes: TopologyNode[],
+  edges: Edge[],
+): { nodes: TopologyNode[]; edges: Edge[] } {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'TB', nodesep: 60, ranksep: 100 })
+
+  nodes.forEach((n) => {
+    const isRouter = n.type === 'routerNode'
+    g.setNode(n.id, {
+      width: isRouter ? ROUTER_WIDTH : DEVICE_WIDTH,
+      height: isRouter ? ROUTER_HEIGHT : DEVICE_HEIGHT,
+    })
+  })
+  edges.forEach((e) => g.setEdge(e.source, e.target))
+  dagre.layout(g)
+
+  return {
+    nodes: nodes.map((n) => {
+      const pos = g.node(n.id)
+      const isRouter = n.type === 'routerNode'
+      const w = isRouter ? ROUTER_WIDTH : DEVICE_WIDTH
+      const h = isRouter ? ROUTER_HEIGHT : DEVICE_HEIGHT
+      return {
+        ...n,
+        position: { x: pos.x - w / 2, y: pos.y - h / 2 },
+      }
+    }),
+    edges,
+  }
+}
+
+// ─── Custom Nodes ───────────────────────────────────────
+
+function RouterNode({ data }: NodeProps<RouterNodeType>) {
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl border border-blue-500/30 bg-gradient-to-br from-slate-800 to-slate-900 px-5 py-4 shadow-lg shadow-blue-500/10"
+      style={{ width: ROUTER_WIDTH, height: ROUTER_HEIGHT }}
+    >
+      <Handle type="source" position={Position.Bottom} className="!bg-blue-500" />
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/20">
+        <Network className="h-5 w-5 text-blue-400" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-white">VyOS Router</p>
+        {data.wanIp && (
+          <p className="truncate text-xs text-slate-400">{data.wanIp}</p>
+        )}
+        <div className="mt-0.5 flex items-center gap-1.5">
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${
+              data.isOnline
+                ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]'
+                : 'bg-rose-400 shadow-[0_0_6px_rgba(251,113,133,0.5)]'
+            }`}
+          />
+          <span className="text-[10px] text-slate-500">
+            {data.isOnline ? 'Online' : 'Offline'}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DeviceNode({ data }: NodeProps<DeviceNodeType>) {
+  const { device } = data
+  const { icon: Icon } = getDeviceIcon(
+    device.vendor,
+    device.hostname,
+    device.mdns_services,
+  )
+  const displayName = device.name || device.hostname || device.mac
+  const primaryIp = device.ips?.[0] || '—'
+
+  return (
+    <div
+      className="flex items-center gap-2.5 rounded-lg border border-slate-700/60 bg-slate-800/90 px-3 py-2.5 shadow-md transition-shadow hover:shadow-lg hover:shadow-slate-700/20"
+      style={{ width: DEVICE_WIDTH, height: DEVICE_HEIGHT }}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-slate-500" />
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-700/60">
+        <Icon className="h-4 w-4 text-slate-300" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-white">{displayName}</p>
+        <p className="truncate text-[10px] text-slate-400">{primaryIp}</p>
+      </div>
+      <span
+        className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+          device.is_online
+            ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]'
+            : 'bg-rose-400/60'
+        }`}
+      />
+    </div>
+  )
+}
+
+const nodeTypes: NodeTypes = {
+  routerNode: RouterNode,
+  deviceNode: DeviceNode,
+}
+
+// ─── Edge style helpers ─────────────────────────────────
+
+function getEdgeStrokeWidth(bps: number): number {
+  if (bps > 10_000_000) return 4
+  if (bps > 1_000_000) return 3
+  if (bps > 100_000) return 2
+  return 1
+}
+
+// ─── Main Page ──────────────────────────────────────────
+
+export default function TopologyPage() {
+  const router = useRouter()
+  const [nodes, setNodes, onNodesChange] = useNodesState<TopologyNode>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+
+  const buildGraph = useCallback(
+    async (isInitial: boolean) => {
+      try {
+        const [devices, topDevices, interfaces] = await Promise.all([
+          fetchDevices(),
+          fetchTopDevices(100),
+          fetchRouterInterfaces().catch(() => [] as VyosInterface[]),
+        ])
+
+        // Find WAN IP from router interfaces
+        const wanIf = interfaces.find(
+          (i) =>
+            i.name === 'eth0' ||
+            i.description?.toLowerCase().includes('wan') ||
+            i.name?.startsWith('pppoe'),
+        )
+        const wanIp = wanIf?.ip_address ?? null
+
+        // Build traffic map from top devices
+        const trafficMap = new Map<string, number>()
+        topDevices.forEach((td: TopDevice) => {
+          trafficMap.set(td.id, (td.rx_bps || 0) + (td.tx_bps || 0))
+        })
+
+        // Build nodes
+        const routerNode: TopologyNode = {
+          id: 'router',
+          type: 'routerNode',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'VyOS Router',
+            wanIp,
+            isOnline: true,
+          },
+          draggable: true,
+        }
+
+        const deviceNodes: TopologyNode[] = devices.map((device) => ({
+          id: device.id,
+          type: 'deviceNode' as const,
+          position: { x: 0, y: 0 },
+          data: {
+            device,
+            trafficBps: trafficMap.get(device.id) || 0,
+          },
+          draggable: true,
+        }))
+
+        const allNodes: TopologyNode[] = [routerNode, ...deviceNodes]
+
+        // Build edges
+        const allEdges: Edge[] = devices.map((device) => {
+          const totalBps = trafficMap.get(device.id) || 0
+          return {
+            id: `router-${device.id}`,
+            source: 'router',
+            target: device.id,
+            type: 'default',
+            animated: totalBps > 100_000,
+            style: {
+              stroke: device.is_online ? '#3b82f6' : '#334155',
+              strokeWidth: getEdgeStrokeWidth(totalBps),
+              opacity: device.is_online ? 0.7 : 0.25,
+            },
+          }
+        })
+
+        // Apply dagre layout only on initial load
+        if (isInitial) {
+          const layouted = getLayoutedElements(allNodes, allEdges)
+          setNodes(layouted.nodes)
+          setEdges(layouted.edges)
+        } else {
+          // On refresh, update data without changing positions
+          setNodes((prev) => {
+            const posMap = new Map(prev.map((n) => [n.id, n.position]))
+            return allNodes.map((n) => ({
+              ...n,
+              position: posMap.get(n.id) ?? n.position,
+            }))
+          })
+          setEdges(allEdges)
+        }
+
+        setLastRefresh(new Date())
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load topology')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [setNodes, setEdges],
+  )
+
+  // Initial load
+  useEffect(() => {
+    buildGraph(true)
+  }, [buildGraph])
+
+  // Auto-refresh every 30s
+  useEffect(() => {
+    const interval = setInterval(() => buildGraph(false), 30_000)
+    return () => clearInterval(interval)
+  }, [buildGraph])
+
+  // Click handler — navigate to devices page with device selected
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: TopologyNode) => {
+      if (node.type === 'deviceNode') {
+        const device = (node.data as DeviceNodeData).device
+        router.push(`/devices?selected=${device.id}`)
+      }
+    },
+    [router],
+  )
+
+  if (loading) {
+    return (
+      <PageTransition>
+        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+            <p className="text-sm text-slate-400">Loading topology…</p>
+          </div>
+        </div>
+      </PageTransition>
+    )
+  }
+
+  if (error) {
+    return (
+      <PageTransition>
+        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-rose-400">{error}</p>
+            <button
+              onClick={() => {
+                setLoading(true)
+                buildGraph(true)
+              }}
+              className="mt-3 text-xs text-blue-400 hover:underline"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </PageTransition>
+    )
+  }
+
+  return (
+    <PageTransition>
+      <div className="-m-6 h-[calc(100vh-56px)]">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.15 }}
+          minZoom={0.3}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+          className="bg-slate-950"
+        >
+          <Controls
+            className="!border-slate-700 !bg-slate-900 [&>button]:!border-slate-700 [&>button]:!bg-slate-900 [&>button]:!text-slate-300 [&>button:hover]:!bg-slate-800"
+            showInteractive={false}
+          />
+          <MiniMap
+            nodeColor={(n) => {
+              if (n.type === 'routerNode') return '#3b82f6'
+              const data = n.data as DeviceNodeData
+              return data.device?.is_online ? '#34d399' : '#475569'
+            }}
+            className="!border-slate-700 !bg-slate-900/90"
+            maskColor="rgba(15, 23, 42, 0.7)"
+          />
+          <Background variant={BackgroundVariant.Dots} color="#334155" gap={24} size={1} />
+
+          {/* Floating refresh indicator */}
+          <div className="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-lg border border-slate-700/50 bg-slate-900/80 px-3 py-1.5 backdrop-blur-sm">
+            <button
+              onClick={() => buildGraph(false)}
+              className="text-slate-400 transition-colors hover:text-white"
+              title="Refresh now"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+            {lastRefresh && (
+              <span className="text-[10px] text-slate-500">
+                {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+        </ReactFlow>
+      </div>
+    </PageTransition>
+  )
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Cpu,
   LayoutDashboard,
   MonitorSmartphone,
+  Network,
   Router,
   Settings,
 } from "lucide-react";
@@ -28,6 +29,7 @@ const navItems = [
   { href: "/devices", label: "Devices", icon: MonitorSmartphone },
   { href: "/agents", label: "Agents", icon: Cpu },
   { href: "/router", label: "Router", icon: Router },
+  { href: "/topology", label: "Topology", icon: Network },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/alerts", label: "Alerts", icon: Bell },
   { href: "/settings", label: "Settings", icon: Settings },


### PR DESCRIPTION
## Network Topology Map (GUI v2 — Final!)

New **Topology** page (/topology) showing the network as an interactive graph:

### Features
- **React Flow v12** (`@xyflow/react`) with dagre auto-layout (top-down tree)
- **RouterNode**: central VyOS router card at top with WAN IP display
- **DeviceNode**: per-device cards with device-type icon (from device-icons.ts), hostname, IP, online/offline status dot
- **Edges**: bezier curves, animated (dashed SVG animation) for devices with active traffic (>100kbps)
- **Traffic-proportional edge width**: 1–4px based on rx+tx bps
- **Controls + MiniMap**: built-in React Flow zoom/pan controls and minimap
- **Dot grid background**: slate-700 dots at 24px gap
- **Auto-refresh**: 30s interval to update device online status and traffic data
- **Click to detail**: click any device node navigates to device detail view
- **Sidebar**: new Topology nav item with Network icon
- **Draggable nodes**: initial dagre layout preserved when dragging, refreshes update data only

### Layout
Dagre top-down layout: Router at top → devices arranged below. On refresh, node positions are preserved (only data/edges update). Initial layout computed via dagre with 60px horizontal and 100px vertical spacing.

### Dependencies
- `@xyflow/react@12.10.1` — React Flow v12
- `@dagrejs/dagre@2.0.4` — automatic graph layout

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented interactive network topology visualization using React Flow v12 and dagre layout algorithm. The new `/topology` page displays the VyOS router and connected devices as a draggable graph with traffic-based edge animations and auto-refresh.

**Key changes:**
- Added React Flow and dagre dependencies for graph visualization
- Created custom RouterNode and DeviceNode components with status indicators
- Implemented automatic top-down layout with 30-second refresh interval
- Added traffic-proportional edge styling (1-4px width, animated for >100kbps)
- Click-to-navigate functionality to device detail pages

**Critical issues:**
- `useEffect` dependency arrays include `buildGraph` which recreates on every render due to `setNodes`/`setEdges` dependencies, causing potential infinite re-render loops
- `proOptions={{ hideAttribution: true }}` requires React Flow Pro license verification

<h3>Confidence Score: 2/5</h3>

- This PR has critical issues that need to be resolved before merging
- The useEffect dependency issues on lines 273-275 and 278-281 will cause infinite re-render loops in production, which is a critical functional bug. The buildGraph callback recreates on every render because setNodes and setEdges (from useNodesState/useEdgesState) change identity on each render, causing the effects that depend on buildGraph to run continuously.
- Pay close attention to `web/src/app/(app)/topology/page.tsx` — the useEffect dependency issues must be fixed to prevent infinite re-renders

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/package.json | Added React Flow v12 and dagre dependencies for network topology visualization |
| web/src/components/layout/Sidebar.tsx | Added Topology navigation item with Network icon |
| web/src/app/(app)/topology/page.tsx | New interactive network topology page with React Flow, dagre layout, and auto-refresh; useEffect dependency issue may cause infinite re-renders |

</details>



<sub>Last reviewed commit: 2c84dda</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->