### PR TITLE
fix: handle VyOS rolling output format in system-info parsers

### DIFF
--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -955,9 +955,7 @@ fn parse_size_with_unit(s: &str) -> Option<u64> {
 /// 2. VyOS rolling key-value format (`Filesystem:`, `Size:`, `Used:`, `Available:`)
 fn parse_storage_text(text: &str) -> Vec<DiskUsage> {
     // Detect VyOS rolling key-value format by looking for "Filesystem:" as a key
-    let has_kv_filesystem = text
-        .lines()
-        .any(|l| l.trim().starts_with("Filesystem:"));
+    let has_kv_filesystem = text.lines().any(|l| l.trim().starts_with("Filesystem:"));
 
     if has_kv_filesystem {
         return parse_storage_kv(text);
@@ -1032,11 +1030,7 @@ fn parse_storage_kv(text: &str) -> Vec<DiskUsage> {
             if let Some(paren_start) = rest.find('(') {
                 used = Some(rest[..paren_start].trim().to_string());
                 let inside = rest[paren_start + 1..].trim_end_matches(')').trim();
-                percent = inside
-                    .trim_end_matches('%')
-                    .parse::<f64>()
-                    .ok()
-                    .or(percent);
+                percent = inside.trim_end_matches('%').parse::<f64>().ok().or(percent);
             } else {
                 used = Some(rest.to_string());
             }
@@ -8112,10 +8106,22 @@ Available:  2.7G (78%)";
 
     #[test]
     fn test_parse_size_with_unit() {
-        assert_eq!(parse_size_with_unit("475.34 MB"), Some((475.34 * 1024.0 * 1024.0) as u64));
-        assert_eq!(parse_size_with_unit("3.7G"), Some((3.7 * 1024.0 * 1024.0 * 1024.0) as u64));
-        assert_eq!(parse_size_with_unit("767M"), Some((767.0 * 1024.0 * 1024.0) as u64));
-        assert_eq!(parse_size_with_unit("512 KB"), Some((512.0 * 1024.0) as u64));
+        assert_eq!(
+            parse_size_with_unit("475.34 MB"),
+            Some((475.34 * 1024.0 * 1024.0) as u64)
+        );
+        assert_eq!(
+            parse_size_with_unit("3.7G"),
+            Some((3.7 * 1024.0 * 1024.0 * 1024.0) as u64)
+        );
+        assert_eq!(
+            parse_size_with_unit("767M"),
+            Some((767.0 * 1024.0 * 1024.0) as u64)
+        );
+        assert_eq!(
+            parse_size_with_unit("512 KB"),
+            Some((512.0 * 1024.0) as u64)
+        );
         assert!(parse_size_with_unit("").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #130

- **`parse_uptime_and_load`**: Added support for VyOS rolling `"Load averages:"` format with per-line `"N minute(s): X.X%"` values, alongside existing standard Linux `"load average: X, Y, Z"` format.
- **`parse_memory_text`**: Added support for VyOS rolling `"Total:/Free:/Used: X MB"` key-value lines, alongside existing `"Mem:"` row with kB columns. Introduced `parse_size_with_unit` helper to convert `"475.34 MB"` / `"3.7G"` strings to bytes.
- **`parse_storage_text`**: Added support for VyOS rolling `"Filesystem:/Size:/Used:/Available:"` key-value blocks, alongside existing `df`-style tabular rows.

All existing tests continue to pass. Added 5 new tests covering VyOS rolling format for each parser.

## Test plan

- [x] All 76 existing + new `api::vyos::tests` pass
- [x] `cargo fmt` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds backward-compatible support for VyOS rolling output format in system-info parsers (`parse_uptime_and_load`, `parse_memory_text`, `parse_storage_text`). The changes introduce fallback parsing logic that tries standard Linux formats first, then VyOS rolling formats.

Key changes:
- `parse_uptime_and_load`: Added support for `"Load averages:"` with per-line `"N minute(s): X.X%"` format
- `parse_memory_text`: Added support for `"Total:/Free:/Used: X MB"` key-value format with new `parse_size_with_unit` helper
- `parse_storage_text`: Added support for `"Filesystem:/Size:/Used:/Available:"` key-value blocks via new `parse_storage_kv` function
- All 76 existing tests pass, plus 5 new tests for VyOS rolling format

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style suggestion
- Well-structured backward-compatible change with comprehensive test coverage (5 new tests). The parsing logic is defensive and handles both formats gracefully. One minor style suggestion for parsing simplification, but existing logic is functional.
- No files require special attention - the changes are localized to parser functions with good test coverage

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Added VyOS rolling format support for system info parsers - uptime/load, memory, and storage. Backward compatible with existing formats, well-tested with 5 new tests covering new format variations. |

</details>



<sub>Last reviewed commit: d6a7547</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->