### PR TITLE
feat: VyOS config backup, download, and rollback

### DIFF
--- a/server/src/api/config_backups.rs
+++ b/server/src/api/config_backups.rs
@@ -1,0 +1,287 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use super::AppState;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ConfigBackup {
+    pub id: i64,
+    pub created_at: String,
+    pub label: Option<String>,
+    pub config_text: String,
+    pub size_bytes: i64,
+    pub created_by: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigBackupSummary {
+    pub id: i64,
+    pub created_at: String,
+    pub label: Option<String>,
+    pub size_bytes: i64,
+    pub created_by: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigBackupListResponse {
+    pub items: Vec<ConfigBackupSummary>,
+    pub total: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateBackupRequest {
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ShowConfigResponse {
+    pub config_text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigDiffResponse {
+    pub current: String,
+    pub backup: String,
+    pub backup_label: Option<String>,
+    pub backup_created_at: String,
+}
+
+// ── sqlx row types ───────────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct BackupSummaryRow {
+    id: i64,
+    created_at: String,
+    label: Option<String>,
+    size_bytes: i64,
+    created_by: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct BackupRow {
+    id: i64,
+    created_at: String,
+    label: Option<String>,
+    config_text: String,
+    size_bytes: i64,
+    created_by: String,
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// GET /api/v1/config-backups — list backup snapshots (without config text).
+pub async fn list(
+    State(state): State<AppState>,
+    Query(params): Query<ListQuery>,
+) -> Result<Json<ConfigBackupListResponse>, StatusCode> {
+    let page = params.page.unwrap_or(1).max(1);
+    let per_page = params.per_page.unwrap_or(25).clamp(1, 100);
+    let offset = (page - 1) * per_page;
+
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vyos_config_backups")
+        .fetch_one(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("config_backups count failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let rows = sqlx::query_as::<_, BackupSummaryRow>(
+        "SELECT id, created_at, label, size_bytes, created_by \
+         FROM vyos_config_backups ORDER BY id DESC LIMIT ? OFFSET ?",
+    )
+    .bind(per_page)
+    .bind(offset)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("config_backups list failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let items = rows
+        .into_iter()
+        .map(|r| ConfigBackupSummary {
+            id: r.id,
+            created_at: r.created_at,
+            label: r.label,
+            size_bytes: r.size_bytes,
+            created_by: r.created_by,
+        })
+        .collect();
+
+    Ok(Json(ConfigBackupListResponse { items, total }))
+}
+
+/// GET /api/v1/config-backups/:id — get a single backup (with config text).
+pub async fn get_one(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<ConfigBackup>, StatusCode> {
+    let row = sqlx::query_as::<_, BackupRow>(
+        "SELECT id, created_at, label, config_text, size_bytes, created_by \
+         FROM vyos_config_backups WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("config_backups get_one failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?
+    .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(ConfigBackup {
+        id: row.id,
+        created_at: row.created_at,
+        label: row.label,
+        config_text: row.config_text,
+        size_bytes: row.size_bytes,
+        created_by: row.created_by,
+    }))
+}
+
+/// POST /api/v1/config-backups — snapshot the current running config into DB.
+pub async fn create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateBackupRequest>,
+) -> Result<(StatusCode, Json<ConfigBackup>), StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let config_text = fetch_running_config(&client).await.map_err(|e| {
+        tracing::error!("Failed to fetch running config for backup: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let size_bytes = config_text.len() as i64;
+
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO vyos_config_backups (label, config_text, size_bytes, created_by) \
+         VALUES (?, ?, ?, 'user') RETURNING id",
+    )
+    .bind(&body.label)
+    .bind(&config_text)
+    .bind(size_bytes)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("config_backups insert failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let row = sqlx::query_as::<_, BackupRow>(
+        "SELECT id, created_at, label, config_text, size_bytes, created_by \
+         FROM vyos_config_backups WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("config_backups fetch after insert failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ConfigBackup {
+            id: row.id,
+            created_at: row.created_at,
+            label: row.label,
+            config_text: row.config_text,
+            size_bytes: row.size_bytes,
+            created_by: row.created_by,
+        }),
+    ))
+}
+
+/// DELETE /api/v1/config-backups/:id — remove a backup snapshot.
+pub async fn delete(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, StatusCode> {
+    let result = sqlx::query("DELETE FROM vyos_config_backups WHERE id = ?")
+        .bind(id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("config_backups delete failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if result.rows_affected() == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /api/v1/config-backups/current — fetch current running config from VyOS.
+pub async fn show_current(
+    State(state): State<AppState>,
+) -> Result<Json<ShowConfigResponse>, StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let config_text = fetch_running_config(&client).await.map_err(|e| {
+        tracing::error!("Failed to fetch running config: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(Json(ShowConfigResponse { config_text }))
+}
+
+/// GET /api/v1/config-backups/:id/diff — diff backup against current running config.
+pub async fn diff(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<Json<ConfigDiffResponse>, StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    // Fetch the backup from DB
+    let row = sqlx::query_as::<_, BackupRow>(
+        "SELECT id, created_at, label, config_text, size_bytes, created_by \
+         FROM vyos_config_backups WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("config_backups diff query failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?
+    .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Fetch current running config
+    let current = fetch_running_config(&client).await.map_err(|e| {
+        tracing::error!("Failed to fetch running config for diff: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(Json(ConfigDiffResponse {
+        current,
+        backup: row.config_text,
+        backup_label: row.label,
+        backup_created_at: row.created_at,
+    }))
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Fetch the full running configuration text from VyOS via `show configuration`.
+async fn fetch_running_config(
+    client: &crate::vyos::client::VyosClient,
+) -> Result<String, anyhow::Error> {
+    let value = client.show(&["configuration"]).await?;
+    Ok(value.as_str().unwrap_or("").to_string())
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -16,6 +16,7 @@ pub mod agents;
 pub mod alerts;
 pub mod audit;
 pub mod auth;
+pub mod config_backups;
 pub mod dashboard;
 pub mod devices;
 pub mod error;
@@ -231,6 +232,13 @@ pub fn router(state: AppState) -> Router {
         .route("/router/speedtest", post(vyos::speedtest))
         // Traffic
         .route("/traffic/history", get(traffic::history))
+        // Config backups
+        .route("/config-backups", get(config_backups::list))
+        .route("/config-backups", post(config_backups::create))
+        .route("/config-backups/current", get(config_backups::show_current))
+        .route("/config-backups/:id", get(config_backups::get_one))
+        .route("/config-backups/:id", delete(config_backups::delete))
+        .route("/config-backups/:id/diff", get(config_backups::diff))
         // Audit log
         .route("/audit-log", get(audit::list))
         .route("/audit-log/actions", get(audit::actions))

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -3670,7 +3670,7 @@ async fn get_vyos_client_from_db(
 }
 
 /// Get VyOS client or return 503 SERVICE_UNAVAILABLE if not configured.
-async fn get_vyos_client_or_503(
+pub(crate) async fn get_vyos_client_or_503(
     state: &AppState,
 ) -> Result<crate::vyos::client::VyosClient, StatusCode> {
     get_vyos_client_from_db(&state.db, &state.config)

--- a/server/src/db/migrations/011_config_backups.sql
+++ b/server/src/db/migrations/011_config_backups.sql
@@ -1,0 +1,9 @@
+-- Config backups: store VyOS running config snapshots for backup & rollback.
+CREATE TABLE IF NOT EXISTS vyos_config_backups (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    label       TEXT,
+    config_text TEXT NOT NULL,
+    size_bytes  INTEGER NOT NULL DEFAULT 0,
+    created_by  TEXT NOT NULL DEFAULT 'user'
+);

--- a/web/src/app/(app)/settings/config-backup/page.tsx
+++ b/web/src/app/(app)/settings/config-backup/page.tsx
@@ -1,0 +1,539 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ArrowLeft,
+  Download,
+  Save,
+  Trash2,
+  RotateCcw,
+  Loader2,
+  HardDrive,
+  AlertCircle,
+  CheckCircle,
+  X,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PageTransition } from "@/components/PageTransition";
+import {
+  fetchConfigBackups,
+  fetchConfigBackup,
+  createConfigBackup,
+  deleteConfigBackup,
+  fetchCurrentConfig,
+  fetchConfigDiff,
+} from "@/lib/api";
+import type { ConfigBackupSummary, ConfigDiffResponse } from "@/lib/types";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso + "Z");
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Trigger a browser download of a text string as a file. */
+function downloadTextFile(text: string, filename: string) {
+  const blob = new Blob([text], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export default function ConfigBackupPage() {
+  const [items, setItems] = useState<ConfigBackupSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  // Save snapshot
+  const [snapshotLabel, setSnapshotLabel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  // Download running config
+  const [downloading, setDownloading] = useState(false);
+
+  // Delete confirmation
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // Diff/Restore dialog
+  const [diffData, setDiffData] = useState<ConfigDiffResponse | null>(null);
+  const [diffLoading, setDiffLoading] = useState<number | null>(null);
+
+  const loadBackups = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchConfigBackups(1, 100);
+      setItems(data.items);
+      setTotal(data.total);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadBackups();
+  }, [loadBackups]);
+
+  async function handleDownloadCurrent() {
+    setDownloading(true);
+    try {
+      const data = await fetchCurrentConfig();
+      const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+      downloadTextFile(data.config_text, `vyos-config-${ts}.conf`);
+    } catch {
+      // ignore
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  async function handleSaveSnapshot() {
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      await createConfigBackup(snapshotLabel || undefined);
+      setSnapshotLabel("");
+      setSaveMsg({ type: "success", text: "Snapshot saved." });
+      setTimeout(() => setSaveMsg(null), 3000);
+      loadBackups();
+    } catch (err) {
+      setSaveMsg({
+        type: "error",
+        text: err instanceof Error ? err.message : "Failed to save snapshot.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDownloadBackup(id: number) {
+    try {
+      const backup = await fetchConfigBackup(id);
+      const ts = backup.created_at.replace(/[: ]/g, "-");
+      const label = backup.label ? `-${backup.label.replace(/\s+/g, "_")}` : "";
+      downloadTextFile(backup.config_text, `vyos-backup-${ts}${label}.conf`);
+    } catch {
+      // ignore
+    }
+  }
+
+  async function handleDelete(id: number) {
+    setDeleting(true);
+    try {
+      await deleteConfigBackup(id);
+      setDeleteId(null);
+      loadBackups();
+    } catch {
+      // ignore
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function handleShowDiff(id: number) {
+    setDiffLoading(id);
+    try {
+      const data = await fetchConfigDiff(id);
+      setDiffData(data);
+    } catch {
+      // ignore
+    } finally {
+      setDiffLoading(null);
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-3xl space-y-6 py-8">
+        {/* Header with back link */}
+        <div className="flex items-center gap-3">
+          <a
+            href="/settings"
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </a>
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Config Backup</h1>
+            <p className="text-sm text-slate-500">
+              Download, snapshot, and compare VyOS router configurations.
+            </p>
+          </div>
+        </div>
+
+        {/* Actions card: Download + Save */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/10">
+                <HardDrive className="h-4 w-4 text-emerald-400" />
+              </div>
+              <div>
+                <CardTitle className="text-base text-white">
+                  Manual Backup
+                </CardTitle>
+                <CardDescription className="text-xs text-slate-500">
+                  Download the running config or save a snapshot to the database.
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Download current config */}
+            <Button
+              variant="outline"
+              className="w-full border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white"
+              disabled={downloading}
+              onClick={handleDownloadCurrent}
+            >
+              {downloading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
+              Download Running Config
+            </Button>
+
+            {/* Save snapshot */}
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <Label htmlFor="snapshot-label" className="sr-only">
+                  Snapshot label
+                </Label>
+                <Input
+                  id="snapshot-label"
+                  placeholder="Optional label (e.g. Before firewall change)"
+                  value={snapshotLabel}
+                  onChange={(e) => setSnapshotLabel(e.target.value)}
+                  className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+                />
+              </div>
+              <Button
+                className="bg-emerald-600 text-white hover:bg-emerald-500"
+                disabled={saving}
+                onClick={handleSaveSnapshot}
+              >
+                {saving ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="mr-2 h-4 w-4" />
+                )}
+                Save Snapshot
+              </Button>
+            </div>
+
+            {saveMsg && (
+              <div
+                className={`flex items-center gap-2 rounded-md border px-3 py-2 ${
+                  saveMsg.type === "success"
+                    ? "border-emerald-500/30 bg-emerald-500/10"
+                    : "border-rose-500/30 bg-rose-500/10"
+                }`}
+              >
+                {saveMsg.type === "success" ? (
+                  <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+                ) : (
+                  <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+                )}
+                <p
+                  className={`text-xs ${
+                    saveMsg.type === "success"
+                      ? "text-emerald-400"
+                      : "text-rose-400"
+                  }`}
+                >
+                  {saveMsg.text}
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Backup history table */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <CardTitle className="text-base text-white">
+              Backup History
+              {total > 0 && (
+                <span className="ml-2 text-sm font-normal text-slate-500">
+                  ({total} snapshot{total !== 1 ? "s" : ""})
+                </span>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-slate-500" />
+              </div>
+            ) : items.length === 0 ? (
+              <p className="py-6 text-center text-sm text-slate-500">
+                No backups yet. Save a snapshot above to get started.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-800 text-left text-xs text-slate-500">
+                      <th className="pb-2 pr-3 font-medium">#</th>
+                      <th className="pb-2 pr-3 font-medium">Timestamp</th>
+                      <th className="pb-2 pr-3 font-medium">Label</th>
+                      <th className="pb-2 pr-3 font-medium">Size</th>
+                      <th className="pb-2 text-right font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-800/50">
+                    {items.map((b) => (
+                      <tr key={b.id} className="group">
+                        <td className="py-2.5 pr-3 text-slate-500">{b.id}</td>
+                        <td className="py-2.5 pr-3 text-slate-300">
+                          {formatDate(b.created_at)}
+                        </td>
+                        <td className="py-2.5 pr-3 text-slate-400">
+                          {b.label || (
+                            <span className="text-slate-600">—</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-3 text-slate-500">
+                          {formatBytes(b.size_bytes)}
+                        </td>
+                        <td className="py-2.5 text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            <button
+                              className="rounded px-2 py-1 text-xs text-blue-400 transition-colors hover:bg-blue-500/10"
+                              onClick={() => handleDownloadBackup(b.id)}
+                              title="Download"
+                            >
+                              <Download className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              className="rounded px-2 py-1 text-xs text-amber-400 transition-colors hover:bg-amber-500/10"
+                              onClick={() => handleShowDiff(b.id)}
+                              disabled={diffLoading === b.id}
+                              title="Compare with current"
+                            >
+                              {diffLoading === b.id ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <RotateCcw className="h-3.5 w-3.5" />
+                              )}
+                            </button>
+                            {deleteId === b.id ? (
+                              <span className="flex items-center gap-1">
+                                <button
+                                  className="rounded bg-rose-600 px-2 py-1 text-xs text-white hover:bg-rose-500"
+                                  onClick={() => handleDelete(b.id)}
+                                  disabled={deleting}
+                                >
+                                  {deleting ? "…" : "Confirm"}
+                                </button>
+                                <button
+                                  className="rounded px-2 py-1 text-xs text-slate-400 hover:text-white"
+                                  onClick={() => setDeleteId(null)}
+                                >
+                                  <X className="h-3.5 w-3.5" />
+                                </button>
+                              </span>
+                            ) : (
+                              <button
+                                className="rounded px-2 py-1 text-xs text-rose-400 transition-colors hover:bg-rose-500/10"
+                                onClick={() => setDeleteId(b.id)}
+                                title="Delete"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Diff overlay */}
+        {diffData && (
+          <DiffDialog
+            data={diffData}
+            onClose={() => setDiffData(null)}
+          />
+        )}
+      </div>
+    </PageTransition>
+  );
+}
+
+// ── Diff dialog component ────────────────────────────────────────────────────
+
+function DiffDialog({
+  data,
+  onClose,
+}: {
+  data: ConfigDiffResponse;
+  onClose: () => void;
+}) {
+  const backupLines = data.backup.split("\n");
+  const currentLines = data.current.split("\n");
+
+  // Build simple line-by-line diff
+  const maxLen = Math.max(backupLines.length, currentLines.length);
+  const diffLines: { type: "same" | "added" | "removed" | "changed"; line: string; num: number }[] = [];
+
+  // Use a simple set-based approach: lines in backup but not current = removed,
+  // lines in current but not backup = added, rest are the same.
+  // For a more useful display, do a sequential comparison.
+  const backupSet = new Set(backupLines);
+  const currentSet = new Set(currentLines);
+
+  // Lines removed (in backup but not in current)
+  const removed = backupLines.filter((l) => !currentSet.has(l));
+  // Lines added (in current but not in backup)
+  const added = currentLines.filter((l) => !backupSet.has(l));
+
+  const hasChanges = removed.length > 0 || added.length > 0;
+
+  function handleDownloadBackup() {
+    const label = data.backup_label
+      ? `-${data.backup_label.replace(/\s+/g, "_")}`
+      : "";
+    const ts = data.backup_created_at.replace(/[: ]/g, "-");
+    downloadTextFile(data.backup, `vyos-backup-${ts}${label}.conf`);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="flex max-h-[85vh] w-full max-w-4xl flex-col rounded-lg border border-slate-700 bg-slate-900 shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-800 px-5 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Config Comparison
+            </h2>
+            <p className="text-xs text-slate-500">
+              Backup: {data.backup_label || "Unlabeled"} — {formatDate(data.backup_created_at)}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-5">
+          {!hasChanges ? (
+            <div className="flex flex-col items-center justify-center py-12">
+              <CheckCircle className="mb-3 h-8 w-8 text-emerald-400" />
+              <p className="text-sm text-slate-300">
+                The backup and current config are identical.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center gap-4 text-xs text-slate-500">
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-2.5 w-2.5 rounded-sm bg-rose-500/60" />
+                  {removed.length} line{removed.length !== 1 ? "s" : ""} in
+                  backup only
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-2.5 w-2.5 rounded-sm bg-emerald-500/60" />
+                  {added.length} line{added.length !== 1 ? "s" : ""} in
+                  current only
+                </span>
+              </div>
+
+              {removed.length > 0 && (
+                <div>
+                  <p className="mb-1 text-xs font-medium text-rose-400">
+                    Lines in backup (missing from current):
+                  </p>
+                  <pre className="max-h-48 overflow-auto rounded border border-rose-500/20 bg-rose-500/5 p-3 text-xs leading-5 text-rose-300">
+                    {removed.join("\n")}
+                  </pre>
+                </div>
+              )}
+
+              {added.length > 0 && (
+                <div>
+                  <p className="mb-1 text-xs font-medium text-emerald-400">
+                    Lines in current (not in backup):
+                  </p>
+                  <pre className="max-h-48 overflow-auto rounded border border-emerald-500/20 bg-emerald-500/5 p-3 text-xs leading-5 text-emerald-300">
+                    {added.join("\n")}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-slate-800 px-5 py-4">
+          <p className="text-xs text-slate-500">
+            To restore, download the backup and apply via SSH:{" "}
+            <code className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-300">
+              configure &amp;&amp; load /path/to/backup.conf &amp;&amp; commit
+            </code>
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white"
+              onClick={handleDownloadBackup}
+            >
+              <Download className="mr-2 h-3.5 w-3.5" />
+              Download Backup
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-slate-700 text-slate-400 hover:bg-slate-800 hover:text-white"
+              onClick={onClose}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -499,6 +499,24 @@ export default function SettingsPage() {
         </Card>
       </a>
 
+      {/* Config Backup link */}
+      <a href="/settings/config-backup">
+        <Card className="border-slate-800 bg-slate-900 transition-colors hover:border-slate-700">
+          <CardContent className="flex items-center gap-3 py-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/10">
+              <Database className="h-4 w-4 text-emerald-400" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-medium text-white">Config Backup</p>
+              <p className="text-xs text-slate-500">
+                Download, snapshot, and restore VyOS router configurations.
+              </p>
+            </div>
+            <ChevronRight className="h-4 w-4 text-slate-600" />
+          </CardContent>
+        </Card>
+      </a>
+
       {/* VyOS Router Connection */}
       <Card className="border-slate-800 bg-slate-900">
         <CardHeader>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,6 +11,9 @@ import type {
   Alert,
   AuditLogListResponse,
   AuthStatus,
+  ConfigBackup,
+  ConfigBackupListResponse,
+  ConfigDiffResponse,
   DashboardStats,
   DbSizeData,
   Device,
@@ -577,4 +580,35 @@ export function saveTopologyPositions(positions: NodePosition[]): Promise<void> 
 
 export function deleteTopologyPositions(): Promise<void> {
   return apiDelete("/api/v1/topology/positions");
+}
+
+// ─── Config Backups ─────────────────────────────────────
+
+export function fetchConfigBackups(
+  page = 1,
+  perPage = 25
+): Promise<ConfigBackupListResponse> {
+  return apiGet<ConfigBackupListResponse>(
+    `/api/v1/config-backups?page=${page}&per_page=${perPage}`
+  );
+}
+
+export function fetchConfigBackup(id: number): Promise<ConfigBackup> {
+  return apiGet<ConfigBackup>(`/api/v1/config-backups/${id}`);
+}
+
+export function createConfigBackup(label?: string): Promise<ConfigBackup> {
+  return apiPost<ConfigBackup>("/api/v1/config-backups", { label: label || null });
+}
+
+export function deleteConfigBackup(id: number): Promise<void> {
+  return apiDelete(`/api/v1/config-backups/${id}`);
+}
+
+export function fetchCurrentConfig(): Promise<{ config_text: string }> {
+  return apiGet<{ config_text: string }>("/api/v1/config-backups/current");
+}
+
+export function fetchConfigDiff(id: number): Promise<ConfigDiffResponse> {
+  return apiGet<ConfigDiffResponse>(`/api/v1/config-backups/${id}/diff`);
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -343,6 +343,32 @@ export interface AuditLogListResponse {
   per_page: number;
 }
 
+// ─── Config Backups ─────────────────────────────────────
+
+export interface ConfigBackupSummary {
+  id: number;
+  created_at: string;
+  label: string | null;
+  size_bytes: number;
+  created_by: string;
+}
+
+export interface ConfigBackup extends ConfigBackupSummary {
+  config_text: string;
+}
+
+export interface ConfigBackupListResponse {
+  items: ConfigBackupSummary[];
+  total: number;
+}
+
+export interface ConfigDiffResponse {
+  current: string;
+  backup: string;
+  backup_label: string | null;
+  backup_created_at: string;
+}
+
 // ─── Auth ───────────────────────────────────────────────
 
 export interface AuthStatus {


### PR DESCRIPTION
## Summary
Closes #82

- **Download running config** — fetches the current VyOS configuration via the API and downloads it as a `.conf` text file
- **Save snapshot** — stores the current config in SQLite with an optional label and timestamp
- **Backup history table** — lists all saved snapshots with timestamp, label, size, and actions (download / compare / delete)
- **Config diff** — compares any backup against the current running config, showing lines added/removed
- **Restore guidance** — provides SSH commands to restore from a downloaded backup file (MVP approach per issue spec)

### Backend
- Migration 011: `vyos_config_backups` table (`id`, `created_at`, `label`, `config_text`, `size_bytes`, `created_by`)
- REST endpoints: `GET/POST /api/v1/config-backups`, `GET/DELETE /api/v1/config-backups/:id`, `GET /api/v1/config-backups/current`, `GET /api/v1/config-backups/:id/diff`
- Fetches running config via VyOS HTTP API (`show configuration`)

### Frontend
- New **Settings → Config Backup** page (link card on Settings page, dedicated sub-page)
- Manual backup section: Download Running Config button + Save Snapshot with optional label
- Backup history table with inline actions
- Diff dialog overlay showing removed/added lines with color-coded display
- Follows existing project patterns (Card layout, dark theme, status messages)

## Test plan
- [x] Backend compiles (`cargo check`)
- [x] All backend tests pass (`cargo test` — 12/12)
- [x] Frontend builds (`bun run build` — 17/17 pages)
- [x] `cargo fmt` check passes
- [ ] Manual: navigate to Settings → Config Backup
- [ ] Manual: click Download Running Config (downloads .conf file)
- [ ] Manual: enter label + Save Snapshot (appears in table)
- [ ] Manual: click Compare icon on a backup (diff dialog opens)
- [ ] Manual: click Delete on a backup (confirm + removes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements VyOS config backup/restore functionality with database-backed snapshots and config diff comparison.

**Key Changes:**
- Backend adds REST API for backup CRUD, current config fetch, and diff comparison
- Migration 011 creates `vyos_config_backups` table for storing snapshots with labels and timestamps
- Frontend provides Settings → Config Backup page with download, snapshot creation, history table, and diff dialog
- Follows existing patterns (Card layout, error handling, dark theme)

**Issues Found:**
- **Critical**: Diff algorithm uses set-based comparison that fails with duplicate config lines (e.g., multiple similar firewall rules will be undercounted)
- **Important**: Backend silently converts non-string VyOS API responses to empty strings instead of logging/erroring
- Tests pass and build succeeds per PR description

<h3>Confidence Score: 3/5</h3>

- Safe to merge with known limitations — core functionality works but diff feature has accuracy issues
- Score reflects two significant logic bugs: set-based diff algorithm incorrectly handles duplicate lines (produces wrong results), and silent error handling in config fetch could mask API failures. These won't break the application but will produce incorrect diffs and potentially store empty backups without warning. The rest of the implementation is solid with proper error handling, follows project patterns, and tests pass.
- Pay close attention to `web/src/app/(app)/settings/config-backup/page.tsx` (diff algorithm) and `server/src/api/config_backups.rs` (error handling)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/config_backups.rs | New config backup API handlers: list, create, delete, diff operations with SQLite storage — found silent error handling issue in `fetch_running_config` |
| server/src/db/migrations/011_config_backups.sql | Creates `vyos_config_backups` table with timestamp, label, config text, and size tracking |
| web/src/app/(app)/settings/config-backup/page.tsx | New Config Backup UI: download, snapshot, diff dialog — found set-based diff algorithm bug with duplicate lines |

</details>



<sub>Last reviewed commit: 3bc634f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->