### PR TITLE
fix: pass HOME env to speedtest subprocess

### DIFF
--- a/server/src/vyos/speedtest_ookla.rs
+++ b/server/src/vyos/speedtest_ookla.rs
@@ -53,6 +53,12 @@ pub async fn run_speedtest_ookla() -> Result<OoklaSpeedtestResult> {
     let output = tokio::time::timeout(Duration::from_secs(120), async {
         Command::new("/usr/local/bin/speedtest")
             .args(["--accept-license", "--accept-gdpr", "--format=json"])
+            // Ookla CLI requires HOME to be set; Tokio spawn inherits env but
+            // HOME may be unset in systemd service contexts.
+            .env(
+                "HOME",
+                std::env::var("HOME").unwrap_or_else(|_| "/root".to_string()),
+            )
             .output()
             .await
             .context("failed to execute speedtest CLI")


### PR DESCRIPTION
Ookla speedtest CLI crashes with SIGABRT when HOME is not set. Tokio spawn inherits env but systemd services may not have HOME. Fix: explicitly pass HOME from the current process env, falling back to /root.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a crash in the Ookla speedtest CLI when running as a systemd service by explicitly passing the `HOME` environment variable to the subprocess. The fix uses `std::env::var("HOME")` with a fallback to `/root` if HOME is unset, preventing SIGABRT crashes that occur when the Ookla CLI tries to access configuration without a HOME directory.

- Added explicit `.env("HOME", ...)` call when spawning the speedtest subprocess
- Includes clear comment explaining why this is necessary (systemd contexts may not have HOME set)
- Falls back to `/root` as a sensible default for root-level services

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, focused, and directly addresses a known issue with the Ookla speedtest CLI. The approach of explicitly setting HOME with a fallback to /root is a standard pattern for subprocess management in systemd environments. No breaking changes or side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/vyos/speedtest_ookla.rs | Explicitly passes HOME environment variable to speedtest subprocess to prevent SIGABRT in systemd contexts |

</details>



<sub>Last reviewed commit: cd1bd6d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->