### PR TITLE
fix: dashboard renders instantly with skeletons — VyOS failures no longer block page

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[derive(Serialize)]
 pub struct DashboardStats {
@@ -74,9 +75,14 @@ pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
         match (url, key) {
             (Some(u), Some(k)) if !u.is_empty() && !k.is_empty() => {
                 let client = crate::vyos::client::VyosClient::new(&u, &k);
-                match client.show(&["system", "uptime"]).await {
-                    Ok(_) => "connected".to_string(),
-                    Err(_) => "disconnected".to_string(),
+                match tokio::time::timeout(
+                    Duration::from_secs(5),
+                    client.show(&["system", "uptime"]),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => "connected".to_string(),
+                    _ => "disconnected".to_string(),
                 }
             }
             _ => "unconfigured".to_string(),

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -4,13 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Activity,
   AlertTriangle,
-  ArrowDown,
-  ArrowUp,
   ArrowRight,
   MonitorSmartphone,
   Router,
-  Shield,
-  Wifi,
+  WifiOff,
 } from "lucide-react";
 import {
   AreaChart,
@@ -26,11 +23,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   fetchDashboardStats,
   fetchRecentAlerts,
-  fetchTopDevices,
   fetchTrafficHistory,
   fetchDevices,
 } from "@/lib/api";
-import type { Alert, DashboardStats, TopDevice, TrafficHistoryPoint, Device } from "@/lib/types";
+import type { Alert, DashboardStats, TrafficHistoryPoint, Device } from "@/lib/types";
 import { formatBps, timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
@@ -190,6 +186,17 @@ function StatCardSkeleton() {
   );
 }
 
+// ─── Error card shown when a section fails to load ──────
+
+function SectionError({ message }: { message: string }) {
+  return (
+    <div className="flex items-center gap-2 py-4 text-sm text-rose-400">
+      <WifiOff className="h-4 w-4 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
 // ─── Derive display values from flat stats ──────────────
 
 function routerStatusLabel(s: DashboardStats): { label: string; status: "online" | "offline" | "warning" } {
@@ -223,41 +230,79 @@ const TYPE_COLORS: Record<string, string> = {
 // ─── Page ───────────────────────────────────────────────
 
 export default function DashboardPage() {
+  // Each section has independent data + error state.
+  // null = still loading (show skeleton), non-null = loaded.
   const [stats, setStats] = useState<DashboardStats | null>(null);
-  const [alerts, setAlerts] = useState<Alert[] | null>(null);
-  const [topDevices, setTopDevices] = useState<TopDevice[] | null>(null);
-  const [trafficHistory, setTrafficHistory] = useState<TrafficHistoryPoint[]>([]);
-  const [devices, setDevices] = useState<Device[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [statsError, setStatsError] = useState(false);
 
-  const load = useCallback(async () => {
+  const [alerts, setAlerts] = useState<Alert[] | null>(null);
+  const [alertsError, setAlertsError] = useState(false);
+
+  const [trafficHistory, setTrafficHistory] = useState<TrafficHistoryPoint[] | null>(null);
+  const [trafficError, setTrafficError] = useState(false);
+
+  const [devices, setDevices] = useState<Device[] | null>(null);
+  const [devicesError, setDevicesError] = useState(false);
+
+  // ── Independent loaders — each resolves on its own ────
+
+  const loadStats = useCallback(async () => {
     try {
-      const [s, a, d, th, devs] = await Promise.all([
-        fetchDashboardStats(),
-        fetchRecentAlerts(5),
-        fetchTopDevices(5),
-        fetchTrafficHistory(60),
-        fetchDevices(),
-      ]);
+      const s = await fetchDashboardStats();
       setStats(s);
-      setAlerts(Array.isArray(a) ? a : []);
-      setTopDevices(Array.isArray(d) ? d : []);
-      setTrafficHistory(th);
-      setDevices(Array.isArray(devs) ? devs : []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load dashboard");
+      setStatsError(false);
+    } catch {
+      setStatsError(true);
     }
   }, []);
 
+  const loadAlerts = useCallback(async () => {
+    try {
+      const a = await fetchRecentAlerts(5);
+      setAlerts(Array.isArray(a) ? a : []);
+      setAlertsError(false);
+    } catch {
+      setAlertsError(true);
+    }
+  }, []);
+
+  const loadTraffic = useCallback(async () => {
+    try {
+      const th = await fetchTrafficHistory(60);
+      setTrafficHistory(th);
+      setTrafficError(false);
+    } catch {
+      setTrafficError(true);
+    }
+  }, []);
+
+  const loadDevices = useCallback(async () => {
+    try {
+      const devs = await fetchDevices();
+      setDevices(Array.isArray(devs) ? devs : []);
+      setDevicesError(false);
+    } catch {
+      setDevicesError(true);
+    }
+  }, []);
+
+  // Fire all fetches in parallel — each resolves independently
+  const loadAll = useCallback(() => {
+    loadStats();
+    loadAlerts();
+    loadTraffic();
+    loadDevices();
+  }, [loadStats, loadAlerts, loadTraffic, loadDevices]);
+
   useEffect(() => {
-    load();
-    const interval = setInterval(load, 30_000);
+    loadAll();
+    const interval = setInterval(loadAll, 30_000);
     return () => clearInterval(interval);
-  }, [load]);
+  }, [loadAll]);
 
   useWsEvent(
     ["device_online", "device_offline", "new_device", "agent_online", "agent_offline"],
-    load
+    loadAll
   );
 
   // ── Compute device type breakdown ──────────────────────
@@ -269,22 +314,12 @@ export default function DashboardPage() {
       counts.set(type, (counts.get(type) ?? 0) + 1);
     }
     for (const [type, count] of counts) {
-      const { label } = getDeviceIcon(type, null, null);
-      // Use label from a dummy call — but we can use the LABEL_MAP via getDeviceIcon
       deviceBreakdown.push({ type, label: getCategoryLabel(type), count });
     }
     deviceBreakdown.sort((a, b) => b.count - a.count);
   }
 
   const maxCount = deviceBreakdown.length > 0 ? Math.max(...deviceBreakdown.map((d) => d.count)) : 1;
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-rose-400">{error}</p>
-      </div>
-    );
-  }
 
   return (
     <PageTransition>
@@ -301,7 +336,9 @@ export default function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="flex items-center justify-center pb-4">
-            {stats ? (
+            {statsError ? (
+              <SectionError message="Failed to load" />
+            ) : stats ? (
               <HealthRing online={stats.devices_online} total={stats.devices_total} />
             ) : (
               <Skeleton className="h-28 w-28 rounded-full" />
@@ -311,7 +348,42 @@ export default function DashboardPage() {
 
         {/* ── Stat Cards Row ───────────────────────────── */}
         <StaggerItem className="lg:col-span-4"><div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-          {stats ? (
+          {statsError ? (
+            <>
+              <StatCard
+                title="Router Status"
+                href="/router"
+                value="Unreachable"
+                subtitle="Cannot load stats"
+                icon={<Router className="h-4 w-4" />}
+                status="offline"
+              />
+              <StatCard
+                title="Active Devices"
+                href="/devices"
+                value="—"
+                subtitle="Cannot load stats"
+                icon={<MonitorSmartphone className="h-4 w-4" />}
+                status="offline"
+              />
+              <StatCard
+                title="WAN Bandwidth"
+                href="/traffic"
+                value="—"
+                subtitle="Cannot load stats"
+                icon={<Activity className="h-4 w-4" />}
+                status="offline"
+              />
+              <StatCard
+                title="Unread Alerts"
+                href="/alerts"
+                value="—"
+                subtitle="Cannot load stats"
+                icon={<AlertTriangle className="h-4 w-4" />}
+                status="offline"
+              />
+            </>
+          ) : stats ? (
             <>
               <StatCard
                 title="Router Status"
@@ -373,7 +445,16 @@ export default function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent>
-            {trafficHistory.length > 0 ? (
+            {trafficError ? (
+              <div className="flex h-[200px] items-center justify-center">
+                <SectionError message="Failed to load traffic data" />
+              </div>
+            ) : trafficHistory === null ? (
+              <div className="h-[200px] space-y-3 pt-4">
+                <Skeleton className="h-[160px] w-full" />
+                <Skeleton className="mx-auto h-3 w-48" />
+              </div>
+            ) : trafficHistory.length > 0 ? (
               <div className="h-[200px]">
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={trafficHistory}>
@@ -460,7 +541,9 @@ export default function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent>
-            {alerts === null ? (
+            {alertsError ? (
+              <SectionError message="Failed to load alerts" />
+            ) : alerts === null ? (
               <div className="space-y-3">
                 {Array.from({ length: 5 }).map((_, i) => (
                   <div key={i} className="flex items-center gap-3">
@@ -515,7 +598,9 @@ export default function DashboardPage() {
             </div>
           </CardHeader>
           <CardContent>
-            {devices === null ? (
+            {devicesError ? (
+              <SectionError message="Failed to load devices" />
+            ) : devices === null ? (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
                 {Array.from({ length: 5 }).map((_, i) => (
                   <Skeleton key={i} className="h-10 w-full" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,46 +65,60 @@ import type {
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+const DEFAULT_TIMEOUT_MS = 15_000;
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    credentials: "include", // always send session cookie (HttpOnly, set by server)
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init?.headers ?? {}),
-    },
-  });
-  if (res.status === 401) {
-    if (typeof window !== "undefined"
-        && !window.location.pathname.startsWith("/login")
-        && !window.location.pathname.startsWith("/setup")) {
-      window.location.href = "/login";
+async function request<T>(
+  path: string,
+  init?: RequestInit & { timeoutMs?: number },
+): Promise<T> {
+  const timeoutMs = init?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      credentials: "include", // always send session cookie (HttpOnly, set by server)
+      ...init,
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+    if (res.status === 401) {
+      if (typeof window !== "undefined"
+          && !window.location.pathname.startsWith("/login")
+          && !window.location.pathname.startsWith("/setup")) {
+        window.location.href = "/login";
+      }
+      throw new Error("Unauthorized");
     }
-    throw new Error("Unauthorized");
-  }
-  if (!res.ok) {
-    // Try to extract server error message from JSON body
-    let detail = res.statusText;
-    try {
-      const body = await res.json();
-      if (body?.error) detail = body.error;
-    } catch {
-      // body wasn't JSON — keep statusText
+    if (!res.ok) {
+      let detail = res.statusText;
+      try {
+        const body = await res.json();
+        if (body?.error) detail = body.error;
+      } catch {
+        // body wasn't JSON — keep statusText
+      }
+      throw new Error(`API error ${res.status}: ${detail}`);
     }
-    throw new Error(`API error ${res.status}: ${detail}`);
+    if (res.status === 204 || res.headers.get("content-length") === "0") {
+      return undefined as unknown as T;
+    }
+    return res.json();
+  } finally {
+    clearTimeout(timer);
   }
-  // 204 No Content — return empty object, don't try to parse JSON
-  if (res.status === 204 || res.headers.get("content-length") === "0") {
-    return undefined as unknown as T;
-  }
-  return res.json();
 }
 
 // ─── Generic CRUD ───────────────────────────────────────
 
-export async function apiGet<T>(path: string): Promise<T> {
-  return request<T>(path);
+export async function apiGet<T>(
+  path: string,
+  opts?: { timeoutMs?: number },
+): Promise<T> {
+  return request<T>(path, opts);
 }
 
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
@@ -134,16 +148,24 @@ export async function apiDelete(path: string): Promise<void> {
 
 // ─── Dashboard ──────────────────────────────────────────
 
+const DASHBOARD_TIMEOUT_MS = 8_000;
+
 export function fetchDashboardStats(): Promise<DashboardStats> {
-  return apiGet<DashboardStats>("/api/v1/dashboard/stats");
+  return apiGet<DashboardStats>("/api/v1/dashboard/stats", {
+    timeoutMs: DASHBOARD_TIMEOUT_MS,
+  });
 }
 
 export function fetchRecentAlerts(limit = 5): Promise<Alert[]> {
-  return apiGet<Alert[]>(`/api/v1/alerts?limit=${limit}`);
+  return apiGet<Alert[]>(`/api/v1/alerts?limit=${limit}`, {
+    timeoutMs: DASHBOARD_TIMEOUT_MS,
+  });
 }
 
 export function fetchTopDevices(limit = 5): Promise<TopDevice[]> {
-  return apiGet<TopDevice[]>(`/api/v1/dashboard/top-devices?limit=${limit}`);
+  return apiGet<TopDevice[]>(`/api/v1/dashboard/top-devices?limit=${limit}`, {
+    timeoutMs: DASHBOARD_TIMEOUT_MS,
+  });
 }
 
 export function fetchAlerts(
@@ -298,7 +320,9 @@ export function fetchAgentReports(id: string, limit = 100): Promise<AgentReport[
 // ─── Traffic ────────────────────────────────────────────
 
 export function fetchTrafficHistory(minutes = 60): Promise<TrafficHistoryPoint[]> {
-  return apiGet<TrafficHistoryPoint[]>(`/api/v1/traffic/history?minutes=${minutes}`);
+  return apiGet<TrafficHistoryPoint[]>(`/api/v1/traffic/history?minutes=${minutes}`, {
+    timeoutMs: DASHBOARD_TIMEOUT_MS,
+  });
 }
 
 // ─── Auth ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Split monolithic `Promise.all` into independent per-section fetchers** so each dashboard card (stats, alerts, traffic chart, device breakdown) loads independently — if one is slow or fails, only that card shows an error while others render normally
- **Added client-side AbortController timeout (8s)** to all dashboard API calls to prevent indefinite hangs when VyOS or backend is unreachable
- **Added server-side `tokio::time::timeout` (5s)** to the VyOS connectivity check in `/api/v1/dashboard/stats` so the stats endpoint returns quickly even when VyOS is down
- **Added skeleton placeholders for traffic chart** (previously showed nothing while loading)
- **Added inline error indicators** (`SectionError` component) for each section that fails, instead of a full-page error

## Test plan
- [ ] Navigate to dashboard — layout, sidebar, and card skeletons should render within ~200ms
- [ ] Each card should show its skeleton independently while data loads
- [ ] If VyOS is unreachable: Router Status card shows "Offline" / "Cannot reach router" after ~5s, all other cards load normally
- [ ] If backend is unreachable: each card shows its own error indicator independently
- [ ] Traffic chart shows skeleton placeholder while loading, then chart or "No traffic data yet"
- [ ] Alerts card shows skeleton, then alert list or "No recent alerts"
- [ ] WebSocket events still trigger data refresh for all sections
- [ ] 30-second auto-refresh still works for all sections

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored dashboard loading architecture to handle slow/failing backend and VyOS gracefully — dashboard now renders instantly with skeletons instead of blocking on slow APIs.

- Split monolithic `Promise.all` into independent per-section fetchers so each card (stats, alerts, traffic, devices) loads and fails independently
- Added client-side AbortController with 8s timeout for dashboard APIs to prevent indefinite hangs
- Added server-side `tokio::time::timeout` (5s) to VyOS connectivity check so stats endpoint returns quickly even when router is unreachable
- Added skeleton placeholders for traffic chart that were previously missing
- Added inline `SectionError` components for per-section failures instead of full-page errors

<h3>Confidence Score: 5/5</h3>

- Safe to merge — well-implemented resilience improvements with proper error handling
- Changes are defensive, add timeouts and graceful degradation without altering core logic. Error handling properly isolates failures and cleans up resources (AbortController timer in finally block). No breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Added 5s `tokio::time::timeout` to VyOS connectivity check — prevents indefinite hangs when router is unreachable |
| web/src/lib/api.ts | Added AbortController with 8s timeout for dashboard endpoints and 15s for others — prevents hanging requests |
| web/src/app/(app)/dashboard/page.tsx | Split monolithic fetch into independent loaders with per-section error states — dashboard renders instantly with skeletons, failures isolated |

</details>



<sub>Last reviewed commit: 29e3786</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->