### PR TITLE
feat: add search/filter to NPM proxy hosts table

### DIFF
--- a/web/src/app/(app)/npm/page.tsx
+++ b/web/src/app/(app)/npm/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArrowRightLeft,
   ExternalLink,
@@ -11,8 +11,10 @@ import {
   Pencil,
   Plus,
   Radio,
+  Search,
   Shield,
   Trash2,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -124,6 +126,18 @@ function ProxyHostsTable({
   const [confirmDelete, setConfirmDelete] = useState<NpmProxyHost | null>(null);
   const [deleting, setDeleting] = useState<number | null>(null);
   const [toggling, setToggling] = useState<number | null>(null);
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search) return hosts;
+    const q = search.toLowerCase();
+    return hosts.filter(
+      (h) =>
+        h.domain_names.some((d) => d.toLowerCase().includes(q)) ||
+        h.forward_host?.toLowerCase().includes(q) ||
+        String(h.forward_port).includes(q),
+    );
+  }, [hosts, search]);
 
   const getAccessListName = (id: number | string | null) => {
     if (!id || id === 0 || id === "0") return null;
@@ -253,17 +267,41 @@ function ProxyHostsTable({
 
   return (
     <>
-      <div className="flex items-center justify-between px-4 py-3">
-        <p className="text-xs text-slate-500">
-          {hosts.length} proxy host{hosts.length !== 1 ? "s" : ""}
-        </p>
-        <Button variant="outline" size="sm" onClick={openCreate}>
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div className="relative max-w-sm flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <Input
+            placeholder="Filter by domain, host, or port…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="border-slate-700 bg-slate-800/50 pl-9 pr-8 text-sm text-white placeholder:text-slate-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-slate-500 hover:text-white"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        {search ? (
+          <span className="text-xs text-slate-500">
+            Showing {filtered.length} of {hosts.length} hosts
+          </span>
+        ) : (
+          <p className="text-xs text-slate-500">
+            {hosts.length} proxy host{hosts.length !== 1 ? "s" : ""}
+          </p>
+        )}
+        <Button variant="outline" size="sm" className="ml-auto" onClick={openCreate}>
           <Plus className="mr-1.5 h-3.5 w-3.5" />
           Add Proxy Host
         </Button>
       </div>
 
-      {hosts.length === 0 ? (
+      {hosts.length === 0 && !search ? (
         <p className="px-4 pb-6 text-center text-sm text-slate-500">
           No proxy hosts found.
         </p>
@@ -281,7 +319,14 @@ function ProxyHostsTable({
               </tr>
             </thead>
             <tbody>
-              {hosts.map((h) => {
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-slate-500">
+                    No hosts match &ldquo;{search}&rdquo;
+                  </td>
+                </tr>
+              ) : (
+              filtered.map((h) => {
                 const alName = getAccessListName(h.access_list_id);
                 return (
                   <tr
@@ -357,7 +402,8 @@ function ProxyHostsTable({
                     </td>
                   </tr>
                 );
-              })}
+              })
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- Adds a client-side search/filter input to the NPM proxy hosts table
- Filters rows in real-time as the user types, matching against domain names, forward host (IP/hostname), and port
- Case-insensitive matching with `useMemo` for performance
- Shows result count ("Showing N of M hosts") when filter is active
- Clear button (×) to reset the search
- Empty state message when no hosts match the query

Closes #137

## Test plan
- [ ] Navigate to the NPM page → Proxy Hosts tab
- [ ] Verify the search input appears above the table
- [ ] Type a domain name fragment — table filters in real-time
- [ ] Type an IP/hostname — matching rows shown
- [ ] Type a port number — matching rows shown
- [ ] Verify filtering is case-insensitive
- [ ] Verify "Showing N of M hosts" count updates correctly
- [ ] Click the × button — filter clears and all rows reappear
- [ ] Search for a non-existent term — empty state message shown
- [ ] With no hosts loaded — "No proxy hosts found" still shown (no search bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added client-side search/filter functionality to the NPM proxy hosts table. The implementation provides real-time filtering as users type, matching against domain names, forward host (IP/hostname), and port numbers. Key features include:

- Case-insensitive search using `useMemo` for performance optimization
- Result count display ("Showing N of M hosts") when actively filtering
- Clear button (×) to reset the search quickly
- Proper empty state message when no hosts match the query
- Clean UI integration with existing table controls

**Issue found**: Search bar displays even when `hosts.length === 0`, which contradicts the test plan requirement that states "With no hosts loaded — 'No proxy hosts found' still shown (no search bar)". The search controls should be conditionally rendered only when there are hosts to filter.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor fix needed for the empty state handling
- The implementation is clean and functional with proper performance optimization via useMemo. There's one logic issue where the search bar displays even when no hosts exist, contrary to the documented test plan. This doesn't break functionality but creates inconsistent UX.
- Pay attention to `web/src/app/(app)/npm/page.tsx` - ensure search bar only shows when hosts exist

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/npm/page.tsx | Added client-side search/filter to NPM proxy hosts table with real-time filtering by domain, host, and port. Implementation uses useMemo for performance and includes proper empty states. Minor issue: search bar shows even when no hosts exist, contrary to test plan requirement. |

</details>



<sub>Last reviewed commit: 5efa930</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->