### PR TITLE
feat: NPM dead hosts — 404 catch-all pages management

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -342,6 +342,9 @@ pub fn router(state: AppState) -> Router {
         .route("/npm/streams/:id", put(npm::update_stream))
         .route("/npm/streams/:id", delete(npm::delete_stream))
         .route("/npm/streams/:id/toggle", post(npm::toggle_stream))
+        .route("/npm/dead-hosts", get(npm::dead_hosts))
+        .route("/npm/dead-hosts", post(npm::create_dead_host))
+        .route("/npm/dead-hosts/:id", delete(npm::delete_dead_host))
         // Audit log
         .route("/audit-log", get(audit::list))
         .route("/audit-log/actions", get(audit::actions))

--- a/server/src/api/npm.rs
+++ b/server/src/api/npm.rs
@@ -8,8 +8,8 @@ use tracing::error;
 
 use super::AppState;
 use crate::npm::client::{
-    NpmCertificate, NpmClient, NpmConnectionStatus, NpmProxyHostPayload, NpmRedirectionHostPayload,
-    NpmStreamPayload,
+    NpmCertificate, NpmClient, NpmConnectionStatus, NpmDeadHostPayload, NpmProxyHostPayload,
+    NpmRedirectionHostPayload, NpmStreamPayload,
 };
 
 /// GET /api/v1/npm/status — check NPM connection health.
@@ -796,6 +796,97 @@ pub async fn toggle_stream(
     }
     .map_err(|e| {
         error!("NPM toggle stream {id} failed: {e}");
+        error_response(StatusCode::BAD_GATEWAY, e.to_string())
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── Dead Hosts ─────────────────────────────────────────
+
+/// Summary returned by the dead hosts list endpoint.
+#[derive(Debug, Serialize)]
+pub struct DeadHostSummary {
+    pub id: i64,
+    pub domain_names: Vec<String>,
+    pub ssl_forced: bool,
+    pub enabled: bool,
+}
+
+/// GET /api/v1/npm/dead-hosts — list all dead hosts from NPM.
+pub async fn dead_hosts(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<DeadHostSummary>>, StatusCode> {
+    let client = get_npm_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let hosts = client.list_dead_hosts().await.map_err(|e| {
+        error!("NPM list dead hosts failed: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let summaries: Vec<DeadHostSummary> = hosts
+        .into_iter()
+        .map(|h| DeadHostSummary {
+            id: h.id,
+            domain_names: h.domain_names,
+            ssl_forced: h.ssl_forced,
+            enabled: h.enabled,
+        })
+        .collect();
+
+    Ok(Json(summaries))
+}
+
+/// Request body for creating a dead host.
+#[derive(Debug, Deserialize)]
+pub struct DeadHostRequest {
+    pub domain_names: Vec<String>,
+    #[serde(default)]
+    pub ssl_forced: bool,
+}
+
+/// POST /api/v1/npm/dead-hosts — create a new dead host.
+pub async fn create_dead_host(
+    State(state): State<AppState>,
+    Json(body): Json<DeadHostRequest>,
+) -> Result<Json<DeadHostSummary>, (StatusCode, Json<ErrorBody>)> {
+    let client = get_npm_client(&state).await.ok_or_else(|| {
+        error_response(StatusCode::SERVICE_UNAVAILABLE, "NPM not configured".into())
+    })?;
+
+    let payload = NpmDeadHostPayload {
+        domain_names: body.domain_names,
+        certificate_id: serde_json::Value::Number(0.into()),
+        ssl_forced: body.ssl_forced,
+        meta: serde_json::json!({}),
+    };
+
+    let host = client.create_dead_host(&payload).await.map_err(|e| {
+        error!("NPM create dead host failed: {e}");
+        error_response(StatusCode::BAD_GATEWAY, e.to_string())
+    })?;
+
+    Ok(Json(DeadHostSummary {
+        id: host.id,
+        domain_names: host.domain_names,
+        ssl_forced: host.ssl_forced,
+        enabled: host.enabled,
+    }))
+}
+
+/// DELETE /api/v1/npm/dead-hosts/:id — delete a dead host.
+pub async fn delete_dead_host(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    let client = get_npm_client(&state).await.ok_or_else(|| {
+        error_response(StatusCode::SERVICE_UNAVAILABLE, "NPM not configured".into())
+    })?;
+
+    client.delete_dead_host(id).await.map_err(|e| {
+        error!("NPM delete dead host {id} failed: {e}");
         error_response(StatusCode::BAD_GATEWAY, e.to_string())
     })?;
 

--- a/server/src/npm/client.rs
+++ b/server/src/npm/client.rs
@@ -135,6 +135,26 @@ pub struct NpmStreamPayload {
     pub meta: serde_json::Value,
 }
 
+/// NPM dead host returned by the API.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NpmDeadHost {
+    pub id: i64,
+    pub domain_names: Vec<String>,
+    pub certificate_id: serde_json::Value,
+    pub ssl_forced: bool,
+    pub enabled: bool,
+    pub meta: Option<serde_json::Value>,
+}
+
+/// Payload for creating a dead host.
+#[derive(Debug, Serialize, Clone)]
+pub struct NpmDeadHostPayload {
+    pub domain_names: Vec<String>,
+    pub certificate_id: serde_json::Value,
+    pub ssl_forced: bool,
+    pub meta: serde_json::Value,
+}
+
 /// Connection test result returned by the `/npm/status` endpoint.
 #[derive(Debug, Serialize)]
 pub struct NpmConnectionStatus {
@@ -837,6 +857,85 @@ impl NpmClient {
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             anyhow::bail!("NPM disable stream failed (HTTP {status}): {body}");
+        }
+
+        Ok(())
+    }
+
+    // ─── Dead Hosts ─────────────────────────────────────────
+
+    /// List all dead hosts.
+    pub async fn list_dead_hosts(&self) -> Result<Vec<NpmDeadHost>> {
+        let token = self.get_token().await?;
+        let url = format!("{}/api/nginx/dead-hosts", self.base_url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("NPM list dead hosts request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM list dead hosts failed (HTTP {status}): {body}");
+        }
+
+        let hosts: Vec<NpmDeadHost> = resp
+            .json()
+            .await
+            .context("failed to parse NPM dead hosts response")?;
+
+        Ok(hosts)
+    }
+
+    /// Create a new dead host.
+    pub async fn create_dead_host(&self, payload: &NpmDeadHostPayload) -> Result<NpmDeadHost> {
+        let token = self.get_token().await?;
+        let url = format!("{}/api/nginx/dead-hosts", self.base_url);
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&token)
+            .json(payload)
+            .send()
+            .await
+            .context("NPM create dead host request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM create dead host failed (HTTP {status}): {body}");
+        }
+
+        let host: NpmDeadHost = resp
+            .json()
+            .await
+            .context("failed to parse NPM create dead host response")?;
+
+        Ok(host)
+    }
+
+    /// Delete a dead host by ID.
+    pub async fn delete_dead_host(&self, id: i64) -> Result<()> {
+        let token = self.get_token().await?;
+        let url = format!("{}/api/nginx/dead-hosts/{id}", self.base_url);
+
+        let resp = self
+            .http
+            .delete(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .context("NPM delete dead host request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("NPM delete dead host failed (HTTP {status}): {body}");
         }
 
         Ok(())

--- a/web/src/app/(app)/npm/page.tsx
+++ b/web/src/app/(app)/npm/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   ArrowRightLeft,
   ExternalLink,
+  FileX2,
   Globe,
   Loader2,
   Lock,
@@ -51,12 +52,16 @@ import {
   updateNpmStream,
   deleteNpmStream,
   toggleNpmStream,
+  fetchNpmDeadHosts,
+  createNpmDeadHost,
+  deleteNpmDeadHost,
 } from "@/lib/api";
 import type {
   NpmConnectionStatus,
   NpmProxyHost,
   NpmRedirectionHost,
   NpmStream,
+  NpmDeadHost,
 } from "@/lib/types";
 
 // ─── Proxy Hosts Table ──────────────────────────────────
@@ -990,6 +995,272 @@ function StreamsTable({
   );
 }
 
+// ─── Dead Hosts Table ────────────────────────────────────
+
+interface DeadHostFormData {
+  domain_names: string;
+  ssl_forced: boolean;
+}
+
+const emptyDeadForm: DeadHostFormData = {
+  domain_names: "",
+  ssl_forced: false,
+};
+
+function DeadHostsTable({
+  hosts,
+  loading,
+  onReload,
+}: {
+  hosts: NpmDeadHost[];
+  loading: boolean;
+  onReload: () => void;
+}) {
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<DeadHostFormData>(emptyDeadForm);
+  const [saving, setSaving] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<NpmDeadHost | null>(null);
+  const [deleting, setDeleting] = useState<number | null>(null);
+
+  const openCreate = () => {
+    setForm(emptyDeadForm);
+    setShowForm(true);
+  };
+
+  const handleSave = async () => {
+    const domainNames = form.domain_names
+      .split(",")
+      .map((d) => d.trim())
+      .filter(Boolean);
+    if (domainNames.length === 0) {
+      toast.error("At least one domain name is required");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await createNpmDeadHost({
+        domain_names: domainNames,
+        ssl_forced: form.ssl_forced,
+      });
+      toast.success("Dead host created");
+      setShowForm(false);
+      setForm(emptyDeadForm);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Create failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    const { id } = confirmDelete;
+    setConfirmDelete(null);
+    setDeleting(id);
+    try {
+      await deleteNpmDeadHost(id);
+      toast.success("Dead host deleted");
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-2 p-4">
+        {[...Array(3)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full bg-slate-800" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between px-4 py-3">
+        <p className="text-xs text-slate-500">
+          {hosts.length} dead host{hosts.length !== 1 ? "s" : ""}
+        </p>
+        <Button variant="outline" size="sm" onClick={openCreate}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Add Dead Host
+        </Button>
+      </div>
+
+      {hosts.length === 0 ? (
+        <p className="px-4 pb-6 text-center text-sm text-slate-500">
+          No dead hosts found.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-800 text-left text-xs uppercase text-slate-500">
+                <th className="px-4 py-2">Domain(s)</th>
+                <th className="px-4 py-2">SSL</th>
+                <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hosts.map((h) => (
+                <tr
+                  key={h.id}
+                  className="border-b border-slate-800/50 hover:bg-slate-800/30"
+                >
+                  <td className="px-4 py-2.5">
+                    <div className="flex flex-wrap gap-1">
+                      {h.domain_names.map((d) => (
+                        <span
+                          key={d}
+                          className="font-mono text-xs text-white"
+                        >
+                          {d}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {h.ssl_forced ? (
+                      <Lock className="h-3.5 w-3.5 text-emerald-400" />
+                    ) : (
+                      <span className="text-xs text-slate-600">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    <Badge
+                      variant="outline"
+                      className={
+                        h.enabled
+                          ? "border-emerald-500/30 text-emerald-400"
+                          : "border-slate-700 text-slate-500"
+                      }
+                    >
+                      {h.enabled ? "Enabled" : "Disabled"}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-2.5 text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-slate-400 hover:text-rose-400"
+                      disabled={deleting === h.id}
+                      onClick={() => setConfirmDelete(h)}
+                    >
+                      {deleting === h.id ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create Dialog */}
+      <Dialog
+        open={showForm}
+        onOpenChange={(open) => {
+          if (!open) setShowForm(false);
+        }}
+      >
+        <DialogContent className="border-slate-800 bg-slate-900 sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="text-white">New Dead Host</DialogTitle>
+            <DialogDescription>
+              Create a 404 catch-all page for one or more domains.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="dead-domains">
+                Domain(s){" "}
+                <span className="text-xs text-slate-500">
+                  (comma-separated)
+                </span>
+              </Label>
+              <Input
+                id="dead-domains"
+                className="border-slate-800 bg-slate-950 text-white"
+                placeholder="expired.example.com, old.example.com"
+                value={form.domain_names}
+                onChange={(e) =>
+                  setForm({ ...form, domain_names: e.target.value })
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label htmlFor="dead-ssl" className="cursor-pointer">
+                Force SSL
+              </Label>
+              <Switch
+                id="dead-ssl"
+                checked={form.ssl_forced}
+                onCheckedChange={(v) => setForm({ ...form, ssl_forced: v })}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowForm(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              )}
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <AlertDialog
+        open={!!confirmDelete}
+        onOpenChange={(open) => !open && setConfirmDelete(null)}
+      >
+        <AlertDialogContent className="border-slate-800 bg-slate-900">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">
+              Delete Dead Host?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              The dead host for{" "}
+              <span className="font-mono text-white">
+                {confirmDelete?.domain_names.join(", ")}
+              </span>{" "}
+              will be permanently removed from Nginx Proxy Manager.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-slate-700">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-rose-600 text-white hover:bg-rose-700"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
 // ─── Main Page ──────────────────────────────────────────
 
 export default function NpmPage() {
@@ -999,9 +1270,11 @@ export default function NpmPage() {
     NpmRedirectionHost[]
   >([]);
   const [streams, setStreams] = useState<NpmStream[]>([]);
+  const [deadHosts, setDeadHosts] = useState<NpmDeadHost[]>([]);
   const [loadingProxy, setLoadingProxy] = useState(true);
   const [loadingRedir, setLoadingRedir] = useState(true);
   const [loadingStreams, setLoadingStreams] = useState(true);
+  const [loadingDead, setLoadingDead] = useState(true);
 
   const loadStatus = useCallback(async () => {
     try {
@@ -1048,12 +1321,25 @@ export default function NpmPage() {
     }
   }, []);
 
+  const loadDeadHosts = useCallback(async () => {
+    setLoadingDead(true);
+    try {
+      const data = await fetchNpmDeadHosts();
+      setDeadHosts(data);
+    } catch {
+      setDeadHosts([]);
+    } finally {
+      setLoadingDead(false);
+    }
+  }, []);
+
   useEffect(() => {
     loadStatus();
     loadProxyHosts();
     loadRedirectionHosts();
     loadStreams();
-  }, [loadStatus, loadProxyHosts, loadRedirectionHosts, loadStreams]);
+    loadDeadHosts();
+  }, [loadStatus, loadProxyHosts, loadRedirectionHosts, loadStreams, loadDeadHosts]);
 
   const configured = status?.configured ?? false;
   const reachable = status?.reachable ?? false;
@@ -1071,7 +1357,7 @@ export default function NpmPage() {
               Nginx Proxy Manager
             </h1>
             <p className="text-sm text-slate-400">
-              Manage proxy hosts, redirections, and TCP/UDP streams
+              Manage proxy hosts, redirections, streams, and dead hosts
             </p>
           </div>
         </div>
@@ -1160,6 +1446,18 @@ export default function NpmPage() {
                 </Badge>
               )}
             </TabsTrigger>
+            <TabsTrigger value="dead-hosts" className="gap-1.5">
+              <FileX2 className="h-3.5 w-3.5" />
+              404 Hosts
+              {deadHosts.length > 0 && (
+                <Badge
+                  variant="secondary"
+                  className="ml-1 h-5 bg-slate-800 px-1.5 text-[10px]"
+                >
+                  {deadHosts.length}
+                </Badge>
+              )}
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="redirections">
@@ -1207,6 +1505,24 @@ export default function NpmPage() {
                   streams={streams}
                   loading={loadingStreams}
                   onReload={loadStreams}
+                />
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="dead-hosts">
+            <Card className="border-slate-800 bg-slate-900/50">
+              <CardHeader className="pb-0">
+                <CardTitle className="flex items-center gap-2 text-lg text-white">
+                  <FileX2 className="h-4 w-4 text-rose-400" />
+                  Dead Hosts (404 Pages)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-0 pb-2">
+                <DeadHostsTable
+                  hosts={deadHosts}
+                  loading={loadingDead}
+                  onReload={loadDeadHosts}
                 />
               </CardContent>
             </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   NetflowStatus,
   NpmCertificate,
   NpmConnectionStatus,
+  NpmDeadHost,
   NpmProxyHost,
   NpmProxyHostRequest,
   NpmRedirectionHost,
@@ -969,4 +970,21 @@ export function toggleNpmStream(
   enabled: boolean
 ): Promise<void> {
   return apiPost<void>(`/api/v1/npm/streams/${id}/toggle`, { enabled });
+}
+
+// ─── Dead Hosts ─────────────────────────────────────────
+
+export function fetchNpmDeadHosts(): Promise<NpmDeadHost[]> {
+  return apiGet<NpmDeadHost[]>("/api/v1/npm/dead-hosts");
+}
+
+export function createNpmDeadHost(body: {
+  domain_names: string[];
+  ssl_forced: boolean;
+}): Promise<NpmDeadHost> {
+  return apiPost<NpmDeadHost>("/api/v1/npm/dead-hosts", body);
+}
+
+export function deleteNpmDeadHost(id: number): Promise<void> {
+  return apiDelete(`/api/v1/npm/dead-hosts/${id}`);
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -444,6 +444,13 @@ export interface NpmStream {
   enabled: boolean;
 }
 
+export interface NpmDeadHost {
+  id: number;
+  domain_names: string[];
+  ssl_forced: boolean;
+  enabled: boolean;
+}
+
 export interface DbSizeData {
   size_bytes: number;
 }


### PR DESCRIPTION
## Summary
- Add dead hosts (404 catch-all pages) management to the NPM integration
- Users can list all dead hosts with domain names, SSL status, and enabled state
- Users can create new dead hosts with domain name(s) and optional SSL
- Users can delete dead hosts with a confirmation dialog

## Changes

**Backend (Rust):**
- `server/src/npm/client.rs` — `NpmDeadHost`, `NpmDeadHostPayload` types + `list_dead_hosts`, `create_dead_host`, `delete_dead_host` client methods
- `server/src/api/npm.rs` — `GET/POST/DELETE /api/v1/npm/dead-hosts` endpoint handlers
- `server/src/api/mod.rs` — Route registration for dead hosts endpoints

**Frontend (TypeScript/React):**
- `web/src/lib/types.ts` — `NpmDeadHost` interface
- `web/src/lib/api.ts` — `fetchNpmDeadHosts`, `createNpmDeadHost`, `deleteNpmDeadHost` functions
- `web/src/app/(app)/npm/page.tsx` — `DeadHostsTable` component with create/delete dialogs + new "Dead Hosts" tab

## Test plan
- [x] All 233 unit tests pass
- [x] All 12 integration tests pass
- [x] Frontend builds successfully (Next.js type checking + compilation)
- [x] Rust backend compiles cleanly (`cargo check`)
- [ ] Manual: verify dead hosts tab appears in NPM page
- [ ] Manual: verify create dead host dialog works
- [ ] Manual: verify delete dead host with confirmation works

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added dead hosts (404 catch-all pages) management to the NPM integration. The implementation follows the existing patterns for proxy hosts, redirection hosts, and streams, with complete CRUD operations (list, create, delete) across the full stack.

- Backend implements three REST endpoints (`GET/POST/DELETE /api/v1/npm/dead-hosts`) with proper error handling
- NPM client correctly interfaces with Nginx Proxy Manager's `/api/nginx/dead-hosts` endpoints
- Frontend provides a new "404 Hosts" tab with table view, create dialog (supporting comma-separated domains and SSL toggle), and delete confirmation
- Hardcodes `certificate_id` to 0 consistently with proxy and redirection host patterns
- All types and API functions properly defined across backend and frontend

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing patterns precisely, includes proper error handling, and passes all tests. The code is well-structured and consistent with the rest of the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/npm.rs | Implemented three dead hosts endpoint handlers with proper error handling and NPM client integration |
| server/src/npm/client.rs | Added `NpmDeadHost` and `NpmDeadHostPayload` types plus client methods for list, create, and delete operations |
| web/src/app/(app)/npm/page.tsx | Added complete `DeadHostsTable` component with create dialog, delete confirmation, and new "404 Hosts" tab |

</details>



<sub>Last reviewed commit: 8d31907</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->