### PR TITLE
feat: VyOS system info dashboard — uptime, version, CPU/memory/disk, syslog

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -137,6 +137,8 @@ pub fn router(state: AppState) -> Router {
         // VyOS router proxy
         .route("/vyos/router-summary", get(vyos::router_summary))
         .route("/vyos/status", get(vyos::status))
+        .route("/vyos/system-info", get(vyos::system_info))
+        .route("/vyos/syslog", get(vyos::syslog))
         .route("/vyos/interfaces", get(vyos::interfaces))
         .route("/vyos/config-interfaces", get(vyos::config_interfaces))
         .route("/vyos/routes", get(vyos::routes))

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -541,6 +541,274 @@ pub async fn router_summary(
     }))
 }
 
+// ── System Info ─────────────────────────────────────────────────────
+
+/// CPU load averages.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CpuLoad {
+    pub load1: f64,
+    pub load5: f64,
+    pub load15: f64,
+}
+
+/// Memory usage in bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryUsage {
+    pub total: u64,
+    pub used: u64,
+    pub free: u64,
+    pub percent: f64,
+}
+
+/// Disk usage for a single filesystem.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DiskUsage {
+    pub filesystem: String,
+    pub size: String,
+    pub used: String,
+    pub available: String,
+    pub percent: f64,
+    pub mount: String,
+}
+
+/// Full system info response.
+#[derive(Debug, Clone, Serialize)]
+pub struct SystemInfo {
+    pub version: Option<String>,
+    pub uptime: Option<String>,
+    pub cpu_load: Option<CpuLoad>,
+    pub memory: Option<MemoryUsage>,
+    pub disk: Vec<DiskUsage>,
+}
+
+/// Syslog response.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyslogResponse {
+    pub lines: Vec<String>,
+}
+
+/// Parse `show system uptime` output.
+///
+/// Example VyOS output:
+/// ```text
+///  14:32:15 up 3 days,  2:17,  1 user,  load average: 0.08, 0.03, 0.05
+/// ```
+fn parse_uptime_and_load(text: &str) -> (Option<String>, Option<CpuLoad>) {
+    let text = text.trim();
+    if text.is_empty() {
+        return (None, None);
+    }
+
+    // Extract load averages from "load average: X, Y, Z"
+    let cpu_load = if let Some(idx) = text.find("load average:") {
+        let after = &text[idx + "load average:".len()..];
+        let parts: Vec<&str> = after.split(',').collect();
+        if parts.len() >= 3 {
+            let load1 = parts[0].trim().parse::<f64>().ok();
+            let load5 = parts[1].trim().parse::<f64>().ok();
+            let load15 = parts[2].trim().parse::<f64>().ok();
+            match (load1, load5, load15) {
+                (Some(l1), Some(l5), Some(l15)) => Some(CpuLoad {
+                    load1: l1,
+                    load5: l5,
+                    load15: l15,
+                }),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Extract uptime from "up X days, Y:Z" (everything between "up " and the next comma before user count)
+    let uptime = if let Some(up_idx) = text.find(" up ") {
+        let after_up = &text[up_idx + 4..];
+        // Find "load average:" to know where uptime description ends
+        let end = after_up.find("load average:").unwrap_or(after_up.len());
+        let uptime_section = &after_up[..end];
+        // Remove trailing user count like ", 1 user,"
+        let cleaned = if let Some(user_idx) = uptime_section.find(" user") {
+            // Find the comma before "N user"
+            let before_user = &uptime_section[..user_idx];
+            if let Some(last_comma) = before_user.rfind(',') {
+                uptime_section[..last_comma].trim()
+            } else {
+                uptime_section.trim()
+            }
+        } else {
+            uptime_section.trim().trim_end_matches(',')
+        };
+        if cleaned.is_empty() {
+            None
+        } else {
+            Some(cleaned.trim_end_matches(',').to_string())
+        }
+    } else {
+        // Fallback: try "Uptime:" prefix format
+        text.lines()
+            .find(|l| l.starts_with("Uptime:"))
+            .map(|l| l.trim_start_matches("Uptime:").trim().to_string())
+    };
+
+    (uptime, cpu_load)
+}
+
+/// Parse `show system memory` output.
+///
+/// Example VyOS output:
+/// ```text
+///               total        used        free      shared  buff/cache   available
+/// Mem:        8028240     1234560     4567890       12340     2225790     6556780
+/// Swap:       2097148           0     2097148
+/// ```
+fn parse_memory_text(text: &str) -> Option<MemoryUsage> {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with("Mem:") {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 4 {
+                let total = parts[1].parse::<u64>().ok()?;
+                let used = parts[2].parse::<u64>().ok()?;
+                let free = parts[3].parse::<u64>().ok()?;
+                let percent = if total > 0 {
+                    (used as f64 / total as f64) * 100.0
+                } else {
+                    0.0
+                };
+                return Some(MemoryUsage {
+                    total: total * 1024, // kB to bytes
+                    used: used * 1024,
+                    free: free * 1024,
+                    percent: (percent * 10.0).round() / 10.0,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Parse `show system storage` output.
+///
+/// Example VyOS output:
+/// ```text
+/// Filesystem      Size  Used Avail Use% Mounted on
+/// /dev/sda1        10G  2.1G  7.4G  22% /
+/// ```
+fn parse_storage_text(text: &str) -> Vec<DiskUsage> {
+    let mut disks = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        // Skip header lines
+        if line.is_empty()
+            || line.starts_with("Filesystem")
+            || line.starts_with("---")
+            || line.starts_with("tmpfs")
+            || line.starts_with("devtmpfs")
+            || line.starts_with("none")
+        {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 6 {
+            let percent_str = parts[4].trim_end_matches('%');
+            let percent = percent_str.parse::<f64>().unwrap_or(0.0);
+            disks.push(DiskUsage {
+                filesystem: parts[0].to_string(),
+                size: parts[1].to_string(),
+                used: parts[2].to_string(),
+                available: parts[3].to_string(),
+                percent,
+                mount: parts[5].to_string(),
+            });
+        }
+    }
+    disks
+}
+
+/// GET /api/v1/vyos/system-info — system version, uptime, CPU, memory, disk.
+pub async fn system_info(State(state): State<AppState>) -> Result<Json<SystemInfo>, StatusCode> {
+    let client = get_vyos_client_or_503(&state).await?;
+
+    let (ver_res, uptime_res, mem_res, storage_res) = tokio::join!(
+        client.show(&["version"]),
+        client.show(&["system", "uptime"]),
+        client.show(&["system", "memory"]),
+        client.show(&["system", "storage"]),
+    );
+
+    let version = ver_res.ok().and_then(|v| {
+        v.as_str().map(|s| {
+            s.lines()
+                .find(|l| l.starts_with("Version:"))
+                .map(|l| l.trim_start_matches("Version:").trim().to_string())
+                .unwrap_or_else(|| s.to_string())
+        })
+    });
+
+    let uptime_text = uptime_res
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+    let (uptime, cpu_load) = parse_uptime_and_load(&uptime_text);
+
+    let memory = mem_res
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .and_then(|text| parse_memory_text(&text));
+
+    let disk = storage_res
+        .ok()
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .map(|text| parse_storage_text(&text))
+        .unwrap_or_default();
+
+    Ok(Json(SystemInfo {
+        version,
+        uptime,
+        cpu_load,
+        memory,
+        disk,
+    }))
+}
+
+/// GET /api/v1/vyos/syslog?lines=50&filter=something — recent syslog entries.
+pub async fn syslog(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<SyslogQuery>,
+) -> Result<Json<SyslogResponse>, StatusCode> {
+    let client = get_vyos_client_or_503(&state).await?;
+
+    let line_count = params.lines.unwrap_or(50).min(500);
+    let count_str = line_count.to_string();
+
+    let raw = client
+        .show(&["log", "tail", &count_str])
+        .await
+        .map_err(|e| {
+            tracing::error!("VyOS syslog query failed: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    let text = raw.as_str().unwrap_or("");
+    let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
+
+    if let Some(ref filter) = params.filter {
+        let filter_lower = filter.to_lowercase();
+        lines.retain(|l| l.to_lowercase().contains(&filter_lower));
+    }
+
+    Ok(Json(SyslogResponse { lines }))
+}
+
+/// Query parameters for the syslog endpoint.
+#[derive(Debug, Deserialize)]
+pub struct SyslogQuery {
+    pub lines: Option<u32>,
+    pub filter: Option<String>,
+}
+
 /// GET /api/v1/vyos/interfaces — fetch VyOS interface information (parsed).
 ///
 /// Calls `show interfaces` on VyOS, parses the tabular text output, and returns
@@ -7364,5 +7632,77 @@ mod tests {
         assert!(peer.last_handshake.is_none());
         assert!(peer.rx_bytes.is_none());
         assert!(peer.tx_bytes.is_none());
+    }
+
+    // ── System Info parsing tests ───────────────────────────
+
+    #[test]
+    fn test_parse_uptime_and_load() {
+        let text = " 14:32:15 up 3 days,  2:17,  1 user,  load average: 0.08, 0.03, 0.05";
+        let (uptime, cpu) = parse_uptime_and_load(text);
+        assert_eq!(uptime.as_deref(), Some("3 days,  2:17"));
+        let cpu = cpu.unwrap();
+        assert!((cpu.load1 - 0.08).abs() < 0.001);
+        assert!((cpu.load5 - 0.03).abs() < 0.001);
+        assert!((cpu.load15 - 0.05).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_parse_uptime_and_load_short() {
+        let text = " 10:00:00 up  5:30,  2 users,  load average: 1.20, 0.80, 0.50";
+        let (uptime, cpu) = parse_uptime_and_load(text);
+        assert_eq!(uptime.as_deref(), Some("5:30"));
+        let cpu = cpu.unwrap();
+        assert!((cpu.load1 - 1.20).abs() < 0.001);
+        assert!((cpu.load5 - 0.80).abs() < 0.001);
+        assert!((cpu.load15 - 0.50).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_parse_uptime_and_load_empty() {
+        let (uptime, cpu) = parse_uptime_and_load("");
+        assert!(uptime.is_none());
+        assert!(cpu.is_none());
+    }
+
+    #[test]
+    fn test_parse_memory_text() {
+        let text = "              total        used        free      shared  buff/cache   available\n\
+                     Mem:        8028240     1234560     4567890       12340     2225790     6556780\n\
+                     Swap:       2097148           0     2097148\n";
+        let mem = parse_memory_text(text).unwrap();
+        assert_eq!(mem.total, 8028240 * 1024);
+        assert_eq!(mem.used, 1234560 * 1024);
+        assert_eq!(mem.free, 4567890 * 1024);
+        assert!((mem.percent - 15.4).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_parse_memory_text_empty() {
+        assert!(parse_memory_text("").is_none());
+        assert!(parse_memory_text("no Mem: line here").is_none());
+    }
+
+    #[test]
+    fn test_parse_storage_text() {
+        let text = "Filesystem      Size  Used Avail Use% Mounted on\n\
+                     /dev/sda1        10G  2.1G  7.4G  22% /\n\
+                     tmpfs           4.0G     0  4.0G   0% /dev/shm\n";
+        let disks = parse_storage_text(text);
+        assert_eq!(disks.len(), 1); // tmpfs filtered out
+        assert_eq!(disks[0].filesystem, "/dev/sda1");
+        assert_eq!(disks[0].size, "10G");
+        assert_eq!(disks[0].used, "2.1G");
+        assert_eq!(disks[0].available, "7.4G");
+        assert!((disks[0].percent - 22.0).abs() < 0.1);
+        assert_eq!(disks[0].mount, "/");
+    }
+
+    #[test]
+    fn test_parse_storage_text_empty() {
+        assert!(parse_storage_text("").is_empty());
+        assert!(
+            parse_storage_text("Filesystem      Size  Used Avail Use% Mounted on\n").is_empty()
+        );
     }
 }

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Router,
   Network,
@@ -34,6 +34,12 @@ import {
   EyeOff,
   Users,
   Search,
+  Cpu,
+  MemoryStick,
+  HardDrive,
+  ScrollText,
+  RefreshCw,
+  Monitor,
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -110,8 +116,10 @@ import {
   addDnsDomainOverride,
   editDnsDomainOverride,
   deleteDnsDomainOverride,
+  fetchSystemInfo,
+  fetchSyslog,
 } from "@/lib/api";
-import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, SpeedTestResult, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride } from "@/lib/types";
+import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, SpeedTestResult, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse } from "@/lib/types";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -192,6 +200,277 @@ function StatusHeader({ status }: { status: RouterStatus }) {
           </Badge>
         )}
       </div>
+    </div>
+  );
+}
+
+// ── System Info Panel ───────────────────────────────────
+
+function SystemInfoPanel({
+  onTabActive,
+}: {
+  onTabActive: boolean;
+}) {
+  const [info, setInfo] = useState<SystemInfo | null>(null);
+  const [syslog, setSyslog] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [syslogLoading, setSyslogLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [logFilter, setLogFilter] = useState("");
+  const [debouncedFilter, setDebouncedFilter] = useState("");
+  const logContainerRef = useRef<HTMLDivElement>(null);
+
+  // Debounce the filter input
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedFilter(logFilter), 300);
+    return () => clearTimeout(timer);
+  }, [logFilter]);
+
+  // Fetch system info
+  const loadInfo = useCallback(async () => {
+    if (!onTabActive) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchSystemInfo();
+      setInfo(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load system info");
+    } finally {
+      setLoading(false);
+    }
+  }, [onTabActive]);
+
+  // Fetch syslog
+  const loadSyslog = useCallback(async () => {
+    if (!onTabActive) return;
+    setSyslogLoading(true);
+    try {
+      const data = await fetchSyslog(50, debouncedFilter || undefined);
+      setSyslog(data.lines);
+    } catch {
+      // Syslog errors are non-critical; keep existing lines
+    } finally {
+      setSyslogLoading(false);
+    }
+  }, [onTabActive, debouncedFilter]);
+
+  // Initial load + 30s auto-refresh
+  useEffect(() => {
+    loadInfo();
+    const interval = setInterval(loadInfo, 30_000);
+    return () => clearInterval(interval);
+  }, [loadInfo]);
+
+  useEffect(() => {
+    loadSyslog();
+    const interval = setInterval(loadSyslog, 30_000);
+    return () => clearInterval(interval);
+  }, [loadSyslog]);
+
+  if (loading && !info) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error && !info) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Top cards: Version, Uptime, CPU, Memory */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Version */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+              <Monitor className="h-4.5 w-4.5 text-blue-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Version</p>
+              <p className="truncate text-sm font-medium text-white">
+                {info?.version ?? "—"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Uptime */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
+              <Clock className="h-4.5 w-4.5 text-emerald-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Uptime</p>
+              <p className="truncate text-sm font-medium text-white">
+                {info?.uptime ?? "—"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* CPU Load */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10">
+              <Cpu className="h-4.5 w-4.5 text-amber-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">CPU Load</p>
+              {info?.cpu_load ? (
+                <p className="text-sm font-medium text-white">
+                  {info.cpu_load.load1.toFixed(2)}{" "}
+                  <span className="text-xs text-slate-500">
+                    / {info.cpu_load.load5.toFixed(2)} / {info.cpu_load.load15.toFixed(2)}
+                  </span>
+                </p>
+              ) : (
+                <p className="text-sm font-medium text-white">—</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Memory */}
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
+              <MemoryStick className="h-4.5 w-4.5 text-purple-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Memory</p>
+              {info?.memory ? (
+                <p className="text-sm font-medium text-white">
+                  {info.memory.percent}%{" "}
+                  <span className="text-xs text-slate-500">
+                    ({formatBytes(info.memory.used)} / {formatBytes(info.memory.total)})
+                  </span>
+                </p>
+              ) : (
+                <p className="text-sm font-medium text-white">—</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Memory + CPU progress bars */}
+      {(info?.memory || info?.cpu_load) && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {info?.memory && (
+            <Card className="border-slate-800 bg-slate-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm text-white">
+                  <MemoryStick className="h-4 w-4 text-purple-400" />
+                  Memory Usage
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Progress
+                  value={info.memory.percent}
+                  className="h-2"
+                />
+                <div className="mt-2 flex justify-between text-xs text-slate-500">
+                  <span>Used: {formatBytes(info.memory.used)}</span>
+                  <span>Free: {formatBytes(info.memory.free)}</span>
+                  <span>Total: {formatBytes(info.memory.total)}</span>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {info?.disk && info.disk.length > 0 && (
+            <Card className="border-slate-800 bg-slate-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm text-white">
+                  <HardDrive className="h-4 w-4 text-cyan-400" />
+                  Disk Usage
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {info.disk.map((d) => (
+                  <div key={d.mount}>
+                    <div className="mb-1 flex items-center justify-between text-xs text-slate-400">
+                      <span className="font-mono">{d.mount}</span>
+                      <span>{d.used} / {d.size} ({d.percent}%)</span>
+                    </div>
+                    <Progress
+                      value={d.percent}
+                      className="h-2"
+                    />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Syslog viewer */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0 pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm text-white">
+            <ScrollText className="h-4 w-4 text-slate-400" />
+            System Log
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-500" />
+              <Input
+                value={logFilter}
+                onChange={(e) => setLogFilter(e.target.value)}
+                placeholder="Filter logs..."
+                className="h-8 w-48 border-slate-800 bg-slate-950 pl-8 text-xs text-slate-300 placeholder:text-slate-600"
+              />
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={loadSyslog}
+              disabled={syslogLoading}
+              className="h-8 text-slate-400 hover:text-white"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${syslogLoading ? "animate-spin" : ""}`} />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div
+            ref={logContainerRef}
+            className="max-h-96 overflow-auto rounded-md border border-slate-800 bg-slate-950 p-3 font-mono text-xs leading-5 text-slate-400"
+          >
+            {syslog.length === 0 ? (
+              <p className="text-center text-slate-600">
+                {syslogLoading ? "Loading..." : "No log entries"}
+              </p>
+            ) : (
+              syslog.map((line, i) => (
+                <div
+                  key={i}
+                  className="hover:bg-slate-900/50 hover:text-slate-300"
+                >
+                  {line}
+                </div>
+              ))
+            )}
+          </div>
+          <p className="mt-2 text-right text-xs text-slate-600">
+            {syslog.length} line{syslog.length !== 1 ? "s" : ""} · auto-refreshes every 30s
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -4507,7 +4786,7 @@ export default function RouterPage() {
 // ── Tabs component (only rendered when configured) ──────
 
 function RouterTabs({ status }: { status: RouterStatus }) {
-  const [tab, setTab] = useState("interfaces");
+  const [tab, setTab] = useState("system");
 
   const interfaces = useAsyncData<VyosInterface[]>(
     useCallback(() => fetchRouterInterfaces(), []),
@@ -4571,6 +4850,13 @@ function RouterTabs({ status }: { status: RouterStatus }) {
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList className="border-slate-800 bg-slate-950">
           <TabsTrigger
+            value="system"
+            className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+          >
+            <Activity className="mr-1.5 h-3.5 w-3.5" />
+            System
+          </TabsTrigger>
+          <TabsTrigger
             value="interfaces"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
@@ -4620,6 +4906,10 @@ function RouterTabs({ status }: { status: RouterStatus }) {
             Speed Test
           </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="system">
+          <SystemInfoPanel onTabActive={tab === "system"} />
+        </TabsContent>
 
         <TabsContent value="interfaces" className="space-y-4">
           <Card className="border-slate-800 bg-slate-900">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -30,6 +30,8 @@ import type {
   SearchResponse,
   SettingsData,
   SpeedTestResult,
+  SystemInfo,
+  SyslogResponse,
   TopDevice,
   TrafficHistoryPoint,
   VyosDhcpLease,
@@ -283,6 +285,19 @@ export function fetchRouterStatus(): Promise<RouterStatus> {
 
 export function fetchRouterSummary(): Promise<RouterSummary> {
   return apiGet<RouterSummary>("/api/v1/vyos/router-summary");
+}
+
+export function fetchSystemInfo(): Promise<SystemInfo> {
+  return apiGet<SystemInfo>("/api/v1/vyos/system-info");
+}
+
+export function fetchSyslog(
+  lines = 50,
+  filter?: string
+): Promise<SyslogResponse> {
+  const params = new URLSearchParams({ lines: String(lines) });
+  if (filter) params.set("filter", filter);
+  return apiGet<SyslogResponse>(`/api/v1/vyos/syslog?${params}`);
 }
 
 export function fetchRouterInterfaces(): Promise<VyosInterface[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -468,6 +468,42 @@ export interface DnsForwardingConfig {
   cache_size: number | null;
 }
 
+// ─── System Info ───────────────────────────────────────
+
+export interface CpuLoad {
+  load1: number;
+  load5: number;
+  load15: number;
+}
+
+export interface MemoryUsage {
+  total: number;
+  used: number;
+  free: number;
+  percent: number;
+}
+
+export interface DiskUsage {
+  filesystem: string;
+  size: string;
+  used: string;
+  available: string;
+  percent: number;
+  mount: string;
+}
+
+export interface SystemInfo {
+  version: string | null;
+  uptime: string | null;
+  cpu_load: CpuLoad | null;
+  memory: MemoryUsage | null;
+  disk: DiskUsage[];
+}
+
+export interface SyslogResponse {
+  lines: string[];
+}
+
 // ─── Auth ───────────────────────────────────────────────
 
 export interface AuthStatus {


### PR DESCRIPTION
## Summary
Closes #90

- Add **System** tab to the router page (set as default) showing VyOS health at a glance
- **Backend**: two new GET endpoints (`/api/v1/vyos/system-info`, `/api/v1/vyos/syslog`) with parallel VyOS API calls and text output parsing
- **Frontend**: responsive system info cards + filterable syslog viewer with 30s auto-refresh

## What's included

### System info card
- VyOS version string (from `show version`)
- System uptime (from `show system uptime`)
- CPU load averages — 1/5/15 min (parsed from uptime output)
- Memory usage with progress bar (from `show system memory`)
- Disk usage for real filesystems, filters tmpfs/devtmpfs (from `show system storage`)

### Syslog viewer
- Last 50 lines from `show log tail`
- Text filter (debounced, case-insensitive) — applied server-side
- Manual refresh button
- Auto-refreshes every 30s alongside system info

### Backend
- `parse_uptime_and_load()` — extracts uptime string + CPU load averages
- `parse_memory_text()` — parses `free`-style output (Mem: line)
- `parse_storage_text()` — parses `df`-style output, filtering virtual filesystems
- Unit tests for all three parsers (7 new tests)

## Test plan
- [x] `cargo test` — all 212 lib + 12 integration tests pass
- [x] `tsc --noEmit` — TypeScript compiles cleanly
- [x] `cargo fmt` — formatted
- [ ] Manual: verify System tab renders with VyOS router connected
- [ ] Manual: verify syslog filter works
- [ ] Manual: verify auto-refresh updates values
- [ ] Manual: verify mobile layout responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a comprehensive System tab to the VyOS router dashboard displaying real-time health metrics (version, uptime, CPU load, memory, disk usage) and a filterable syslog viewer. The implementation uses parallel VyOS API calls for efficiency, includes robust text parsing with 7 unit tests covering all parsers, and features 30-second auto-refresh for live monitoring.

**Key changes:**
- Backend: Two new GET endpoints (`/api/v1/vyos/system-info`, `/api/v1/vyos/syslog`) with parallel VyOS command execution and text parsing utilities
- Text parsers for `show system uptime`, `show system memory`, and `show system storage` with comprehensive unit test coverage
- Frontend: Responsive system info cards with progress bars and a syslog viewer with debounced search filtering
- Auto-refresh every 30 seconds for both system info and logs
- Proper error handling and loading states throughout

**Technical highlights:**
- Uses `tokio::join!` for parallel VyOS API calls to minimize latency
- Memory values correctly converted from kB to bytes
- Filters out virtual filesystems (tmpfs, devtmpfs) from disk usage
- Server-side syslog filtering with 500-line safety limit
- Type-safe TypeScript interfaces matching Rust backend structures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with comprehensive unit tests (7 new tests), proper error handling, parallel API calls for performance, and type-safe interfaces. All parsing functions have edge case coverage and the frontend includes appropriate loading/error states.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Added system info and syslog endpoints with text parsing, parallel VyOS API calls, and comprehensive unit tests (7 new tests covering all parsers) |
| server/src/api/mod.rs | Added two new route handlers for `/vyos/system-info` and `/vyos/syslog` endpoints |
| web/src/app/(app)/router/page.tsx | Added System tab with 4 metric cards, progress bars, syslog viewer with debounced filtering and 30s auto-refresh |
| web/src/lib/api.ts | Added `fetchSystemInfo()` and `fetchSyslog()` API client methods with proper query parameter handling |
| web/src/lib/types.ts | Added TypeScript interfaces for system info data structures matching Rust backend types |

</details>



<sub>Last reviewed commit: 12eefb4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->