### PR TITLE
feat: settings page — scan interval, subnets, data retention sections

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -108,6 +108,8 @@ pub fn router(state: AppState) -> Router {
         .route("/settings", patch(settings::update_settings))
         .route("/settings/test-webhook", post(settings::test_webhook))
         .route("/settings/netflow-status", get(settings::netflow_status))
+        .route("/settings/db-size", get(settings::db_size))
+        .route("/settings/vacuum", post(settings::vacuum))
         // VyOS router proxy
         .route("/vyos/status", get(vyos::status))
         .route("/vyos/interfaces", get(vyos::interfaces))

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -12,6 +12,14 @@ pub struct SettingsResponse {
     pub vyos_url: Option<String>,
     /// Masked API key — never return the full key to the frontend.
     pub vyos_api_key_set: bool,
+    // --- Network Scanner ---
+    pub scan_interval_seconds: Option<u64>,
+    pub scan_subnets: Option<String>,
+    pub ping_sweep_enabled: Option<bool>,
+    // --- Data Retention ---
+    pub retention_traffic_hours: Option<u64>,
+    pub retention_alerts_days: Option<u64>,
+    pub retention_agent_reports_days: Option<u64>,
 }
 
 /// Request body for updating settings.
@@ -20,6 +28,25 @@ pub struct UpdateSettingsRequest {
     pub webhook_url: Option<String>,
     pub vyos_url: Option<String>,
     pub vyos_api_key: Option<String>,
+    // --- Network Scanner ---
+    pub scan_interval_seconds: Option<u64>,
+    pub scan_subnets: Option<String>,
+    pub ping_sweep_enabled: Option<bool>,
+    // --- Data Retention ---
+    pub retention_traffic_hours: Option<u64>,
+    pub retention_alerts_days: Option<u64>,
+    pub retention_agent_reports_days: Option<u64>,
+}
+
+/// Helper: read a string setting from the settings table.
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
 }
 
 /// GET /api/v1/settings — return current settings.
@@ -28,26 +55,51 @@ pub async fn get_settings(
 ) -> Result<Json<SettingsResponse>, StatusCode> {
     let webhook_url = webhook::get_webhook_url(&state.db).await;
 
-    let vyos_url: Option<String> =
-        sqlx::query_scalar(r#"SELECT value FROM settings WHERE key = 'vyos_url'"#)
-            .fetch_optional(&state.db)
-            .await
-            .ok()
-            .flatten();
+    let vyos_url = get_setting(&state, "vyos_url").await;
 
-    let vyos_api_key_set: bool =
-        sqlx::query_scalar::<_, String>(r#"SELECT value FROM settings WHERE key = 'vyos_api_key'"#)
-            .fetch_optional(&state.db)
-            .await
-            .ok()
-            .flatten()
-            .map(|v| !v.is_empty())
-            .unwrap_or(false);
+    let vyos_api_key_set = get_setting(&state, "vyos_api_key").await.is_some();
+
+    // Network Scanner settings (fall back to config defaults).
+    let scan_interval_seconds = get_setting(&state, "scan_interval_seconds")
+        .await
+        .and_then(|v| v.parse().ok())
+        .or(Some(state.config.scanner.interval_seconds));
+
+    let scan_subnets = get_setting(&state, "scan_subnets")
+        .await
+        .or_else(|| Some(state.config.scanner.subnets.join(",")));
+
+    let ping_sweep_enabled = get_setting(&state, "ping_sweep_enabled")
+        .await
+        .map(|v| v == "true")
+        .or(Some(true));
+
+    // Data Retention settings (fall back to config defaults).
+    let retention_traffic_hours = get_setting(&state, "retention_traffic_hours")
+        .await
+        .and_then(|v| v.parse().ok())
+        .or(Some(state.config.retention.traffic_samples_hours));
+
+    let retention_alerts_days = get_setting(&state, "retention_alerts_days")
+        .await
+        .and_then(|v| v.parse().ok())
+        .or(Some(state.config.retention.alerts_days));
+
+    let retention_agent_reports_days = get_setting(&state, "retention_agent_reports_days")
+        .await
+        .and_then(|v| v.parse().ok())
+        .or(Some(state.config.retention.agent_reports_days));
 
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
         vyos_api_key_set,
+        scan_interval_seconds,
+        scan_subnets,
+        ping_sweep_enabled,
+        retention_traffic_hours,
+        retention_alerts_days,
+        retention_agent_reports_days,
     }))
 }
 
@@ -76,6 +128,41 @@ pub async fn update_settings(
         // is added in the future.
         upsert_setting(&state, "vyos_api_key", key).await?;
         info!("VyOS API key updated");
+    }
+
+    // --- Network Scanner settings ---
+    if let Some(interval) = body.scan_interval_seconds {
+        upsert_setting(&state, "scan_interval_seconds", &interval.to_string()).await?;
+        info!(scan_interval_seconds = interval, "Scan interval updated");
+    }
+
+    if let Some(ref subnets) = body.scan_subnets {
+        upsert_setting(&state, "scan_subnets", subnets).await?;
+        info!(scan_subnets = %subnets, "Scan subnets updated");
+    }
+
+    if let Some(enabled) = body.ping_sweep_enabled {
+        upsert_setting(&state, "ping_sweep_enabled", &enabled.to_string()).await?;
+        info!(ping_sweep_enabled = enabled, "Ping sweep toggle updated");
+    }
+
+    // --- Data Retention settings ---
+    if let Some(hours) = body.retention_traffic_hours {
+        upsert_setting(&state, "retention_traffic_hours", &hours.to_string()).await?;
+        info!(retention_traffic_hours = hours, "Traffic retention updated");
+    }
+
+    if let Some(days) = body.retention_alerts_days {
+        upsert_setting(&state, "retention_alerts_days", &days.to_string()).await?;
+        info!(retention_alerts_days = days, "Alerts retention updated");
+    }
+
+    if let Some(days) = body.retention_agent_reports_days {
+        upsert_setting(&state, "retention_agent_reports_days", &days.to_string()).await?;
+        info!(
+            retention_agent_reports_days = days,
+            "Agent reports retention updated"
+        );
     }
 
     // Return current state.
@@ -120,6 +207,71 @@ pub async fn netflow_status(State(state): State<AppState>) -> Json<NetflowStatus
         port: state.config.scanner.netflow_port,
         flows_received: netflow::flows_received(),
     })
+}
+
+/// Response for the db-size endpoint.
+#[derive(Debug, Serialize)]
+pub struct DbSizeResponse {
+    pub size_bytes: u64,
+}
+
+/// GET /api/v1/settings/db-size — return the current database file size.
+pub async fn db_size(State(state): State<AppState>) -> Result<Json<DbSizeResponse>, StatusCode> {
+    // Use SQLite's page_count * page_size to get the logical size.
+    let page_count: i64 = sqlx::query_scalar("PRAGMA page_count")
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| {
+            error!("Failed to get page_count: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let page_size: i64 = sqlx::query_scalar("PRAGMA page_size")
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| {
+            error!("Failed to get page_size: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let size_bytes = (page_count * page_size) as u64;
+    Ok(Json(DbSizeResponse { size_bytes }))
+}
+
+/// POST /api/v1/settings/vacuum — manually trigger a database VACUUM.
+pub async fn vacuum(State(state): State<AppState>) -> Result<StatusCode, (StatusCode, String)> {
+    info!("Manual VACUUM requested");
+
+    // Checkpoint WAL first.
+    if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&state.db)
+        .await
+    {
+        error!("WAL checkpoint failed: {e}");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("WAL checkpoint failed: {e}"),
+        ));
+    }
+
+    // Run VACUUM.
+    if let Err(e) = sqlx::query("VACUUM").execute(&state.db).await {
+        error!("VACUUM failed: {e}");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("VACUUM failed: {e}"),
+        ));
+    }
+
+    // Update last_vacuum_at.
+    let _ = sqlx::query(
+        r#"INSERT INTO settings (key, value) VALUES ('last_vacuum_at', datetime('now'))
+           ON CONFLICT(key) DO UPDATE SET value = datetime('now')"#,
+    )
+    .execute(&state.db)
+    .await;
+
+    info!("Manual VACUUM completed successfully");
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Helper to upsert a key-value pair into the settings table.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   Alert,
   AuthStatus,
   DashboardStats,
+  DbSizeData,
   Device,
   FirewallConfig,
   LoginResponse,
@@ -260,6 +261,20 @@ export function updateSettings(body: {
   webhook_url?: string;
   vyos_url?: string;
   vyos_api_key?: string;
+  scan_interval_seconds?: number;
+  scan_subnets?: string;
+  ping_sweep_enabled?: boolean;
+  retention_traffic_hours?: number;
+  retention_alerts_days?: number;
+  retention_agent_reports_days?: number;
 }): Promise<SettingsData> {
   return apiPatch<SettingsData>("/api/v1/settings", body);
+}
+
+export function fetchDbSize(): Promise<DbSizeData> {
+  return apiGet<DbSizeData>("/api/v1/settings/db-size");
+}
+
+export function triggerVacuum(): Promise<void> {
+  return apiPost<void>("/api/v1/settings/vacuum");
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -198,6 +198,18 @@ export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;
   vyos_api_key_set: boolean;
+  // Network Scanner
+  scan_interval_seconds: number | null;
+  scan_subnets: string | null;
+  ping_sweep_enabled: boolean | null;
+  // Data Retention
+  retention_traffic_hours: number | null;
+  retention_alerts_days: number | null;
+  retention_agent_reports_days: number | null;
+}
+
+export interface DbSizeData {
+  size_bytes: number;
 }
 
 // ─── Search ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add **Network Scanner** settings section: scan interval (seconds), subnets to scan (CIDR), and active ping sweep enable/disable toggle
- Add **Data Retention** settings section: current DB size display, configurable retention periods for traffic samples, alerts, and agent reports, and manual VACUUM button
- Extend `GET/PATCH /api/v1/settings` with new scanner and retention fields
- Add `GET /api/v1/settings/db-size` and `POST /api/v1/settings/vacuum` endpoints

Closes #60

## Changes

### Backend (`server/src/api/settings.rs`)
- Extended `SettingsResponse` and `UpdateSettingsRequest` with scanner fields (`scan_interval_seconds`, `scan_subnets`, `ping_sweep_enabled`) and retention fields (`retention_traffic_hours`, `retention_alerts_days`, `retention_agent_reports_days`)
- Settings fall back to config file defaults when no DB override exists
- New `db_size` endpoint returns current DB size via `PRAGMA page_count * page_size`
- New `vacuum` endpoint performs WAL checkpoint + VACUUM and updates `last_vacuum_at`

### Backend (`server/src/api/mod.rs`)
- Registered new routes: `GET /api/v1/settings/db-size` and `POST /api/v1/settings/vacuum`

### Frontend (`web/src/app/(app)/settings/page.tsx`)
- **Network Scanner card**: scan interval input (min 10s), subnets textarea (comma-separated CIDR), toggle switch for active ping sweep
- **Data Retention card**: DB size display, three configurable retention period inputs, VACUUM button with loading/success/error states
- All sections follow existing patterns: dirty state tracking, status messages with auto-dismiss, race condition guards via `settingsLoadTokenRef`

### Types & API client
- Extended `SettingsData` interface and `updateSettings` function signature
- Added `DbSizeData` type, `fetchDbSize()`, and `triggerVacuum()` functions

## Test plan
- [x] `cargo test` — 130 unit tests + 8 integration tests pass
- [x] `bun run tsc --noEmit` — no TypeScript errors
- [x] `bun run build` — Next.js static export succeeds
- [x] `cargo fmt` — formatting verified
- [ ] Manual: verify scanner settings save/load round-trip
- [ ] Manual: verify retention settings save/load round-trip
- [ ] Manual: verify VACUUM button works and DB size refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Network Scanner and Data Retention settings sections to the settings page, along with `db-size` and `vacuum` API endpoints. The frontend UI is well-structured, following existing patterns for dirty-state tracking, status messages, and race-condition guards.

- **Settings are persisted but not consumed at runtime**: The scanner and retention background tasks (`start_scanner_task`, `start_retention_task`) clone their config at startup and never re-read from the DB. Changes saved via the UI have no effect until server restart, which is not communicated to the user.
- **No server-side validation on scan interval**: The frontend enforces a minimum of 10 seconds, but the backend accepts any `u64` including 0. Direct API calls can persist invalid values.
- **`formatBytes` doesn't handle GB+**: A monitoring tool's database can easily exceed 1 GB, which would display as "1073.7 MB".

<h3>Confidence Score: 2/5</h3>

- Settings UI works correctly but saved values have no runtime effect — users will think they've changed scanner/retention behavior when they haven't.
- The core issue is that the new settings are a UI-only illusion: values are saved to the database but the background tasks that should use them (scanner interval, subnets, retention periods) clone their config at startup and never re-read. This creates a misleading user experience where changes appear to save successfully but have no effect. Additionally, there is no server-side validation on critical inputs like scan_interval_seconds.
- Pay close attention to `server/src/api/settings.rs` — the scanner and retention settings are persisted but never consumed by the running background tasks. The runtime behavior gap needs to be addressed before this feature is meaningful.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/settings.rs | New scanner/retention settings and db-size/vacuum endpoints. Settings are persisted to DB but never consumed by running background tasks — effectively no-op until server restart. No server-side validation on scan interval minimum. |
| server/src/api/mod.rs | Two new routes registered for db-size and vacuum endpoints. Clean and follows existing patterns. |
| web/src/app/(app)/settings/page.tsx | New Network Scanner and Data Retention UI cards with dirty state tracking and status messages. formatBytes utility doesn't handle GB+ sizes. Uses inline fetch instead of typed API client functions defined in api.ts. |
| web/src/lib/api.ts | Added updateSettings parameters, fetchDbSize, and triggerVacuum functions. Types and API calls are correct, though the settings page doesn't use these functions. |
| web/src/lib/types.ts | Extended SettingsData with new scanner/retention fields and added DbSizeData interface. Types correctly mirror the Rust API response shapes. |

</details>



<sub>Last reviewed commit: 7a4f32d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->