### PR TITLE
fix: await clipboard write and add fallback for non-secure contexts

### DIFF
--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -41,6 +41,7 @@ import type { Agent, AgentCreateResponse, AgentReport } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 import { useWsEvent } from "@/lib/ws";
 import { PageTransition } from "@/components/PageTransition";
+import { copyToClipboard } from "@/lib/utils";
 
 export default function AgentsPage() {
   const [agents, setAgents] = useState<Agent[] | null>(null);
@@ -491,33 +492,12 @@ function CopyBlock({ text }: { text: string }) {
   const preRef = useRef<HTMLPreElement>(null);
 
   const handleCopy = async () => {
-    // Modern clipboard API (HTTPS / localhost)
-    if (navigator.clipboard && window.isSecureContext) {
-      try {
-        await navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-        return;
-      } catch {}
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return;
     }
-
-    // HTTP fallback: execCommand
-    try {
-      const ta = document.createElement("textarea");
-      ta.value = text;
-      ta.style.cssText =
-        "position:fixed;top:50%;left:50%;width:2em;height:2em;padding:0;border:none;outline:none;background:transparent;opacity:0;";
-      document.body.appendChild(ta);
-      ta.focus();
-      ta.setSelectionRange(0, text.length);
-      const ok = document.execCommand("copy");
-      document.body.removeChild(ta);
-      if (ok) {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-        return;
-      }
-    } catch {}
 
     // Last resort: select text so user can Ctrl+C manually
     if (preRef.current) {

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -128,6 +128,7 @@ import MikrotikRouter from "@/components/MikrotikRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
+import { copyToClipboard } from "@/lib/utils";
 
 // ── Not Configured state ────────────────────────────────
 
@@ -4261,9 +4262,9 @@ function CreateWireGuardInterfaceDialog({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => {
-                    navigator.clipboard.writeText(publicKey);
-                    toast.success("Public key copied");
+                  onClick={async () => {
+                    const ok = await copyToClipboard(publicKey);
+                    toast[ok ? "success" : "error"](ok ? "Public key copied" : "Copy failed");
                   }}
                 >
                   <Copy className="h-3.5 w-3.5" />
@@ -4414,9 +4415,9 @@ function WireGuardInterfaceCard({
               variant="ghost"
               size="sm"
               className="h-5 w-5 p-0"
-              onClick={() => {
-                navigator.clipboard.writeText(iface.public_key!);
-                toast.success("Public key copied");
+              onClick={async () => {
+                const ok = await copyToClipboard(iface.public_key!);
+                toast[ok ? "success" : "error"](ok ? "Public key copied" : "Copy failed");
               }}
             >
               <Copy className="h-3 w-3" />
@@ -4776,10 +4777,10 @@ function GenerateClientConfigDialog({
     URL.revokeObjectURL(url);
   };
 
-  const handleCopyConfig = () => {
+  const handleCopyConfig = async () => {
     if (!configResult) return;
-    navigator.clipboard.writeText(configResult.config);
-    toast.success("Config copied to clipboard");
+    const ok = await copyToClipboard(configResult.config);
+    toast[ok ? "success" : "error"](ok ? "Config copied to clipboard" : "Copy failed");
   };
 
   return (

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -4,3 +4,35 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Copy text to clipboard with fallback for non-secure (HTTP) contexts.
+ * Returns true if the copy succeeded, false otherwise.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Modern clipboard API (HTTPS / localhost)
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to legacy fallback
+    }
+  }
+
+  // Fallback for HTTP contexts: execCommand('copy')
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.cssText =
+      "position:fixed;top:0;left:0;width:1px;height:1px;padding:0;border:none;outline:none;background:transparent;opacity:0;";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.setSelectionRange(0, text.length);
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes copy buttons showing "Copied!" while clipboard is actually empty in non-HTTPS contexts
- Extracts a shared `copyToClipboard()` utility in `lib/utils.ts` that properly awaits `navigator.clipboard.writeText()` and falls back to `document.execCommand('copy')` for HTTP contexts
- Fixes all 3 unguarded `navigator.clipboard.writeText()` calls in `router/page.tsx`
- Refactors `CopyBlock` in `agents/page.tsx` to reuse the shared utility
- Shows "Copy failed" error toast when clipboard write actually fails

Closes #114

## Test plan
- [ ] Open Panoptikon over HTTP (not HTTPS/localhost) — copy buttons should work via execCommand fallback
- [ ] Open over HTTPS or localhost — copy uses modern clipboard API
- [ ] Verify toast shows "Copy failed" when both methods fail (e.g. in restrictive iframe)
- [ ] Test copy buttons: server public key, interface public key, WireGuard config, agent download URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes clipboard copy functionality in non-HTTPS contexts by properly awaiting clipboard writes and implementing an `execCommand` fallback. Extracts a reusable `copyToClipboard()` utility that consolidates the copy logic previously duplicated across components.

**Key improvements:**
- Fixed unguarded `navigator.clipboard.writeText()` calls that failed silently in HTTP contexts
- All copy operations now properly await the clipboard write and handle errors
- Error toast displays when both modern API and fallback fail
- Reduced code duplication by centralizing clipboard logic in `lib/utils.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Well-implemented bug fix that properly handles both secure and non-secure contexts. The refactoring eliminates code duplication, adds proper error handling, and maintains backward compatibility through a sensible fallback mechanism.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/utils.ts | Added `copyToClipboard()` utility with modern API and execCommand fallback for HTTP contexts |
| web/src/app/(app)/router/page.tsx | Refactored 3 copy buttons to use shared utility with proper async/await and error handling |
| web/src/app/(app)/agents/page.tsx | Simplified CopyBlock component to reuse shared clipboard utility |

</details>



<sub>Last reviewed commit: d5583e5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->