### PR TITLE
feat: DHCP server management — pools, static mappings, leases view

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -152,6 +152,7 @@ pub fn router(state: AppState) -> Router {
             "/vyos/interfaces/:name/toggle",
             post(vyos::interface_toggle),
         )
+        .route("/vyos/dhcp/config", get(vyos::dhcp_server_config))
         .route(
             "/vyos/dhcp/static-mappings",
             get(vyos::dhcp_static_mappings),
@@ -162,7 +163,15 @@ pub fn router(state: AppState) -> Router {
         )
         .route(
             "/vyos/dhcp/static-mappings/:network/:subnet/:name",
+            put(vyos::update_dhcp_static_mapping),
+        )
+        .route(
+            "/vyos/dhcp/static-mappings/:network/:subnet/:name",
             delete(vyos::delete_dhcp_static_mapping),
+        )
+        .route(
+            "/vyos/dhcp/subnets/:network/:subnet/toggle",
+            post(vyos::dhcp_subnet_toggle),
         )
         // Firewall write operations
         .route(

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -2232,6 +2232,435 @@ fn is_valid_mac(mac: &str) -> bool {
             .all(|p| p.len() == 2 && p.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
+// ── DHCP Server Config (pools, subnets, service state) ──────────────────────
+
+/// A DHCP pool range (start-stop).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DhcpPoolRange {
+    pub name: String,
+    pub start: String,
+    pub stop: String,
+}
+
+/// A DHCP subnet configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DhcpSubnetConfig {
+    pub subnet: String,
+    pub default_router: Option<String>,
+    pub name_server: Option<String>,
+    pub domain_name: Option<String>,
+    pub lease: Option<String>,
+    pub ranges: Vec<DhcpPoolRange>,
+    pub static_mapping_count: usize,
+    pub disabled: bool,
+}
+
+/// A shared network containing subnets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DhcpSharedNetwork {
+    pub name: String,
+    pub subnets: Vec<DhcpSubnetConfig>,
+}
+
+/// Full DHCP server configuration response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DhcpServerConfig {
+    pub shared_networks: Vec<DhcpSharedNetwork>,
+}
+
+/// Parse the full DHCP server config from VyOS JSON.
+fn parse_dhcp_server_config(config: &Value) -> DhcpServerConfig {
+    let mut shared_networks = Vec::new();
+
+    let networks = match config
+        .get("shared-network-name")
+        .and_then(|v| v.as_object())
+    {
+        Some(n) => n,
+        None => return DhcpServerConfig { shared_networks },
+    };
+
+    for (network_name, network_val) in networks {
+        let subnets_obj = match network_val.get("subnet").and_then(|v| v.as_object()) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let mut subnets = Vec::new();
+
+        for (subnet_cidr, subnet_val) in subnets_obj {
+            let default_router = subnet_val
+                .get("default-router")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let name_server = subnet_val.get("name-server").and_then(|v| {
+                // Can be single string or array; take first
+                v.as_str().map(|s| s.to_string()).or_else(|| {
+                    v.as_array()
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                })
+            });
+
+            let domain_name = subnet_val
+                .get("domain-name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let lease = subnet_val.get("lease").and_then(|v| {
+                v.as_str().or_else(|| v.as_u64().map(|_| "")).and_then(|s| {
+                    if s.is_empty() {
+                        v.as_u64().map(|n| n.to_string())
+                    } else {
+                        Some(s.to_string())
+                    }
+                })
+            });
+
+            let disabled = subnet_val.get("disable").is_some();
+
+            // Parse pool ranges
+            let mut ranges = Vec::new();
+            if let Some(range_obj) = subnet_val.get("range").and_then(|v| v.as_object()) {
+                for (range_name, range_val) in range_obj {
+                    let start = range_val
+                        .get("start")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let stop = range_val
+                        .get("stop")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if !start.is_empty() && !stop.is_empty() {
+                        ranges.push(DhcpPoolRange {
+                            name: range_name.clone(),
+                            start,
+                            stop,
+                        });
+                    }
+                }
+            }
+
+            let static_mapping_count = subnet_val
+                .get("static-mapping")
+                .and_then(|v| v.as_object())
+                .map(|m| m.len())
+                .unwrap_or(0);
+
+            subnets.push(DhcpSubnetConfig {
+                subnet: subnet_cidr.clone(),
+                default_router,
+                name_server,
+                domain_name,
+                lease,
+                ranges,
+                static_mapping_count,
+                disabled,
+            });
+        }
+
+        subnets.sort_by(|a, b| a.subnet.cmp(&b.subnet));
+
+        shared_networks.push(DhcpSharedNetwork {
+            name: network_name.clone(),
+            subnets,
+        });
+    }
+
+    shared_networks.sort_by(|a, b| a.name.cmp(&b.name));
+    DhcpServerConfig { shared_networks }
+}
+
+/// GET /api/v1/vyos/dhcp/config — fetch full DHCP server configuration.
+pub async fn dhcp_server_config(
+    State(state): State<AppState>,
+) -> Result<Json<DhcpServerConfig>, StatusCode> {
+    let client = get_vyos_client_or_503(&state).await?;
+
+    let config = match client.retrieve(&["service", "dhcp-server"]).await {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("empty") || msg.contains("does not exist") {
+                return Ok(Json(DhcpServerConfig {
+                    shared_networks: Vec::new(),
+                }));
+            }
+            tracing::error!("VyOS DHCP server config query failed: {e}");
+            return Err(StatusCode::BAD_GATEWAY);
+        }
+    };
+
+    let parsed = parse_dhcp_server_config(&config);
+    Ok(Json(parsed))
+}
+
+/// Path parameters for subnet toggle.
+#[derive(Debug, Deserialize)]
+pub struct DhcpSubnetPath {
+    pub network: String,
+    pub subnet: String,
+}
+
+/// Request body for toggling DHCP on a subnet.
+#[derive(Debug, Deserialize)]
+pub struct DhcpSubnetToggleRequest {
+    pub disable: bool,
+}
+
+/// POST /api/v1/vyos/dhcp/subnets/:network/:subnet/toggle — enable/disable DHCP for a subnet.
+pub async fn dhcp_subnet_toggle(
+    State(state): State<AppState>,
+    Path(path): Path<DhcpSubnetPath>,
+    Json(body): Json<DhcpSubnetToggleRequest>,
+) -> Result<Json<VyosWriteResponse>, (StatusCode, Json<VyosWriteResponse>)> {
+    let client = get_vyos_client_or_503(&state).await.map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Router not configured".to_string(),
+            }),
+        )
+    })?;
+
+    let action = if body.disable { "Disable" } else { "Enable" };
+    let description = format!(
+        "{action} DHCP on subnet {} (network={})",
+        path.subnet, path.network
+    );
+
+    let base = [
+        "service",
+        "dhcp-server",
+        "shared-network-name",
+        &path.network,
+        "subnet",
+        &path.subnet,
+        "disable",
+    ];
+
+    let result = if body.disable {
+        let commands = vec![format!(
+            "set service dhcp-server shared-network-name {} subnet {} disable",
+            path.network, path.subnet
+        )];
+
+        match client.configure_set(&base).await {
+            Ok(_) => {
+                audit::log_success(&state.db, "dhcp_subnet_toggle", &description, &commands).await;
+                Ok(Json(VyosWriteResponse {
+                    success: true,
+                    message: format!("DHCP disabled on subnet {}", path.subnet),
+                }))
+            }
+            Err(e) => {
+                let msg = format!("VyOS error: {e}");
+                audit::log_failure(
+                    &state.db,
+                    "dhcp_subnet_toggle",
+                    &description,
+                    &commands,
+                    &msg,
+                )
+                .await;
+                Err((
+                    StatusCode::BAD_GATEWAY,
+                    Json(VyosWriteResponse {
+                        success: false,
+                        message: msg,
+                    }),
+                ))
+            }
+        }
+    } else {
+        let commands = vec![format!(
+            "delete service dhcp-server shared-network-name {} subnet {} disable",
+            path.network, path.subnet
+        )];
+
+        match client.configure_delete(&base).await {
+            Ok(_) => {
+                audit::log_success(&state.db, "dhcp_subnet_toggle", &description, &commands).await;
+                Ok(Json(VyosWriteResponse {
+                    success: true,
+                    message: format!("DHCP enabled on subnet {}", path.subnet),
+                }))
+            }
+            Err(e) => {
+                // "does not exist" is fine — means it was already enabled
+                let msg = e.to_string();
+                if msg.contains("does not exist") || msg.contains("empty") {
+                    audit::log_success(&state.db, "dhcp_subnet_toggle", &description, &commands)
+                        .await;
+                    return Ok(Json(VyosWriteResponse {
+                        success: true,
+                        message: format!("DHCP already enabled on subnet {}", path.subnet),
+                    }));
+                }
+                let msg = format!("VyOS error: {e}");
+                audit::log_failure(
+                    &state.db,
+                    "dhcp_subnet_toggle",
+                    &description,
+                    &commands,
+                    &msg,
+                )
+                .await;
+                Err((
+                    StatusCode::BAD_GATEWAY,
+                    Json(VyosWriteResponse {
+                        success: false,
+                        message: msg,
+                    }),
+                ))
+            }
+        }
+    };
+
+    result
+}
+
+/// PUT /api/v1/vyos/dhcp/static-mappings/:network/:subnet/:name — update a DHCP static mapping.
+pub async fn update_dhcp_static_mapping(
+    State(state): State<AppState>,
+    Path(path): Path<DhcpStaticMappingPath>,
+    Json(body): Json<CreateDhcpStaticMappingRequest>,
+) -> Result<Json<VyosWriteResponse>, (StatusCode, Json<VyosWriteResponse>)> {
+    let client = get_vyos_client_or_503(&state).await.map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Router not configured".to_string(),
+            }),
+        )
+    })?;
+
+    if !is_valid_mac(&body.mac) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid MAC address format. Expected XX:XX:XX:XX:XX:XX".to_string(),
+            }),
+        ));
+    }
+
+    if body.ip.parse::<std::net::Ipv4Addr>().is_err() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid IP address format".to_string(),
+            }),
+        ));
+    }
+
+    let description = format!(
+        "Update DHCP static mapping '{}': {} -> {} (network={}, subnet={})",
+        path.name, body.mac, body.ip, path.network, path.subnet
+    );
+    let commands = vec![
+        format!(
+            "set service dhcp-server shared-network-name {} subnet {} static-mapping {} mac-address {}",
+            path.network, path.subnet, path.name, body.mac
+        ),
+        format!(
+            "set service dhcp-server shared-network-name {} subnet {} static-mapping {} ip-address {}",
+            path.network, path.subnet, path.name, body.ip
+        ),
+    ];
+
+    // Update mac-address
+    if let Err(e) = client
+        .configure_set(&[
+            "service",
+            "dhcp-server",
+            "shared-network-name",
+            &path.network,
+            "subnet",
+            &path.subnet,
+            "static-mapping",
+            &path.name,
+            "mac-address",
+            &body.mac,
+        ])
+        .await
+    {
+        let msg = format!("Failed to update MAC address: {e}");
+        audit::log_failure(
+            &state.db,
+            "dhcp_static_mapping_update",
+            &description,
+            &commands,
+            &msg,
+        )
+        .await;
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(VyosWriteResponse {
+                success: false,
+                message: msg,
+            }),
+        ));
+    }
+
+    // Update ip-address
+    if let Err(e) = client
+        .configure_set(&[
+            "service",
+            "dhcp-server",
+            "shared-network-name",
+            &path.network,
+            "subnet",
+            &path.subnet,
+            "static-mapping",
+            &path.name,
+            "ip-address",
+            &body.ip,
+        ])
+        .await
+    {
+        let msg = format!("Failed to update IP address: {e}");
+        audit::log_failure(
+            &state.db,
+            "dhcp_static_mapping_update",
+            &description,
+            &commands,
+            &msg,
+        )
+        .await;
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(VyosWriteResponse {
+                success: false,
+                message: msg,
+            }),
+        ));
+    }
+
+    audit::log_success(
+        &state.db,
+        "dhcp_static_mapping_update",
+        &description,
+        &commands,
+    )
+    .await;
+
+    Ok(Json(VyosWriteResponse {
+        success: true,
+        message: format!(
+            "Static mapping '{}' updated: {} -> {}",
+            path.name, body.mac, body.ip
+        ),
+    }))
+}
+
 // ── Static Routes ───────────────────────────────────────────────────────────
 
 /// Request body for creating a static route.
@@ -6027,6 +6456,136 @@ mod tests {
         let guest = mappings.iter().find(|m| m.network == "GUEST").unwrap();
         assert_eq!(guest.name, "printer");
         assert_eq!(guest.ip, "192.168.1.10");
+    }
+
+    // ── DHCP server config parsing ────────────────────────────
+
+    #[test]
+    fn test_parse_dhcp_server_config_basic() {
+        let config: Value = serde_json::from_str(
+            r#"{
+                "shared-network-name": {
+                    "LAN": {
+                        "subnet": {
+                            "10.10.0.0/24": {
+                                "default-router": "10.10.0.1",
+                                "name-server": "10.10.0.1",
+                                "domain-name": "local",
+                                "lease": "86400",
+                                "range": {
+                                    "0": {
+                                        "start": "10.10.0.100",
+                                        "stop": "10.10.0.254"
+                                    }
+                                },
+                                "static-mapping": {
+                                    "host1": {
+                                        "mac-address": "aa:bb:cc:dd:ee:ff",
+                                        "ip-address": "10.10.0.50"
+                                    },
+                                    "host2": {
+                                        "mac-address": "11:22:33:44:55:66",
+                                        "ip-address": "10.10.0.51"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_dhcp_server_config(&config);
+        assert_eq!(result.shared_networks.len(), 1);
+
+        let net = &result.shared_networks[0];
+        assert_eq!(net.name, "LAN");
+        assert_eq!(net.subnets.len(), 1);
+
+        let sub = &net.subnets[0];
+        assert_eq!(sub.subnet, "10.10.0.0/24");
+        assert_eq!(sub.default_router.as_deref(), Some("10.10.0.1"));
+        assert_eq!(sub.name_server.as_deref(), Some("10.10.0.1"));
+        assert_eq!(sub.domain_name.as_deref(), Some("local"));
+        assert_eq!(sub.lease.as_deref(), Some("86400"));
+        assert!(!sub.disabled);
+        assert_eq!(sub.static_mapping_count, 2);
+        assert_eq!(sub.ranges.len(), 1);
+        assert_eq!(sub.ranges[0].start, "10.10.0.100");
+        assert_eq!(sub.ranges[0].stop, "10.10.0.254");
+    }
+
+    #[test]
+    fn test_parse_dhcp_server_config_disabled_subnet() {
+        let config: Value = serde_json::from_str(
+            r#"{
+                "shared-network-name": {
+                    "LAN": {
+                        "subnet": {
+                            "10.10.0.0/24": {
+                                "default-router": "10.10.0.1",
+                                "disable": {},
+                                "range": {
+                                    "0": {
+                                        "start": "10.10.0.100",
+                                        "stop": "10.10.0.200"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_dhcp_server_config(&config);
+        assert_eq!(result.shared_networks.len(), 1);
+        let sub = &result.shared_networks[0].subnets[0];
+        assert!(sub.disabled);
+    }
+
+    #[test]
+    fn test_parse_dhcp_server_config_empty() {
+        let config: Value = serde_json::json!({});
+        assert!(parse_dhcp_server_config(&config).shared_networks.is_empty());
+
+        let config2: Value = serde_json::json!(null);
+        assert!(parse_dhcp_server_config(&config2)
+            .shared_networks
+            .is_empty());
+    }
+
+    #[test]
+    fn test_parse_dhcp_server_config_multiple_ranges() {
+        let config: Value = serde_json::from_str(
+            r#"{
+                "shared-network-name": {
+                    "LAN": {
+                        "subnet": {
+                            "10.10.0.0/24": {
+                                "range": {
+                                    "pool1": {
+                                        "start": "10.10.0.100",
+                                        "stop": "10.10.0.150"
+                                    },
+                                    "pool2": {
+                                        "start": "10.10.0.200",
+                                        "stop": "10.10.0.254"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_dhcp_server_config(&config);
+        let sub = &result.shared_networks[0].subnets[0];
+        assert_eq!(sub.ranges.len(), 2);
     }
 
     // ── Firewall groups parsing ─────────────────────────────

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -75,7 +75,10 @@ import {
   toggleInterface,
   fetchDhcpStaticMappings,
   createDhcpStaticMapping,
+  updateDhcpStaticMapping,
   deleteDhcpStaticMapping,
+  fetchDhcpServerConfig,
+  toggleDhcpSubnet,
   createFirewallRule,
   updateFirewallRule,
   deleteFirewallRule,
@@ -108,7 +111,7 @@ import {
   editDnsDomainOverride,
   deleteDnsDomainOverride,
 } from "@/lib/api";
-import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, SpeedTestResult, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride } from "@/lib/types";
+import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, SpeedTestResult, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride } from "@/lib/types";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -1774,6 +1777,9 @@ function StaticMappingsTable({
     ip: "",
   });
   const [adding, setAdding] = useState(false);
+  const [editMapping, setEditMapping] = useState<DhcpStaticMapping | null>(null);
+  const [editForm, setEditForm] = useState({ mac: "", ip: "" });
+  const [saving, setSaving] = useState(false);
 
   const handleDelete = async () => {
     if (!confirmDelete) return;
@@ -1807,6 +1813,35 @@ function StaticMappingsTable({
       toast.error(e instanceof Error ? e.message : "Create failed");
     } finally {
       setAdding(false);
+    }
+  };
+
+  const handleEdit = (m: DhcpStaticMapping) => {
+    setEditMapping(m);
+    setEditForm({ mac: m.mac, ip: m.ip });
+  };
+
+  const handleEditSave = async () => {
+    if (!editMapping) return;
+    if (!editForm.mac || !editForm.ip) {
+      toast.error("MAC and IP are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await updateDhcpStaticMapping(
+        editMapping.network,
+        editMapping.subnet,
+        editMapping.name,
+        { ...editMapping, mac: editForm.mac, ip: editForm.ip }
+      );
+      toast.success(res.message);
+      setEditMapping(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -2008,18 +2043,28 @@ function StaticMappingsTable({
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    {deleting === m.name ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
-                    ) : (
+                    <div className="flex items-center gap-1 justify-end">
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => setConfirmDelete(m)}
-                        className="h-8 w-8 p-0 text-slate-400 hover:text-rose-400"
+                        onClick={() => handleEdit(m)}
+                        className="h-8 w-8 p-0 text-slate-400 hover:text-blue-400"
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Pencil className="h-3.5 w-3.5" />
                       </Button>
-                    )}
+                      {deleting === m.name ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setConfirmDelete(m)}
+                          className="h-8 w-8 p-0 text-slate-400 hover:text-rose-400"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -2027,6 +2072,71 @@ function StaticMappingsTable({
           </table>
         </div>
       )}
+
+      {/* Edit dialog */}
+      <Dialog open={editMapping !== null} onOpenChange={(open) => { if (!open) setEditMapping(null); }}>
+        <DialogContent className="border-slate-800 bg-slate-900">
+          <DialogHeader>
+            <DialogTitle className="text-white">
+              Edit Static Mapping &ldquo;{editMapping?.name}&rdquo;
+            </DialogTitle>
+            <DialogDescription className="text-slate-400">
+              Update MAC or IP address for this mapping.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-slate-300">MAC Address</Label>
+              <Input
+                value={editForm.mac}
+                onChange={(e) => setEditForm({ ...editForm, mac: e.target.value })}
+                placeholder="aa:bb:cc:dd:ee:ff"
+                className="border-slate-800 bg-slate-950 font-mono text-white"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-slate-300">IP Address</Label>
+              <Input
+                value={editForm.ip}
+                onChange={(e) => setEditForm({ ...editForm, ip: e.target.value })}
+                placeholder="10.10.0.100"
+                className="border-slate-800 bg-slate-950 font-mono text-white"
+              />
+            </div>
+            {editMapping && editForm.mac && editForm.ip && (
+              <div className="rounded-md border border-slate-800 bg-slate-950 p-3">
+                <p className="text-xs font-medium text-slate-500">Config change:</p>
+                <code className="mt-1 block whitespace-pre-wrap text-xs text-blue-400">
+                  {`set service dhcp-server shared-network-name ${editMapping.network} subnet ${editMapping.subnet} static-mapping ${editMapping.name} mac-address ${editForm.mac}\nset service dhcp-server shared-network-name ${editMapping.network} subnet ${editMapping.subnet} static-mapping ${editMapping.name} ip-address ${editForm.ip}`}
+                </code>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEditMapping(null)}
+              className="border-slate-800 text-slate-300 hover:bg-slate-800"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleEditSave}
+              disabled={saving}
+              className="bg-blue-600 text-white hover:bg-blue-700"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                "Save Changes"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete confirmation dialog */}
       <AlertDialog
@@ -2067,6 +2177,176 @@ function StaticMappingsTable({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+}
+
+// ── DHCP Pools & Subnets ────────────────────────────────
+
+function DhcpPoolsCard({
+  config,
+  loading,
+  error,
+  onReload,
+}: {
+  config: DhcpServerConfig | null;
+  loading: boolean;
+  error: string | null;
+  onReload: () => void;
+}) {
+  const [toggling, setToggling] = useState<string | null>(null);
+
+  const handleToggle = async (network: string, subnet: DhcpSubnetConfig) => {
+    const key = `${network}/${subnet.subnet}`;
+    setToggling(key);
+    try {
+      const newDisabled = !subnet.disabled;
+      const res = await toggleDhcpSubnet(network, subnet.subnet, newDisabled);
+      toast.success(res.message);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Toggle failed");
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!config || config.shared_networks.length === 0) {
+    return (
+      <p className="py-4 text-sm text-slate-500">
+        No DHCP shared networks configured.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {config.shared_networks.map((net) => (
+        <div key={net.name} className="space-y-3">
+          <h4 className="text-sm font-medium text-slate-300">
+            Shared Network: <span className="text-white">{net.name}</span>
+          </h4>
+
+          {net.subnets.map((sub) => {
+            const key = `${net.name}/${sub.subnet}`;
+            const isToggling = toggling === key;
+
+            return (
+              <div
+                key={sub.subnet}
+                className="rounded-md border border-slate-800 bg-slate-950 p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="font-mono text-sm font-medium text-white">
+                      {sub.subnet}
+                    </span>
+                    {sub.disabled ? (
+                      <Badge
+                        variant="outline"
+                        className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+                      >
+                        disabled
+                      </Badge>
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                      >
+                        active
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {isToggling && (
+                      <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                    )}
+                    <Switch
+                      checked={!sub.disabled}
+                      onCheckedChange={() => handleToggle(net.name, sub)}
+                      disabled={isToggling}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-4">
+                  <div>
+                    <span className="text-slate-500">Gateway</span>
+                    <p className="font-mono text-slate-300">
+                      {sub.default_router ?? "—"}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">DNS</span>
+                    <p className="font-mono text-slate-300">
+                      {sub.name_server ?? "—"}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Domain</span>
+                    <p className="text-slate-300">
+                      {sub.domain_name ?? "—"}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-slate-500">Lease</span>
+                    <p className="text-slate-300">
+                      {sub.lease ? `${sub.lease}s` : "—"}
+                    </p>
+                  </div>
+                </div>
+
+                {sub.ranges.length > 0 && (
+                  <div className="mt-3">
+                    <span className="text-xs text-slate-500">Pool Ranges</span>
+                    <div className="mt-1 space-y-1">
+                      {sub.ranges.map((r) => (
+                        <div
+                          key={r.name}
+                          className="flex items-center gap-2 text-xs"
+                        >
+                          <span className="text-slate-500">{r.name}:</span>
+                          <span className="font-mono text-slate-300">
+                            {r.start}
+                          </span>
+                          <span className="text-slate-600">→</span>
+                          <span className="font-mono text-slate-300">
+                            {r.stop}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {sub.static_mapping_count > 0 && (
+                  <p className="mt-2 text-xs text-slate-500">
+                    {sub.static_mapping_count} static mapping{sub.static_mapping_count !== 1 ? "s" : ""}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -4198,6 +4478,11 @@ function RouterTabs({ status }: { status: RouterStatus }) {
     tab === "dhcp"
   );
 
+  const dhcpConfig = useAsyncData<DhcpServerConfig>(
+    useCallback(() => fetchDhcpServerConfig(), []),
+    tab === "dhcp"
+  );
+
   const firewall = useAsyncData<FirewallConfig>(
     useCallback(() => fetchRouterFirewall(), []),
     tab === "firewall"
@@ -4329,7 +4614,23 @@ function RouterTabs({ status }: { status: RouterStatus }) {
           <Card className="border-slate-800 bg-slate-900">
             <CardHeader>
               <CardTitle className="text-base text-white">
-                DHCP Server Leases
+                Pools &amp; Subnets
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DhcpPoolsCard
+                config={dhcpConfig.data ?? null}
+                loading={dhcpConfig.loading}
+                error={dhcpConfig.error}
+                onReload={dhcpConfig.reload}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="border-slate-800 bg-slate-900">
+            <CardHeader>
+              <CardTitle className="text-base text-white">
+                Active Leases
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -4344,7 +4645,7 @@ function RouterTabs({ status }: { status: RouterStatus }) {
           <Card className="border-slate-800 bg-slate-900">
             <CardHeader>
               <CardTitle className="text-base text-white">
-                DHCP Configuration
+                Static Mappings
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   DashboardStats,
   DbSizeData,
   Device,
+  DhcpServerConfig,
   DhcpStaticMapping,
   DnsForwardingConfig,
   FirewallConfig,
@@ -484,6 +485,18 @@ export function createDhcpStaticMapping(body: {
   return apiPost<VyosWriteResponse>("/api/v1/vyos/dhcp/static-mappings", body);
 }
 
+export function updateDhcpStaticMapping(
+  network: string,
+  subnet: string,
+  name: string,
+  body: { network: string; subnet: string; name: string; mac: string; ip: string }
+): Promise<VyosWriteResponse> {
+  return apiPut<VyosWriteResponse>(
+    `/api/v1/vyos/dhcp/static-mappings/${encodeURIComponent(network)}/${encodeURIComponent(subnet)}/${encodeURIComponent(name)}`,
+    body
+  );
+}
+
 export function deleteDhcpStaticMapping(
   network: string,
   subnet: string,
@@ -492,6 +505,21 @@ export function deleteDhcpStaticMapping(
   return apiDelete(
     `/api/v1/vyos/dhcp/static-mappings/${encodeURIComponent(network)}/${encodeURIComponent(subnet)}/${encodeURIComponent(name)}`
   ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function fetchDhcpServerConfig(): Promise<DhcpServerConfig> {
+  return apiGet<DhcpServerConfig>("/api/v1/vyos/dhcp/config");
+}
+
+export function toggleDhcpSubnet(
+  network: string,
+  subnet: string,
+  disable: boolean
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(
+    `/api/v1/vyos/dhcp/subnets/${encodeURIComponent(network)}/${encodeURIComponent(subnet)}/toggle`,
+    { disable }
+  );
 }
 
 // ─── Static Routes ──────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -204,6 +204,34 @@ export interface DhcpStaticMapping {
   ip: string;
 }
 
+// ─── DHCP Server Config ────────────────────────────────
+
+export interface DhcpPoolRange {
+  name: string;
+  start: string;
+  stop: string;
+}
+
+export interface DhcpSubnetConfig {
+  subnet: string;
+  default_router: string | null;
+  name_server: string | null;
+  domain_name: string | null;
+  lease: string | null;
+  ranges: DhcpPoolRange[];
+  static_mapping_count: number;
+  disabled: boolean;
+}
+
+export interface DhcpSharedNetwork {
+  name: string;
+  subnets: DhcpSubnetConfig[];
+}
+
+export interface DhcpServerConfig {
+  shared_networks: DhcpSharedNetwork[];
+}
+
 export interface VyosWriteResponse {
   success: boolean;
   message: string;


### PR DESCRIPTION
## Summary

Full DHCP server management in the VyOS router page. Closes #88.

- **Pools & Subnets card** — displays shared networks, subnets, pool ranges, gateway/DNS/domain/lease settings
- **Service enable/disable toggle** per subnet with audit logging
- **Static mappings CRUD** — add, edit (new), and delete with config diff preview
- **Active leases table** — IP, MAC, hostname, pool, expiry, state (existing, reorganised)

### Backend
- `GET /api/v1/vyos/dhcp/config` — full DHCP server configuration (shared networks, subnets, pool ranges, settings, disabled state)
- `PUT /api/v1/vyos/dhcp/static-mappings/:network/:subnet/:name` — edit existing static mapping
- `POST /api/v1/vyos/dhcp/subnets/:network/:subnet/toggle` — enable/disable DHCP per subnet
- Parser + 4 unit tests for DHCP server config JSON

### Frontend
- New `DhcpPoolsCard` component with subnet details and enable/disable `Switch`
- Edit dialog for static mappings (MAC/IP) with VyOS config diff preview
- DHCP tab reorganised: Pools & Subnets → Active Leases → Static Mappings

## Test plan
- [x] All 216 Rust tests pass (including 4 new DHCP config parser tests)
- [x] TypeScript compiles with zero errors in changed files
- [ ] Manual: navigate to Router → DHCP tab, verify pools/subnets display
- [ ] Manual: toggle subnet enable/disable, verify state change
- [ ] Manual: add/edit/delete a static mapping
- [ ] Manual: verify active leases table with real DHCP data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive DHCP server management functionality for the VyOS router page. The changes are well-structured with proper separation of concerns between backend and frontend.

**Backend changes:**
- Added DHCP server config parser with proper handling of shared networks, subnets, pool ranges, and disabled state
- Implemented subnet enable/disable toggle endpoint with audit logging
- Added static mapping update endpoint (PUT) with MAC and IP validation
- Included 4 unit tests for the DHCP config parser covering basic config, disabled subnets, empty config, and multiple ranges

**Frontend changes:**
- Created new `DhcpPoolsCard` component displaying subnet details with enable/disable toggle
- Added edit dialog for static mappings with VyOS config diff preview
- Reorganized DHCP tab: Pools & Subnets → Active Leases → Static Mappings
- Proper loading/error states and user feedback via toast notifications

**Code quality:**
- Consistent validation patterns (MAC address, IP address)
- Proper error handling with audit logging on both success and failure
- URL encoding for path parameters to prevent injection
- Type safety maintained across TypeScript and Rust boundaries

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, includes comprehensive unit tests (4 new tests), proper input validation (MAC/IP formats), audit logging for all state changes, and graceful error handling. The frontend changes are well-integrated with existing components and maintain consistency with the UI patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Added three new DHCP endpoints (config GET, static mapping PUT, subnet toggle POST) with proper routing |
| server/src/api/vyos.rs | Implemented DHCP server config parser with 4 unit tests, subnet toggle endpoint, and static mapping update endpoint with validation and audit logging |
| web/src/app/(app)/router/page.tsx | Added DhcpPoolsCard component for pool/subnet display, edit dialog for static mappings with config diff preview, reorganized DHCP tab layout |
| web/src/lib/api.ts | Added API client functions for DHCP server config fetch, static mapping update, and subnet toggle operations |
| web/src/lib/types.ts | Defined TypeScript types for DHCP server config structures (pool ranges, subnets, shared networks) |

</details>



<sub>Last reviewed commit: 2f759f6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->