### PR TITLE
feat: Wake-on-LAN button on device cards and table rows

### DIFF
--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -362,6 +362,7 @@ export default function DevicesPage() {
                 <TableHead className="text-slate-400">Vendor</TableHead>
                 <TableHead className="text-slate-400">Agent</TableHead>
                 <TableHead className="text-slate-400">Last Seen</TableHead>
+                <TableHead className="w-16 text-slate-400" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -375,6 +376,7 @@ export default function DevicesPage() {
                   <TableCell><Skeleton className="h-3 w-20" /></TableCell>
                   <TableCell><Skeleton className="h-3 w-12" /></TableCell>
                   <TableCell><Skeleton className="h-3 w-16" /></TableCell>
+                  <TableCell />
                 </TableRow>
               ))}
             </TableBody>
@@ -443,6 +445,7 @@ function DeviceCard({
   device: Device;
   onClick: () => void;
 }) {
+  const [waking, setWaking] = useState(false);
   const ips = device.ips ?? [];
   const primaryIp = ips[0] ?? "—";
   const displayName = device.custom_name ?? device.name ?? device.hostname ?? "Unknown Device";
@@ -453,6 +456,21 @@ function DeviceCard({
       ? (device.custom_vendor ?? device.vendor)!.slice(0, 20) + "…"
       : (device.custom_vendor ?? device.vendor)
     : null;
+
+  const canWake = !device.is_online && device.mac && !device.is_randomized_mac;
+
+  const handleWake = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setWaking(true);
+    try {
+      await wakeDevice(device.id);
+      toast.success("Magic packet sent! Device should wake up shortly.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send magic packet");
+    } finally {
+      setWaking(false);
+    }
+  };
 
   return (
     <Card
@@ -562,6 +580,20 @@ function DeviceCard({
             Last seen {timeAgo(device.last_seen_at)}
           </p>
         )}
+
+        {/* Wake-on-LAN button — offline devices with known MAC */}
+        {canWake && (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3 w-full gap-2"
+            disabled={waking}
+            onClick={handleWake}
+          >
+            <Power className="h-3.5 w-3.5" />
+            {waking ? "Sending…" : "Wake"}
+          </Button>
+        )}
       </CardContent>
     </Card>
   );
@@ -591,6 +623,21 @@ function DevicesTable({
   onSort: (field: SortField) => void;
   onSelect: (device: Device) => void;
 }) {
+  const [wakingId, setWakingId] = useState<string | null>(null);
+
+  const handleWake = async (e: React.MouseEvent, device: Device) => {
+    e.stopPropagation();
+    setWakingId(device.id);
+    try {
+      await wakeDevice(device.id);
+      toast.success("Magic packet sent! Device should wake up shortly.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send magic packet");
+    } finally {
+      setWakingId(null);
+    }
+  };
+
   return (
     <div className="rounded-md border border-slate-800 bg-slate-900">
       <Table>
@@ -622,6 +669,7 @@ function DevicesTable({
               Last Seen
               <SortIcon field="last_seen_at" sortField={sortField} sortDir={sortDir} />
             </TableHead>
+            <TableHead className="w-16 text-slate-400" />
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -633,6 +681,7 @@ function DevicesTable({
                 ? device.vendor.slice(0, 20) + "…"
                 : device.vendor
               : "—";
+            const canWake = !device.is_online && device.mac && !device.is_randomized_mac;
 
             return (
               <TableRow
@@ -690,6 +739,21 @@ function DevicesTable({
                 </TableCell>
                 <TableCell className="text-xs text-slate-500">
                   {timeAgo(device.last_seen_at)}
+                </TableCell>
+                <TableCell>
+                  {canWake && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 gap-1.5 text-xs text-slate-400 hover:text-white"
+                      disabled={wakingId === device.id}
+                      onClick={(e) => handleWake(e, device)}
+                      title="Send Wake-on-LAN magic packet"
+                    >
+                      <Power className="h-3.5 w-3.5" />
+                      {wakingId === device.id ? "Sending…" : "Wake"}
+                    </Button>
+                  )}
                 </TableCell>
               </TableRow>
             );


### PR DESCRIPTION
## Summary
- Adds a **Wake** button directly on device cards (grid view) and table rows for offline devices with a known MAC address
- Button is hidden for online devices and devices with randomized MACs (locally administered addresses from manual asset creation)
- Click propagation is stopped so tapping Wake doesn't open the device detail sheet
- Reuses the existing backend `POST /api/v1/devices/:id/wake` endpoint and `wakeDevice()` API client — no backend changes needed

## Details
The backend WoL implementation (magic packet builder, UDP broadcast to `255.255.255.255:9`) and the detail-sheet Wake button were already in place. This PR surfaces the Wake action at the card/table level per the issue request, making it a single-click operation without needing to open the detail panel.

**Grid view:** Full-width secondary button at the bottom of the card  
**Table view:** Compact ghost button in a new trailing column

Closes #180

## Test plan
- [ ] Verify Wake button appears on offline device cards with real MAC
- [ ] Verify Wake button does NOT appear on online devices
- [ ] Verify Wake button does NOT appear on devices with randomized MACs
- [ ] Verify clicking Wake sends toast notification and doesn't open detail sheet
- [ ] Verify table view shows Wake button in last column for eligible devices
- [ ] Verify loading state ("Sending...") displays during API call
- [ ] Backend tests pass (`cargo test api::devices::tests` — 20 tests)
- [ ] Frontend builds with no TypeScript errors (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Surfaces the existing Wake-on-LAN action directly on device cards (grid view) and table rows (table view) for offline devices with a known, non-randomized MAC address. Reuses the existing `wakeDevice()` API client and backend endpoint with no backend changes.

- New `canWake` guard (`!device.is_online && device.mac && !device.is_randomized_mac`) is stricter and more correct than the existing detail-sheet condition (which only checks `!device.is_online`)
- `e.stopPropagation()` correctly prevents the Wake button click from opening the device detail sheet
- Skeleton loading state updated to include the new table column
- Minor concern: the table view tracks waking state with a single `wakingId` string, which can lose loading indicators if multiple devices are woken concurrently

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a straightforward UI addition reusing existing backend infrastructure with no functional regressions.
- Single file changed with well-structured additions. The wake logic correctly mirrors the existing pattern. The only issue is a minor UX state-tracking concern in the table view that won't cause runtime errors.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Adds Wake-on-LAN button to DeviceCard and DevicesTable for offline devices with known MAC. Clean implementation with proper click propagation stopping. Minor issue: table view uses a single `wakingId` state which can lose loading state on concurrent wakes. |

</details>



<sub>Last reviewed commit: 6e2282e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->