### PR TITLE
fix: return empty arrays instead of 502 when VyOS queries fail

### DIFF
--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -825,13 +825,13 @@ pub async fn syslog(
     let line_count = params.lines.unwrap_or(50).min(500);
     let count_str = line_count.to_string();
 
-    let raw = client
-        .show(&["log", "tail", &count_str])
-        .await
-        .map_err(|e| {
-            tracing::error!("VyOS syslog query failed: {e}");
-            StatusCode::BAD_GATEWAY
-        })?;
+    let raw = match client.show(&["log", "tail", &count_str]).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("VyOS syslog query failed (returning empty): {e}");
+            return Ok(Json(SyslogResponse { lines: vec![] }));
+        }
+    };
 
     let text = raw.as_str().unwrap_or("");
     let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
@@ -867,10 +867,13 @@ pub async fn interfaces(
     }
 
     let client = get_vyos_client_or_503(&state).await?;
-    let raw_value = client.show(&["interfaces"]).await.map_err(|e| {
-        tracing::error!("VyOS interfaces query failed: {e}");
-        StatusCode::BAD_GATEWAY
-    })?;
+    let raw_value = match client.show(&["interfaces"]).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("VyOS interfaces query failed (returning empty): {e}");
+            return Ok(Json(vec![]));
+        }
+    };
 
     let text = raw_value.as_str().unwrap_or("");
     let parsed = parse_interfaces_text(text);
@@ -894,10 +897,13 @@ pub async fn routes(State(state): State<AppState>) -> Result<Json<Vec<VyosRoute>
     }
 
     let client = get_vyos_client_or_503(&state).await?;
-    let raw_value = client.show(&["ip", "route"]).await.map_err(|e| {
-        tracing::error!("VyOS routes query failed: {e}");
-        StatusCode::BAD_GATEWAY
-    })?;
+    let raw_value = match client.show(&["ip", "route"]).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("VyOS routes query failed (returning empty): {e}");
+            return Ok(Json(vec![]));
+        }
+    };
 
     let text = raw_value.as_str().unwrap_or("");
     let parsed = parse_routes_text(text);
@@ -1091,13 +1097,13 @@ pub async fn dhcp_leases(
     }
 
     let client = get_vyos_client_or_503(&state).await?;
-    let raw_value = client
-        .show(&["dhcp", "server", "leases"])
-        .await
-        .map_err(|e| {
-            tracing::error!("VyOS DHCP leases query failed: {e}");
-            StatusCode::BAD_GATEWAY
-        })?;
+    let raw_value = match client.show(&["dhcp", "server", "leases"]).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("VyOS DHCP leases query failed (returning empty): {e}");
+            return Ok(Json(vec![]));
+        }
+    };
 
     let text = raw_value.as_str().unwrap_or("");
     let parsed = parse_dhcp_leases_text(text);
@@ -1353,14 +1359,8 @@ pub async fn firewall(State(state): State<AppState>) -> Result<Json<FirewallConf
             Ok(Json(config))
         }
         Err(e) => {
-            let msg = e.to_string();
-            // VyOS returns error when path is empty (no firewall configured)
-            if msg.contains("empty") || msg.contains("does not exist") {
-                Ok(Json(FirewallConfig { chains: Vec::new() }))
-            } else {
-                tracing::error!("VyOS firewall query failed: {e}");
-                Err(StatusCode::BAD_GATEWAY)
-            }
+            tracing::warn!("VyOS firewall query failed (returning empty): {e}");
+            Ok(Json(FirewallConfig { chains: Vec::new() }))
         }
     }
 }
@@ -2193,12 +2193,8 @@ pub async fn dhcp_static_mappings(
     let config = match client.retrieve(&["service", "dhcp-server"]).await {
         Ok(c) => c,
         Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("empty") || msg.contains("does not exist") {
-                return Ok(Json(Vec::new()));
-            }
-            tracing::error!("VyOS DHCP config query failed: {e}");
-            return Err(StatusCode::BAD_GATEWAY);
+            tracing::warn!("VyOS DHCP config query failed (returning empty): {e}");
+            return Ok(Json(Vec::new()));
         }
     };
 
@@ -2694,14 +2690,10 @@ pub async fn dhcp_server_config(
     let config = match client.retrieve(&["service", "dhcp-server"]).await {
         Ok(c) => c,
         Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("empty") || msg.contains("does not exist") {
-                return Ok(Json(DhcpServerConfig {
-                    shared_networks: Vec::new(),
-                }));
-            }
-            tracing::error!("VyOS DHCP server config query failed: {e}");
-            return Err(StatusCode::BAD_GATEWAY);
+            tracing::warn!("VyOS DHCP server config query failed (returning empty): {e}");
+            return Ok(Json(DhcpServerConfig {
+                shared_networks: Vec::new(),
+            }));
         }
     };
 
@@ -4582,18 +4574,14 @@ pub async fn dns_forwarding(
     let config = match client.retrieve(&["service", "dns", "forwarding"]).await {
         Ok(c) => c,
         Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("empty") || msg.contains("does not exist") {
-                return Ok(Json(DnsForwardingConfig {
-                    name_servers: Vec::new(),
-                    domain_overrides: Vec::new(),
-                    listen_addresses: Vec::new(),
-                    allow_from: Vec::new(),
-                    cache_size: None,
-                }));
-            }
-            tracing::error!("VyOS DNS forwarding config query failed: {e}");
-            return Err(StatusCode::BAD_GATEWAY);
+            tracing::warn!("VyOS DNS forwarding config query failed (returning empty): {e}");
+            return Ok(Json(DnsForwardingConfig {
+                name_servers: Vec::new(),
+                domain_overrides: Vec::new(),
+                listen_addresses: Vec::new(),
+                allow_from: Vec::new(),
+                cache_size: None,
+            }));
         }
     };
 
@@ -5243,13 +5231,13 @@ pub async fn wireguard_list(
 ) -> Result<Json<Vec<WireguardInterface>>, StatusCode> {
     let client = get_vyos_client_or_503(&state).await?;
 
-    let config = client
-        .retrieve(&["interfaces", "wireguard"])
-        .await
-        .map_err(|e| {
-            tracing::error!("VyOS wireguard config query failed: {e}");
-            StatusCode::BAD_GATEWAY
-        })?;
+    let config = match client.retrieve(&["interfaces", "wireguard"]).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("VyOS wireguard config query failed (returning empty): {e}");
+            return Ok(Json(vec![]));
+        }
+    };
 
     let mut interfaces = parse_wireguard_config(&config);
 


### PR DESCRIPTION
## Summary
- Read-only VyOS API endpoints (`dhcp-leases`, `interfaces`, `routes`, `syslog`, `firewall`, `wireguard`, `dns-forwarding`, `dhcp-static-mappings`, `dhcp-server-config`) now return empty results (HTTP 200) instead of HTTP 502 when VyOS is unreachable, the feature isn't configured, or a transient error occurs.
- Error logging downgraded from `error!` to `warn!` for these expected scenarios, since they're not server-side bugs.
- Write/mutation endpoints still return 502 on failure, as callers need to know the operation didn't succeed.

## Motivation
When VyOS DHCP (or other optional features) aren't configured, the frontend shows "API error 502: Bad Gateway" with a red error banner. The expected behavior is an empty table with graceful degradation.

Closes #125

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes (no warnings)
- [x] All 238 unit tests pass
- [x] All 12 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error handling for 9 read-only VyOS API endpoints to return empty results (HTTP 200) instead of 502 when VyOS is unreachable or features are not configured. This provides graceful degradation for the frontend, preventing error banners when optional features like DHCP or WireGuard aren't set up.

- Changed error logging from `error!` to `warn!` for expected failure scenarios in read-only endpoints
- Updated endpoints: `dhcp-leases`, `interfaces`, `routes`, `syslog`, `firewall`, `wireguard`, `dns-forwarding`, `dhcp-static-mappings`, `dhcp-server-config`
- Write/mutation endpoints correctly still return 502 on failure
- Two read-only endpoints (`config_interfaces` at line 2024, `firewall_groups` at line 3376) still return 502 for some errors — consider applying the same graceful degradation pattern for consistency

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor inconsistencies
- The changes are well-implemented and tested (238 unit tests, 12 integration tests passing). The pattern consistently separates read-only endpoints (return empty) from mutations (return 502), improving UX. Two similar read-only endpoints weren't updated but this doesn't introduce bugs, just leaves room for future consistency improvements.
- No files require special attention — the changes are straightforward error handling improvements

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Converted 9 read-only VyOS endpoints to return empty results (HTTP 200) instead of 502 on failure, with logging downgraded to warn level. Two similar read-only endpoints (`config_interfaces`, `firewall_groups`) remain inconsistent with this approach. |

</details>



<sub>Last reviewed commit: 8cd8e14</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->