### PR TITLE
feat: auto-create asset records from discovered devices and agents

### DIFF
--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -942,9 +942,7 @@ async fn handle_agent_report(text: &str, agent_id: &str, state: &AppState) -> an
                             crate::oui::lookup(mac).map(|v| v.to_string())
                         };
                         let hostname = report.hostname.as_deref();
-                        let dev_name = hostname
-                            .or(vendor.as_deref())
-                            .map(|s| s.to_string());
+                        let dev_name = hostname.or(vendor.as_deref()).map(|s| s.to_string());
 
                         if let Err(e) = sqlx::query(
                             "INSERT INTO devices (id, mac, name, hostname, vendor, is_randomized_mac, \
@@ -1701,8 +1699,7 @@ mod tests {
     /// Helper: create a test AppState with an in-memory database.
     async fn test_app_state() -> (sqlx::SqlitePool, crate::api::AppState) {
         let pool = test_db().await;
-        let state =
-            crate::api::AppState::new(pool.clone(), crate::config::AppConfig::default());
+        let state = crate::api::AppState::new(pool.clone(), crate::config::AppConfig::default());
         (pool, state)
     }
 
@@ -1727,13 +1724,15 @@ mod tests {
             .expect("handle_agent_report should succeed");
 
         // Verify a device was created with the agent's MAC.
-        let device: Option<(String, String, Option<String>)> = sqlx::query_as(
-            "SELECT id, mac, hostname FROM devices WHERE mac = 'aa:bb:cc:dd:ee:f1'",
-        )
-        .fetch_optional(&pool)
-        .await
-        .unwrap();
-        assert!(device.is_some(), "Device should be auto-created from agent MAC");
+        let device: Option<(String, String, Option<String>)> =
+            sqlx::query_as("SELECT id, mac, hostname FROM devices WHERE mac = 'aa:bb:cc:dd:ee:f1'")
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert!(
+            device.is_some(),
+            "Device should be auto-created from agent MAC"
+        );
         let (device_id, mac, hostname) = device.unwrap();
         assert_eq!(mac, "aa:bb:cc:dd:ee:f1");
         assert_eq!(hostname.as_deref(), Some("test-host"));
@@ -1802,12 +1801,11 @@ mod tests {
         );
 
         // Verify no duplicate device was created.
-        let device_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE mac = ?")
-                .bind(existing_mac)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
+        let device_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE mac = ?")
+            .bind(existing_mac)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
         assert_eq!(device_count, 1, "No duplicate device should be created");
     }
 
@@ -1918,10 +1916,26 @@ mod tests {
         let os_version: Option<String> = sqlx::Row::get(&row, "os_version");
         let serial_number: Option<String> = sqlx::Row::get(&row, "serial_number");
 
-        assert_eq!(hostname.as_deref(), Some("existing-host"), "hostname should NOT be overwritten");
-        assert_eq!(os_family.as_deref(), Some("Windows"), "os_family should NOT be overwritten");
-        assert_eq!(os_version.as_deref(), Some("11"), "os_version should NOT be overwritten");
-        assert_eq!(serial_number.as_deref(), Some("PRE-SN"), "serial_number should NOT be overwritten");
+        assert_eq!(
+            hostname.as_deref(),
+            Some("existing-host"),
+            "hostname should NOT be overwritten"
+        );
+        assert_eq!(
+            os_family.as_deref(),
+            Some("Windows"),
+            "os_family should NOT be overwritten"
+        );
+        assert_eq!(
+            os_version.as_deref(),
+            Some("11"),
+            "os_version should NOT be overwritten"
+        );
+        assert_eq!(
+            serial_number.as_deref(),
+            Some("PRE-SN"),
+            "serial_number should NOT be overwritten"
+        );
     }
 
     #[tokio::test]
@@ -1969,32 +1983,35 @@ mod tests {
             .expect("agent 2 report");
 
         // Both agents should be linked to the same device.
-        let dev1: Option<String> =
-            sqlx::query_scalar("SELECT device_id FROM agents WHERE id = ?")
-                .bind(&agent1_id)
-                .fetch_optional(&pool)
-                .await
-                .unwrap()
-                .flatten();
-        let dev2: Option<String> =
-            sqlx::query_scalar("SELECT device_id FROM agents WHERE id = ?")
-                .bind(&agent2_id)
-                .fetch_optional(&pool)
-                .await
-                .unwrap()
-                .flatten();
+        let dev1: Option<String> = sqlx::query_scalar("SELECT device_id FROM agents WHERE id = ?")
+            .bind(&agent1_id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap()
+            .flatten();
+        let dev2: Option<String> = sqlx::query_scalar("SELECT device_id FROM agents WHERE id = ?")
+            .bind(&agent2_id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap()
+            .flatten();
 
         assert!(dev1.is_some(), "Agent 1 should have a device_id");
-        assert_eq!(dev1, dev2, "Both agents should be linked to the same device");
+        assert_eq!(
+            dev1, dev2,
+            "Both agents should be linked to the same device"
+        );
 
         // Only one device should exist with that MAC.
-        let device_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE mac = ?")
-                .bind(shared_mac)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-        assert_eq!(device_count, 1, "Only one device should exist for shared MAC");
+        let device_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE mac = ?")
+            .bind(shared_mac)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            device_count, 1,
+            "Only one device should exist for shared MAC"
+        );
     }
 
     #[tokio::test]
@@ -2027,6 +2044,9 @@ mod tests {
                 .await
                 .unwrap()
                 .flatten();
-        assert!(device_id.is_none(), "Agent should have no device_id without MAC");
+        assert!(
+            device_id.is_none(),
+            "Agent should have no device_id without MAC"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #155

- **Auto-create device (asset) from agent**: When an agent sends its first report with MAC addresses that don't match any existing device, a new device record is automatically created (with hostname, OUI vendor, randomized MAC detection) and the agent is linked to it.
- **MAC-based deduplication**: If an agent's MAC matches an existing ARP-discovered device, the agent links to that device — no duplicate is created. Two agents sharing the same MAC are linked to the same device.
- **Auto-populate device fields from agent data**: Agent-reported hostname, OS (family/version), and hardware specs (serial number, CPU, RAM, model) flow into the linked device's asset fields via `COALESCE` — only empty fields are populated, existing values are never overwritten.

## Acceptance Criteria

- [x] New discovered device → asset auto-created (ARP scanner already did this)
- [x] New agent registration → asset auto-created/linked (via first report with MACs)
- [x] Same host with both device record + agent → single asset with both linked
- [x] Asset list shows auto-populated entries after first scan/agent connect

## Test plan

- [x] `test_agent_report_auto_creates_device` — unknown MAC → device created + agent linked
- [x] `test_agent_report_links_to_existing_device` — known MAC → links to existing, no duplicate
- [x] `test_agent_report_populates_device_fields` — OS, hardware, hostname flow into device record
- [x] `test_agent_does_not_overwrite_existing_device_fields` — COALESCE preserves existing values
- [x] `test_two_agents_same_mac_single_device` — deduplication: two agents → one device
- [x] `test_agent_no_mac_no_device_created` — no network interfaces → no device created
- [x] All 253 unit tests + 12 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements automatic asset creation when agents report network interfaces with MACs that don't match existing devices. The new logic:

**Auto-creation flow:**
- When no MAC match is found, checks if agent already has a linked device
- If not linked, creates new device record with first non-randomized MAC (or first MAC if all randomized)
- Enriches new device with hostname, OUI vendor lookup, and randomized MAC detection
- Links agent to the newly created device
- Broadcasts `new_device` event to WebSocket clients

**Device field population:**
- After device linking, uses `COALESCE` to populate empty device fields from agent data
- Two separate UPDATE queries populate: hostname, OS family/version, device type (defaults to 'computer')
- Hardware specs: serial number, CPU, RAM (formatted), hardware model
- Existing values are never overwritten due to COALESCE semantics

**Deduplication:**
- MAC-based deduplication works correctly: multiple agents with same MAC link to same device
- No duplicate devices created when MAC already exists in devices table

**Test coverage:**
All 6 new integration tests pass, covering: auto-creation, linking to existing device, field population, COALESCE preservation, two-agents-one-device, and no-MAC edge case.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean implementation with comprehensive test coverage (6 new integration tests), proper use of COALESCE to prevent overwriting existing data, robust MAC deduplication logic, and follows existing codebase patterns. All edge cases are tested and handled correctly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/agents.rs | Added auto-device creation from agent MACs (lines 918-989) and device field population via COALESCE (lines 1134-1182). Comprehensive test coverage with 6 new tests covering all edge cases. |

</details>



<sub>Last reviewed commit: cbe8068</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->