### PR TITLE
feat: serve pre-built agent binaries from install endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-agent:
+    name: Build Agent (${{ matrix.platform }})
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            platform: linux-amd64
+            os: ubuntu-latest
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            platform: linux-arm64
+            os: ubuntu-latest
+            use_cross: true
+          - target: x86_64-pc-windows-gnu
+            platform: windows-amd64
+            os: ubuntu-latest
+            use_cross: true
+          - target: aarch64-apple-darwin
+            platform: darwin-arm64
+            os: macos-latest
+            use_cross: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux/Windows cross-compile)
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build agent
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p panoptikon-agent
+          else
+            cargo build --release --target ${{ matrix.target }} -p panoptikon-agent
+          fi
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p dist
+          if [[ "${{ matrix.platform }}" == windows-* ]]; then
+            cp target/${{ matrix.target }}/release/panoptikon-agent.exe dist/panoptikon-agent-${{ matrix.platform }}.exe
+          else
+            cp target/${{ matrix.target }}/release/panoptikon-agent dist/panoptikon-agent-${{ matrix.platform }}
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: panoptikon-agent-${{ matrix.platform }}
+          path: dist/panoptikon-agent-*
+
+  release:
+    name: Create Release
+    needs: build-agent
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          find artifacts -type f -name 'panoptikon-agent-*' -exec cp {} release/ \;
+          ls -la release/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          generate_release_notes: true

--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -1213,8 +1213,55 @@ fn format_bytes(bytes: i64) -> String {
     }
 }
 
-/// GET /api/v1/agent/install/:platform?key=<api_key>
-/// Returns a shell script that installs the panoptikon-agent on the target platform.
+/// Supported agent platforms with their metadata.
+struct PlatformInfo {
+    /// File name for the pre-built binary artifact.
+    artifact: &'static str,
+    /// Whether this is a Windows target.
+    is_windows: bool,
+}
+
+fn platform_info(platform: &str) -> Option<PlatformInfo> {
+    match platform {
+        "linux-amd64" => Some(PlatformInfo {
+            artifact: "panoptikon-agent-linux-amd64",
+            is_windows: false,
+        }),
+        "linux-arm64" => Some(PlatformInfo {
+            artifact: "panoptikon-agent-linux-arm64",
+            is_windows: false,
+        }),
+        "darwin-arm64" => Some(PlatformInfo {
+            artifact: "panoptikon-agent-darwin-arm64",
+            is_windows: false,
+        }),
+        "darwin-amd64" => Some(PlatformInfo {
+            artifact: "panoptikon-agent-darwin-amd64",
+            is_windows: false,
+        }),
+        "windows-amd64" => Some(PlatformInfo {
+            artifact: "panoptikon-agent-windows-amd64.exe",
+            is_windows: true,
+        }),
+        _ => None,
+    }
+}
+
+/// Derive the server URL from the incoming request headers / config.
+fn server_url_from_request(headers: &HeaderMap, config: &crate::config::AppConfig) -> String {
+    if let Some(host) = headers.get("host").and_then(|v| v.to_str().ok()) {
+        format!("http://{}", host)
+    } else {
+        let listen = config.listen.as_deref().unwrap_or("0.0.0.0:8080");
+        format!("http://{}", listen)
+    }
+}
+
+/// GET /api/v1/agent/install/:platform?key=<api_key>&id=<agent_id>
+///
+/// Returns an install script for the given platform:
+/// - Linux / macOS: shell script that downloads the binary via curl
+/// - Windows: PowerShell script that downloads the .exe and registers a service
 pub async fn install_script(
     Path(platform): Path<String>,
     Query(params): Query<HashMap<String, String>>,
@@ -1229,38 +1276,102 @@ pub async fn install_script(
     };
     let agent_id = params.get("id").cloned().unwrap_or_default();
 
-    // Validate the API key exists (future: reject unknown keys)
-    let _key_exists: bool =
-        sqlx::query_scalar("SELECT COUNT(*) > 0 FROM agents WHERE api_key_hash != ''")
-            .fetch_one(&state.db)
-            .await
-            .unwrap_or(false);
-
-    // Determine server URL: prefer the Host header from the incoming request,
-    // fall back to config listen address (without hardcoded IPs).
-    let server_url = if let Some(host) = headers.get("host").and_then(|v| v.to_str().ok()) {
-        format!("http://{}", host)
-    } else {
-        let listen = state.config.listen.as_deref().unwrap_or("0.0.0.0:8080");
-        format!("http://{}", listen)
-    };
-
-    let (_target_triple, _binary_name) = match platform.as_str() {
-        "linux-amd64" => ("x86_64-unknown-linux-musl", "panoptikon-agent-linux-amd64"),
-        "linux-arm64" => ("aarch64-unknown-linux-musl", "panoptikon-agent-linux-arm64"),
-        "darwin-arm64" => ("aarch64-apple-darwin", "panoptikon-agent-darwin-arm64"),
-        "darwin-amd64" => ("x86_64-apple-darwin", "panoptikon-agent-darwin-amd64"),
-        _ => {
+    let info = match platform_info(&platform) {
+        Some(i) => i,
+        None => {
             return (
                 StatusCode::BAD_REQUEST,
-                "Unknown platform. Use: linux-amd64, linux-arm64, darwin-arm64, darwin-amd64",
+                "Unknown platform. Use: linux-amd64, linux-arm64, darwin-arm64, darwin-amd64, windows-amd64",
             )
                 .into_response();
         }
     };
 
-    // Generate install script (builds from source for now; binary releases once CI is set up)
-    let script = format!(
+    let server_url = server_url_from_request(&headers, &state.config);
+
+    if info.is_windows {
+        let script = generate_windows_script(&platform, &server_url, &api_key, &agent_id);
+        return (
+            StatusCode::OK,
+            [("content-type", "text/plain; charset=utf-8")],
+            script,
+        )
+            .into_response();
+    }
+
+    let script = generate_unix_script(&platform, &server_url, &api_key, &agent_id);
+    (
+        StatusCode::OK,
+        [("content-type", "text/plain; charset=utf-8")],
+        script,
+    )
+        .into_response()
+}
+
+/// GET /api/v1/agent/install/:platform/binary
+///
+/// Serves the pre-built agent binary for the given platform.
+/// Looks for the binary in:
+///   1. The configured `agent_binaries_dir` on the server filesystem
+///   2. Falls back to redirecting to GitHub Releases
+pub async fn install_binary(
+    Path(platform): Path<String>,
+    State(state): State<AppState>,
+) -> Response {
+    let info = match platform_info(&platform) {
+        Some(i) => i,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                "Unknown platform. Use: linux-amd64, linux-arm64, darwin-arm64, darwin-amd64, windows-amd64",
+            )
+                .into_response();
+        }
+    };
+
+    // Try to serve from local filesystem first.
+    if let Some(dir) = &state.config.agent_binaries_dir {
+        let path = std::path::Path::new(dir).join(info.artifact);
+        if path.is_file() {
+            match tokio::fs::read(&path).await {
+                Ok(bytes) => {
+                    let content_type = if info.is_windows {
+                        "application/vnd.microsoft.portable-executable"
+                    } else {
+                        "application/octet-stream"
+                    };
+                    return (
+                        StatusCode::OK,
+                        [
+                            ("content-type", content_type),
+                            (
+                                "content-disposition",
+                                &format!("attachment; filename=\"{}\"", info.artifact),
+                            ),
+                        ],
+                        bytes,
+                    )
+                        .into_response();
+                }
+                Err(e) => {
+                    error!("Failed to read agent binary {}: {}", path.display(), e);
+                    // Fall through to GitHub redirect.
+                }
+            }
+        }
+    }
+
+    // Redirect to GitHub Releases.
+    let release_url = format!(
+        "https://github.com/BeFeast/panoptikon/releases/latest/download/{}",
+        info.artifact,
+    );
+    (StatusCode::TEMPORARY_REDIRECT, [("location", release_url)]).into_response()
+}
+
+/// Generate a Unix (Linux / macOS) install script that downloads a pre-built binary.
+fn generate_unix_script(platform: &str, server_url: &str, api_key: &str, agent_id: &str) -> String {
+    format!(
         r#"#!/bin/sh
 # Panoptikon Agent Installer — {platform}
 # Server: {server_url}
@@ -1287,30 +1398,18 @@ echo "==> Installing Panoptikon Agent ({platform})"
 echo "    Binary  : $INSTALL_DIR/panoptikon-agent"
 echo "    Config  : $CONFIG_DIR/config.toml"
 
-# Check if pre-built binary is available from GitHub releases
-RELEASE_URL="https://github.com/BeFeast/panoptikon/releases/latest/download/panoptikon-agent-{platform}"
+# Download the pre-built binary — try the server's own binary endpoint first,
+# then fall back to GitHub Releases.
+BINARY_URL="$SERVER_URL/api/v1/agent/install/{platform}/binary"
 
-if curl -fsSL --head "$RELEASE_URL" 2>/dev/null | grep -q "200\|302"; then
-    echo "==> Downloading pre-built binary..."
-    curl -fsSL "$RELEASE_URL" -o /tmp/panoptikon-agent
-    chmod +x /tmp/panoptikon-agent
-    mv /tmp/panoptikon-agent "$INSTALL_DIR/panoptikon-agent"
-else
-    echo "==> No pre-built binary found. Building from source (requires Rust)..."
-    if ! command -v cargo >/dev/null 2>&1; then
-        echo "==> Installing Rust toolchain..."
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-        . "$HOME/.cargo/env"
-    fi
-    TMPDIR=$(mktemp -d)
-    echo "==> Cloning repository..."
-    git clone --depth=1 https://github.com/BeFeast/panoptikon.git "$TMPDIR/panoptikon"
-    cd "$TMPDIR/panoptikon"
-    echo "==> Building (this takes a few minutes)..."
-    cargo build --release --bin panoptikon-agent
-    mv "target/release/panoptikon-agent" "$INSTALL_DIR/panoptikon-agent"
-    rm -rf "$TMPDIR"
+echo "==> Downloading pre-built binary..."
+if ! curl -fsSL "$BINARY_URL" -o /tmp/panoptikon-agent 2>/dev/null; then
+    RELEASE_URL="https://github.com/BeFeast/panoptikon/releases/latest/download/panoptikon-agent-{platform}"
+    echo "==> Server binary not available, trying GitHub Releases..."
+    curl -fsSL -L "$RELEASE_URL" -o /tmp/panoptikon-agent
 fi
+chmod +x /tmp/panoptikon-agent
+mv /tmp/panoptikon-agent "$INSTALL_DIR/panoptikon-agent"
 
 echo "==> Writing config..."
 mkdir -p "$CONFIG_DIR"
@@ -1401,14 +1500,86 @@ echo "==> Done! Agent is reporting to $SERVER_URL"
         server_url = server_url,
         api_key = api_key,
         agent_id = agent_id,
-    );
-
-    (
-        StatusCode::OK,
-        [("content-type", "text/plain; charset=utf-8")],
-        script,
     )
-        .into_response()
+}
+
+/// Generate a Windows PowerShell install script that downloads the .exe and
+/// registers it as a Windows Service.
+fn generate_windows_script(
+    platform: &str,
+    server_url: &str,
+    api_key: &str,
+    agent_id: &str,
+) -> String {
+    format!(
+        r#"# Panoptikon Agent Installer — {platform}
+# Server: {server_url}
+# Run as Administrator: powershell -ExecutionPolicy Bypass -File panoptikon-install.ps1
+
+$ErrorActionPreference = "Stop"
+
+$ServerUrl    = "{server_url}"
+$ApiKey       = "{api_key}"
+$AgentId      = "{agent_id}"
+$InstallDir   = "$env:ProgramFiles\panoptikon"
+$ConfigDir    = "$env:ProgramData\panoptikon-agent"
+$BinaryPath   = "$InstallDir\panoptikon-agent.exe"
+
+Write-Host "==> Installing Panoptikon Agent ({platform})"
+Write-Host "    Binary  : $BinaryPath"
+Write-Host "    Config  : $ConfigDir\config.toml"
+
+# Create directories
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+New-Item -ItemType Directory -Force -Path $ConfigDir  | Out-Null
+
+# Download the pre-built binary — try the server first, then GitHub Releases.
+$BinaryUrl  = "$ServerUrl/api/v1/agent/install/{platform}/binary"
+$ReleaseUrl = "https://github.com/BeFeast/panoptikon/releases/latest/download/panoptikon-agent-{platform}.exe"
+
+Write-Host "==> Downloading pre-built binary..."
+try {{
+    Invoke-WebRequest -Uri $BinaryUrl -OutFile $BinaryPath -UseBasicParsing
+}} catch {{
+    Write-Host "==> Server binary not available, trying GitHub Releases..."
+    Invoke-WebRequest -Uri $ReleaseUrl -OutFile $BinaryPath -UseBasicParsing
+}}
+
+# Write config
+Write-Host "==> Writing config..."
+@"
+server_url = "$ServerUrl"
+api_key = "$ApiKey"
+agent_id = "$AgentId"
+report_interval_seconds = 30
+"@ | Out-File "$ConfigDir\config.toml" -Encoding utf8
+
+# Stop existing service if running
+if (Get-Service -Name "PanoptikonAgent" -ErrorAction SilentlyContinue) {{
+    Write-Host "==> Stopping existing service..."
+    Stop-Service -Name "PanoptikonAgent" -Force -ErrorAction SilentlyContinue
+    sc.exe delete "PanoptikonAgent" | Out-Null
+    Start-Sleep -Seconds 2
+}}
+
+# Register as Windows Service
+Write-Host "==> Registering Windows service..."
+New-Service -Name "PanoptikonAgent" `
+    -BinaryPathName "`"$BinaryPath`" --config `"$ConfigDir\config.toml`"" `
+    -StartupType Automatic `
+    -DisplayName "Panoptikon Agent" `
+    -Description "Panoptikon system metrics collector"
+
+Start-Service -Name "PanoptikonAgent"
+
+Write-Host ""
+Write-Host "==> Done! Agent is reporting to $ServerUrl"
+"#,
+        platform = platform,
+        server_url = server_url,
+        api_key = api_key,
+        agent_id = agent_id,
+    )
 }
 
 #[cfg(test)]

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -104,7 +104,11 @@ pub fn router(state: AppState) -> Router {
     // Agent WebSocket + install script — authenticated via API key, not session cookie.
     let agent_ws = Router::new()
         .route("/agent/ws", get(agents::ws_handler))
-        .route("/agent/install/:platform", get(agents::install_script));
+        .route("/agent/install/:platform", get(agents::install_script))
+        .route(
+            "/agent/install/:platform/binary",
+            get(agents::install_binary),
+        );
 
     // Protected routes — each method registered in its own .route() call to avoid
     // Axum 0.7 MethodRouter chaining issue where DELETE/PATCH can be dropped

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -28,6 +28,11 @@ pub struct AppConfig {
     /// Retention section — data cleanup periods.
     #[serde(default)]
     pub retention: RetentionConfig,
+
+    /// Directory containing pre-built agent binaries for download.
+    /// Expected layout: <dir>/panoptikon-agent-<platform>[.exe]
+    #[serde(default)]
+    pub agent_binaries_dir: Option<String>,
 }
 
 fn default_listen() -> Option<String> {
@@ -199,6 +204,7 @@ impl Default for AppConfig {
             scanner: ScannerConfig::default(),
             auth: AuthConfig::default(),
             retention: RetentionConfig::default(),
+            agent_binaries_dir: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #116

- **Replace build-from-source fallback** with download-only install scripts that fetch pre-built binaries
- **Add `GET /api/v1/agent/install/:platform/binary`** endpoint — serves binaries from local `agent_binaries_dir` config path, or redirects to GitHub Releases as fallback
- **Add `windows-amd64` platform support** — returns a PowerShell `.ps1` script that downloads `panoptikon-agent.exe` and registers it as a Windows Service
- **Add GitHub Actions release workflow** (`.github/workflows/release.yml`) — cross-compiles the agent for `linux-amd64`, `linux-arm64`, `windows-amd64`, and `darwin-arm64` using `cross` on tagged releases
- **Add `agent_binaries_dir`** server config option for self-hosted binary distribution

## Test plan

- [x] All 274 existing tests pass (257 unit + 12 integration + 5 agent)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Verify install script output for `linux-amd64` downloads binary via curl (no cargo/git)
- [ ] Verify install script output for `windows-amd64` returns PowerShell script
- [ ] Verify `/binary` endpoint redirects to GitHub Releases when no local binaries configured
- [ ] Verify `/binary` endpoint serves local file when `agent_binaries_dir` is set
- [ ] Test release workflow triggers on `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the build-from-source agent installation approach with pre-built binary downloads. It adds a new `/api/v1/agent/install/:platform/binary` endpoint that serves binaries from a configured directory or redirects to GitHub Releases, plus a GitHub Actions workflow to cross-compile binaries for Linux, macOS, and Windows.

**Key changes:**
- New binary download endpoint with local filesystem + GitHub fallback
- Refactored install scripts for Unix and Windows (PowerShell with service registration)
- GitHub Actions release workflow for cross-compilation
- New `agent_binaries_dir` config option

**Issues found:**
- Missing `darwin-amd64` build target in CI workflow (API and UI support it but workflow doesn't build it)
- Host header injection vulnerability in `server_url_from_request` — untrusted Host header is embedded in install scripts, allowing attackers to redirect binary downloads to malicious servers

<h3>Confidence Score: 3/5</h3>

- This PR has two logical issues that should be resolved before merging
- Score reflects one missing platform target in CI and one security vulnerability (Host header injection) that could allow malicious binary distribution
- Pay close attention to `server/src/api/agents.rs` (Host header validation) and `.github/workflows/release.yml` (missing darwin-amd64)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds GitHub Actions workflow for cross-compiling agent binaries on tagged releases, but missing darwin-amd64 target |
| server/src/api/agents.rs | Implements binary download endpoint and refactored install scripts; Host header injection risk in server_url_from_request function |
| server/src/api/mod.rs | Adds new /agent/install/:platform/binary route to agent_ws router |
| server/src/config.rs | Adds agent_binaries_dir config option for self-hosted binary distribution |

</details>



<sub>Last reviewed commit: 971b73d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->