### PR TITLE
feat: agent detail page — show hardware info (CPU, GPU, disk, cores)

### DIFF
--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -96,6 +96,25 @@ pub struct Agent {
     pub cpu_percent: Option<f64>,
     pub mem_total: Option<i64>,
     pub mem_used: Option<i64>,
+    // From device_sysinfo (hardware inventory):
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hardware_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_cores: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_speed: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serial_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime_seconds: Option<i64>,
 }
 
 /// Request body for registering a new agent.
@@ -219,6 +238,15 @@ impl Agent {
             cpu_percent: row.try_get("cpu_percent").ok(),
             mem_total: row.try_get("mem_total").ok(),
             mem_used: row.try_get("mem_used").ok(),
+            hardware_model: row.try_get("hardware_model").ok().flatten(),
+            cpu_name: row.try_get("cpu_name").ok().flatten(),
+            cpu_cores: row.try_get("cpu_cores").ok().flatten(),
+            cpu_speed: row.try_get("cpu_speed").ok().flatten(),
+            gpu_name: row.try_get("gpu_name").ok().flatten(),
+            disk_name: row.try_get("disk_name").ok().flatten(),
+            disk_size: row.try_get("disk_size").ok().flatten(),
+            serial_number: row.try_get("serial_number").ok().flatten(),
+            uptime_seconds: row.try_get("uptime_seconds").ok().flatten(),
         })
     }
 }
@@ -228,7 +256,9 @@ pub async fn list(State(state): State<AppState>) -> Result<Json<Vec<Agent>>, Sta
     let rows = sqlx::query(
         "SELECT a.id, a.device_id, a.name, a.platform, a.version, a.is_online, \
                 a.last_report_at, a.created_at, \
-                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used \
+                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used, \
+                ds.hardware_model, ds.cpu_name, ds.cpu_cores, ds.cpu_speed, \
+                ds.gpu_name, ds.disk_name, ds.disk_size, ds.serial_number, ds.uptime_seconds \
          FROM agents a \
          LEFT JOIN agent_reports r ON r.agent_id = a.id \
            AND r.id = ( \
@@ -237,6 +267,7 @@ pub async fn list(State(state): State<AppState>) -> Result<Json<Vec<Agent>>, Sta
                ORDER BY ar.reported_at DESC, ar.id DESC \
                LIMIT 1 \
            ) \
+         LEFT JOIN device_sysinfo ds ON ds.device_id = a.device_id \
          ORDER BY a.created_at DESC",
     )
     .fetch_all(&state.db)
@@ -266,7 +297,9 @@ pub async fn get_one(
     let row = sqlx::query(
         "SELECT a.id, a.device_id, a.name, a.platform, a.version, a.is_online, \
                 a.last_report_at, a.created_at, \
-                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used \
+                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used, \
+                ds.hardware_model, ds.cpu_name, ds.cpu_cores, ds.cpu_speed, \
+                ds.gpu_name, ds.disk_name, ds.disk_size, ds.serial_number, ds.uptime_seconds \
          FROM agents a \
          LEFT JOIN agent_reports r ON r.agent_id = a.id \
            AND r.id = ( \
@@ -275,6 +308,7 @@ pub async fn get_one(
                ORDER BY ar.reported_at DESC, ar.id DESC \
                LIMIT 1 \
            ) \
+         LEFT JOIN device_sysinfo ds ON ds.device_id = a.device_id \
          WHERE a.id = ?",
     )
     .bind(&id)
@@ -345,7 +379,9 @@ pub async fn update(
     let row = sqlx::query(
         "SELECT a.id, a.device_id, a.name, a.platform, a.version, a.is_online, \
                 a.last_report_at, a.created_at, \
-                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used \
+                r.hostname, r.os_name, r.os_version, r.cpu_percent, r.mem_total, r.mem_used, \
+                ds.hardware_model, ds.cpu_name, ds.cpu_cores, ds.cpu_speed, \
+                ds.gpu_name, ds.disk_name, ds.disk_size, ds.serial_number, ds.uptime_seconds \
          FROM agents a \
          LEFT JOIN agent_reports r ON r.agent_id = a.id \
            AND r.id = ( \
@@ -354,6 +390,7 @@ pub async fn update(
                ORDER BY ar.reported_at DESC, ar.id DESC \
                LIMIT 1 \
            ) \
+         LEFT JOIN device_sysinfo ds ON ds.device_id = a.device_id \
          WHERE a.id = ?",
     )
     .bind(&id)

--- a/web/src/app/(app)/agents/detail/content.tsx
+++ b/web/src/app/(app)/agents/detail/content.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Cpu, HardDrive, Monitor, Timer } from "lucide-react";
 import {
   LineChart,
   Line,
@@ -140,6 +140,9 @@ export default function AgentDetailContent() {
           {agent.os_name && <> · {agent.os_name} {agent.os_version ?? ""}</>}
         </p>
       </div>
+
+      {/* Hardware Info */}
+      <HardwareInfoCard agent={agent} />
 
       {/* Charts */}
       {chartData.length > 0 ? (
@@ -281,6 +284,83 @@ export default function AgentDetailContent() {
             </TableBody>
           </Table>
         )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Hardware Info Card ──────────────────────────────────
+
+function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+function HardwareInfoCard({ agent }: { agent: Agent }) {
+  const hasAny =
+    agent.hardware_model ||
+    agent.cpu_name ||
+    agent.gpu_name ||
+    agent.disk_name ||
+    agent.uptime_seconds != null ||
+    agent.serial_number;
+
+  if (!hasAny) return null;
+
+  const cpuDetail = [
+    agent.cpu_name,
+    agent.cpu_cores != null || agent.cpu_speed
+      ? `(${[agent.cpu_cores != null ? `${agent.cpu_cores} cores` : null, agent.cpu_speed].filter(Boolean).join(" @ ")})`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const diskDetail = [
+    agent.disk_name,
+    agent.disk_size ? `(${agent.disk_size})` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const items: { icon: React.ReactNode; label: string; value: string }[] = [];
+
+  if (agent.hardware_model) {
+    items.push({ icon: <Monitor size={14} />, label: "Model", value: agent.hardware_model });
+  }
+  if (cpuDetail) {
+    items.push({ icon: <Cpu size={14} />, label: "CPU", value: cpuDetail });
+  }
+  if (agent.gpu_name) {
+    items.push({ icon: <Monitor size={14} />, label: "GPU", value: agent.gpu_name });
+  }
+  if (diskDetail) {
+    items.push({ icon: <HardDrive size={14} />, label: "Disk", value: diskDetail });
+  }
+  if (agent.uptime_seconds != null) {
+    items.push({ icon: <Timer size={14} />, label: "Uptime", value: formatUptime(agent.uptime_seconds) });
+  }
+  if (agent.serial_number) {
+    items.push({ icon: <Monitor size={14} />, label: "Serial", value: agent.serial_number });
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <h2 className="text-sm font-medium text-slate-400 mb-3">Hardware Info</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
+        {items.map((item) => (
+          <div key={item.label} className="flex items-start gap-2 text-sm">
+            <span className="mt-0.5 text-slate-500">{item.icon}</span>
+            <span className="text-slate-500 shrink-0">{item.label}:</span>
+            <span className="text-white truncate" title={item.value}>{item.value}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -228,23 +228,32 @@ export default function AgentsPage() {
                       </form>
                     ) : (
                       <span className="group flex items-center gap-1">
-                        <Link
-                          href={`/agents/detail?id=${agent.id}`}
-                          className="hover:text-blue-400 transition-colors hover:underline"
-                        >
-                          {agent.name ?? agent.id.slice(0, 8)}
-                        </Link>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setRenamingId(agent.id);
-                            setRenameValue(agent.name ?? "");
-                            setRenameError(null);
-                          }}
-                          className="opacity-0 group-hover:opacity-50 text-slate-400 hover:text-gray-200"
-                        >
-                          <Pencil size={12} />
-                        </button>
+                        <span className="flex flex-col">
+                          <span className="flex items-center gap-1">
+                            <Link
+                              href={`/agents/detail?id=${agent.id}`}
+                              className="hover:text-blue-400 transition-colors hover:underline"
+                            >
+                              {agent.name ?? agent.id.slice(0, 8)}
+                            </Link>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setRenamingId(agent.id);
+                                setRenameValue(agent.name ?? "");
+                                setRenameError(null);
+                              }}
+                              className="opacity-0 group-hover:opacity-50 text-slate-400 hover:text-gray-200"
+                            >
+                              <Pencil size={12} />
+                            </button>
+                          </span>
+                          {agent.cpu_name && (
+                            <span className="text-xs text-slate-500 font-normal truncate max-w-[200px]" title={agent.cpu_name}>
+                              {agent.cpu_name}
+                            </span>
+                          )}
+                        </span>
                       </span>
                     )}
                   </TableCell>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -97,6 +97,16 @@ export interface Agent {
   is_online: boolean;
   last_report_at: string | null;
   created_at: string;
+  // Hardware inventory (from device_sysinfo)
+  hardware_model?: string | null;
+  cpu_name?: string | null;
+  cpu_cores?: number | null;
+  cpu_speed?: string | null;
+  gpu_name?: string | null;
+  disk_name?: string | null;
+  disk_size?: string | null;
+  serial_number?: string | null;
+  uptime_seconds?: number | null;
 }
 
 export interface AgentCreateResponse {


### PR DESCRIPTION
## Summary
- **Backend:** Added `LEFT JOIN device_sysinfo` to the agents `list`, `get_one`, and `update` SQL queries, exposing hardware fields (`hardware_model`, `cpu_name`, `cpu_cores`, `cpu_speed`, `gpu_name`, `disk_name`, `disk_size`, `serial_number`, `uptime_seconds`) on the `Agent` struct with `skip_serializing_if = "Option::is_none"`
- **Frontend detail page:** New "Hardware Info" card below the header showing model, CPU (cores @ speed), GPU, disk (size), uptime (human-readable Xd Xh Xm), and serial number — gracefully hidden when no hardware data exists, individual fields show only when non-null
- **Frontend list page:** CPU name displayed as a subtitle under the agent name column for at-a-glance hardware identification

Closes #135

## Test plan
- [x] All 243 Rust tests pass (`cargo test --lib`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify agent detail page shows hardware info when agent is linked to device with sysinfo
- [ ] Verify fields gracefully absent (card hidden) when agent has no linked device_sysinfo
- [ ] Verify agent list shows CPU name subtitle for agents with hardware data
- [ ] Verify uptime displays as human-readable "Xd Xh Xm" format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds hardware information display to both the agent detail and list pages by joining `device_sysinfo` data into agent queries. The implementation is clean and well-structured:

- **Backend**: Added 9 new optional fields to the `Agent` struct (hardware_model, cpu_name, cpu_cores, cpu_speed, gpu_name, disk_name, disk_size, serial_number, uptime_seconds) with proper serialization skipping for null values
- **SQL**: All three agent queries (list, get_one, update) now LEFT JOIN `device_sysinfo` on `device_id`, ensuring agents without linked devices continue to work gracefully
- **Frontend detail page**: New "Hardware Info" card displays hardware details with smart formatting (CPU shows cores @ speed, disk shows size, uptime is human-readable as "Xd Xh Xm") and hides entirely when no hardware data exists
- **Frontend list page**: CPU name appears as a subtitle under agent name for quick hardware identification

The changes are backward-compatible, well-tested (243 Rust tests pass), and handle null values gracefully throughout the stack.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are additive and backward-compatible. The LEFT JOIN ensures agents without device_sysinfo continue to work. Optional fields with skip_serializing_if prevent API bloat. Frontend gracefully handles null values. All 243 tests pass.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/agents.rs | Added hardware fields to Agent struct and LEFT JOINed device_sysinfo in all queries (list, get_one, update) - clean implementation |
| web/src/app/(app)/agents/detail/content.tsx | Added HardwareInfoCard component with proper null handling, uptime formatting, and conditional rendering |
| web/src/app/(app)/agents/page.tsx | Added CPU name subtitle under agent name in list view with proper truncation and tooltip |
| web/src/lib/types.ts | Added hardware inventory fields to Agent interface matching backend schema |

</details>



<sub>Last reviewed commit: 9ba76ba</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->