### PR TITLE
feat: firewall address-groups, network-groups, and port-groups CRUD

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -164,6 +164,56 @@ pub fn router(state: AppState) -> Router {
             "/vyos/firewall/:chain/rules/:number/enabled",
             patch(vyos::toggle_firewall_rule),
         )
+        // Firewall groups
+        .route("/vyos/firewall/groups", get(vyos::firewall_groups))
+        .route(
+            "/vyos/firewall/groups/address-group",
+            post(vyos::create_address_group),
+        )
+        .route(
+            "/vyos/firewall/groups/address-group/:name",
+            delete(vyos::delete_address_group),
+        )
+        .route(
+            "/vyos/firewall/groups/address-group/:name/members",
+            post(vyos::add_address_group_member),
+        )
+        .route(
+            "/vyos/firewall/groups/address-group/:name/members/:value",
+            delete(vyos::remove_address_group_member),
+        )
+        .route(
+            "/vyos/firewall/groups/network-group",
+            post(vyos::create_network_group),
+        )
+        .route(
+            "/vyos/firewall/groups/network-group/:name",
+            delete(vyos::delete_network_group),
+        )
+        .route(
+            "/vyos/firewall/groups/network-group/:name/members",
+            post(vyos::add_network_group_member),
+        )
+        .route(
+            "/vyos/firewall/groups/network-group/:name/members/:value",
+            delete(vyos::remove_network_group_member),
+        )
+        .route(
+            "/vyos/firewall/groups/port-group",
+            post(vyos::create_port_group),
+        )
+        .route(
+            "/vyos/firewall/groups/port-group/:name",
+            delete(vyos::delete_port_group),
+        )
+        .route(
+            "/vyos/firewall/groups/port-group/:name/members",
+            post(vyos::add_port_group_member),
+        )
+        .route(
+            "/vyos/firewall/groups/port-group/:name/members/:value",
+            delete(vyos::remove_port_group_member),
+        )
         // Topology positions
         .route("/topology/positions", get(topology::get_positions))
         .route("/topology/positions", put(topology::save_positions))

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   DhcpStaticMapping,
   FirewallConfig,
   FirewallRuleRequest,
+  FirewallGroups,
   LoginResponse,
   NetflowStatus,
   RouterStatus,
@@ -277,6 +278,111 @@ export function fetchRouterFirewall(): Promise<FirewallConfig> {
 
 export function runSpeedTest(): Promise<SpeedTestResult> {
   return apiPost<SpeedTestResult>("/api/v1/router/speedtest");
+}
+
+// ─── Firewall Groups ─────────────────────────────────────
+
+export function fetchFirewallGroups(): Promise<FirewallGroups> {
+  return apiGet<FirewallGroups>("/api/v1/vyos/firewall/groups");
+}
+
+export function createAddressGroup(body: {
+  name: string;
+  description?: string;
+  addresses?: string[];
+}): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>("/api/v1/vyos/firewall/groups/address-group", body);
+}
+
+export function deleteAddressGroup(name: string): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/address-group/${encodeURIComponent(name)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function addAddressGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(
+    `/api/v1/vyos/firewall/groups/address-group/${encodeURIComponent(name)}/members`,
+    { value }
+  );
+}
+
+export function removeAddressGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/address-group/${encodeURIComponent(name)}/members/${encodeURIComponent(value)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function createNetworkGroup(body: {
+  name: string;
+  description?: string;
+  networks?: string[];
+}): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>("/api/v1/vyos/firewall/groups/network-group", body);
+}
+
+export function deleteNetworkGroup(name: string): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/network-group/${encodeURIComponent(name)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function addNetworkGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(
+    `/api/v1/vyos/firewall/groups/network-group/${encodeURIComponent(name)}/members`,
+    { value }
+  );
+}
+
+export function removeNetworkGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/network-group/${encodeURIComponent(name)}/members/${encodeURIComponent(value)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function createPortGroup(body: {
+  name: string;
+  description?: string;
+  ports?: string[];
+}): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>("/api/v1/vyos/firewall/groups/port-group", body);
+}
+
+export function deletePortGroup(name: string): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/port-group/${encodeURIComponent(name)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function addPortGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(
+    `/api/v1/vyos/firewall/groups/port-group/${encodeURIComponent(name)}/members`,
+    { value }
+  );
+}
+
+export function removePortGroupMember(
+  name: string,
+  value: string
+): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/firewall/groups/port-group/${encodeURIComponent(name)}/members/${encodeURIComponent(value)}`
+  ) as unknown as Promise<VyosWriteResponse>;
 }
 
 export function toggleInterface(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -237,6 +237,30 @@ export interface FirewallConfig {
   chains: FirewallChain[];
 }
 
+export interface FirewallAddressGroup {
+  name: string;
+  description: string | null;
+  members: string[];
+}
+
+export interface FirewallNetworkGroup {
+  name: string;
+  description: string | null;
+  members: string[];
+}
+
+export interface FirewallPortGroup {
+  name: string;
+  description: string | null;
+  members: string[];
+}
+
+export interface FirewallGroups {
+  address_groups: FirewallAddressGroup[];
+  network_groups: FirewallNetworkGroup[];
+  port_groups: FirewallPortGroup[];
+}
+
 export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;


### PR DESCRIPTION
## Summary

Closes #78

- **Backend**: Full CRUD API for VyOS firewall groups (address-group, network-group, port-group) with parsing, validation, and 14 new endpoints
- **Frontend**: FirewallGroupsPanel on the Firewall tab with create/delete groups, add/remove members, config-change previews, and inline badge management
- **Tests**: Unit tests for group parsing (full, empty, numeric port) and validation helpers (group names, CIDRs, port ranges)

## Details

### API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/vyos/firewall/groups` | List all firewall groups |
| POST | `/vyos/firewall/groups/address-group` | Create address group |
| DELETE | `/vyos/firewall/groups/address-group/:name` | Delete address group |
| POST | `/vyos/firewall/groups/address-group/:name/members` | Add IP to group |
| DELETE | `/vyos/firewall/groups/address-group/:name/members/:value` | Remove IP from group |
| POST | `/vyos/firewall/groups/network-group` | Create network group |
| DELETE | `/vyos/firewall/groups/network-group/:name` | Delete network group |
| POST | `/vyos/firewall/groups/network-group/:name/members` | Add CIDR to group |
| DELETE | `/vyos/firewall/groups/network-group/:name/members/:value` | Remove CIDR from group |
| POST | `/vyos/firewall/groups/port-group` | Create port group |
| DELETE | `/vyos/firewall/groups/port-group/:name` | Delete port group |
| POST | `/vyos/firewall/groups/port-group/:name/members` | Add port to group |
| DELETE | `/vyos/firewall/groups/port-group/:name/members/:value` | Remove port from group |

### UI
Groups are shown below the existing firewall rules on the Firewall tab, organized into three sections (Address Groups, Network Groups, Port Groups). Each section has:
- "New Group" button → create dialog with name, description, initial members, and VyOS config preview
- Group cards showing members as removable badges
- Add member and delete group actions per card
- Confirmation dialogs with VyOS config-change preview for destructive actions

## Test plan
- [x] `cargo test` — 150 unit + 12 integration tests pass
- [x] `next build` — frontend compiles with no errors
- [x] `tsc --noEmit` — TypeScript type-check passes
- [ ] Manual: navigate to Router → Firewall tab, verify groups section renders
- [ ] Manual: create/delete address, network, and port groups against a VyOS router

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements comprehensive firewall groups management for VyOS routers with address-groups, network-groups, and port-groups. Backend adds robust parsing, validation (IPv4, CIDR, port/port-range), and 14 RESTful API endpoints. Frontend introduces `FirewallGroupsPanel` with full CRUD UI, real-time VyOS config previews, and inline badge-based member management.

**Key Changes:**
- Backend validates group names (alphanumeric + hyphens/underscores), IP addresses (IPv4 only), CIDR notation (with /0-32 prefix), and port entries (single ports or ranges)
- API properly handles URL-encoded parameters (group names, IPs, CIDRs with `/` character)
- Unit tests cover parsing edge cases: numeric port values, single vs array members, empty groups, invalid input rejection
- Frontend splits comma/space-separated values for batch member creation
- Config change previews show VyOS commands before execution for transparency

**Notes:**
- IPv6 addresses are not supported (validation only accepts IPv4)
- Port 0 is correctly rejected by validation
- All delete operations show confirmation dialogs with config preview

<h3>Confidence Score: 4/5</h3>

- Safe to merge after reviewing the config preview logic — the implementation is solid with comprehensive validation and testing
- The implementation is well-structured with proper input validation (group names, IPs, CIDRs, port ranges), comprehensive error handling, and unit tests covering edge cases. Backend uses strong typing and validation. Frontend properly encodes URLs. One potential issue identified with config preview formatting that should be verified through manual testing.
- Pay close attention to `web/src/app/(app)/router/page.tsx` line 2379 — verify the config preview formatting with multiple addresses works as expected

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Added 14 new firewall groups API routes (GET, POST, DELETE) for address, network, and port groups with proper REST structure |
| server/src/api/vyos.rs | Added comprehensive firewall groups implementation with parsing, validation (IP/CIDR/port), 14 endpoints, and thorough unit tests (covers edge cases like numeric ports, empty groups, invalid ranges) |
| web/src/lib/types.ts | Added TypeScript types for firewall groups (address, network, port) matching backend Rust structs |
| web/src/lib/api.ts | Added 13 API client functions for firewall groups with proper URL encoding (encodeURIComponent) for group names and member values |
| web/src/app/(app)/router/page.tsx | Added FirewallGroupsPanel with create/delete/add/remove UI, config previews, and inline badge management — one potential issue with config preview formatting for multiple members |

</details>



<sub>Last reviewed commit: 4b7cd43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->