### PR TITLE
fix: use correct column name di.seen_at in assets SQL queries

### DIFF
--- a/server/src/api/assets.rs
+++ b/server/src/api/assets.rs
@@ -170,7 +170,7 @@ const LIST_QUERY: &str = "\
            a.created_at, a.updated_at, \
            d.is_online AS device_online, d.last_seen_at AS device_last_seen, \
            d.mac AS device_mac, \
-           (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id ORDER BY di.last_seen DESC LIMIT 1) AS device_ip, \
+           (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id ORDER BY di.seen_at DESC LIMIT 1) AS device_ip, \
            ag.name AS agent_name, ar.os_name AS agent_os_name, ar.os_version AS agent_os_version, \
            ar.reported_at AS agent_last_report, \
            st.name AS ssh_name, sr.os_name AS ssh_os_name, sr.os_version AS ssh_os_version, \
@@ -191,7 +191,7 @@ const GET_ONE_QUERY: &str = "\
            a.created_at, a.updated_at, \
            d.is_online AS device_online, d.last_seen_at AS device_last_seen, \
            d.mac AS device_mac, \
-           (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id ORDER BY di.last_seen DESC LIMIT 1) AS device_ip, \
+           (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id ORDER BY di.seen_at DESC LIMIT 1) AS device_ip, \
            ag.name AS agent_name, ar.os_name AS agent_os_name, ar.os_version AS agent_os_version, \
            ar.reported_at AS agent_last_report, \
            st.name AS ssh_name, sr.os_name AS ssh_os_name, sr.os_version AS ssh_os_version, \


### PR DESCRIPTION
## Problem

Assets page (/assets) was returning 500 for all users:
```
ERROR: Failed to list assets: no such column: di.last_seen
```

## Root Cause

Both `LIST_QUERY` and `GET_ONE_QUERY` in `api/assets.rs` reference `di.last_seen` in a subquery to get the device IP. The actual column in the `device_ips` table (per `001_init.sql`) is `seen_at`, not `last_seen`.

## Fix

Changed both occurrences:
```sql
-- Before (broken)
ORDER BY di.last_seen DESC
-- After (correct)
ORDER BY di.seen_at DESC
```

Fixes #187

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed a critical bug causing 500 errors on the assets page by correcting the SQL column name from `di.last_seen` to `di.seen_at` in both `LIST_QUERY` and `GET_ONE_QUERY`.

- The `device_ips` table schema defines the column as `seen_at`, not `last_seen`
- Both queries now correctly reference the actual column name
- No other incorrect references remain in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a straightforward column name correction that directly addresses a critical bug. The change has been verified against the database schema, and no other incorrect references exist in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/assets.rs | Fixed SQL column name from `di.last_seen` to `di.seen_at` in two queries |

</details>



<sub>Last reviewed commit: 9ad6f13</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->