### PR TITLE
feat: MikroTik CHR — router page integration (multi-router support)

### DIFF
--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -32,18 +32,11 @@ const settingsGroups: SettingsGroup[] = [
     label: "Integrations",
     items: [
       {
-        href: "/settings/vyos",
+        href: "/settings/router",
         icon: <Router className="h-4 w-4 text-blue-400" />,
         iconBg: "bg-blue-500/10",
-        title: "VyOS Router",
-        description: "Connect to your VyOS router via its HTTP API.",
-      },
-      {
-        href: "/settings/mikrotik",
-        icon: <Router className="h-4 w-4 text-pink-400" />,
-        iconBg: "bg-pink-500/10",
-        title: "MikroTik Router",
-        description: "Connect to your MikroTik router via its REST API.",
+        title: "Router",
+        description: "Configure VyOS or MikroTik router integration.",
       },
       {
         href: "/settings/npm",

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Router,
+  Plug,
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  ArrowLeft,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fetchRouterStatus, fetchMikrotikStatus } from "@/lib/api";
+import { PageTransition } from "@/components/PageTransition";
+import Link from "next/link";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+// ── VyOS settings panel ──────────────────────────────────
+
+function VyosPanel() {
+  const [url, setUrl] = useState("");
+  const [savedUrl, setSavedUrl] = useState<string | null>(null);
+  const [apiKey, setApiKey] = useState("");
+  const [apiKeySet, setApiKeySet] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<Status>("idle");
+  const [saveMsg, setSaveMsg] = useState("");
+  const [testStatus, setTestStatus] = useState<Status>("idle");
+  const [testMsg, setTestMsg] = useState("");
+  const loadTokenRef = useRef(0);
+
+  useEffect(() => {
+    const loadToken = ++loadTokenRef.current;
+    fetch("/api/v1/settings", { credentials: "include" })
+      .then((res) => res.json())
+      .then(
+        (data: { vyos_url: string | null; vyos_api_key_set: boolean }) => {
+          if (loadToken !== loadTokenRef.current) return;
+          setUrl(data.vyos_url ?? "");
+          setSavedUrl(data.vyos_url ?? null);
+          setApiKeySet(data.vyos_api_key_set);
+        }
+      )
+      .catch(() => {});
+  }, []);
+
+  const dirty = url !== (savedUrl ?? "") || apiKey.length > 0;
+
+  async function handleSave() {
+    loadTokenRef.current++;
+    setSaveStatus("loading");
+    setSaveMsg("");
+    try {
+      const body: Record<string, string> = {};
+      if (url !== (savedUrl ?? "")) body.vyos_url = url;
+      if (apiKey.length > 0) body.vyos_api_key = apiKey;
+
+      const res = await fetch("/api/v1/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data: { vyos_url: string | null; vyos_api_key_set: boolean } =
+          await res.json();
+        setSavedUrl(data.vyos_url ?? null);
+        setUrl(data.vyos_url ?? "");
+        setApiKeySet(data.vyos_api_key_set);
+        setApiKey("");
+        setSaveStatus("success");
+        setSaveMsg("VyOS settings saved.");
+        setTimeout(() => setSaveStatus("idle"), 3000);
+      } else {
+        setSaveStatus("error");
+        setSaveMsg(`Failed to save (${res.status}).`);
+      }
+    } catch {
+      setSaveStatus("error");
+      setSaveMsg("Network error.");
+    }
+  }
+
+  async function handleTest() {
+    setTestStatus("loading");
+    setTestMsg("");
+    try {
+      const data = await fetchRouterStatus();
+      if (data.reachable) {
+        setTestStatus("success");
+        setTestMsg(
+          `Connected! ${data.version ? `Version: ${data.version}` : ""} ${data.uptime ? `· Uptime: ${data.uptime}` : ""}`
+        );
+        setTimeout(() => setTestStatus("idle"), 5000);
+      } else if (data.configured) {
+        setTestStatus("error");
+        setTestMsg("Router configured but unreachable. Check URL and network.");
+      } else {
+        setTestStatus("error");
+        setTestMsg("Router not configured. Save URL and API key first.");
+      }
+    } catch {
+      setTestStatus("error");
+      setTestMsg("Failed to test connection.");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="vyos-url" className="text-xs text-slate-400">
+          Router URL
+        </Label>
+        <Input
+          id="vyos-url"
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+          placeholder="https://10.10.0.50"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="vyos-key" className="text-xs text-slate-400">
+          API Key{" "}
+          {apiKeySet && <span className="text-emerald-500">(saved)</span>}
+        </Label>
+        <Input
+          id="vyos-key"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+          placeholder={
+            apiKeySet
+              ? "••••••••  (leave blank to keep current)"
+              : "Enter VyOS API key"
+          }
+        />
+      </div>
+
+      <StatusMessages
+        saveStatus={saveStatus}
+        saveMsg={saveMsg}
+        testStatus={testStatus}
+        testMsg={testMsg}
+      />
+
+      <div className="flex gap-2">
+        <Button
+          onClick={handleSave}
+          disabled={!dirty || saveStatus === "loading"}
+          className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
+        >
+          {saveStatus === "loading" && (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          )}
+          Save
+        </Button>
+        <Button
+          variant="outline"
+          onClick={handleTest}
+          disabled={(!savedUrl && !url) || testStatus === "loading"}
+          className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+        >
+          {testStatus === "loading" ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Plug className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Test Connection
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── MikroTik settings panel ──────────────────────────────
+
+function MikrotikPanel() {
+  const [url, setUrl] = useState("");
+  const [savedUrl, setSavedUrl] = useState<string | null>(null);
+  const [user, setUser] = useState("");
+  const [savedUser, setSavedUser] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [passwordSet, setPasswordSet] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [savedEnabled, setSavedEnabled] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<Status>("idle");
+  const [saveMsg, setSaveMsg] = useState("");
+  const [testStatus, setTestStatus] = useState<Status>("idle");
+  const [testMsg, setTestMsg] = useState("");
+  const loadTokenRef = useRef(0);
+
+  useEffect(() => {
+    const loadToken = ++loadTokenRef.current;
+    fetch("/api/v1/settings", { credentials: "include" })
+      .then((res) => res.json())
+      .then(
+        (data: {
+          mikrotik_url: string | null;
+          mikrotik_user: string | null;
+          mikrotik_password_set: boolean;
+          mikrotik_enabled: boolean;
+        }) => {
+          if (loadToken !== loadTokenRef.current) return;
+          setUrl(data.mikrotik_url ?? "");
+          setSavedUrl(data.mikrotik_url ?? null);
+          setUser(data.mikrotik_user ?? "");
+          setSavedUser(data.mikrotik_user ?? null);
+          setPasswordSet(data.mikrotik_password_set);
+          setEnabled(data.mikrotik_enabled);
+          setSavedEnabled(data.mikrotik_enabled);
+        }
+      )
+      .catch(() => {});
+  }, []);
+
+  const dirty =
+    url !== (savedUrl ?? "") ||
+    user !== (savedUser ?? "") ||
+    password.length > 0 ||
+    enabled !== savedEnabled;
+
+  async function handleSave() {
+    loadTokenRef.current++;
+    setSaveStatus("loading");
+    setSaveMsg("");
+    try {
+      const body: Record<string, string | boolean> = {};
+      if (url !== (savedUrl ?? "")) body.mikrotik_url = url;
+      if (user !== (savedUser ?? "")) body.mikrotik_user = user;
+      if (password.length > 0) body.mikrotik_password = password;
+      if (enabled !== savedEnabled) body.mikrotik_enabled = enabled;
+
+      const res = await fetch("/api/v1/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data: {
+          mikrotik_url: string | null;
+          mikrotik_user: string | null;
+          mikrotik_password_set: boolean;
+          mikrotik_enabled: boolean;
+        } = await res.json();
+        setSavedUrl(data.mikrotik_url ?? null);
+        setUrl(data.mikrotik_url ?? "");
+        setSavedUser(data.mikrotik_user ?? null);
+        setUser(data.mikrotik_user ?? "");
+        setPasswordSet(data.mikrotik_password_set);
+        setEnabled(data.mikrotik_enabled);
+        setSavedEnabled(data.mikrotik_enabled);
+        setPassword("");
+        setSaveStatus("success");
+        setSaveMsg("MikroTik settings saved.");
+        setTimeout(() => setSaveStatus("idle"), 3000);
+      } else {
+        setSaveStatus("error");
+        setSaveMsg(`Failed to save (${res.status}).`);
+      }
+    } catch {
+      setSaveStatus("error");
+      setSaveMsg("Network error.");
+    }
+  }
+
+  async function handleTest() {
+    setTestStatus("loading");
+    setTestMsg("");
+    try {
+      const data = await fetchMikrotikStatus();
+      if (data.reachable) {
+        setTestStatus("success");
+        setTestMsg(
+          `Connected! ${data.version ? `RouterOS ${data.version}` : ""} ${data.uptime ? `· Uptime: ${data.uptime}` : ""}`
+        );
+        setTimeout(() => setTestStatus("idle"), 5000);
+      } else if (data.configured) {
+        setTestStatus("error");
+        setTestMsg(
+          "Router configured but unreachable. Check URL and credentials."
+        );
+      } else {
+        setTestStatus("error");
+        setTestMsg(
+          "Router not configured. Save URL, user, and password first."
+        );
+      }
+    } catch {
+      setTestStatus("error");
+      setTestMsg("Failed to test connection.");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Label htmlFor="mt-enabled" className="text-xs text-slate-400">
+          Enable MikroTik integration
+        </Label>
+        <Switch
+          id="mt-enabled"
+          checked={enabled}
+          onCheckedChange={setEnabled}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="mt-url" className="text-xs text-slate-400">
+          Router URL
+        </Label>
+        <Input
+          id="mt-url"
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+          placeholder="http://10.10.0.109"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="mt-user" className="text-xs text-slate-400">
+          Username
+        </Label>
+        <Input
+          id="mt-user"
+          type="text"
+          value={user}
+          onChange={(e) => setUser(e.target.value)}
+          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+          placeholder="admin"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="mt-password" className="text-xs text-slate-400">
+          Password{" "}
+          {passwordSet && <span className="text-emerald-500">(saved)</span>}
+        </Label>
+        <Input
+          id="mt-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+          placeholder={
+            passwordSet
+              ? "••••••••  (leave blank to keep current)"
+              : "Enter password"
+          }
+        />
+      </div>
+
+      <StatusMessages
+        saveStatus={saveStatus}
+        saveMsg={saveMsg}
+        testStatus={testStatus}
+        testMsg={testMsg}
+      />
+
+      <div className="flex gap-2">
+        <Button
+          onClick={handleSave}
+          disabled={!dirty || saveStatus === "loading"}
+          className="bg-pink-600 text-white hover:bg-pink-500 disabled:opacity-40"
+        >
+          {saveStatus === "loading" && (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          )}
+          Save
+        </Button>
+        <Button
+          variant="outline"
+          onClick={handleTest}
+          disabled={(!savedUrl && !url) || testStatus === "loading"}
+          className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+        >
+          {testStatus === "loading" ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Plug className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Test Connection
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Shared status messages ───────────────────────────────
+
+function StatusMessages({
+  saveStatus,
+  saveMsg,
+  testStatus,
+  testMsg,
+}: {
+  saveStatus: Status;
+  saveMsg: string;
+  testStatus: Status;
+  testMsg: string;
+}) {
+  return (
+    <>
+      {saveStatus === "success" && saveMsg && (
+        <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+          <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+          <p className="text-xs text-emerald-400">{saveMsg}</p>
+        </div>
+      )}
+      {saveStatus === "error" && saveMsg && (
+        <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+          <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+          <p className="text-xs text-rose-400">{saveMsg}</p>
+        </div>
+      )}
+      {testStatus === "success" && testMsg && (
+        <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+          <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+          <p className="text-xs text-emerald-400">{testMsg}</p>
+        </div>
+      )}
+      {testStatus === "error" && testMsg && (
+        <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+          <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+          <p className="text-xs text-rose-400">{testMsg}</p>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── Main page ────────────────────────────────────────────
+
+export default function RouterSettingsPage() {
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-lg space-y-6 py-8">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/settings"
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-800 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <h1 className="text-2xl font-semibold text-white">
+            Router Settings
+          </h1>
+        </div>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
+                <Router className="h-4 w-4 text-blue-400" />
+              </div>
+              <div>
+                <CardTitle className="text-base text-white">
+                  Router Connection
+                </CardTitle>
+                <CardDescription className="text-xs text-slate-500">
+                  Configure VyOS or MikroTik router integration.
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Tabs defaultValue="vyos">
+              <TabsList className="mb-4 w-full border-slate-800 bg-slate-950">
+                <TabsTrigger
+                  value="vyos"
+                  className="flex-1 data-[state=active]:bg-blue-600 data-[state=active]:text-white"
+                >
+                  <Router className="mr-1.5 h-3.5 w-3.5" />
+                  VyOS
+                </TabsTrigger>
+                <TabsTrigger
+                  value="mikrotik"
+                  className="flex-1 data-[state=active]:bg-pink-600 data-[state=active]:text-white"
+                >
+                  <Router className="mr-1.5 h-3.5 w-3.5" />
+                  MikroTik
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="vyos">
+                <VyosPanel />
+              </TabsContent>
+              <TabsContent value="mikrotik">
+                <MikrotikPanel />
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -7,18 +7,20 @@ import {
   Globe,
   Shield,
   Server,
-  Loader2,
   AlertCircle,
   Activity,
   Lock,
   Search,
-  RefreshCw,
+  Cpu,
+  Clock,
+  MemoryStick,
+  Monitor,
+  HardDrive,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 import {
   fetchMikrotikStatus,
   fetchMikrotikInterfaces,
@@ -39,7 +41,7 @@ import type {
 } from "@/lib/types";
 
 function formatBytes(bytes: string | null): string {
-  if (!bytes) return "-";
+  if (!bytes) return "\u2014";
   const n = parseInt(bytes, 10);
   if (isNaN(n)) return bytes;
   if (n < 1024) return `${n} B`;
@@ -49,107 +51,10 @@ function formatBytes(bytes: string | null): string {
 }
 
 function formatMemory(bytes: string | null): string {
-  if (!bytes) return "-";
+  if (!bytes) return "\u2014";
   const n = parseInt(bytes, 10);
   if (isNaN(n)) return bytes;
   return `${(n / 1024 / 1024).toFixed(0)} MB`;
-}
-
-// ── Status Header ─────────────────────────────────────────
-
-function StatusHeader({ status }: { status: MikrotikStatus }) {
-  return (
-    <div className="flex flex-wrap items-center gap-4">
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-pink-500/10">
-          <Router className="h-5 w-5 text-pink-400" />
-        </div>
-        <div>
-          <h1 className="text-2xl font-semibold text-white">MikroTik Router</h1>
-          <p className="text-xs text-slate-500">
-            {status.board_name ?? "RouterOS"}{" "}
-            {status.version && (
-              <span className="text-slate-600">· RouterOS {status.version}</span>
-            )}
-          </p>
-        </div>
-      </div>
-      <div className="flex items-center gap-2">
-        {status.reachable ? (
-          <Badge
-            variant="outline"
-            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-          >
-            Connected
-          </Badge>
-        ) : (
-          <Badge
-            variant="outline"
-            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
-          >
-            Unreachable
-          </Badge>
-        )}
-        {status.uptime && (
-          <Badge
-            variant="outline"
-            className="border-slate-800 text-slate-400"
-          >
-            Uptime: {status.uptime}
-          </Badge>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ── System Tab ────────────────────────────────────────────
-
-function SystemTab({ status }: { status: MikrotikStatus }) {
-  return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">Version</p>
-          <p className="text-lg text-white">{status.version ?? "-"}</p>
-        </CardContent>
-      </Card>
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">CPU Load</p>
-          <p className="text-lg text-white">{status.cpu_load ? `${status.cpu_load}%` : "-"}</p>
-        </CardContent>
-      </Card>
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">Memory</p>
-          <p className="text-lg text-white">
-            {status.free_memory && status.total_memory
-              ? `${formatMemory(String(parseInt(status.total_memory) - parseInt(status.free_memory)))} / ${formatMemory(status.total_memory)}`
-              : "-"}
-          </p>
-        </CardContent>
-      </Card>
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">Uptime</p>
-          <p className="text-lg text-white">{status.uptime ?? "-"}</p>
-        </CardContent>
-      </Card>
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">Platform</p>
-          <p className="text-lg text-white">{status.platform ?? "-"} {status.architecture ? `(${status.architecture})` : ""}</p>
-        </CardContent>
-      </Card>
-      <Card className="border-slate-800 bg-slate-900">
-        <CardContent className="space-y-2 py-4">
-          <p className="text-xs font-medium uppercase text-slate-500">Board</p>
-          <p className="text-lg text-white">{status.board_name ?? "-"}</p>
-        </CardContent>
-      </Card>
-    </div>
-  );
 }
 
 // ── Generic data loader hook ──────────────────────────────
@@ -179,65 +84,917 @@ function useData<T>(fetcher: () => Promise<T>) {
   return { data, loading, error, reload: load };
 }
 
-// ── Table wrapper ─────────────────────────────────────────
+// ── Status Header ─────────────────────────────────────────
 
-function DataTable<T>({
+function StatusHeader({ status }: { status: MikrotikStatus }) {
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-pink-500/10">
+          <Router className="h-5 w-5 text-pink-400" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-white">MikroTik Router</h1>
+          <p className="text-xs text-slate-500">
+            {status.board_name ?? "RouterOS"}{" "}
+            {status.version && (
+              <span className="text-slate-600">&middot; RouterOS {status.version}</span>
+            )}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {status.reachable ? (
+          <Badge
+            variant="outline"
+            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+          >
+            &#9679; Connected
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+          >
+            &#9679; Unreachable
+          </Badge>
+        )}
+        {status.uptime && (
+          <Badge variant="outline" className="border-slate-800 text-slate-400">
+            Uptime: {status.uptime}
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── System Tab ────────────────────────────────────────────
+
+function SystemTab({ status }: { status: MikrotikStatus }) {
+  const memUsed =
+    status.free_memory && status.total_memory
+      ? String(parseInt(status.total_memory) - parseInt(status.free_memory))
+      : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-pink-500/10">
+              <Monitor className="h-4.5 w-4.5 text-pink-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Version</p>
+              <p className="truncate text-sm font-medium text-white">
+                {status.version ?? "\u2014"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
+              <Clock className="h-4.5 w-4.5 text-emerald-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Uptime</p>
+              <p className="truncate text-sm font-medium text-white">
+                {status.uptime ?? "\u2014"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10">
+              <Cpu className="h-4.5 w-4.5 text-amber-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">CPU Load</p>
+              <p className="text-sm font-medium text-white">
+                {status.cpu_load ? `${status.cpu_load}%` : "\u2014"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
+              <MemoryStick className="h-4.5 w-4.5 text-purple-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Memory</p>
+              <p className="text-sm font-medium text-white">
+                {memUsed
+                  ? `${formatMemory(memUsed)} / ${formatMemory(status.total_memory)}`
+                  : "\u2014"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-cyan-500/10">
+              <HardDrive className="h-4.5 w-4.5 text-cyan-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Platform</p>
+              <p className="truncate text-sm font-medium text-white">
+                {status.platform ?? "\u2014"}{" "}
+                {status.architecture ? `(${status.architecture})` : ""}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex items-center gap-3 py-4">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+              <Server className="h-4.5 w-4.5 text-blue-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-slate-500">Board</p>
+              <p className="truncate text-sm font-medium text-white">
+                {status.board_name ?? "\u2014"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// ── Interfaces Table ──────────────────────────────────────
+
+function InterfacesTable({
   data,
   loading,
   error,
-  onReload,
-  columns,
-  renderRow,
 }: {
-  data: T[] | null;
+  data: MikrotikInterface[] | null;
   loading: boolean;
   error: string | null;
-  onReload: () => void;
-  columns: string[];
-  renderRow: (item: T, i: number) => React.ReactNode;
 }) {
+  const headerCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">Status</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Interface</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Type</th>
+      <th className="px-4 py-3 font-medium text-slate-400">IP Address</th>
+      <th className="px-4 py-3 font-medium text-slate-400">MAC</th>
+      <th className="px-4 py-3 font-medium text-slate-400">MTU</th>
+      <th className="px-4 py-3 font-medium text-slate-400">TX</th>
+      <th className="px-4 py-3 font-medium text-slate-400">RX</th>
+    </tr>
+  );
+
   if (loading) {
     return (
-      <div className="space-y-2">
-        <Skeleton className="h-8 w-full" />
-        <Skeleton className="h-8 w-full" />
-        <Skeleton className="h-8 w-full" />
+      <div className="overflow-x-auto rounded-md border border-slate-800">
+        <table className="w-full text-sm">
+          <thead>{headerCols}</thead>
+          <tbody>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <tr key={i} className="border-b border-slate-800 last:border-b-0">
+                <td className="px-4 py-3"><div className="flex items-center gap-2"><Skeleton className="h-2.5 w-2.5 rounded-full" /><Skeleton className="h-5 w-10 rounded-full" /></div></td>
+                <td className="px-4 py-3"><Skeleton className="h-5 w-16" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-16" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-28" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-32" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-12" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-16" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-16" /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex items-center gap-2 text-sm text-rose-400">
-        <AlertCircle className="h-4 w-4" />
-        {error}
-        <Button variant="ghost" size="sm" onClick={onReload}>
-          <RefreshCw className="h-3.5 w-3.5" />
-        </Button>
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
       </div>
     );
   }
 
   if (!data || data.length === 0) {
-    return <p className="text-sm text-slate-500">No data available.</p>;
+    return <p className="py-4 text-sm text-slate-500">No interfaces found.</p>;
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-md border border-slate-800">
       <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-slate-800 text-left text-xs text-slate-500">
-            {columns.map((col) => (
-              <th key={col} className="px-3 py-2 font-medium">
-                {col}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-slate-800/50">
-          {data.map(renderRow)}
+        <thead>{headerCols}</thead>
+        <tbody>
+          {data.map((iface) => (
+            <tr
+              key={iface.name}
+              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+            >
+              <td className="px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${
+                      iface.running
+                        ? "bg-emerald-400"
+                        : iface.disabled
+                          ? "bg-slate-600"
+                          : "bg-amber-400"
+                    }`}
+                  />
+                  <Badge
+                    variant="outline"
+                    className={
+                      iface.running
+                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                        : "border-slate-700 text-slate-500 text-xs"
+                    }
+                  >
+                    {iface.running ? "up" : iface.disabled ? "disabled" : "down"}
+                  </Badge>
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums font-medium text-white">
+                  {iface.name}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-slate-400">{iface.iface_type ?? "\u2014"}</span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-slate-300">
+                  {iface.ip_address ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {iface.mac ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-slate-300">{iface.mtu ?? "\u2014"}</span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {formatBytes(iface.tx_bytes)}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {formatBytes(iface.rx_bytes)}
+                </span>
+              </td>
+            </tr>
+          ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+// ── Routes Table ──────────────────────────────────────────
+
+function RoutesTable({
+  data,
+  loading,
+  error,
+}: {
+  data: MikrotikRoute[] | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  const headerCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">Status</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Destination</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Gateway</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Distance</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Table</th>
+    </tr>
+  );
+
+  if (loading) {
+    return (
+      <div className="overflow-x-auto rounded-md border border-slate-800">
+        <table className="w-full text-sm">
+          <thead>{headerCols}</thead>
+          <tbody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i} className="border-b border-slate-800 last:border-b-0">
+                <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-5 w-28" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-10" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-16" /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return <p className="py-4 text-sm text-slate-500">No routes found.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-slate-800">
+      <table className="w-full text-sm">
+        <thead>{headerCols}</thead>
+        <tbody>
+          {data.map((route, idx) => (
+            <tr
+              key={`${route.dst_address}-${idx}`}
+              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+            >
+              <td className="px-4 py-3">
+                <div className="flex items-center gap-1.5">
+                  {route.active ? (
+                    <Badge
+                      variant="outline"
+                      className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                    >
+                      active
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="border-slate-700 text-slate-500 text-xs"
+                    >
+                      {route.disabled ? "disabled" : "inactive"}
+                    </Badge>
+                  )}
+                  {route.dynamic && (
+                    <Badge
+                      variant="outline"
+                      className="border-blue-500/30 text-blue-400 text-xs"
+                    >
+                      dynamic
+                    </Badge>
+                  )}
+                </div>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums font-medium text-white">
+                  {route.dst_address}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-slate-300">
+                  {route.gateway ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {route.distance ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-slate-400">
+                  {route.routing_table ?? "main"}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── DHCP Leases Table ─────────────────────────────────────
+
+function DhcpLeasesTable({
+  data,
+  loading,
+  error,
+}: {
+  data: MikrotikDhcpLease[] | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  const headerCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">IP Address</th>
+      <th className="px-4 py-3 font-medium text-slate-400">MAC Address</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Hostname</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Server</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Expires</th>
+      <th className="px-4 py-3 font-medium text-slate-400">State</th>
+    </tr>
+  );
+
+  if (loading) {
+    return (
+      <div className="overflow-x-auto rounded-md border border-slate-800">
+        <table className="w-full text-sm">
+          <thead>{headerCols}</thead>
+          <tbody>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i} className="border-b border-slate-800 last:border-b-0">
+                <td className="px-4 py-3"><Skeleton className="h-5 w-24" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-32" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-3 w-28" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <p className="py-4 text-sm text-slate-500">
+        No DHCP leases found. DHCP server may not be configured.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border border-slate-800">
+      <table className="w-full text-sm">
+        <thead>{headerCols}</thead>
+        <tbody>
+          {data.map((lease, idx) => (
+            <tr
+              key={`${lease.address}-${idx}`}
+              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+            >
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums font-medium text-white">
+                  {lease.address}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {lease.mac_address ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-slate-300">
+                  {lease.host_name ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="text-slate-300">
+                  {lease.server ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="font-mono tabular-nums text-xs text-slate-400">
+                  {lease.expires_after ?? "\u2014"}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <Badge
+                  variant="outline"
+                  className={
+                    lease.status === "bound"
+                      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                      : "border-slate-700 text-slate-500 text-xs"
+                  }
+                >
+                  {lease.status ?? "\u2014"}
+                </Badge>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Firewall Tables ───────────────────────────────────────
+
+function FirewallPanel({
+  data,
+  loading,
+  error,
+}: {
+  data: MikrotikFirewall | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  const filterHeaderCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Action</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Src</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Port</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Status</th>
+    </tr>
+  );
+
+  const natHeaderCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Action</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Port</th>
+      <th className="px-4 py-3 font-medium text-slate-400">To</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
+    </tr>
+  );
+
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="text-base text-white">Filter Rules</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto rounded-md border border-slate-800">
+            <table className="w-full text-sm">
+              <thead>{filterHeaderCols}</thead>
+              <tbody>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <tr key={i} className="border-b border-slate-800 last:border-b-0">
+                    <td className="px-4 py-3"><Skeleton className="h-4 w-14" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-4 w-10" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-3 w-20" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-3 w-20" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-4 w-10" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-3 w-24" /></td>
+                    <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="py-4">
+          <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+            <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+            <p className="text-xs text-rose-400">{error}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="text-base text-white">Filter Rules</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!data?.filter_rules.length ? (
+            <p className="py-4 text-sm text-slate-500">No filter rules configured.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border border-slate-800">
+              <table className="w-full text-sm">
+                <thead>{filterHeaderCols}</thead>
+                <tbody>
+                  {data.filter_rules.map((rule, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+                    >
+                      <td className="px-4 py-3 text-slate-300">{rule.chain ?? "\u2014"}</td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant="outline"
+                          className={
+                            rule.action === "accept"
+                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                              : rule.action === "drop"
+                                ? "border-rose-500/30 bg-rose-500/10 text-rose-400 text-xs"
+                                : "border-slate-700 text-slate-400 text-xs"
+                          }
+                        >
+                          {rule.action ?? "\u2014"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3 text-slate-300">{rule.protocol ?? "any"}</td>
+                      <td className="px-4 py-3">
+                        <span className="font-mono tabular-nums text-xs text-slate-400">
+                          {rule.src_address ?? "any"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="font-mono tabular-nums text-xs text-slate-400">
+                          {rule.dst_address ?? "any"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-slate-300">{rule.dst_port ?? "\u2014"}</td>
+                      <td className="px-4 py-3">
+                        <span className="text-slate-500">{rule.comment ?? ""}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant="outline"
+                          className={
+                            rule.disabled
+                              ? "border-slate-700 text-slate-500 text-xs"
+                              : "border-emerald-500/30 text-emerald-400 text-xs"
+                          }
+                        >
+                          {rule.disabled ? "disabled" : "enabled"}
+                        </Badge>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="text-base text-white">NAT Rules</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!data?.nat_rules.length ? (
+            <p className="py-4 text-sm text-slate-500">No NAT rules configured.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border border-slate-800">
+              <table className="w-full text-sm">
+                <thead>{natHeaderCols}</thead>
+                <tbody>
+                  {data.nat_rules.map((rule, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+                    >
+                      <td className="px-4 py-3 text-slate-300">{rule.chain ?? "\u2014"}</td>
+                      <td className="px-4 py-3 text-slate-300">{rule.action ?? "\u2014"}</td>
+                      <td className="px-4 py-3 text-slate-300">{rule.protocol ?? "any"}</td>
+                      <td className="px-4 py-3">
+                        <span className="font-mono tabular-nums text-xs text-slate-400">
+                          {rule.dst_address ?? "any"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-slate-300">{rule.dst_port ?? "\u2014"}</td>
+                      <td className="px-4 py-3">
+                        <span className="font-mono tabular-nums text-slate-300">
+                          {rule.to_addresses ?? "\u2014"}
+                          {rule.to_ports ? `:${rule.to_ports}` : ""}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-slate-500">{rule.comment ?? ""}</span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ── DNS Panel ─────────────────────────────────────────────
+
+function DnsPanel({
+  data,
+  loading,
+  error,
+}: {
+  data: MikrotikDns | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase text-slate-500">
+          Upstream Servers
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {data.servers.length > 0 ? (
+            data.servers.map((s) => (
+              <Badge
+                key={s}
+                variant="outline"
+                className="border-slate-700 font-mono text-xs text-slate-300"
+              >
+                {s}
+              </Badge>
+            ))
+          ) : (
+            <p className="text-sm text-slate-500">No DNS servers configured.</p>
+          )}
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card className="border-slate-800 bg-slate-950">
+          <CardContent className="py-3">
+            <p className="text-xs text-slate-500">Allow Remote Requests</p>
+            <p className="text-sm font-medium text-white">
+              {data.allow_remote_requests ? "Yes" : "No"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-slate-800 bg-slate-950">
+          <CardContent className="py-3">
+            <p className="text-xs text-slate-500">Cache Size</p>
+            <p className="text-sm font-medium text-white">
+              {data.cache_size ?? "\u2014"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-slate-800 bg-slate-950">
+          <CardContent className="py-3">
+            <p className="text-xs text-slate-500">Cache Used</p>
+            <p className="text-sm font-medium text-white">
+              {data.cache_used ?? "\u2014"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// ── WireGuard Panel ───────────────────────────────────────
+
+function WireGuardPanel({
+  data,
+  loading,
+  error,
+}: {
+  data: MikrotikWireguard | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+        <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+        <p className="text-xs text-rose-400">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data?.interfaces.length) {
+    return (
+      <p className="py-4 text-sm text-slate-500">
+        No WireGuard interfaces configured.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {data.interfaces.map((iface) => (
+        <div
+          key={iface.name}
+          className="rounded-lg border border-slate-800 bg-slate-950 p-4"
+        >
+          <div className="mb-3 flex items-center gap-3">
+            <span className="font-mono text-sm font-medium text-white">
+              {iface.name}
+            </span>
+            <Badge
+              variant="outline"
+              className={
+                iface.running
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                  : "border-slate-700 text-slate-500 text-xs"
+              }
+            >
+              {iface.running ? "running" : iface.disabled ? "disabled" : "down"}
+            </Badge>
+            {iface.listen_port && (
+              <span className="text-xs text-slate-500">
+                port {iface.listen_port}
+              </span>
+            )}
+          </div>
+          {iface.peers.length > 0 && (
+            <div className="overflow-x-auto rounded-md border border-slate-800">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-slate-800 bg-slate-900 text-left">
+                    <th className="px-3 py-2 font-medium text-slate-400">
+                      Public Key
+                    </th>
+                    <th className="px-3 py-2 font-medium text-slate-400">
+                      Endpoint
+                    </th>
+                    <th className="px-3 py-2 font-medium text-slate-400">
+                      Allowed IPs
+                    </th>
+                    <th className="px-3 py-2 font-medium text-slate-400">RX</th>
+                    <th className="px-3 py-2 font-medium text-slate-400">TX</th>
+                    <th className="px-3 py-2 font-medium text-slate-400">
+                      Last Handshake
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {iface.peers.map((peer, i) => (
+                    <tr
+                      key={i}
+                      className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors text-slate-300"
+                    >
+                      <td className="px-3 py-2 font-mono">
+                        {peer.public_key
+                          ? `${peer.public_key.slice(0, 12)}...`
+                          : "\u2014"}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {peer.endpoint ?? "\u2014"}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {peer.allowed_address ?? "\u2014"}
+                      </td>
+                      <td className="px-3 py-2">{formatBytes(peer.rx)}</td>
+                      <td className="px-3 py-2">{formatBytes(peer.tx)}</td>
+                      <td className="px-3 py-2">
+                        {peer.last_handshake ?? "\u2014"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ))}
     </div>
   );
 }
@@ -269,24 +1026,12 @@ export default function MikrotikRouter() {
       .finally(() => setLoading(false));
   }, []);
 
-  const ifaces = useData(
-    useCallback(() => fetchMikrotikInterfaces(), [])
-  );
-  const routes = useData(
-    useCallback(() => fetchMikrotikRoutes(), [])
-  );
-  const dhcp = useData(
-    useCallback(() => fetchMikrotikDhcpLeases(), [])
-  );
-  const fw = useData(
-    useCallback(() => fetchMikrotikFirewall(), [])
-  );
-  const dns = useData(
-    useCallback(() => fetchMikrotikDns(), [])
-  );
-  const wg = useData(
-    useCallback(() => fetchMikrotikWireguard(), [])
-  );
+  const ifaces = useData(useCallback(() => fetchMikrotikInterfaces(), []));
+  const routes = useData(useCallback(() => fetchMikrotikRoutes(), []));
+  const dhcp = useData(useCallback(() => fetchMikrotikDhcpLeases(), []));
+  const fw = useData(useCallback(() => fetchMikrotikFirewall(), []));
+  const dns = useData(useCallback(() => fetchMikrotikDns(), []));
+  const wg = useData(useCallback(() => fetchMikrotikWireguard(), []));
 
   if (loading) {
     return (
@@ -363,7 +1108,7 @@ export default function MikrotikRouter() {
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
             <Lock className="mr-1.5 h-3.5 w-3.5" />
-            WireGuard
+            VPN
           </TabsTrigger>
         </TabsList>
 
@@ -379,32 +1124,10 @@ export default function MikrotikRouter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <DataTable<MikrotikInterface>
+              <InterfacesTable
                 data={ifaces.data}
                 loading={ifaces.loading}
                 error={ifaces.error}
-                onReload={ifaces.reload}
-                columns={["Name", "Type", "IP Address", "MAC", "MTU", "Status", "TX", "RX"]}
-                renderRow={(iface, i) => (
-                  <tr key={i} className="text-slate-300">
-                    <td className="px-3 py-2 font-mono text-xs">{iface.name}</td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{iface.iface_type ?? "-"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{iface.ip_address ?? "-"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{iface.mac ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs">{iface.mtu ?? "-"}</td>
-                    <td className="px-3 py-2">
-                      {iface.running ? (
-                        <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs">up</Badge>
-                      ) : (
-                        <Badge variant="outline" className="border-slate-700 text-slate-500 text-xs">
-                          {iface.disabled ? "disabled" : "down"}
-                        </Badge>
-                      )}
-                    </td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{formatBytes(iface.tx_bytes)}</td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{formatBytes(iface.rx_bytes)}</td>
-                  </tr>
-                )}
               />
             </CardContent>
           </Card>
@@ -418,32 +1141,10 @@ export default function MikrotikRouter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <DataTable<MikrotikRoute>
+              <RoutesTable
                 data={routes.data}
                 loading={routes.loading}
                 error={routes.error}
-                onReload={routes.reload}
-                columns={["Destination", "Gateway", "Distance", "Table", "Status"]}
-                renderRow={(route, i) => (
-                  <tr key={i} className="text-slate-300">
-                    <td className="px-3 py-2 font-mono text-xs">{route.dst_address}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{route.gateway ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs">{route.distance ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{route.routing_table ?? "main"}</td>
-                    <td className="px-3 py-2">
-                      {route.active ? (
-                        <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs">active</Badge>
-                      ) : (
-                        <Badge variant="outline" className="border-slate-700 text-slate-500 text-xs">
-                          {route.disabled ? "disabled" : "inactive"}
-                        </Badge>
-                      )}
-                      {route.dynamic && (
-                        <Badge variant="outline" className="ml-1 border-blue-500/30 text-blue-400 text-xs">dynamic</Badge>
-                      )}
-                    </td>
-                  </tr>
-                )}
               />
             </CardContent>
           </Card>
@@ -457,33 +1158,10 @@ export default function MikrotikRouter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <DataTable<MikrotikDhcpLease>
+              <DhcpLeasesTable
                 data={dhcp.data}
                 loading={dhcp.loading}
                 error={dhcp.error}
-                onReload={dhcp.reload}
-                columns={["IP Address", "MAC", "Hostname", "Status", "Expires", "Server"]}
-                renderRow={(lease, i) => (
-                  <tr key={i} className="text-slate-300">
-                    <td className="px-3 py-2 font-mono text-xs">{lease.address}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{lease.mac_address ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs">{lease.host_name ?? "-"}</td>
-                    <td className="px-3 py-2">
-                      <Badge
-                        variant="outline"
-                        className={
-                          lease.status === "bound"
-                            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
-                            : "border-slate-700 text-slate-500 text-xs"
-                        }
-                      >
-                        {lease.status ?? "-"}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{lease.expires_after ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{lease.server ?? "-"}</td>
-                  </tr>
-                )}
               />
             </CardContent>
           </Card>
@@ -497,128 +1175,21 @@ export default function MikrotikRouter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {dns.loading ? (
-                <Skeleton className="h-20 w-full" />
-              ) : dns.error ? (
-                <div className="flex items-center gap-2 text-sm text-rose-400">
-                  <AlertCircle className="h-4 w-4" />
-                  {dns.error}
-                </div>
-              ) : dns.data ? (
-                <div className="space-y-4">
-                  <div>
-                    <p className="mb-1 text-xs font-medium uppercase text-slate-500">Servers</p>
-                    <div className="flex flex-wrap gap-2">
-                      {dns.data.servers.length > 0 ? (
-                        dns.data.servers.map((s) => (
-                          <Badge key={s} variant="outline" className="border-slate-700 font-mono text-xs text-slate-300">
-                            {s}
-                          </Badge>
-                        ))
-                      ) : (
-                        <p className="text-sm text-slate-500">No DNS servers configured.</p>
-                      )}
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-3 gap-4 text-sm">
-                    <div>
-                      <p className="text-xs text-slate-500">Allow Remote Requests</p>
-                      <p className="text-white">{dns.data.allow_remote_requests ? "Yes" : "No"}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-slate-500">Cache Size</p>
-                      <p className="text-white">{dns.data.cache_size ?? "-"}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-slate-500">Cache Used</p>
-                      <p className="text-white">{dns.data.cache_used ?? "-"}</p>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
+              <DnsPanel
+                data={dns.data}
+                loading={dns.loading}
+                error={dns.error}
+              />
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="firewall" className="space-y-4">
-          <Card className="border-slate-800 bg-slate-900">
-            <CardHeader>
-              <CardTitle className="text-base text-white">
-                Filter Rules
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <DataTable
-                data={fw.data?.filter_rules ?? null}
-                loading={fw.loading}
-                error={fw.error}
-                onReload={fw.reload}
-                columns={["Chain", "Action", "Protocol", "Src", "Dst", "Port", "Comment", "Status"]}
-                renderRow={(rule, i) => (
-                  <tr key={i} className="text-slate-300">
-                    <td className="px-3 py-2 text-xs">{rule.chain ?? "-"}</td>
-                    <td className="px-3 py-2">
-                      <Badge
-                        variant="outline"
-                        className={
-                          rule.action === "accept"
-                            ? "border-emerald-500/30 text-emerald-400 text-xs"
-                            : rule.action === "drop"
-                              ? "border-rose-500/30 text-rose-400 text-xs"
-                              : "border-slate-700 text-slate-400 text-xs"
-                        }
-                      >
-                        {rule.action ?? "-"}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-2 text-xs">{rule.protocol ?? "any"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{rule.src_address ?? "any"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{rule.dst_address ?? "any"}</td>
-                    <td className="px-3 py-2 text-xs">{rule.dst_port ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{rule.comment ?? ""}</td>
-                    <td className="px-3 py-2">
-                      <Badge
-                        variant="outline"
-                        className={rule.disabled ? "border-slate-700 text-slate-500 text-xs" : "border-emerald-500/30 text-emerald-400 text-xs"}
-                      >
-                        {rule.disabled ? "disabled" : "enabled"}
-                      </Badge>
-                    </td>
-                  </tr>
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card className="border-slate-800 bg-slate-900">
-            <CardHeader>
-              <CardTitle className="text-base text-white">
-                NAT Rules
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <DataTable
-                data={fw.data?.nat_rules ?? null}
-                loading={fw.loading}
-                error={fw.error}
-                onReload={fw.reload}
-                columns={["Chain", "Action", "Protocol", "Dst", "Port", "To", "Comment"]}
-                renderRow={(rule, i) => (
-                  <tr key={i} className="text-slate-300">
-                    <td className="px-3 py-2 text-xs">{rule.chain ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs">{rule.action ?? "-"}</td>
-                    <td className="px-3 py-2 text-xs">{rule.protocol ?? "any"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">{rule.dst_address ?? "any"}</td>
-                    <td className="px-3 py-2 text-xs">{rule.dst_port ?? "-"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">
-                      {rule.to_addresses ?? "-"}{rule.to_ports ? `:${rule.to_ports}` : ""}
-                    </td>
-                    <td className="px-3 py-2 text-xs text-slate-500">{rule.comment ?? ""}</td>
-                  </tr>
-                )}
-              />
-            </CardContent>
-          </Card>
+          <FirewallPanel
+            data={fw.data}
+            loading={fw.loading}
+            error={fw.error}
+          />
         </TabsContent>
 
         <TabsContent value="vpn">
@@ -629,61 +1200,11 @@ export default function MikrotikRouter() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {wg.loading ? (
-                <Skeleton className="h-20 w-full" />
-              ) : wg.error ? (
-                <div className="flex items-center gap-2 text-sm text-rose-400">
-                  <AlertCircle className="h-4 w-4" />
-                  {wg.error}
-                </div>
-              ) : !wg.data?.interfaces.length ? (
-                <p className="text-sm text-slate-500">No WireGuard interfaces configured.</p>
-              ) : (
-                <div className="space-y-4">
-                  {wg.data.interfaces.map((iface) => (
-                    <div key={iface.name} className="rounded-lg border border-slate-800 p-4">
-                      <div className="mb-3 flex items-center gap-3">
-                        <span className="font-mono text-sm text-white">{iface.name}</span>
-                        <Badge
-                          variant="outline"
-                          className={iface.running ? "border-emerald-500/30 text-emerald-400 text-xs" : "border-slate-700 text-slate-500 text-xs"}
-                        >
-                          {iface.running ? "running" : iface.disabled ? "disabled" : "down"}
-                        </Badge>
-                        {iface.listen_port && (
-                          <span className="text-xs text-slate-500">port {iface.listen_port}</span>
-                        )}
-                      </div>
-                      {iface.peers.length > 0 && (
-                        <table className="w-full text-xs">
-                          <thead>
-                            <tr className="border-b border-slate-800 text-left text-slate-500">
-                              <th className="px-2 py-1">Public Key</th>
-                              <th className="px-2 py-1">Endpoint</th>
-                              <th className="px-2 py-1">Allowed IPs</th>
-                              <th className="px-2 py-1">RX</th>
-                              <th className="px-2 py-1">TX</th>
-                              <th className="px-2 py-1">Last Handshake</th>
-                            </tr>
-                          </thead>
-                          <tbody className="divide-y divide-slate-800/50">
-                            {iface.peers.map((peer, i) => (
-                              <tr key={i} className="text-slate-300">
-                                <td className="px-2 py-1 font-mono">{peer.public_key ? `${peer.public_key.slice(0, 12)}...` : "-"}</td>
-                                <td className="px-2 py-1 font-mono">{peer.endpoint ?? "-"}</td>
-                                <td className="px-2 py-1 font-mono">{peer.allowed_address ?? "-"}</td>
-                                <td className="px-2 py-1">{formatBytes(peer.rx)}</td>
-                                <td className="px-2 py-1">{formatBytes(peer.tx)}</td>
-                                <td className="px-2 py-1">{peer.last_handshake ?? "-"}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+              <WireGuardPanel
+                data={wg.data}
+                loading={wg.loading}
+                error={wg.error}
+              />
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
## Summary

Closes #183

- **Unified router settings page** (`/settings/router`) with VyOS / MikroTik type-selector tabs, so users configure both router types from a single location
- **Upgraded MikroTik router display** to match VyOS UI patterns — bordered table containers, `bg-slate-950` headers, `font-mono tabular-nums` for IPs/MACs, skeleton loading, hover transitions, icon-based system info cards
- **Consolidated settings index** — two separate VyOS/MikroTik cards replaced with a single "Router" entry linking to the unified page

### What changed

| Area | Before | After |
|------|--------|-------|
| Settings page | Separate VyOS + MikroTik cards | Single "Router" card → tabbed config |
| MikroTik System tab | Plain text cards | Icon cards matching VyOS (Version, Uptime, CPU, Memory, Platform, Board) |
| MikroTik tables | Generic `DataTable` with `px-3 py-2` | VyOS-style bordered containers, `px-4 py-3`, header backgrounds, row hover |
| MikroTik Firewall | Single generic table | Split Filter Rules + NAT Rules cards |
| MikroTik WireGuard | Basic peer rows | Bordered table container with proper headers |

## Test plan

- [ ] Navigate to `/settings/router` — verify VyOS and MikroTik tabs render, save, and test-connection work
- [ ] Old routes (`/settings/vyos`, `/settings/mikrotik`) still accessible for backward compatibility
- [ ] Navigate to `/router` — verify VyOS/MikroTik toggle appears when both configured
- [ ] Select MikroTik — verify System, Interfaces, Routes, DHCP, DNS, Firewall, VPN tabs render with new styling
- [ ] Verify skeleton loading states appear before data loads
- [ ] Build passes (`next build` succeeds with no TS errors)
- [ ] Backend tests pass (`cargo test` — 12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Unified VyOS and MikroTik router configuration into a single tabbed settings page (`/settings/router`), upgraded MikroTik UI to match VyOS design patterns with icon-based system cards, bordered table containers, skeleton loading states, and split firewall views.

**Key Changes:**
- Settings index now shows single "Router" card instead of separate VyOS/MikroTik cards
- New `/settings/router` page provides tabbed interface for configuring both router types
- MikroTik System tab redesigned with icon cards for Version, Uptime, CPU, Memory, Platform, and Board
- Tables upgraded with `bg-slate-950` headers, `px-4 py-3` padding, `font-mono tabular-nums` for IPs/MACs, and hover transitions
- Firewall split into separate "Filter Rules" and "NAT Rules" cards
- Replaced em-dash character (`—`) with Unicode `\u2014` throughout for consistency
- Removed unused imports (`Loader2`, `RefreshCw`, `Button`)

**Backward Compatibility:**
Old routes `/settings/vyos` and `/settings/mikrotik` remain accessible (verified via filesystem check)

<h3>Confidence Score: 5/5</h3>

- Safe to merge — well-structured refactoring with no functional issues
- Code is clean, well-organized, and follows existing patterns. All changes are UI/UX improvements with proper backward compatibility. No logic errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/page.tsx | Consolidated two router cards into single unified Router entry pointing to `/settings/router` |
| web/src/app/(app)/settings/router/page.tsx | Created unified router settings page with VyOS/MikroTik tabs, connection testing, and form validation |
| web/src/components/MikrotikRouter.tsx | Refactored MikroTik display with VyOS-style tables, icon-based system cards, split firewall views, and improved skeleton loading states |

</details>



<sub>Last reviewed commit: 945f8bd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->