### PR TITLE
feat: CSV/JSON export — devices, alerts, asset inventory

### DIFF
--- a/server/src/api/export.rs
+++ b/server/src/api/export.rs
@@ -9,7 +9,7 @@ use sqlx::Row;
 use super::AppState;
 
 #[derive(Debug, Deserialize)]
-pub struct DevicesExportQuery {
+pub struct ExportQuery {
     pub format: Option<String>,
 }
 
@@ -41,6 +41,39 @@ struct ExportTrafficSample {
     rx_bps: i64,
     tx_bps: i64,
     source: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ExportAlert {
+    id: String,
+    #[serde(rename = "type")]
+    alert_type: String,
+    severity: String,
+    message: String,
+    device_id: String,
+    agent_id: String,
+    is_read: bool,
+    acknowledged_at: String,
+    acknowledged_by: String,
+    created_at: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ExportAsset {
+    id: String,
+    name: String,
+    asset_type: String,
+    location: String,
+    owner: String,
+    tags: String,
+    serial_number: String,
+    purchase_date: String,
+    notes: String,
+    device_id: String,
+    agent_id: String,
+    ssh_target_id: String,
+    created_at: String,
+    updated_at: String,
 }
 
 fn csv_escape(value: &str) -> String {
@@ -119,9 +152,79 @@ fn download_response(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
 
+fn format_alerts_csv(items: &[ExportAlert]) -> String {
+    let mut out = String::from(
+        "id,type,severity,message,device_id,agent_id,is_read,acknowledged_at,acknowledged_by,created_at\n",
+    );
+
+    for a in items {
+        out.push_str(&csv_escape(&a.id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.alert_type));
+        out.push(',');
+        out.push_str(&csv_escape(&a.severity));
+        out.push(',');
+        out.push_str(&csv_escape(&a.message));
+        out.push(',');
+        out.push_str(&csv_escape(&a.device_id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.agent_id));
+        out.push(',');
+        out.push_str(if a.is_read { "true" } else { "false" });
+        out.push(',');
+        out.push_str(&csv_escape(&a.acknowledged_at));
+        out.push(',');
+        out.push_str(&csv_escape(&a.acknowledged_by));
+        out.push(',');
+        out.push_str(&csv_escape(&a.created_at));
+        out.push('\n');
+    }
+
+    out
+}
+
+fn format_assets_csv(items: &[ExportAsset]) -> String {
+    let mut out = String::from(
+        "id,name,asset_type,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at\n",
+    );
+
+    for a in items {
+        out.push_str(&csv_escape(&a.id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.name));
+        out.push(',');
+        out.push_str(&csv_escape(&a.asset_type));
+        out.push(',');
+        out.push_str(&csv_escape(&a.location));
+        out.push(',');
+        out.push_str(&csv_escape(&a.owner));
+        out.push(',');
+        out.push_str(&csv_escape(&a.tags));
+        out.push(',');
+        out.push_str(&csv_escape(&a.serial_number));
+        out.push(',');
+        out.push_str(&csv_escape(&a.purchase_date));
+        out.push(',');
+        out.push_str(&csv_escape(&a.notes));
+        out.push(',');
+        out.push_str(&csv_escape(&a.device_id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.agent_id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.ssh_target_id));
+        out.push(',');
+        out.push_str(&csv_escape(&a.created_at));
+        out.push(',');
+        out.push_str(&csv_escape(&a.updated_at));
+        out.push('\n');
+    }
+
+    out
+}
+
 pub async fn devices_export(
     State(state): State<AppState>,
-    Query(query): Query<DevicesExportQuery>,
+    Query(query): Query<ExportQuery>,
 ) -> Result<Response<Body>, StatusCode> {
     let format = query
         .format
@@ -263,6 +366,150 @@ pub async fn traffic_export(
     }
 }
 
+pub async fn alerts_export(
+    State(state): State<AppState>,
+    Query(query): Query<ExportQuery>,
+) -> Result<Response<Body>, StatusCode> {
+    let format = query
+        .format
+        .unwrap_or_else(|| "csv".to_string())
+        .to_lowercase();
+
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            id,
+            type,
+            COALESCE(severity, 'WARNING') AS severity,
+            message,
+            COALESCE(device_id, '') AS device_id,
+            COALESCE(agent_id, '') AS agent_id,
+            is_read,
+            COALESCE(acknowledged_at, '') AS acknowledged_at,
+            COALESCE(acknowledged_by, '') AS acknowledged_by,
+            created_at
+        FROM alerts
+        ORDER BY created_at DESC
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("alerts_export query failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let alerts: Vec<ExportAlert> = rows
+        .into_iter()
+        .map(|r| ExportAlert {
+            id: r.try_get("id").unwrap_or_default(),
+            alert_type: r.try_get("type").unwrap_or_default(),
+            severity: r.try_get("severity").unwrap_or_default(),
+            message: r.try_get("message").unwrap_or_default(),
+            device_id: r.try_get("device_id").unwrap_or_default(),
+            agent_id: r.try_get("agent_id").unwrap_or_default(),
+            is_read: r.try_get::<i32, _>("is_read").unwrap_or(0) != 0,
+            acknowledged_at: r.try_get("acknowledged_at").unwrap_or_default(),
+            acknowledged_by: r.try_get("acknowledged_by").unwrap_or_default(),
+            created_at: r.try_get("created_at").unwrap_or_default(),
+        })
+        .collect();
+
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+
+    if format == "json" {
+        let body = serde_json::to_string_pretty(&alerts).unwrap_or_else(|_| "[]".to_string());
+        download_response(
+            "application/json",
+            &format!("panoptikon-alerts-{date}.json"),
+            body,
+        )
+    } else {
+        let body = format_alerts_csv(&alerts);
+        download_response(
+            "text/csv; charset=utf-8",
+            &format!("panoptikon-alerts-{date}.csv"),
+            body,
+        )
+    }
+}
+
+pub async fn assets_export(
+    State(state): State<AppState>,
+    Query(query): Query<ExportQuery>,
+) -> Result<Response<Body>, StatusCode> {
+    let format = query
+        .format
+        .unwrap_or_else(|| "csv".to_string())
+        .to_lowercase();
+
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            id,
+            name,
+            asset_type,
+            COALESCE(location, '') AS location,
+            COALESCE(owner, '') AS owner,
+            COALESCE(tags, '') AS tags,
+            COALESCE(serial_number, '') AS serial_number,
+            COALESCE(purchase_date, '') AS purchase_date,
+            COALESCE(notes, '') AS notes,
+            COALESCE(device_id, '') AS device_id,
+            COALESCE(agent_id, '') AS agent_id,
+            COALESCE(ssh_target_id, '') AS ssh_target_id,
+            created_at,
+            updated_at
+        FROM assets
+        ORDER BY name ASC
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("assets_export query failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let assets: Vec<ExportAsset> = rows
+        .into_iter()
+        .map(|r| ExportAsset {
+            id: r.try_get("id").unwrap_or_default(),
+            name: r.try_get("name").unwrap_or_default(),
+            asset_type: r.try_get("asset_type").unwrap_or_default(),
+            location: r.try_get("location").unwrap_or_default(),
+            owner: r.try_get("owner").unwrap_or_default(),
+            tags: r.try_get("tags").unwrap_or_default(),
+            serial_number: r.try_get("serial_number").unwrap_or_default(),
+            purchase_date: r.try_get("purchase_date").unwrap_or_default(),
+            notes: r.try_get("notes").unwrap_or_default(),
+            device_id: r.try_get("device_id").unwrap_or_default(),
+            agent_id: r.try_get("agent_id").unwrap_or_default(),
+            ssh_target_id: r.try_get("ssh_target_id").unwrap_or_default(),
+            created_at: r.try_get("created_at").unwrap_or_default(),
+            updated_at: r.try_get("updated_at").unwrap_or_default(),
+        })
+        .collect();
+
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+
+    if format == "json" {
+        let body = serde_json::to_string_pretty(&assets).unwrap_or_else(|_| "[]".to_string());
+        download_response(
+            "application/json",
+            &format!("panoptikon-assets-{date}.json"),
+            body,
+        )
+    } else {
+        let body = format_assets_csv(&assets);
+        download_response(
+            "text/csv; charset=utf-8",
+            &format!("panoptikon-assets-{date}.csv"),
+            body,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,6 +618,118 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].0, recent);
+    }
+
+    #[tokio::test]
+    async fn test_alerts_csv_format() {
+        let alerts = vec![ExportAlert {
+            id: "alert-1".to_string(),
+            alert_type: "device_offline".to_string(),
+            severity: "WARNING".to_string(),
+            message: "Device went offline".to_string(),
+            device_id: "dev-1".to_string(),
+            agent_id: "".to_string(),
+            is_read: false,
+            acknowledged_at: "".to_string(),
+            acknowledged_by: "".to_string(),
+            created_at: "2026-02-20 00:00:00".to_string(),
+        }];
+
+        let csv = format_alerts_csv(&alerts);
+        let mut lines = csv.lines();
+        assert_eq!(
+            lines.next().unwrap_or(""),
+            "id,type,severity,message,device_id,agent_id,is_read,acknowledged_at,acknowledged_by,created_at"
+        );
+        let row = lines.next().unwrap_or("");
+        assert!(row.contains("alert-1"));
+        assert!(row.contains("device_offline"));
+        assert!(row.contains("WARNING"));
+        assert!(row.contains("Device went offline"));
+    }
+
+    #[tokio::test]
+    async fn test_alerts_json_format() {
+        let alerts = vec![ExportAlert {
+            id: "alert-1".to_string(),
+            alert_type: "new_device".to_string(),
+            severity: "INFO".to_string(),
+            message: "New device discovered".to_string(),
+            device_id: "dev-1".to_string(),
+            agent_id: "".to_string(),
+            is_read: true,
+            acknowledged_at: "2026-02-20 01:00:00".to_string(),
+            acknowledged_by: "admin".to_string(),
+            created_at: "2026-02-20 00:00:00".to_string(),
+        }];
+
+        let body = serde_json::to_string(&alerts).unwrap_or_default();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).unwrap_or(serde_json::json!([]));
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0]["id"], "alert-1");
+        assert_eq!(parsed[0]["type"], "new_device");
+        assert_eq!(parsed[0]["severity"], "INFO");
+    }
+
+    #[tokio::test]
+    async fn test_assets_csv_format() {
+        let assets = vec![ExportAsset {
+            id: "asset-1".to_string(),
+            name: "web-server-01".to_string(),
+            asset_type: "server".to_string(),
+            location: "DC-1 Rack A".to_string(),
+            owner: "ops-team".to_string(),
+            tags: "[\"production\"]".to_string(),
+            serial_number: "SN-12345".to_string(),
+            purchase_date: "2025-01-15".to_string(),
+            notes: "Primary web server".to_string(),
+            device_id: "dev-1".to_string(),
+            agent_id: "".to_string(),
+            ssh_target_id: "".to_string(),
+            created_at: "2026-02-20 00:00:00".to_string(),
+            updated_at: "2026-02-20 01:00:00".to_string(),
+        }];
+
+        let csv = format_assets_csv(&assets);
+        let mut lines = csv.lines();
+        assert_eq!(
+            lines.next().unwrap_or(""),
+            "id,name,asset_type,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at"
+        );
+        let row = lines.next().unwrap_or("");
+        assert!(row.contains("asset-1"));
+        assert!(row.contains("web-server-01"));
+        assert!(row.contains("server"));
+        assert!(row.contains("ops-team"));
+    }
+
+    #[tokio::test]
+    async fn test_assets_json_format() {
+        let assets = vec![ExportAsset {
+            id: "asset-1".to_string(),
+            name: "web-server-01".to_string(),
+            asset_type: "server".to_string(),
+            location: "DC-1".to_string(),
+            owner: "ops".to_string(),
+            tags: "".to_string(),
+            serial_number: "SN-001".to_string(),
+            purchase_date: "".to_string(),
+            notes: "".to_string(),
+            device_id: "".to_string(),
+            agent_id: "".to_string(),
+            ssh_target_id: "".to_string(),
+            created_at: "2026-02-20 00:00:00".to_string(),
+            updated_at: "2026-02-20 01:00:00".to_string(),
+        }];
+
+        let body = serde_json::to_string(&assets).unwrap_or_default();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).unwrap_or(serde_json::json!([]));
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0]["id"], "asset-1");
+        assert_eq!(parsed[0]["name"], "web-server-01");
+        assert_eq!(parsed[0]["asset_type"], "server");
     }
 
     #[tokio::test]

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -397,6 +397,8 @@ pub fn router(state: AppState) -> Router {
         // Export
         .route("/devices/export", get(export::devices_export))
         .route("/traffic/export", get(export::traffic_export))
+        .route("/alerts/export", get(export::alerts_export))
+        .route("/assets/export", get(export::assets_export))
         // WebSocket for UI live updates
         .route("/ws", get(agents::ui_ws_handler))
         .route_layer(middleware::from_fn_with_state(

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -8,7 +8,9 @@ import {
   BellOff,
   Check,
   CheckCheck,
+  ChevronDown,
   Clock,
+  Download,
   MonitorSmartphone,
   Shield,
   Trash2,
@@ -38,8 +40,16 @@ import {
   deleteAllAlerts,
   markAllAlertsRead,
 } from "@/lib/api";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { Alert } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
+import { downloadExport } from "@/lib/export";
+import { toast } from "sonner";
 import { PageTransition } from "@/components/PageTransition";
 
 function alertIcon(type: Alert["type"]) {
@@ -240,6 +250,41 @@ export default function AlertsPage() {
         </div>
         {alerts && alerts.length > 0 && (
           <div className="flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Export
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={async () => {
+                    try {
+                      await downloadExport("/api/v1/alerts/export?format=csv", "panoptikon-alerts.csv");
+                      toast.success("Alerts exported as CSV");
+                    } catch { toast.error("Export failed"); }
+                  }}
+                >
+                  Export CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={async () => {
+                    try {
+                      await downloadExport("/api/v1/alerts/export?format=json", "panoptikon-alerts.json");
+                      toast.success("Alerts exported as JSON");
+                    } catch { toast.error("Export failed"); }
+                  }}
+                >
+                  Export JSON
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
             {(alerts ?? []).some((a) => !a.is_read) && (
               <Button
                 variant="outline"

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -5,6 +5,8 @@ import { useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
   Box,
+  ChevronDown,
+  Download,
   Pencil,
   Plus,
   Search,
@@ -53,6 +55,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   createAssetInventory,
   deleteAssetInventory,
   fetchAssets,
@@ -60,6 +68,7 @@ import {
 } from "@/lib/api";
 import type { Asset, AssetRequest, AssetType } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
+import { downloadExport } from "@/lib/export";
 import { PageTransition } from "@/components/PageTransition";
 import { toast } from "sonner";
 import AssetDetailContent from "./detail/content";
@@ -194,14 +203,51 @@ function AssetsListPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold text-white">Assets</h1>
-          <AssetFormDialog
-            open={addOpen}
-            onOpenChange={setAddOpen}
-            onSaved={() => {
-              setAddOpen(false);
-              load();
-            }}
-          />
+          <div className="flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  Export
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={async () => {
+                    try {
+                      await downloadExport("/api/v1/assets/export?format=csv", "panoptikon-assets.csv");
+                      toast.success("Assets exported as CSV");
+                    } catch { toast.error("Export failed"); }
+                  }}
+                >
+                  Export CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={async () => {
+                    try {
+                      await downloadExport("/api/v1/assets/export?format=json", "panoptikon-assets.json");
+                      toast.success("Assets exported as JSON");
+                    } catch { toast.error("Export failed"); }
+                  }}
+                >
+                  Export JSON
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <AssetFormDialog
+              open={addOpen}
+              onOpenChange={setAddOpen}
+              onSaved={() => {
+                setAddOpen(false);
+                load();
+              }}
+            />
+          </div>
         </div>
 
         {/* Filter bar */}

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowDown, ArrowUp, Battery, Box, CircuitBoard, Container, Cpu, Download, ExternalLink, Gamepad2, HardDrive, HelpCircle, Laptop, Loader2, LayoutGrid, List, MemoryStick, Monitor, Network, Pencil, Plus, Power, Printer, Radar, RotateCcw, Router, Search, Server, Smartphone, Tablet, Tv, VolumeX, Wifi, WifiOff } from "lucide-react";
+import { ArrowDown, ArrowUp, Battery, Box, ChevronDown, CircuitBoard, Container, Cpu, Download, ExternalLink, Gamepad2, HardDrive, HelpCircle, Laptop, Loader2, LayoutGrid, List, MemoryStick, Monitor, Network, Pencil, Plus, Power, Printer, Radar, RotateCcw, Router, Search, Server, Smartphone, Tablet, Tv, VolumeX, Wifi, WifiOff } from "lucide-react";
 import { getDeviceIcon } from "@/lib/device-icons";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,6 +26,12 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { fetchDevices, fetchDeviceEvents, fetchDeviceUptime, wakeDevice, triggerPortScan, fetchPortScan, updateDevice, resetDeviceCustom, fetchDeviceSysinfo, createAsset } from "@/lib/api";
 import type { DeviceEvent, UptimeStats, PortScanResult, DeviceCustomFields, CreateAssetRequest } from "@/lib/api";
 import type { Device, DeviceSysinfo } from "@/lib/types";
@@ -46,21 +52,12 @@ import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
 import { MotionCard } from "@/components/MotionCard";
 
+import { downloadExport } from "@/lib/export";
+
 type Filter = "all" | "online" | "offline" | "unknown";
 type ViewMode = "grid" | "table";
 type SortField = "last_seen_at" | "ip" | "hostname";
 type SortDir = "asc" | "desc";
-
-async function downloadExport(url: string, filename: string) {
-  const res = await fetch(url, { credentials: "include" });
-  if (!res.ok) throw new Error(`Export failed: ${res.status}`);
-  const blob = await res.blob();
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
 
 export default function DevicesPage() {
   const [devices, setDevices] = useState<Device[] | null>(null);
@@ -278,24 +275,37 @@ export default function DevicesPage() {
           />
         </div>
 
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={async () => {
-            try {
-              await downloadExport(
-                "/api/v1/devices/export?format=csv",
-                "panoptikon-devices.csv"
-              );
-              toast.success("Devices exported");
-            } catch {
-              toast.error("Export failed");
-            }
-          }}
-        >
-          <Download className="mr-2 h-4 w-4" />
-          Export CSV
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary" size="sm" className="gap-1.5">
+              <Download className="h-4 w-4" />
+              Export
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={async () => {
+                try {
+                  await downloadExport("/api/v1/devices/export?format=csv", "panoptikon-devices.csv");
+                  toast.success("Devices exported as CSV");
+                } catch { toast.error("Export failed"); }
+              }}
+            >
+              Export CSV
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={async () => {
+                try {
+                  await downloadExport("/api/v1/devices/export?format=json", "panoptikon-devices.json");
+                  toast.success("Devices exported as JSON");
+                } catch { toast.error("Export failed"); }
+              }}
+            >
+              Export JSON
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         {/* View toggle */}
         <div className="flex shrink-0 gap-1">

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -33,17 +33,7 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageTransition } from "@/components/PageTransition";
-
-async function downloadExport(url: string, filename: string) {
-  const res = await fetch(url, { credentials: "include" });
-  if (!res.ok) throw new Error(`Export failed: ${res.status}`);
-  const blob = await res.blob();
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
+import { downloadExport } from "@/lib/export";
 
 /** Format an ISO minute string to HH:mm for the X axis. */
 function formatTime(iso: string): string {

--- a/web/src/lib/export.ts
+++ b/web/src/lib/export.ts
@@ -1,0 +1,16 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+
+/**
+ * Download a file from an export API endpoint.
+ * Triggers a browser download with the given filename.
+ */
+export async function downloadExport(url: string, filename: string) {
+  const res = await fetch(`${API_BASE}${url}`, { credentials: "include" });
+  if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+  const blob = await res.blob();
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}


### PR DESCRIPTION
## Summary

Closes #182

- Add backend export endpoints for **alerts** (`GET /api/v1/alerts/export`) and **assets** (`GET /api/v1/assets/export`) supporting both CSV and JSON formats via `?format=csv|json` query parameter
- Upgrade the existing devices export button from CSV-only to a CSV/JSON dropdown
- Add export dropdown buttons to the **alerts page** and **assets page** headers
- Extract the shared `downloadExport` utility from duplicated code in devices/traffic pages into `lib/export.ts`
- Add 4 new unit tests for alerts and assets CSV/JSON formatting

## Changes

### Backend (`server/src/api/export.rs`)
- New `ExportAlert` and `ExportAsset` structs with serde serialization
- New `format_alerts_csv()` and `format_assets_csv()` formatters
- New `alerts_export()` and `assets_export()` axum handlers
- Unified `ExportQuery` struct (replaces `DevicesExportQuery`)
- Routes registered in `mod.rs`

### Frontend
- `web/src/lib/export.ts` — shared download utility (extracted from devices + traffic)
- Devices page: CSV-only button → CSV/JSON dropdown menu
- Alerts page: new export dropdown in header
- Assets page: new export dropdown in header
- Traffic page: uses shared export utility

## Test plan
- [x] `cargo test --lib api::export` — all 8 tests pass (4 existing + 4 new)
- [x] `cargo test` — full server test suite passes (261 tests)
- [x] `npx next build` — frontend builds successfully
- [ ] Manual: verify export buttons appear on devices, alerts, and assets pages
- [ ] Manual: verify CSV and JSON downloads work for each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing export functionality from devices and traffic to also cover alerts and assets, supporting both CSV and JSON formats.

**Key changes:**
- Backend adds `alerts_export()` and `assets_export()` handlers following the same pattern as existing exports
- Frontend extracts duplicate `downloadExport` code into shared utility `lib/export.ts`
- All four pages (devices, alerts, assets, traffic) now use the shared export utility
- Export buttons upgraded from CSV-only to CSV/JSON dropdown menus
- 4 new unit tests added for CSV/JSON formatting (8 total export tests)

**Security & quality:**
- Export endpoints properly protected by authentication middleware
- SQL queries use parameterized queries (no user input in query strings)
- CSV escaping correctly handles special characters (commas, quotes, newlines)
- Date formatting for filenames uses safe `chrono` format (no user input)
- Consistent error handling across all export handlers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns consistently, includes comprehensive test coverage (4 new tests, all 8 passing), properly handles security concerns (authentication, SQL injection prevention, CSV escaping), and successfully refactors duplicate code into a shared utility
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/export.rs | adds alerts and assets export handlers with proper CSV escaping, SQL parameterization, and comprehensive test coverage |
| web/src/lib/export.ts | extracts shared export utility with proper blob handling and cleanup |
| web/src/app/(app)/devices/page.tsx | replaces CSV-only button with CSV/JSON dropdown, uses shared export utility |
| web/src/app/(app)/alerts/page.tsx | adds CSV/JSON export dropdown to alerts page header |
| web/src/app/(app)/assets/page.tsx | adds CSV/JSON export dropdown to assets page header |

</details>



<sub>Last reviewed commit: 3326dbc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->