### PR TITLE
feat: add panoptikon_agents_total metric to Prometheus endpoint

### DIFF
--- a/server/src/api/metrics.rs
+++ b/server/src/api/metrics.rs
@@ -51,6 +51,11 @@ pub async fn handler(State(state): State<AppState>) -> Result<Response, StatusCo
     );
 
     // ── Agents ─────────────────────────────────────────────────────────
+    let agents_total: i64 = sqlx::query_scalar(r#"SELECT COUNT(*) FROM agents"#)
+        .fetch_one(&state.db)
+        .await
+        .unwrap_or(0);
+
     let agents_online: i64 = sqlx::query_scalar(
         r#"SELECT COUNT(*) FROM agents WHERE last_report_at > datetime('now', '-120 seconds')"#,
     )
@@ -58,6 +63,12 @@ pub async fn handler(State(state): State<AppState>) -> Result<Response, StatusCo
     .await
     .unwrap_or(0);
 
+    write_gauge(
+        &mut out,
+        "panoptikon_agents_total",
+        "Total number of registered agents",
+        agents_total,
+    );
     write_gauge(
         &mut out,
         "panoptikon_agents_online_total",
@@ -201,6 +212,7 @@ mod tests {
         assert!(body.contains("panoptikon_devices_online_total"));
         assert!(body.contains("panoptikon_devices_offline_total"));
         assert!(body.contains("panoptikon_devices_total"));
+        assert!(body.contains("panoptikon_agents_total"));
         assert!(body.contains("panoptikon_agents_online_total"));
         assert!(body.contains("panoptikon_alerts_total"));
         assert!(body.contains("panoptikon_netflow_flows_received_total"));
@@ -208,6 +220,7 @@ mod tests {
         // HELP/TYPE for each gauge.
         assert!(body.contains("# TYPE panoptikon_devices_online_total gauge"));
         assert!(body.contains("# TYPE panoptikon_devices_total gauge"));
+        assert!(body.contains("# TYPE panoptikon_agents_total gauge"));
         assert!(body.contains("# TYPE panoptikon_agents_online_total gauge"));
         assert!(body.contains("# TYPE panoptikon_alerts_total gauge"));
         assert!(body.contains("# TYPE panoptikon_netflow_flows_received_total counter"));
@@ -279,6 +292,43 @@ mod tests {
         assert!(
             body.contains("panoptikon_devices_total 2"),
             "Expected total=2, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metrics_agents_count() {
+        let state = test_state().await;
+
+        // Insert 2 agents — one recently reporting, one stale.
+        let id1 = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO agents (id, api_key_hash, name, platform, is_online, last_report_at, created_at)
+               VALUES (?, '$2b$12$dummy_hash_value_placeholder', 'agent-1', 'linux', 1, datetime('now'), datetime('now'))"#,
+        )
+        .bind(&id1)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        let id2 = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO agents (id, api_key_hash, name, platform, is_online, last_report_at, created_at)
+               VALUES (?, '$2b$12$dummy_hash_value_placeholder', 'agent-2', 'linux', 0, datetime('now', '-1 hour'), datetime('now'))"#,
+        )
+        .bind(&id2)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        let body = get_metrics_body(&state).await;
+
+        assert!(
+            body.contains("panoptikon_agents_total 2"),
+            "Expected agents_total=2, got:\n{body}"
+        );
+        assert!(
+            body.contains("panoptikon_agents_online_total 1"),
+            "Expected agents_online=1, got:\n{body}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds `panoptikon_agents_total` gauge to the `/metrics` Prometheus endpoint, reporting total registered agents alongside the existing `panoptikon_agents_online_total`
- The issue requested `agent_count` which was the only metric not yet exposed — the endpoint already had `device_count`, `online_device_count`, per-device bandwidth gauges, and alert counts
- Adds test `test_metrics_agents_count` verifying both total and online agent counts with stale vs active agents

Closes #181

## Metrics now exposed

| Metric | Type | Description |
|--------|------|-------------|
| `panoptikon_devices_total` | gauge | Total discovered devices |
| `panoptikon_devices_online_total` | gauge | Devices currently online |
| `panoptikon_devices_offline_total` | gauge | Devices currently offline |
| `panoptikon_agents_total` | gauge | **NEW** — Total registered agents |
| `panoptikon_agents_online_total` | gauge | Agents seen in last 120s |
| `panoptikon_alerts_total{severity,status}` | gauge | Alerts by severity × status |
| `panoptikon_traffic_rx_bps{device_id,ip}` | gauge | RX bps per device |
| `panoptikon_traffic_tx_bps{device_id,ip}` | gauge | TX bps per device |
| `panoptikon_netflow_flows_received_total` | counter | Total NetFlow records |

## Test plan
- [x] All 258 unit tests pass (`cargo test -p panoptikon-server`)
- [x] All 12 integration tests pass
- [x] New `test_metrics_agents_count` verifies total vs online agent split
- [ ] Verify scraping with `curl localhost:8080/metrics` on a running instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `panoptikon_agents_total` gauge metric to the Prometheus `/metrics` endpoint, reporting the total number of registered agents. This complements the existing `panoptikon_agents_online_total` metric (agents seen in the last 120 seconds) and follows the same query + `write_gauge` pattern already used for device metrics.

- New `SELECT COUNT(*) FROM agents` query with `unwrap_or(0)` fallback, consistent with the existing `devices_total` implementation
- Updated `test_metrics_format_valid` to assert the new metric's presence and TYPE line
- New `test_metrics_agents_count` test inserts one active and one stale agent, verifying both `panoptikon_agents_total 2` and `panoptikon_agents_online_total 1`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a single read-only metric following established patterns with no risk to existing functionality.
- The change is minimal and self-contained: one new SQL count query, one new write_gauge call, and test coverage for both the metric format and the actual values. The implementation exactly mirrors the existing devices_total pattern. No logic changes, no schema modifications, no new dependencies.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/metrics.rs | Adds `panoptikon_agents_total` gauge via a simple `SELECT COUNT(*) FROM agents` query, mirroring the existing `devices_total` pattern. New test `test_metrics_agents_count` validates total vs online agent split. No issues found. |

</details>



<sub>Last reviewed commit: d51b198</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->