### PR TITLE
fix: agent offline — http→ws conversion, agent_id optional, install script id param

### DIFF
--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -19,6 +19,8 @@ pub struct AgentConfig {
     pub api_key: String,
 
     /// Unique agent identifier (UUID, assigned by the server).
+    /// Optional — not required for WebSocket auth (server identifies by api_key).
+    #[serde(default)]
     pub agent_id: String,
 
     /// How often to send reports, in seconds.

--- a/agent/src/ws.rs
+++ b/agent/src/ws.rs
@@ -11,10 +11,13 @@ use crate::config::AgentConfig;
 /// Returns Ok(()) if the server closes the connection gracefully.
 /// Returns Err on connection failure or protocol errors.
 pub async fn run_session(config: &AgentConfig, collector: &mut SystemCollector) -> Result<()> {
-    let ws_url = format!(
-        "{}/api/v1/agent/ws",
-        config.server_url.trim_end_matches('/')
-    );
+    // Convert http:// → ws:// and https:// → wss:// for WebSocket connection.
+    let base = config
+        .server_url
+        .trim_end_matches('/')
+        .replacen("https://", "wss://", 1)
+        .replacen("http://", "ws://", 1);
+    let ws_url = format!("{base}/api/v1/agent/ws");
 
     // Build the request with auth header.
     let request = http::Request::builder()

--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -982,6 +982,7 @@ pub async fn install_script(
             return (StatusCode::BAD_REQUEST, "Missing ?key= parameter").into_response();
         }
     };
+    let agent_id = params.get("id").cloned().unwrap_or_default();
 
     // Validate the API key exists (future: reject unknown keys)
     let _key_exists: bool =
@@ -1023,6 +1024,7 @@ set -e
 
 SERVER_URL="{server_url}"
 API_KEY="{api_key}"
+AGENT_ID="{agent_id}"
 
 # Detect root vs. unprivileged user and set paths accordingly
 if [ "$(id -u)" = "0" ]; then
@@ -1070,6 +1072,7 @@ mkdir -p "$CONFIG_DIR"
 cat > "$CONFIG_DIR/config.toml" <<TOMLEOF
 server_url = "$SERVER_URL"
 api_key = "$API_KEY"
+agent_id = "$AGENT_ID"
 report_interval_seconds = 30
 TOMLEOF
 
@@ -1152,6 +1155,7 @@ echo "==> Done! Agent is reporting to $SERVER_URL"
         platform = platform,
         server_url = server_url,
         api_key = api_key,
+        agent_id = agent_id,
     );
 
     (

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -442,22 +442,22 @@ function AddAgentDialog({ onCreated }: { onCreated: () => void }) {
                 </TabsList>
                 <TabsContent value="linux-amd64">
                   <CopyBlock
-                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/linux-amd64?key=${result.api_key} | sh`}
+                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/linux-amd64?key=${result.api_key}&id=${result.id} | sh`}
                   />
                 </TabsContent>
                 <TabsContent value="linux-arm64">
                   <CopyBlock
-                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/linux-arm64?key=${result.api_key} | sh`}
+                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/linux-arm64?key=${result.api_key}&id=${result.id} | sh`}
                   />
                 </TabsContent>
                 <TabsContent value="darwin-arm64">
                   <CopyBlock
-                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/darwin-arm64?key=${result.api_key} | sh`}
+                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/darwin-arm64?key=${result.api_key}&id=${result.id} | sh`}
                   />
                 </TabsContent>
                 <TabsContent value="darwin-amd64">
                   <CopyBlock
-                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/darwin-amd64?key=${result.api_key} | sh`}
+                    text={`curl -fsSL ${serverUrl}/api/v1/agent/install/darwin-amd64?key=${result.api_key}&id=${result.id} | sh`}
                   />
                 </TabsContent>
               </Tabs>


### PR DESCRIPTION
Fixes agent always showing Offline:
- Convert http:// → ws:// in ws.rs (Tokio-tungstenite requires ws:// scheme)
- Make agent_id optional in config.rs (#[serde(default)]) so old configs without it still work
- Install script: accept ?id= param and write agent_id to config.toml
- Frontend: include &id=${result.id} in all install command URLs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes agents showing as permanently offline by correcting WebSocket URL scheme conversion and improving backward compatibility.

**Key Changes:**
- Converts `http://` → `ws://` and `https://` → `wss://` in agent WebSocket connection logic (tokio-tungstenite requires proper WebSocket scheme)
- Makes `agent_id` field optional in agent config to prevent breaking existing deployments without the field
- Passes agent ID through install script via `?id=` parameter and writes it to generated `config.toml`
- Updates frontend to include agent ID in all platform install commands

**Impact:**
This resolves a critical connectivity issue where agents could not establish WebSocket connections due to incorrect URL schemes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a critical bug with clean, minimal changes
- All changes are targeted fixes with no introduced complexity or risk. The URL conversion logic is correct (chained replacen only matches one scheme), backward compatibility is preserved via `#[serde(default)]`, and the install script properly handles the new parameter with a safe default
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| agent/src/ws.rs | Converts HTTP/HTTPS URLs to WS/WSS for WebSocket connections — critical fix for agent connectivity |
| agent/src/config.rs | Makes `agent_id` optional with `#[serde(default)]` to support backward compatibility with old configs |
| server/src/api/agents.rs | Accepts `?id=` param in install script endpoint and writes `agent_id` to generated config.toml |
| web/src/app/(app)/agents/page.tsx | Adds `&id=${result.id}` parameter to all install command URLs across all platforms |

</details>



<sub>Last reviewed commit: 2adb774</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->