### PR TITLE
feat: VyOS write operations — interface enable/disable + DHCP static mappings

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -126,6 +126,23 @@ pub fn router(state: AppState) -> Router {
         .route("/vyos/routes", get(vyos::routes))
         .route("/vyos/dhcp-leases", get(vyos::dhcp_leases))
         .route("/vyos/firewall", get(vyos::firewall))
+        // VyOS write operations
+        .route(
+            "/vyos/interfaces/:name/toggle",
+            post(vyos::interface_toggle),
+        )
+        .route(
+            "/vyos/dhcp/static-mappings",
+            get(vyos::dhcp_static_mappings),
+        )
+        .route(
+            "/vyos/dhcp/static-mappings",
+            post(vyos::create_dhcp_static_mapping),
+        )
+        .route(
+            "/vyos/dhcp/static-mappings/:network/:subnet/:name",
+            delete(vyos::delete_dhcp_static_mapping),
+        )
         // Topology positions
         .route("/topology/positions", get(topology::get_positions))
         .route("/topology/positions", put(topology::save_positions))

--- a/server/src/vyos/client.rs
+++ b/server/src/vyos/client.rs
@@ -60,6 +60,30 @@ impl VyosClient {
         self.post_form("/show", &data).await
     }
 
+    /// POST /configure — set a configuration path.
+    ///
+    /// Example: `configure_set(&["interfaces", "ethernet", "eth0", "disable"])`
+    /// sets the `disable` flag on `eth0`.
+    pub async fn configure_set(&self, path: &[&str]) -> Result<Value> {
+        let data = serde_json::json!({
+            "op": "set",
+            "path": path,
+        });
+        self.post_form("/configure", &data).await
+    }
+
+    /// POST /configure — delete a configuration path.
+    ///
+    /// Example: `configure_delete(&["interfaces", "ethernet", "eth0", "disable"])`
+    /// removes the `disable` flag from `eth0`.
+    pub async fn configure_delete(&self, path: &[&str]) -> Result<Value> {
+        let data = serde_json::json!({
+            "op": "delete",
+            "path": path,
+        });
+        self.post_form("/configure", &data).await
+    }
+
     /// Run an nmap scan against a target IP via VyOS.
     ///
     /// Uses the VyOS `/show` endpoint with `path: ["nmap", "-sV", "<ip>"]`.

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,6 +13,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@xyflow/react": "^12.10.1",
@@ -228,6 +229,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
+
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
     "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
@@ -243,6 +246,8 @@
     "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
 
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@xyflow/react": "^12.10.1",

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   DashboardStats,
   DbSizeData,
   Device,
+  DhcpStaticMapping,
   FirewallConfig,
   LoginResponse,
   NetflowStatus,
@@ -25,6 +26,7 @@ import type {
   VyosDhcpLease,
   VyosInterface,
   VyosRoute,
+  VyosWriteResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -250,6 +252,39 @@ export function fetchRouterFirewall(): Promise<FirewallConfig> {
 
 export function runSpeedTest(): Promise<SpeedTestResult> {
   return apiPost<SpeedTestResult>("/api/v1/router/speedtest");
+}
+
+export function toggleInterface(
+  name: string,
+  disable: boolean
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(`/api/v1/vyos/interfaces/${name}/toggle`, {
+    disable,
+  });
+}
+
+export function fetchDhcpStaticMappings(): Promise<DhcpStaticMapping[]> {
+  return apiGet<DhcpStaticMapping[]>("/api/v1/vyos/dhcp/static-mappings");
+}
+
+export function createDhcpStaticMapping(body: {
+  network: string;
+  subnet: string;
+  name: string;
+  mac: string;
+  ip: string;
+}): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>("/api/v1/vyos/dhcp/static-mappings", body);
+}
+
+export function deleteDhcpStaticMapping(
+  network: string,
+  subnet: string,
+  name: string
+): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/dhcp/static-mappings/${encodeURIComponent(network)}/${encodeURIComponent(subnet)}/${encodeURIComponent(name)}`
+  ) as unknown as Promise<VyosWriteResponse>;
 }
 
 // ─── NetFlow ────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -172,6 +172,21 @@ export interface VyosDhcpLease {
   pool: string | null;
 }
 
+// ─── DHCP Static Mappings ──────────────────────────────
+
+export interface DhcpStaticMapping {
+  network: string;
+  subnet: string;
+  name: string;
+  mac: string;
+  ip: string;
+}
+
+export interface VyosWriteResponse {
+  success: boolean;
+  message: string;
+}
+
 // ─── Firewall ───────────────────────────────────────────
 
 export interface FirewallRule {


### PR DESCRIPTION
## Summary
- Add interface enable/disable toggle switch on Router > Interfaces tab with confirmation dialog and config diff preview
- Add DHCP static mapping management (create/delete) on Router > DHCP tab with form dialog and validation
- All write operations use VyOS configure API (`set`/`delete` endpoints) with safety confirmations

## Changes

### Backend (Rust/Axum)
- **VyOS Client**: Added `configure_set()` and `configure_delete()` methods for VyOS HTTP API `/configure` endpoint
- **New API endpoints**:
  - `POST /api/v1/vyos/interfaces/:name/toggle` — enable/disable an interface
  - `GET /api/v1/vyos/dhcp/static-mappings` — list DHCP static mappings from config
  - `POST /api/v1/vyos/dhcp/static-mappings` — create a static mapping
  - `DELETE /api/v1/vyos/dhcp/static-mappings/:network/:subnet/:name` — delete a static mapping
- Input validation: MAC format, IP format, mapping name characters
- Interface type detection (ethernet, bonding, bridge, wireguard, loopback, etc.)
- Comprehensive unit tests for all new pure functions

### Frontend (Next.js/React)
- **Interfaces tab**: Added "Enabled" column with toggle switch per interface (except loopback)
- **DHCP tab**: Added "DHCP Configuration" card with static mappings table and "Add Static Mapping" button
- **Safety**: AlertDialog confirmation with VyOS config diff preview before every write operation
- **Feedback**: Sonner toast notifications for success/error on all operations
- **New components**: shadcn Switch component, Dialog for add form

## Safety requirements (per issue)
- [x] All write operations require confirmation dialog (shadcn AlertDialog)
- [x] Show diff preview: what will change in VyOS config
- [x] Error handling: VyOS API errors shown as toast with details
- [x] No bulk operations — one change at a time

## Test plan
- [x] All 141 unit tests pass + 12 integration tests
- [x] TypeScript compiles with no errors
- [ ] Manual test: toggle an interface on/off and verify VyOS config changes
- [ ] Manual test: create and delete a DHCP static mapping
- [ ] Verify confirmation dialog appears before every write operation
- [ ] Verify error toasts display when VyOS API returns errors

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added VyOS write operations for interface enable/disable toggling and DHCP static mapping management (create/delete). All operations include confirmation dialogs with config diff previews and comprehensive error handling.

**Key changes:**
- Backend: New VyOS client methods `configure_set()` and `configure_delete()` with 4 new API endpoints
- Frontend: Interface toggle switches and DHCP static mappings table with add/delete functionality
- Safety: AlertDialog confirmations before all write operations, toast notifications for feedback
- Validation: MAC address format, IP address format, mapping name character restrictions
- Error handling: Rollback logic for failed DHCP mapping creation
- Testing: 141 unit tests pass including tests for interface type detection and MAC validation

**Issues found:**
- Config diff preview in interface toggle dialog hardcodes "ethernet" instead of dynamically determining the actual interface type (bonding, bridge, wireguard, etc.)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one bug fix needed for interface toggle config preview
- Backend implementation is solid with proper validation, error handling, and rollback logic. Comprehensive unit tests cover edge cases. However, the frontend config diff preview contains a bug where it hardcodes "ethernet" instead of showing the correct interface type, which could confuse users when toggling non-ethernet interfaces.
- Review `web/src/app/(app)/router/page.tsx:1032-1035` - the config preview shows incorrect interface type

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/vyos/client.rs | Added `configure_set()` and `configure_delete()` methods for VyOS HTTP API `/configure` endpoint |
| server/src/api/vyos.rs | Implemented interface toggle and DHCP static mapping endpoints with validation, error handling, and rollback. Contains comprehensive unit tests. |
| web/src/app/(app)/router/page.tsx | Added interface toggle switches with confirmation dialogs and DHCP static mappings management UI. Config diff preview hardcodes "ethernet" interface type which doesn't match all interface types. |

</details>



<sub>Last reviewed commit: 434cf8e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->