### PR TITLE
feat: first-run setup wizard (set admin password on fresh install)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod metrics;
 pub mod scanner;
 pub mod search;
 pub mod settings;
+pub mod setup;
 pub mod traffic;
 pub mod vyos;
 
@@ -65,7 +66,8 @@ pub fn router(state: AppState) -> Router {
         .route("/auth/login", post(auth::login))
         .route("/auth/logout", post(auth::logout))
         .route("/auth/status", get(auth::status))
-        .route("/auth/change-password", post(auth::change_password));
+        .route("/auth/change-password", post(auth::change_password))
+        .route("/setup", post(setup::setup));
 
     // Agent WebSocket + install script — authenticated via API key, not session cookie.
     let agent_ws = Router::new()

--- a/server/src/api/setup.rs
+++ b/server/src/api/setup.rs
@@ -1,0 +1,131 @@
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+use std::net::SocketAddr;
+use tracing::info;
+
+use super::AppState;
+
+/// Request body for initial setup.
+#[derive(Debug, Deserialize)]
+pub struct SetupRequest {
+    pub password: String,
+    pub vyos_url: Option<String>,
+    pub vyos_api_key: Option<String>,
+}
+
+/// POST /api/v1/setup — first-run setup: set admin password and optional VyOS config.
+///
+/// This endpoint only works once. If the admin password has already been set,
+/// it returns 409 Conflict.
+pub async fn setup(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Json(body): Json<SetupRequest>,
+) -> Result<Response, Response> {
+    // Check if setup has already been completed (password already exists).
+    let already_set: bool = sqlx::query("SELECT 1 FROM settings WHERE key = 'admin_password_hash'")
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to query settings: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })?
+        .is_some();
+
+    if already_set {
+        return Err((StatusCode::CONFLICT, "Setup already completed").into_response());
+    }
+
+    // Validate password.
+    if body.password.len() < 8 {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Password must be at least 8 characters",
+        )
+            .into_response());
+    }
+
+    // Hash and store the admin password.
+    let hash = bcrypt::hash(&body.password, bcrypt::DEFAULT_COST).map_err(|e| {
+        tracing::error!("Failed to hash password: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+    })?;
+
+    sqlx::query("INSERT INTO settings (key, value) VALUES ('admin_password_hash', ?)")
+        .bind(&hash)
+        .execute(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to store password: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })?;
+
+    // Store optional VyOS settings.
+    if let Some(ref url) = body.vyos_url {
+        if !url.is_empty() {
+            upsert_setting(&state, "vyos_url", url).await?;
+        }
+    }
+    if let Some(ref key) = body.vyos_api_key {
+        if !key.is_empty() {
+            upsert_setting(&state, "vyos_api_key", key).await?;
+        }
+    }
+
+    // Mark setup as complete.
+    upsert_setting(&state, "setup_complete", "true").await?;
+
+    info!(peer = %addr, "Initial setup completed — admin password set");
+
+    // Auto-login: create a session so the user doesn't have to log in immediately.
+    let token = uuid::Uuid::new_v4().to_string();
+    let expiry_secs = state.config.auth.session_expiry_seconds.max(1);
+    let expiry_modifier = format!("+{expiry_secs} seconds");
+
+    sqlx::query("INSERT INTO sessions (token, expires_at) VALUES (?, datetime('now', ?))")
+        .bind(&token)
+        .bind(&expiry_modifier)
+        .execute(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create session: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })?;
+
+    let cookie = format!(
+        "panoptikon_session={token}; HttpOnly; SameSite=Lax; Path=/; Max-Age={expiry_secs}"
+    );
+
+    let mut response = Json(serde_json::json!({
+        "message": "Setup complete"
+    }))
+    .into_response();
+    response.headers_mut().insert(
+        header::SET_COOKIE,
+        header::HeaderValue::from_str(&cookie).expect("cookie value is always valid ASCII"),
+    );
+
+    Ok(response)
+}
+
+/// Helper to upsert a setting.
+async fn upsert_setting(state: &AppState, key: &str, value: &str) -> Result<(), Response> {
+    sqlx::query(
+        "INSERT INTO settings (key, value) VALUES (?, ?) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to save setting '{key}': {e}");
+        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+    })?;
+    Ok(())
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -7,17 +7,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { fetchAuthStatus, login, setupPassword } from "@/lib/api";
+import { fetchAuthStatus, login } from "@/lib/api";
 
 export default function LoginPage() {
   const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [firstRun, setFirstRun] = useState<boolean | null>(null);
+  const [ready, setReady] = useState(false);
 
-  // Check if this is first-run (no password set yet)
+  // Check auth status — redirect to /setup if first-run, /dashboard if already logged in.
   useEffect(() => {
     fetchAuthStatus()
       .then((status) => {
@@ -25,22 +24,21 @@ export default function LoginPage() {
           window.location.href = "/dashboard";
           return;
         }
-        setFirstRun(status.needs_setup);
+        if (status.needs_setup) {
+          window.location.href = "/setup";
+          return;
+        }
+        setReady(true);
       })
       .catch(() => {
-        // API not reachable — assume login mode
-        setFirstRun(false);
+        // API not reachable — show login form anyway.
+        setReady(true);
       });
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-
-    if (firstRun && password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
 
     if (password.length < 1) {
       setError("Password is required");
@@ -49,19 +47,10 @@ export default function LoginPage() {
 
     setLoading(true);
     try {
-      if (firstRun) {
-        if (password.length < 8) {
-          setError("Password must be at least 8 characters");
-          setLoading(false);
-          return;
-        }
-        await setupPassword(password);
-      } else {
-        await login(password);
-      }
+      await login(password);
       window.location.href = "/dashboard";
     } catch {
-      setError(firstRun ? "Failed to set password" : "Invalid password");
+      setError("Invalid password");
     } finally {
       setLoading(false);
     }
@@ -77,16 +66,12 @@ export default function LoginPage() {
           </div>
           <h1 className="text-2xl font-bold text-white">Panoptikon</h1>
           <p className="text-sm text-slate-500">
-            {firstRun === null
-              ? " "
-              : firstRun
-                ? "Welcome! Set your admin password."
-                : "Sign in to your network dashboard"}
+            Sign in to your network dashboard
           </p>
         </CardHeader>
 
         <CardContent>
-          {firstRun === null ? (
+          {!ready ? (
             /* Loading state */
             <div className="space-y-4 pt-4">
               <Skeleton className="h-10 w-full" />
@@ -95,9 +80,7 @@ export default function LoginPage() {
           ) : (
             <form onSubmit={handleSubmit} className="space-y-4 pt-2">
               <div className="space-y-2">
-                <Label htmlFor="password">
-                  {firstRun ? "New Password" : "Password"}
-                </Label>
+                <Label htmlFor="password">Password</Label>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
                   <Input
@@ -125,24 +108,6 @@ export default function LoginPage() {
                 </div>
               </div>
 
-              {firstRun && (
-                <div className="space-y-2">
-                  <Label htmlFor="confirm">Confirm Password</Label>
-                  <div className="relative">
-                    <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-                    <Input
-                      id="confirm"
-                      type={showPassword ? "text" : "password"}
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      className="pl-9"
-                      placeholder="••••••••"
-                      required
-                    />
-                  </div>
-                </div>
-              )}
-
               {error && (
                 <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
                   {error}
@@ -150,13 +115,7 @@ export default function LoginPage() {
               )}
 
               <Button type="submit" className="w-full" disabled={loading}>
-                {loading
-                  ? firstRun
-                    ? "Setting up…"
-                    : "Signing in…"
-                  : firstRun
-                    ? "Set Password & Continue"
-                    : "Sign In"}
+                {loading ? "Signing in..." : "Sign In"}
               </Button>
             </form>
           )}

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Eye, EyeOff, Lock, Shield, Server } from "lucide-react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchAuthStatus, runSetup } from "@/lib/api";
+
+export default function SetupPage() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [vyosUrl, setVyosUrl] = useState("");
+  const [vyosApiKey, setVyosApiKey] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [checking, setChecking] = useState(true);
+
+  // If setup is already complete, redirect to login.
+  useEffect(() => {
+    fetchAuthStatus()
+      .then((status) => {
+        if (!status.needs_setup) {
+          window.location.href = status.authenticated ? "/dashboard" : "/login";
+          return;
+        }
+        setChecking(false);
+      })
+      .catch(() => {
+        // If API unreachable, show setup form anyway — it'll fail on submit.
+        setChecking(false);
+      });
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await runSetup({
+        password,
+        vyos_url: vyosUrl || undefined,
+        vyos_api_key: vyosApiKey || undefined,
+      });
+      window.location.href = "/dashboard";
+    } catch {
+      setError("Setup failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 p-4">
+      <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+        <CardHeader className="items-center pb-2">
+          <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
+            <Shield className="h-7 w-7 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-white">Welcome to Panoptikon</h1>
+          <p className="text-center text-sm text-slate-500">
+            Set up your admin password to get started.
+          </p>
+        </CardHeader>
+
+        <CardContent>
+          {checking ? (
+            <div className="space-y-4 pt-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+              {/* Password section */}
+              <div className="space-y-2">
+                <Label htmlFor="password">Admin Password</Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="pl-9 pr-9"
+                    placeholder="Min. 8 characters"
+                    autoFocus
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirm">Confirm Password</Label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                  <Input
+                    id="confirm"
+                    type={showPassword ? "text" : "password"}
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className="pl-9"
+                    placeholder="Repeat password"
+                    required
+                  />
+                </div>
+              </div>
+
+              <Separator className="my-4 bg-slate-800" />
+
+              {/* Optional VyOS section */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Server className="h-4 w-4 text-slate-400" />
+                  <span className="text-sm font-medium text-slate-300">
+                    VyOS Router
+                  </span>
+                  <span className="text-xs text-slate-600">(optional)</span>
+                </div>
+                <p className="text-xs text-slate-500">
+                  You can configure your VyOS router later in Settings.
+                </p>
+                <div className="space-y-2">
+                  <Label htmlFor="vyos-url">VyOS URL</Label>
+                  <Input
+                    id="vyos-url"
+                    type="url"
+                    value={vyosUrl}
+                    onChange={(e) => setVyosUrl(e.target.value)}
+                    placeholder="https://192.168.1.1"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="vyos-key">API Key</Label>
+                  <Input
+                    id="vyos-key"
+                    type="password"
+                    value={vyosApiKey}
+                    onChange={(e) => setVyosApiKey(e.target.value)}
+                    placeholder="VyOS HTTP API key"
+                  />
+                </div>
+              </div>
+
+              {error && (
+                <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
+                  {error}
+                </p>
+              )}
+
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? "Setting up..." : "Complete Setup"}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,7 +38,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     },
   });
   if (res.status === 401) {
-    if (typeof window !== "undefined" && !window.location.pathname.startsWith("/login")) {
+    if (typeof window !== "undefined"
+        && !window.location.pathname.startsWith("/login")
+        && !window.location.pathname.startsWith("/setup")) {
       window.location.href = "/login";
     }
     throw new Error("Unauthorized");
@@ -204,8 +206,12 @@ export function login(password: string): Promise<LoginResponse> {
   return apiPost<LoginResponse>("/api/v1/auth/login", { password });
 }
 
-export function setupPassword(password: string): Promise<LoginResponse> {
-  return apiPost<LoginResponse>("/api/v1/auth/login", { password });
+export function runSetup(body: {
+  password: string;
+  vyos_url?: string;
+  vyos_api_key?: string;
+}): Promise<LoginResponse> {
+  return apiPost<LoginResponse>("/api/v1/setup", body);
 }
 
 // ─── Router / VyOS ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a dedicated `/setup` wizard page for fresh installs — collects admin password (required) and optional VyOS router URL + API key
- `POST /api/v1/setup` endpoint that only works once (returns 409 Conflict on repeat calls), auto-logs the user in after setup
- Login endpoint now returns 428 Precondition Required when no password has been set, guiding users to `/setup` instead
- Login page and API client redirect to `/setup` when `needs_setup` is true
- Sets `setup_complete=true` in the settings table after initial setup

## Test plan
- [x] All 142 existing tests pass (130 unit + 12 integration)
- [x] 4 new integration tests for setup flow:
  - Setup creates password and auto-logs in
  - Short password rejected (422)
  - Setup only works once (409 on second call)
  - VyOS settings stored correctly
  - Login before setup returns 428
  - Auth status reflects setup completion
- [x] Frontend builds successfully with new `/setup` route
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` passes

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors first-run setup by introducing a dedicated `/setup` endpoint and page, separating initialization from the login flow.

**Key changes:**
- New `POST /api/v1/setup` endpoint validates password (≥8 chars), stores optional VyOS config, sets `setup_complete` flag, and auto-logs user in
- Login endpoint now returns 428 Precondition Required when no password exists, directing users to `/setup`
- Frontend routing ensures users land on `/setup` for first-run, `/login` after setup, and `/dashboard` when authenticated
- Comprehensive test coverage with 4 new integration tests validating setup flow, password requirements, single-use constraint, and VyOS config storage
- All 142 existing tests updated and passing

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence
- Clean architectural refactoring with comprehensive test coverage (146 total tests), proper separation of concerns, and no security issues identified
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/auth.rs | Removed first-run password setup logic from login endpoint, now returns 428 when no password exists and clears rate limit to avoid penalizing setup redirect |
| server/src/api/setup.rs | New dedicated setup endpoint that validates password, stores VyOS config, sets setup_complete flag, and auto-logs user in with session cookie |
| server/tests/integration.rs | Updated all tests to use new `/setup` endpoint instead of first-run login flow, added 4 new tests for setup validation, VyOS config storage, and precondition checks |
| web/src/app/setup/page.tsx | New dedicated setup page with password confirmation, optional VyOS config fields, and redirect logic when setup is already complete |

</details>



<sub>Last reviewed commit: 7f52f5f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->