### PR TITLE
perf: router page — use /router-summary bulk endpoint

### DIFF
--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -407,9 +407,15 @@ pub async fn status(State(state): State<AppState>) -> Json<RouterStatus> {
 pub struct RouterSummary {
     pub status: RouterStatus,
     pub interfaces: Vec<VyosInterface>,
+    pub config_interfaces: Value,
     pub routes: Vec<VyosRoute>,
     pub dhcp_leases: Vec<VyosDhcpLease>,
+    pub dhcp_static_mappings: Vec<DhcpStaticMapping>,
+    pub dhcp_server_config: DhcpServerConfig,
     pub firewall: FirewallConfig,
+    pub firewall_groups: FirewallGroups,
+    pub dns_forwarding: DnsForwardingConfig,
+    pub wireguard: Vec<WireguardInterface>,
 }
 
 /// GET /api/v1/vyos/router-summary — fetch all router data in a single request.
@@ -434,9 +440,27 @@ pub async fn router_summary(
                     hostname: None,
                 },
                 interfaces: Vec::new(),
+                config_interfaces: Value::Null,
                 routes: Vec::new(),
                 dhcp_leases: Vec::new(),
+                dhcp_static_mappings: Vec::new(),
+                dhcp_server_config: DhcpServerConfig {
+                    shared_networks: Vec::new(),
+                },
                 firewall: FirewallConfig { chains: Vec::new() },
+                firewall_groups: FirewallGroups {
+                    address_groups: Vec::new(),
+                    network_groups: Vec::new(),
+                    port_groups: Vec::new(),
+                },
+                dns_forwarding: DnsForwardingConfig {
+                    name_servers: Vec::new(),
+                    domain_overrides: Vec::new(),
+                    listen_addresses: Vec::new(),
+                    allow_from: Vec::new(),
+                    cache_size: None,
+                },
+                wireguard: Vec::new(),
             }));
         }
     };
@@ -446,14 +470,29 @@ pub async fn router_summary(
     let route_key = cache_key("show", &["ip", "route"]);
     let dhcp_key = cache_key("show", &["dhcp", "server", "leases"]);
     let fw_key = cache_key("retrieve", &["firewall"]);
+    let config_iface_key = cache_key("retrieve", &["interfaces"]);
 
     let cached_iface = state.vyos_cache.get(&iface_key);
     let cached_routes = state.vyos_cache.get(&route_key);
     let cached_dhcp = state.vyos_cache.get(&dhcp_key);
     let cached_fw = state.vyos_cache.get(&fw_key);
+    let cached_config_iface = state.vyos_cache.get(&config_iface_key);
 
     // Fire all uncached fetches in parallel alongside status queries.
-    let (ver_res, up_res, host_res, iface_res, route_res, dhcp_res, fw_res) = tokio::join!(
+    let (
+        ver_res,
+        up_res,
+        host_res,
+        iface_res,
+        route_res,
+        dhcp_res,
+        fw_res,
+        config_iface_res,
+        dhcp_server_res,
+        fw_groups_res,
+        dns_fwd_res,
+        wg_config_res,
+    ) = tokio::join!(
         client.show(&["version"]),
         client.show(&["system", "uptime"]),
         client.show(&["host", "name"]),
@@ -485,6 +524,17 @@ pub async fn router_summary(
                 client.retrieve(&["firewall"]).await
             }
         },
+        async {
+            if cached_config_iface.is_some() {
+                Ok(Value::Null)
+            } else {
+                client.retrieve(&["interfaces"]).await
+            }
+        },
+        client.retrieve(&["service", "dhcp-server"]),
+        client.retrieve(&["firewall", "group"]),
+        client.retrieve(&["service", "dns", "forwarding"]),
+        client.retrieve(&["interfaces", "wireguard"]),
     );
 
     // --- Status ---
@@ -510,18 +560,32 @@ pub async fn router_summary(
     let reachable = version.is_some() || uptime.is_some();
 
     // --- Interfaces ---
+    let iface_text = if cached_iface.is_some() {
+        None
+    } else {
+        iface_res
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+    };
     let interfaces = if let Some(cached) = cached_iface {
         serde_json::from_value(cached).unwrap_or_default()
     } else {
-        let text = iface_res
-            .ok()
-            .and_then(|v| v.as_str().map(|s| s.to_string()))
-            .unwrap_or_default();
-        let parsed = parse_interfaces_text(&text);
+        let parsed = parse_interfaces_text(iface_text.as_deref().unwrap_or(""));
         if let Ok(v) = serde_json::to_value(&parsed) {
             state.vyos_cache.set(iface_key, v);
         }
         parsed
+    };
+
+    // --- Config Interfaces ---
+    let config_interfaces = if let Some(cached) = cached_config_iface {
+        cached
+    } else {
+        let value = config_iface_res.unwrap_or(Value::Null);
+        if !value.is_null() {
+            state.vyos_cache.set(config_iface_key, value.clone());
+        }
+        value
     };
 
     // --- Routes ---
@@ -554,6 +618,11 @@ pub async fn router_summary(
         parsed
     };
 
+    // --- DHCP static mappings & server config (same source data) ---
+    let dhcp_server_val = dhcp_server_res.unwrap_or(Value::Null);
+    let dhcp_static_mappings = parse_dhcp_static_mappings(&dhcp_server_val);
+    let dhcp_server_config = parse_dhcp_server_config(&dhcp_server_val);
+
     // --- Firewall ---
     let firewall_parsed = if let Some(cached) = cached_fw {
         serde_json::from_value(cached).unwrap_or(FirewallConfig { chains: Vec::new() })
@@ -568,6 +637,55 @@ pub async fn router_summary(
         config
     };
 
+    // --- Firewall Groups ---
+    let firewall_groups = match fw_groups_res {
+        Ok(data) => parse_firewall_groups(&data),
+        Err(_) => FirewallGroups {
+            address_groups: Vec::new(),
+            network_groups: Vec::new(),
+            port_groups: Vec::new(),
+        },
+    };
+
+    // --- DNS Forwarding ---
+    let dns_forwarding = match dns_fwd_res {
+        Ok(data) => parse_dns_forwarding_config(&data),
+        Err(_) => DnsForwardingConfig {
+            name_servers: Vec::new(),
+            domain_overrides: Vec::new(),
+            listen_addresses: Vec::new(),
+            allow_from: Vec::new(),
+            cache_size: None,
+        },
+    };
+
+    // --- WireGuard ---
+    let mut wireguard = match wg_config_res {
+        Ok(data) => parse_wireguard_config(&data),
+        Err(_) => Vec::new(),
+    };
+    // Merge link status from interfaces data (already fetched above)
+    let iface_list_for_wg: Option<Vec<VyosInterface>> = if let Some(ref text) = iface_text {
+        Some(parse_interfaces_text(text))
+    } else {
+        // interfaces were from cache — reuse them
+        Some(interfaces.clone())
+    };
+    if let Some(iface_list) = &iface_list_for_wg {
+        for wg in &mut wireguard {
+            if let Some(sys_iface) = iface_list.iter().find(|i| i.name == wg.name) {
+                wg.status = Some(sys_iface.link_state.clone());
+            }
+        }
+    }
+    // Fetch per-interface runtime stats
+    for wg in &mut wireguard {
+        if let Ok(raw) = client.show(&["interfaces", "wireguard", &wg.name]).await {
+            let text = raw.as_str().unwrap_or("");
+            merge_wireguard_runtime_stats(wg, text);
+        }
+    }
+
     Ok(Json(RouterSummary {
         status: RouterStatus {
             configured: true,
@@ -577,9 +695,15 @@ pub async fn router_summary(
             hostname,
         },
         interfaces,
+        config_interfaces,
         routes: routes_parsed,
         dhcp_leases: dhcp_leases_parsed,
+        dhcp_static_mappings,
+        dhcp_server_config,
         firewall: firewall_parsed,
+        firewall_groups,
+        dns_forwarding,
+        wireguard,
     }))
 }
 

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -72,7 +72,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-  fetchRouterStatus,
+  fetchRouterSummary,
   fetchRouterInterfaces,
   fetchRouterRoutes,
   fetchRouterDhcpLeases,
@@ -121,7 +121,7 @@ import {
   fetchSystemInfo,
   fetchSyslog,
 } from "@/lib/api";
-import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse } from "@/lib/types";
+import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse } from "@/lib/types";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -486,23 +486,22 @@ function SystemInfoPanel({
   );
 }
 
-// ── Hook: fetch with loading/error ──────────────────────
+// ── Hook: pre-populated data with reload ────────────────
 
-function useAsyncData<T>(
-  fetcher: () => Promise<T>,
-  enabled: boolean
+/** State pre-populated from the router summary with reload via individual endpoint. */
+function useSummaryData<T>(
+  initial: T,
+  fetcher: () => Promise<T>
 ): { data: T | null; loading: boolean; error: string | null; reload: () => void } {
-  const [data, setData] = useState<T | null>(null);
+  const [data, setData] = useState<T | null>(initial);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    if (!enabled) return;
+  const reload = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const result = await fetcher();
-      setData(result);
+      setData(await fetcher());
     } catch (e) {
       if (e instanceof Error && e.message.includes("503")) {
         setError("Router not configured");
@@ -512,13 +511,9 @@ function useAsyncData<T>(
     } finally {
       setLoading(false);
     }
-  }, [fetcher, enabled]);
+  }, [fetcher]);
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  return { data, loading, error, reload: load };
+  return { data, loading, error, reload };
 }
 
 // ── DNS Forwarding Panel ────────────────────────────────
@@ -4919,25 +4914,31 @@ function GenerateClientConfigDialog({
 // ── Main Page ───────────────────────────────────────────
 
 export default function RouterPage() {
-  const [status, setStatus] = useState<RouterStatus | null>(null);
-  const [statusLoading, setStatusLoading] = useState(true);
+  const [summary, setSummary] = useState<RouterSummary | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchRouterStatus()
-      .then(setStatus)
+    fetchRouterSummary()
+      .then(setSummary)
       .catch(() =>
-        setStatus({
-          configured: false,
-          reachable: false,
-          version: null,
-          uptime: null,
-          hostname: null,
+        setSummary({
+          status: { configured: false, reachable: false, version: null, uptime: null, hostname: null },
+          interfaces: [],
+          config_interfaces: {},
+          routes: [],
+          dhcp_leases: [],
+          dhcp_static_mappings: [],
+          dhcp_server_config: { shared_networks: [] },
+          firewall: { chains: [] },
+          firewall_groups: { address_groups: [], network_groups: [], port_groups: [] },
+          dns_forwarding: { name_servers: [], domain_overrides: [], listen_addresses: [], allow_from: [], cache_size: null },
+          wireguard: [],
         })
       )
-      .finally(() => setStatusLoading(false));
+      .finally(() => setLoading(false));
   }, []);
 
-  if (statusLoading) {
+  if (loading) {
     return (
       <div className="space-y-6">
         <Skeleton className="h-10 w-64" />
@@ -4946,66 +4947,67 @@ export default function RouterPage() {
     );
   }
 
-  if (!status?.configured) {
+  if (!summary?.status.configured) {
     return <PageTransition><NotConfigured /></PageTransition>;
   }
 
-  return <PageTransition><RouterTabs status={status} /></PageTransition>;
+  return <PageTransition><RouterTabs summary={summary} /></PageTransition>;
 }
 
 // ── Tabs component (only rendered when configured) ──────
 
-function RouterTabs({ status }: { status: RouterStatus }) {
+function RouterTabs({ summary }: { summary: RouterSummary }) {
   const [tab, setTab] = useState("system");
+  const { status } = summary;
 
-  const interfaces = useAsyncData<VyosInterface[]>(
-    useCallback(() => fetchRouterInterfaces(), []),
-    tab === "interfaces"
+  const interfaces = useSummaryData(
+    summary.interfaces,
+    useCallback(() => fetchRouterInterfaces(), [])
   );
 
-  const configIfaces = useAsyncData<Record<string, unknown>>(
-    useCallback(() => fetchRouterConfigInterfaces(), []),
-    tab === "interfaces"
+  const configIfaces = useSummaryData(
+    summary.config_interfaces,
+    useCallback(() => fetchRouterConfigInterfaces(), [])
   );
 
-  const routes = useAsyncData<VyosRoute[]>(
-    useCallback(() => fetchRouterRoutes(), []),
-    tab === "routes"
+  const routes = useSummaryData(
+    summary.routes,
+    useCallback(() => fetchRouterRoutes(), [])
   );
 
-  const dhcp = useAsyncData<VyosDhcpLease[]>(
-    useCallback(() => fetchRouterDhcpLeases(), []),
-    tab === "dhcp"
+  const dhcp = useSummaryData(
+    summary.dhcp_leases,
+    useCallback(() => fetchRouterDhcpLeases(), [])
   );
 
-  const staticMappings = useAsyncData<DhcpStaticMapping[]>(
-    useCallback(() => fetchDhcpStaticMappings(), []),
-    tab === "dhcp"
+  const staticMappings = useSummaryData(
+    summary.dhcp_static_mappings,
+    useCallback(() => fetchDhcpStaticMappings(), [])
   );
 
-  const dhcpConfig = useAsyncData<DhcpServerConfig>(
-    useCallback(() => fetchDhcpServerConfig(), []),
-    tab === "dhcp"
+  const dhcpConfig = useSummaryData(
+    summary.dhcp_server_config,
+    useCallback(() => fetchDhcpServerConfig(), [])
   );
 
-  const firewall = useAsyncData<FirewallConfig>(
-    useCallback(() => fetchRouterFirewall(), []),
-    tab === "firewall"
+  const firewall = useSummaryData(
+    summary.firewall,
+    useCallback(() => fetchRouterFirewall(), [])
   );
 
-  const firewallGroups = useAsyncData<FirewallGroups>(
-    useCallback(() => fetchFirewallGroups(), []),
-    tab === "firewall"
+  const firewallGroups = useSummaryData(
+    summary.firewall_groups,
+    useCallback(() => fetchFirewallGroups(), [])
   );
 
-  const dnsForwarding = useAsyncData<DnsForwardingConfig>(
-    useCallback(() => fetchDnsForwarding(), []),
-    tab === "dns"
+  const dnsForwarding = useSummaryData(
+    summary.dns_forwarding,
+    useCallback(() => fetchDnsForwarding(), [])
   );
 
-  const wireguard = useAsyncData<WireguardInterface[]>(
-    useCallback(() => fetchWireguardInterfaces(), []),
-    tab === "vpn"
+  const wireguard = useSummaryData(
+    summary.wireguard,
+    useCallback(() => fetchWireguardInterfaces(), [])
   );
 
   const reloadInterfaces = useCallback(() => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -167,9 +167,15 @@ export interface RouterStatus {
 export interface RouterSummary {
   status: RouterStatus;
   interfaces: VyosInterface[];
+  config_interfaces: Record<string, unknown>;
   routes: VyosRoute[];
   dhcp_leases: VyosDhcpLease[];
+  dhcp_static_mappings: DhcpStaticMapping[];
+  dhcp_server_config: DhcpServerConfig;
   firewall: FirewallConfig;
+  firewall_groups: FirewallGroups;
+  dns_forwarding: DnsForwardingConfig;
+  wireguard: WireguardInterface[];
 }
 
 export interface SpeedTestResult {


### PR DESCRIPTION
## Summary
- **Backend**: Extended `RouterSummary` struct and handler to include all router page data (config interfaces, DHCP static mappings/server config, firewall groups, DNS forwarding, WireGuard) fetched in parallel via `tokio::join!`
- **Frontend**: Replaced 10+ lazy `useAsyncData` calls with a single upfront `fetchRouterSummary()` call, pre-populating all tab data immediately while preserving individual reload functions for post-mutation refreshes
- **Expected result**: Router page load time drops from 7-8s to <1s (single cached API call)

Closes #118

## Test plan
- [x] Rust backend compiles (`cargo check`)
- [x] All 12 backend tests pass (`cargo test`)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [ ] Manual: Verify router page loads with all tabs populated from single API call
- [ ] Manual: Verify reload after mutations (create/edit/delete firewall rules, DHCP mappings, etc.) still refreshes correctly
- [ ] Manual: Verify unconfigured router still shows "Not Configured" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Consolidated router page data fetching from 10+ sequential lazy-loaded API calls into a single upfront `/router-summary` bulk endpoint, reducing load time from 7-8s to <1s.

- Backend extends `RouterSummary` struct with 7 new fields (config_interfaces, dhcp_static_mappings, dhcp_server_config, firewall_groups, dns_forwarding, wireguard) fetched in parallel via `tokio::join!`
- Frontend replaces conditional `useAsyncData` hook with `useSummaryData` that pre-populates all tab data from initial summary while preserving individual reload functions for post-mutation refreshes
- Type definitions updated to match backend struct

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor performance consideration for WireGuard stats
- The refactoring is well-structured with proper error handling and maintains backward compatibility. Backend parallel fetching via tokio::join! is implemented correctly, types are synchronized between frontend and backend, and the frontend hook pattern cleanly separates initial load from reload logic. Minor deduction for sequential WireGuard per-interface stats fetch (lines 682-687) which partially defeats the parallel optimization goal, though this is not critical.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Extended RouterSummary to fetch all router data in parallel via tokio::join!, adding 7 new fields (config_interfaces, dhcp_static_mappings, dhcp_server_config, firewall_groups, dns_forwarding, wireguard) with sequential WireGuard stats fetch |
| web/src/app/(app)/router/page.tsx | Replaced lazy useAsyncData hook with useSummaryData that pre-populates from single router-summary call, removing conditional fetching and useEffect auto-load |
| web/src/lib/types.ts | Added 7 new fields to RouterSummary interface to match backend struct |

</details>



<sub>Last reviewed commit: a53ed74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->