### PR TITLE
feat: NPM integration — API client, credentials in settings, connection test

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -24,6 +24,7 @@ pub mod devices;
 pub mod error;
 pub mod export;
 pub mod metrics;
+pub mod npm;
 pub mod scanner;
 pub mod search;
 pub mod settings;
@@ -46,6 +47,8 @@ pub struct AppState {
     pub vyos_http: reqwest::Client,
     /// TTL cache for VyOS read operations (show / retrieve).
     pub vyos_cache: Arc<crate::vyos::cache::VyosCache>,
+    /// Shared reqwest::Client for Nginx Proxy Manager API.
+    pub npm_http: reqwest::Client,
 }
 
 impl AppState {
@@ -59,6 +62,7 @@ impl AppState {
             last_speedtest: Arc::new(Mutex::new(None)),
             vyos_http: crate::vyos::client::shared_http_client(),
             vyos_cache: Arc::new(crate::vyos::cache::VyosCache::new()),
+            npm_http: crate::npm::client::shared_http_client(),
         }
     }
 }
@@ -305,6 +309,9 @@ pub fn router(state: AppState) -> Router {
         .route("/config-backups/:id", delete(config_backups::delete))
         .route("/config-backups/:id/diff", get(config_backups::diff))
         .route("/config-backups/:id/restore", post(config_backups::restore))
+        // Nginx Proxy Manager
+        .route("/npm/status", get(npm::status))
+        .route("/npm/proxy-hosts", get(npm::proxy_hosts))
         // Audit log
         .route("/audit-log", get(audit::list))
         .route("/audit-log/actions", get(audit::actions))

--- a/server/src/api/npm.rs
+++ b/server/src/api/npm.rs
@@ -1,0 +1,101 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Serialize;
+use tracing::error;
+
+use super::AppState;
+use crate::npm::client::{NpmClient, NpmConnectionStatus};
+
+/// GET /api/v1/npm/status — check NPM connection health.
+///
+/// Returns whether NPM is configured and reachable, plus the number
+/// of proxy hosts as a quick health signal.
+pub async fn status(State(state): State<AppState>) -> Json<NpmConnectionStatus> {
+    let client = match get_npm_client(&state).await {
+        Some(c) => c,
+        None => {
+            return Json(NpmConnectionStatus {
+                configured: false,
+                reachable: false,
+                host_count: None,
+            });
+        }
+    };
+
+    match client.test_connection().await {
+        Ok(status) => Json(status),
+        Err(e) => {
+            error!("NPM connection test failed: {e}");
+            Json(NpmConnectionStatus {
+                configured: true,
+                reachable: false,
+                host_count: None,
+            })
+        }
+    }
+}
+
+/// Response for the proxy hosts list endpoint.
+#[derive(Debug, Serialize)]
+pub struct ProxyHostSummary {
+    pub id: i64,
+    pub domain_names: Vec<String>,
+    pub forward_host: String,
+    pub forward_port: u16,
+    pub forward_scheme: String,
+    pub enabled: bool,
+    pub ssl_forced: bool,
+}
+
+/// GET /api/v1/npm/proxy-hosts — list all proxy hosts from NPM.
+pub async fn proxy_hosts(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ProxyHostSummary>>, StatusCode> {
+    let client = get_npm_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let hosts = client.list_proxy_hosts().await.map_err(|e| {
+        error!("NPM list proxy hosts failed: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let summaries: Vec<ProxyHostSummary> = hosts
+        .into_iter()
+        .map(|h| ProxyHostSummary {
+            id: h.id,
+            domain_names: h.domain_names,
+            forward_host: h.forward_host,
+            forward_port: h.forward_port,
+            forward_scheme: h.forward_scheme,
+            enabled: h.enabled,
+            ssl_forced: h.ssl_forced,
+        })
+        .collect();
+
+    Ok(Json(summaries))
+}
+
+/// Build an [`NpmClient`] from current settings, or `None` if not configured.
+async fn get_npm_client(state: &AppState) -> Option<NpmClient> {
+    let url = get_setting(state, "npm_url").await?;
+    let email = get_setting(state, "npm_email").await?;
+    let password = get_setting(state, "npm_password").await?;
+
+    Some(NpmClient::new(
+        &url,
+        &email,
+        &password,
+        state.npm_http.clone(),
+    ))
+}
+
+/// Helper: read a string setting from the settings table.
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -20,6 +20,11 @@ pub struct SettingsResponse {
     pub retention_traffic_hours: Option<u64>,
     pub retention_alerts_days: Option<u64>,
     pub retention_agent_reports_days: Option<u64>,
+    // --- Nginx Proxy Manager ---
+    pub npm_url: Option<String>,
+    pub npm_email: Option<String>,
+    /// Never return the password to the frontend — just whether one is set.
+    pub npm_password_set: bool,
 }
 
 /// Request body for updating settings.
@@ -36,6 +41,10 @@ pub struct UpdateSettingsRequest {
     pub retention_traffic_hours: Option<u64>,
     pub retention_alerts_days: Option<u64>,
     pub retention_agent_reports_days: Option<u64>,
+    // --- Nginx Proxy Manager ---
+    pub npm_url: Option<String>,
+    pub npm_email: Option<String>,
+    pub npm_password: Option<String>,
 }
 
 /// Helper: read a string setting from the settings table.
@@ -90,6 +99,11 @@ pub async fn get_settings(
         .and_then(|v| v.parse().ok())
         .or(Some(state.config.retention.agent_reports_days));
 
+    // Nginx Proxy Manager settings.
+    let npm_url = get_setting(&state, "npm_url").await;
+    let npm_email = get_setting(&state, "npm_email").await;
+    let npm_password_set = get_setting(&state, "npm_password").await.is_some();
+
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
@@ -100,6 +114,9 @@ pub async fn get_settings(
         retention_traffic_hours,
         retention_alerts_days,
         retention_agent_reports_days,
+        npm_url,
+        npm_email,
+        npm_password_set,
     }))
 }
 
@@ -163,6 +180,22 @@ pub async fn update_settings(
             retention_agent_reports_days = days,
             "Agent reports retention updated"
         );
+    }
+
+    // --- Nginx Proxy Manager settings ---
+    if let Some(ref url) = body.npm_url {
+        upsert_setting(&state, "npm_url", url).await?;
+        info!(npm_url = %url, "NPM URL updated");
+    }
+
+    if let Some(ref email) = body.npm_email {
+        upsert_setting(&state, "npm_email", email).await?;
+        info!(npm_email = %email, "NPM email updated");
+    }
+
+    if let Some(ref password) = body.npm_password {
+        upsert_setting(&state, "npm_password", password).await?;
+        info!("NPM password updated");
     }
 
     // Return current state.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod enrichment;
 pub mod mdns;
 pub mod netflow;
+pub mod npm;
 pub mod oui;
 pub mod retention;
 pub mod scanner;

--- a/server/src/npm/client.rs
+++ b/server/src/npm/client.rs
@@ -1,0 +1,232 @@
+//! Nginx Proxy Manager HTTP API client.
+//!
+//! Handles token-based authentication with auto-renewal.
+//! NPM uses `POST /api/tokens` to obtain a bearer token that expires
+//! after ~1 day. This client caches the token and re-authenticates
+//! before expiry.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Cached bearer token with its creation time.
+#[derive(Debug, Clone)]
+struct CachedToken {
+    token: String,
+    obtained_at: Instant,
+}
+
+/// Shared token cache across clones of [`NpmClient`].
+#[derive(Debug, Clone, Default)]
+pub struct NpmTokenCache {
+    inner: Arc<RwLock<Option<CachedToken>>>,
+}
+
+/// A client for the Nginx Proxy Manager API.
+#[derive(Debug, Clone)]
+pub struct NpmClient {
+    base_url: String,
+    email: String,
+    password: String,
+    http: reqwest::Client,
+    token_cache: NpmTokenCache,
+}
+
+/// Response from `POST /api/tokens`.
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    token: String,
+    // NPM returns `expires` as an ISO date string; we ignore it and use
+    // a conservative 20-hour TTL to avoid clock-drift issues.
+}
+
+/// NPM proxy host (subset of fields relevant to Panoptikon).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NpmProxyHost {
+    pub id: i64,
+    pub domain_names: Vec<String>,
+    pub forward_host: String,
+    pub forward_port: u16,
+    pub forward_scheme: String,
+    pub enabled: bool,
+    pub ssl_forced: bool,
+    pub meta: Option<serde_json::Value>,
+}
+
+/// Connection test result returned by the `/npm/status` endpoint.
+#[derive(Debug, Serialize)]
+pub struct NpmConnectionStatus {
+    pub configured: bool,
+    pub reachable: bool,
+    pub host_count: Option<usize>,
+}
+
+/// Build the shared `reqwest::Client` for NPM API calls.
+pub fn shared_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(10))
+        .pool_max_idle_per_host(4)
+        .tcp_keepalive(Duration::from_secs(30))
+        .build()
+        .expect("failed to build shared reqwest client for NPM")
+}
+
+impl NpmClient {
+    /// Create a new NPM client.
+    ///
+    /// `base_url` should include scheme + host + port, e.g. `"http://10.10.0.20:81"`.
+    pub fn new(base_url: &str, email: &str, password: &str, http: reqwest::Client) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            email: email.to_string(),
+            password: password.to_string(),
+            http,
+            token_cache: NpmTokenCache::default(),
+        }
+    }
+
+    /// Authenticate and obtain a fresh bearer token.
+    async fn authenticate(&self) -> Result<String> {
+        #[derive(Serialize)]
+        struct TokenRequest<'a> {
+            identity: &'a str,
+            secret: &'a str,
+        }
+
+        let url = format!("{}/api/tokens", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&TokenRequest {
+                identity: &self.email,
+                secret: &self.password,
+            })
+            .send()
+            .await
+            .context("NPM token request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM auth failed (HTTP {status}): {body}");
+        }
+
+        let parsed: TokenResponse = resp
+            .json()
+            .await
+            .context("failed to parse NPM token response")?;
+
+        Ok(parsed.token)
+    }
+
+    /// Get a valid bearer token, re-authenticating if needed.
+    ///
+    /// Tokens are considered valid for 20 hours (NPM default expiry is 1 day).
+    async fn get_token(&self) -> Result<String> {
+        const TOKEN_TTL: Duration = Duration::from_secs(20 * 3600);
+
+        // Try cached token first.
+        {
+            let guard = self.token_cache.inner.read().await;
+            if let Some(ref cached) = *guard {
+                if cached.obtained_at.elapsed() < TOKEN_TTL {
+                    return Ok(cached.token.clone());
+                }
+            }
+        }
+
+        // Re-authenticate.
+        let token = self.authenticate().await?;
+
+        // Cache the new token.
+        {
+            let mut guard = self.token_cache.inner.write().await;
+            *guard = Some(CachedToken {
+                token: token.clone(),
+                obtained_at: Instant::now(),
+            });
+        }
+
+        Ok(token)
+    }
+
+    /// List all proxy hosts.
+    pub async fn list_proxy_hosts(&self) -> Result<Vec<NpmProxyHost>> {
+        let token = self.get_token().await?;
+        let url = format!(
+            "{}/api/nginx/proxy-hosts?expand=certificate,owner,access_list",
+            self.base_url
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("NPM list proxy hosts request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM list proxy hosts failed (HTTP {status}): {body}");
+        }
+
+        let hosts: Vec<NpmProxyHost> = resp
+            .json()
+            .await
+            .context("failed to parse NPM proxy hosts response")?;
+
+        Ok(hosts)
+    }
+
+    /// Test the connection by authenticating and fetching proxy hosts.
+    ///
+    /// Returns the number of proxy hosts as a health signal.
+    pub async fn test_connection(&self) -> Result<NpmConnectionStatus> {
+        // Force re-auth to verify credentials are still valid.
+        let token = self.authenticate().await?;
+
+        // Cache the fresh token.
+        {
+            let mut guard = self.token_cache.inner.write().await;
+            *guard = Some(CachedToken {
+                token: token.clone(),
+                obtained_at: Instant::now(),
+            });
+        }
+
+        let url = format!(
+            "{}/api/nginx/proxy-hosts?expand=certificate,owner,access_list",
+            self.base_url
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("NPM proxy hosts request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM proxy hosts failed (HTTP {status}): {body}");
+        }
+
+        let hosts: Vec<NpmProxyHost> = resp
+            .json()
+            .await
+            .context("failed to parse NPM proxy hosts")?;
+
+        Ok(NpmConnectionStatus {
+            configured: true,
+            reachable: true,
+            host_count: Some(hosts.len()),
+        })
+    }
+}

--- a/server/src/npm/mod.rs
+++ b/server/src/npm/mod.rs
@@ -1,0 +1,1 @@
+pub mod client;

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -17,6 +17,7 @@ import {
   Trash2,
   FileText,
   ChevronRight,
+  Globe,
 } from "lucide-react";
 import {
   Card,
@@ -28,7 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { fetchRouterStatus } from "@/lib/api";
+import { fetchRouterStatus, fetchNpmStatus } from "@/lib/api";
 import { PageTransition } from "@/components/PageTransition";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -90,6 +91,18 @@ export default function SettingsPage() {
   const [vacuumStatus, setVacuumStatus] = useState<Status>("idle");
   const [vacuumMsg, setVacuumMsg] = useState("");
 
+  // --- Nginx Proxy Manager state ---
+  const [npmUrl, setNpmUrl] = useState("");
+  const [savedNpmUrl, setSavedNpmUrl] = useState<string | null>(null);
+  const [npmEmail, setNpmEmail] = useState("");
+  const [savedNpmEmail, setSavedNpmEmail] = useState<string | null>(null);
+  const [npmPassword, setNpmPassword] = useState("");
+  const [npmPasswordSet, setNpmPasswordSet] = useState(false);
+  const [npmStatus, setNpmStatus] = useState<Status>("idle");
+  const [npmMsg, setNpmMsg] = useState("");
+  const [npmTestStatus, setNpmTestStatus] = useState<Status>("idle");
+  const [npmTestMsg, setNpmTestMsg] = useState("");
+
   // Guards against race: initial GET /settings resolving after user saves.
   const settingsLoadTokenRef = useRef(0);
 
@@ -110,6 +123,9 @@ export default function SettingsPage() {
           retention_traffic_hours: number | null;
           retention_alerts_days: number | null;
           retention_agent_reports_days: number | null;
+          npm_url: string | null;
+          npm_email: string | null;
+          npm_password_set: boolean;
         }) => {
           // Ignore stale response if a newer local action (e.g. Save) already happened.
           if (loadToken !== settingsLoadTokenRef.current) return;
@@ -141,6 +157,13 @@ export default function SettingsPage() {
           const agentD = String(data.retention_agent_reports_days ?? 7);
           setRetAgentDays(agentD);
           setSavedRetAgentDays(agentD);
+
+          // NPM
+          setNpmUrl(data.npm_url ?? "");
+          setSavedNpmUrl(data.npm_url ?? null);
+          setNpmEmail(data.npm_email ?? "");
+          setSavedNpmEmail(data.npm_email ?? null);
+          setNpmPasswordSet(data.npm_password_set);
         }
       )
       .catch(() => {});
@@ -178,6 +201,10 @@ export default function SettingsPage() {
     retTrafficHours !== savedRetTrafficHours ||
     retAlertsDays !== savedRetAlertsDays ||
     retAgentDays !== savedRetAgentDays;
+  const npmDirty =
+    npmUrl !== (savedNpmUrl ?? "") ||
+    npmEmail !== (savedNpmEmail ?? "") ||
+    npmPassword.length > 0;
 
   async function handlePasswordSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -476,6 +503,67 @@ export default function SettingsPage() {
     }
   }
 
+  async function handleNpmSave() {
+    settingsLoadTokenRef.current++;
+    setNpmStatus("loading");
+    setNpmMsg("");
+    try {
+      const body: Record<string, string> = {};
+      if (npmUrl !== (savedNpmUrl ?? "")) body.npm_url = npmUrl;
+      if (npmEmail !== (savedNpmEmail ?? "")) body.npm_email = npmEmail;
+      if (npmPassword.length > 0) body.npm_password = npmPassword;
+
+      const res = await fetch("/api/v1/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSavedNpmUrl(data.npm_url ?? null);
+        setNpmUrl(data.npm_url ?? "");
+        setSavedNpmEmail(data.npm_email ?? null);
+        setNpmEmail(data.npm_email ?? "");
+        setNpmPasswordSet(data.npm_password_set);
+        setNpmPassword("");
+        setNpmStatus("success");
+        setNpmMsg("NPM settings saved.");
+        setTimeout(() => setNpmStatus("idle"), 3000);
+      } else {
+        setNpmStatus("error");
+        setNpmMsg(`Failed to save (${res.status}).`);
+      }
+    } catch {
+      setNpmStatus("error");
+      setNpmMsg("Network error.");
+    }
+  }
+
+  async function handleNpmTest() {
+    setNpmTestStatus("loading");
+    setNpmTestMsg("");
+    try {
+      const data = await fetchNpmStatus();
+      if (data.reachable) {
+        setNpmTestStatus("success");
+        setNpmTestMsg(
+          `Connected! ${data.host_count !== null ? `${data.host_count} proxy host${data.host_count !== 1 ? "s" : ""}` : ""}`
+        );
+        setTimeout(() => setNpmTestStatus("idle"), 5000);
+      } else if (data.configured) {
+        setNpmTestStatus("error");
+        setNpmTestMsg("NPM configured but unreachable. Check URL and credentials.");
+      } else {
+        setNpmTestStatus("error");
+        setNpmTestMsg("NPM not configured. Save URL, email, and password first.");
+      }
+    } catch {
+      setNpmTestStatus("error");
+      setNpmTestMsg("Failed to test connection.");
+    }
+  }
+
   return (
     <PageTransition>
     <div className="mx-auto max-w-lg space-y-6 py-8">
@@ -616,6 +704,129 @@ export default function SettingsPage() {
               className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
             >
               {vyosTestStatus === "loading" ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Plug className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              Test Connection
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Nginx Proxy Manager */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-orange-500/10">
+              <Globe className="h-4 w-4 text-orange-400" />
+            </div>
+            <div>
+              <CardTitle className="text-base text-white">
+                Nginx Proxy Manager
+              </CardTitle>
+              <CardDescription className="text-xs text-slate-500">
+                Connect to your NPM instance to manage reverse proxy hosts.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="npm-url" className="text-xs text-slate-400">
+              NPM URL
+            </Label>
+            <Input
+              id="npm-url"
+              type="url"
+              value={npmUrl}
+              onChange={(e) => setNpmUrl(e.target.value)}
+              className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+              placeholder="http://10.10.0.20:81"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="npm-email" className="text-xs text-slate-400">
+              Email
+            </Label>
+            <Input
+              id="npm-email"
+              type="email"
+              value={npmEmail}
+              onChange={(e) => setNpmEmail(e.target.value)}
+              className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+              placeholder="admin@example.com"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="npm-password" className="text-xs text-slate-400">
+              Password{" "}
+              {npmPasswordSet && (
+                <span className="text-emerald-500">(saved)</span>
+              )}
+            </Label>
+            <Input
+              id="npm-password"
+              type="password"
+              value={npmPassword}
+              onChange={(e) => setNpmPassword(e.target.value)}
+              className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+              placeholder={
+                npmPasswordSet
+                  ? "••••••••  (leave blank to keep current)"
+                  : "Enter NPM password"
+              }
+            />
+          </div>
+
+          {/* Status messages */}
+          {npmStatus === "success" && npmMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{npmMsg}</p>
+            </div>
+          )}
+          {npmStatus === "error" && npmMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{npmMsg}</p>
+            </div>
+          )}
+          {npmTestStatus === "success" && npmTestMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{npmTestMsg}</p>
+            </div>
+          )}
+          {npmTestStatus === "error" && npmTestMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{npmTestMsg}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <Button
+              onClick={handleNpmSave}
+              disabled={!npmDirty || npmStatus === "loading"}
+              className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
+            >
+              {npmStatus === "loading" ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Save
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleNpmTest}
+              disabled={
+                (!savedNpmUrl && !npmUrl) || npmTestStatus === "loading"
+              }
+              className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+            >
+              {npmTestStatus === "loading" ? (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
               ) : (
                 <Plug className="mr-1.5 h-3.5 w-3.5" />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -35,10 +35,40 @@ const navItems = [
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 
+/** NPM connectivity state: null = not configured, true = reachable, false = unreachable. */
+function useNpmStatus(): null | boolean {
+  const [status, setStatus] = useState<null | boolean>(null);
+
+  const poll = useCallback(() => {
+    fetch("/api/v1/npm/status", { credentials: "include" })
+      .then((res) => {
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((data) => {
+        if (!data || !data.configured) {
+          setStatus(null);
+        } else {
+          setStatus(data.reachable === true);
+        }
+      })
+      .catch(() => setStatus(null));
+  }, []);
+
+  useEffect(() => {
+    poll();
+    const id = setInterval(poll, 60_000); // refresh every 60s
+    return () => clearInterval(id);
+  }, [poll]);
+
+  return status;
+}
+
 export function Sidebar() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const wsConnected = useWsConnected();
+  const npmStatus = useNpmStatus();
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -129,12 +159,29 @@ export function Sidebar() {
                   <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
                 </TooltipContent>
               </Tooltip>
+              {npmStatus !== null && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
+                        npmStatus
+                          ? "bg-orange-400 ring-2 ring-orange-400/30"
+                          : "bg-rose-500 ring-2 ring-rose-500/30"
+                      )}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="border-slate-800 bg-slate-900">
+                    <p>{npmStatus ? "NPM — connected" : "NPM — unreachable"}</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
               <p className="text-[10px] text-slate-700">Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.1.0"}</p>
             </div>
           ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="mt-1 flex justify-center">
+            <div className="mt-1 flex flex-col items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
                   <span
                     className={cn(
                       "inline-block h-1.5 w-1.5 rounded-full",
@@ -143,12 +190,29 @@ export function Sidebar() {
                         : "bg-slate-600"
                     )}
                   />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="right" className="border-slate-800 bg-slate-900">
-                <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
-              </TooltipContent>
-            </Tooltip>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="border-slate-800 bg-slate-900">
+                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
+                </TooltipContent>
+              </Tooltip>
+              {npmStatus !== null && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        "inline-block h-1.5 w-1.5 rounded-full",
+                        npmStatus
+                          ? "bg-orange-400 ring-2 ring-orange-400/30"
+                          : "bg-rose-500 ring-2 ring-rose-500/30"
+                      )}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="right" className="border-slate-800 bg-slate-900">
+                    <p>{npmStatus ? "NPM — connected" : "NPM — unreachable"}</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           )}
         </div>
       </aside>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,8 @@ import type {
   FirewallGroups,
   LoginResponse,
   NetflowStatus,
+  NpmConnectionStatus,
+  NpmProxyHost,
   PendingChangesResponse,
   RouterStatus,
   RouterSummary,
@@ -635,6 +637,9 @@ export function updateSettings(body: {
   retention_traffic_hours?: number;
   retention_alerts_days?: number;
   retention_agent_reports_days?: number;
+  npm_url?: string;
+  npm_email?: string;
+  npm_password?: string;
 }): Promise<SettingsData> {
   return apiPatch<SettingsData>("/api/v1/settings", body);
 }
@@ -800,4 +805,14 @@ export function restoreConfigBackup(
   return apiPost<ConfigActionResponse>(`/api/v1/config-backups/${id}/restore`, {
     snapshot_label: snapshotLabel || null,
   });
+}
+
+// ─── Nginx Proxy Manager ─────────────────────────────────
+
+export function fetchNpmStatus(): Promise<NpmConnectionStatus> {
+  return apiGet<NpmConnectionStatus>("/api/v1/npm/status");
+}
+
+export function fetchNpmProxyHosts(): Promise<NpmProxyHost[]> {
+  return apiGet<NpmProxyHost[]>("/api/v1/npm/proxy-hosts");
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -323,6 +323,28 @@ export interface SettingsData {
   retention_traffic_hours: number | null;
   retention_alerts_days: number | null;
   retention_agent_reports_days: number | null;
+  // Nginx Proxy Manager
+  npm_url: string | null;
+  npm_email: string | null;
+  npm_password_set: boolean;
+}
+
+// ─── Nginx Proxy Manager ─────────────────────────────────
+
+export interface NpmConnectionStatus {
+  configured: boolean;
+  reachable: boolean;
+  host_count: number | null;
+}
+
+export interface NpmProxyHost {
+  id: number;
+  domain_names: string[];
+  forward_host: string;
+  forward_port: number;
+  forward_scheme: string;
+  enabled: boolean;
+  ssl_forced: boolean;
 }
 
 export interface DbSizeData {


### PR DESCRIPTION
## Summary
Foundation for Nginx Proxy Manager integration in Panoptikon.

- **NPM API client** (`server/src/npm/client.rs`) with token-based auth (`POST /api/tokens`) and automatic token renewal before 20-hour expiry
- **Settings section** for NPM URL, email, and password — stored in the existing settings table, following the same pattern as VyOS credentials
- **Connection test** button that authenticates against NPM and returns the proxy host count
- **NPM status indicator** in sidebar — orange dot when connected, red when unreachable, hidden when not configured (polls every 60s)
- **Backend endpoints**: `GET /api/v1/npm/status` and `GET /api/v1/npm/proxy-hosts`

## Acceptance Criteria
- [x] Settings form for NPM credentials (URL, email, password)
- [x] Token auth working (auto-renew before expiry)
- [x] Connection test returns host count
- [x] Status indicator visible in sidebar UI

Closes #91

## Test plan
- [x] All 222 unit tests pass
- [x] All 12 integration tests pass
- [x] TypeScript type-checks cleanly (`tsc --noEmit`)
- [x] `cargo fmt` passes
- [ ] Manual: configure NPM credentials in settings, verify connection test shows host count
- [ ] Manual: verify sidebar shows orange dot when NPM is connected
- [ ] Manual: verify sidebar hides NPM dot when NPM is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds foundational NPM integration with token-based authentication, settings UI, and status monitoring. The implementation follows existing patterns from VyOS integration.

**Key changes:**
- NPM API client (`server/src/npm/client.rs`) with bearer token auth and 20-hour token caching
- Settings section for NPM URL, email, and password with connection test button
- Status indicator in sidebar (orange dot when connected, red when unreachable, hidden when not configured)
- Backend endpoints: `GET /api/v1/npm/status` and `GET /api/v1/npm/proxy-hosts`

**Issues found:**
- Token cache not shared between `NpmClient` instances — each API request creates a new client with its own cache, defeating the caching mechanism
- NPM password stored in plaintext without explanatory comment (unlike VyOS API key which has detailed security rationale)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical bug affecting token caching performance
- Token cache bug causes unnecessary re-authentication on every request (performance issue, not correctness). Password storage follows existing VyOS pattern. Otherwise clean implementation.
- Pay close attention to `server/src/npm/client.rs` — token caching mechanism needs architectural fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/npm/client.rs | NPM API client with token auth. Token cache not shared between instances - caching ineffective. |
| server/src/api/npm.rs | API endpoints for NPM status and proxy hosts. Creates new client per request. |
| server/src/api/settings.rs | Settings endpoints extended to support NPM credentials. Follows existing patterns for VyOS. |
| web/src/app/(app)/settings/page.tsx | NPM settings form with connection test. Follows existing VyOS credentials pattern. |
| web/src/components/layout/Sidebar.tsx | Added NPM status indicator with 60s polling. Clean implementation following existing patterns. |

</details>



<sub>Last reviewed commit: 016d119</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->