### PR TITLE
feat: alert management UI — filter by type, mark read/unread, mute feedback

### DIFF
--- a/server/src/api/alerts.rs
+++ b/server/src/api/alerts.rs
@@ -36,6 +36,9 @@ pub struct ListAlertsQuery {
     pub status: Option<String>,
     /// Filter by severity: INFO, WARNING, CRITICAL.
     pub severity: Option<String>,
+    /// Filter by alert type: new_device, device_online, device_offline, agent_offline, high_bandwidth.
+    #[serde(rename = "type")]
+    pub alert_type: Option<String>,
 }
 
 /// Request body for acknowledging an alert.
@@ -94,6 +97,17 @@ pub async fn list(
         }
     }
 
+    // Alert type filter
+    if let Some(ref alert_type) = params.alert_type {
+        let t = alert_type.to_lowercase();
+        if matches!(
+            t.as_str(),
+            "new_device" | "device_online" | "device_offline" | "agent_offline" | "high_bandwidth"
+        ) {
+            conditions.push(format!("type = '{t}'"));
+        }
+    }
+
     let where_clause = if conditions.is_empty() {
         String::new()
     } else {
@@ -133,6 +147,27 @@ pub async fn mark_read(
         .await
         .map_err(|e| {
             tracing::error!("Failed to mark alert {id} as read: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if result.rows_affected() == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// POST /api/v1/alerts/:id/unread — mark an alert as unread.
+pub async fn mark_unread(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let result = sqlx::query("UPDATE alerts SET is_read = 0 WHERE id = ?")
+        .bind(&id)
+        .execute(&state.db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to mark alert {id} as unread: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
@@ -514,6 +549,72 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(unread_after, 0, "No unread alerts should remain");
+    }
+
+    #[tokio::test]
+    async fn test_mark_unread() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:13").await;
+        let alert_id = insert_test_alert(&pool, &device_id, "device_offline", "WARNING").await;
+
+        // Mark the alert as read first
+        sqlx::query("UPDATE alerts SET is_read = 1 WHERE id = ?")
+            .bind(&alert_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Verify it's read
+        let is_read: i32 = sqlx::query_scalar("SELECT is_read FROM alerts WHERE id = ?")
+            .bind(&alert_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(is_read, 1, "Alert should be marked as read");
+
+        // Mark as unread
+        sqlx::query("UPDATE alerts SET is_read = 0 WHERE id = ?")
+            .bind(&alert_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Verify it's unread
+        let is_read: i32 = sqlx::query_scalar("SELECT is_read FROM alerts WHERE id = ?")
+            .bind(&alert_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(is_read, 0, "Alert should be marked as unread");
+    }
+
+    #[tokio::test]
+    async fn test_filter_by_alert_type() {
+        let pool = test_db().await;
+        let device_id = insert_test_device(&pool, "AA:BB:CC:DD:EE:14").await;
+        insert_test_alert(&pool, &device_id, "device_offline", "WARNING").await;
+        insert_test_alert(&pool, &device_id, "new_device", "INFO").await;
+        insert_test_alert(&pool, &device_id, "device_online", "INFO").await;
+
+        // Query only device_offline alerts
+        let rows = sqlx::query("SELECT id FROM alerts WHERE type = ? AND device_id = ?")
+            .bind("device_offline")
+            .bind(&device_id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1, "Only one device_offline alert should match");
+
+        // Query new_device alerts
+        let rows = sqlx::query("SELECT id FROM alerts WHERE type = ? AND device_id = ?")
+            .bind("new_device")
+            .bind(&device_id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1, "Only one new_device alert should match");
     }
 
     #[tokio::test]

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -145,6 +145,7 @@ pub fn router(state: AppState) -> Router {
         .route("/alerts/read-all", patch(alerts::mark_all_read))
         .route("/alerts/:id", delete(alerts::delete_one))
         .route("/alerts/:id/read", post(alerts::mark_read))
+        .route("/alerts/:id/unread", post(alerts::mark_unread))
         .route("/alerts/:id/acknowledge", post(alerts::acknowledge))
         // Device mute
         .route("/devices/:id/mute", post(alerts::mute_device))

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -34,6 +34,7 @@ import {
 import {
   fetchAlerts,
   markAlertRead,
+  markAlertUnread,
   acknowledgeAlert,
   muteDevice,
   deleteAlert,
@@ -112,11 +113,22 @@ function severityBadge(severity: Alert["severity"]) {
 }
 
 type StatusFilter = "all" | "active" | "acknowledged";
+type TypeFilter = "all" | Alert["type"];
+
+const ALERT_TYPES: { value: TypeFilter; label: string }[] = [
+  { value: "all", label: "All Types" },
+  { value: "new_device", label: "New Device" },
+  { value: "device_online", label: "Online" },
+  { value: "device_offline", label: "Offline" },
+  { value: "agent_offline", label: "Agent Offline" },
+  { value: "high_bandwidth", label: "High Bandwidth" },
+];
 
 export default function AlertsPage() {
   const [alerts, setAlerts] = useState<Alert[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [ackDialogOpen, setAckDialogOpen] = useState(false);
   const [ackAlertId, setAckAlertId] = useState<string | null>(null);
   const [ackNote, setAckNote] = useState("");
@@ -126,12 +138,13 @@ export default function AlertsPage() {
   const load = useCallback(async () => {
     try {
       const status = statusFilter === "all" ? undefined : statusFilter;
-      const data = await fetchAlerts(100, status);
+      const alertType = typeFilter === "all" ? undefined : typeFilter;
+      const data = await fetchAlerts(100, status, undefined, alertType);
       setAlerts(Array.isArray(data) ? data : []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load alerts");
     }
-  }, [statusFilter]);
+  }, [statusFilter, typeFilter]);
 
   useEffect(() => {
     load();
@@ -144,6 +157,17 @@ export default function AlertsPage() {
       await markAlertRead(id);
       setAlerts((prev) =>
         (prev ?? []).map((a) => (a.id === id ? { ...a, is_read: true } : a))
+      );
+    } catch {
+      // silently ignore
+    }
+  }
+
+  async function handleMarkUnread(id: string) {
+    try {
+      await markAlertUnread(id);
+      setAlerts((prev) =>
+        (prev ?? []).map((a) => (a.id === id ? { ...a, is_read: false } : a))
       );
     } catch {
       // silently ignore
@@ -203,8 +227,9 @@ export default function AlertsPage() {
       setAlerts((prev) =>
         (prev ?? []).map((a) => ({ ...a, is_read: true }))
       );
+      toast.success("All alerts marked as read");
     } catch {
-      // silently ignore
+      toast.error("Failed to mark all as read");
     }
   }
 
@@ -212,8 +237,13 @@ export default function AlertsPage() {
     try {
       await muteDevice(deviceId, hours);
       setMuteDropdownId(null);
+      if (hours > 0) {
+        toast.success(`Device muted for ${hours}h`);
+      } else {
+        toast.success("Device unmuted");
+      }
     } catch {
-      // silently ignore
+      toast.error("Failed to mute device");
     }
   }
 
@@ -310,22 +340,46 @@ export default function AlertsPage() {
       </div>
 
       {/* Filter tabs */}
-      <div className="flex gap-2">
-        {(["all", "active", "acknowledged"] as StatusFilter[]).map((f) => (
-          <Button
-            key={f}
-            variant={statusFilter === f ? "default" : "outline"}
-            size="sm"
-            onClick={() => setStatusFilter(f)}
-            className={
-              statusFilter === f
-                ? ""
-                : "border-gray-700 text-slate-400 hover:text-gray-200"
-            }
-          >
-            {f === "all" ? "All" : f === "active" ? "Active" : "Acknowledged"}
-          </Button>
-        ))}
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          {(["all", "active", "acknowledged"] as StatusFilter[]).map((f) => (
+            <Button
+              key={f}
+              variant={statusFilter === f ? "default" : "outline"}
+              size="sm"
+              onClick={() => setStatusFilter(f)}
+              className={
+                statusFilter === f
+                  ? ""
+                  : "border-gray-700 text-slate-400 hover:text-gray-200"
+              }
+            >
+              {f === "all" ? "All" : f === "active" ? "Active" : "Acknowledged"}
+            </Button>
+          ))}
+        </div>
+
+        {/* Type filter */}
+        <div className="flex gap-2 flex-wrap">
+          {ALERT_TYPES.map((t) => (
+            <Button
+              key={t.value}
+              variant={typeFilter === t.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => setTypeFilter(t.value)}
+              className={
+                typeFilter === t.value
+                  ? ""
+                  : "border-gray-700 text-slate-400 hover:text-gray-200"
+              }
+            >
+              {t.value !== "all" && (
+                <span className="mr-1.5">{alertIcon(t.value as Alert["type"])}</span>
+              )}
+              {t.label}
+            </Button>
+          ))}
+        </div>
       </div>
 
       {/* Alert list */}
@@ -420,19 +474,35 @@ export default function AlertsPage() {
 
                 {/* Actions */}
                 <div className="flex items-center gap-1 shrink-0">
-                  {/* Mark read */}
-                  {!alert.is_read && !alert.acknowledged_at && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 px-2 text-slate-500 hover:text-gray-200"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleMarkRead(alert.id);
-                      }}
-                    >
-                      <Check className="h-3.5 w-3.5" />
-                    </Button>
+                  {/* Mark read / unread toggle */}
+                  {!alert.acknowledged_at && (
+                    alert.is_read ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-slate-500 hover:text-blue-400"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleMarkUnread(alert.id);
+                        }}
+                        title="Mark unread"
+                      >
+                        <Bell className="h-3.5 w-3.5" />
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-slate-500 hover:text-gray-200"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleMarkRead(alert.id);
+                        }}
+                        title="Mark read"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </Button>
+                    )
                   )}
 
                   {/* Acknowledge */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -180,16 +180,22 @@ export function fetchTopDevices(limit = 5): Promise<TopDevice[]> {
 export function fetchAlerts(
   limit = 50,
   status?: "active" | "acknowledged" | "all",
-  severity?: "INFO" | "WARNING" | "CRITICAL"
+  severity?: "INFO" | "WARNING" | "CRITICAL",
+  alertType?: Alert["type"]
 ): Promise<Alert[]> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (status) params.set("status", status);
   if (severity) params.set("severity", severity);
+  if (alertType) params.set("type", alertType);
   return apiGet<Alert[]>(`/api/v1/alerts?${params}`);
 }
 
 export function markAlertRead(id: string): Promise<void> {
   return apiPost<void>(`/api/v1/alerts/${id}/read`);
+}
+
+export function markAlertUnread(id: string): Promise<void> {
+  return apiPost<void>(`/api/v1/alerts/${id}/unread`);
 }
 
 export function acknowledgeAlert(id: string, note?: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Add alert type filter buttons (New Device, Online, Offline, Agent Offline, High Bandwidth) to the alerts page, backed by a new `type` query parameter on `GET /api/v1/alerts`
- Add mark-unread capability (`POST /api/v1/alerts/:id/unread`) so users can toggle alert read state instead of one-way mark-read
- Improve UX with toast notifications for mute device and mark-all-read actions

## Changes

**Backend (Rust/Axum):**
- `ListAlertsQuery` gains `alert_type` field with `#[serde(rename = "type")]` for filtering alerts by type
- New `mark_unread` handler sets `is_read = 0` on a single alert
- Route registered at `POST /alerts/:id/unread`
- Two new unit tests: `test_mark_unread` and `test_filter_by_alert_type`

**Frontend (Next.js/React):**
- New `TypeFilter` state and `ALERT_TYPES` constant for the type filter row
- `fetchAlerts` now accepts optional `alertType` parameter
- New `markAlertUnread` API function
- Read/unread toggle button (Bell icon for mark-unread, Check for mark-read)
- Toast feedback via sonner for mute and bulk-read actions

## Test plan

- [x] All 10 alert unit tests pass (`cargo test --lib api::alerts`)
- [x] Full test suite passes (22 tests total)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: verify type filter buttons correctly filter the alert list
- [ ] Manual: verify mark-unread button toggles alert state
- [ ] Manual: verify toast notifications appear for mute/mark-all-read

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added alert type filtering and mark-unread capabilities to enhance alert management UX.

**Backend changes:**
- Added `alert_type` filter field to `ListAlertsQuery` with safe SQL injection protection using whitelist validation
- Implemented `mark_unread` handler that mirrors `mark_read` with proper error handling
- Added comprehensive unit tests for both new features (`test_mark_unread` and `test_filter_by_alert_type`)

**Frontend changes:**
- Added type filter buttons (New Device, Online, Offline, Agent Offline, High Bandwidth) with visual icons
- Implemented read/unread toggle button (Bell icon for mark-unread, Check for mark-read)
- Added toast notifications for mute device and mark-all-read actions to provide user feedback

All changes are well-tested, follow existing patterns, and maintain consistency with the codebase architecture.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns, includes SQL injection protection via whitelist validation, adds comprehensive unit tests (10 total tests passing), and TypeScript compiles cleanly. All changes are incremental enhancements with no breaking changes or risky refactoring.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/alerts.rs | Added alert type filter and mark-unread handler with SQL injection protection, comprehensive tests |
| server/src/api/mod.rs | Registered new mark_unread route at POST /alerts/:id/unread |
| web/src/app/(app)/alerts/page.tsx | Added type filter UI with toggle buttons, mark-unread functionality, and toast notifications for UX feedback |
| web/src/lib/api.ts | Added markAlertUnread API function and alertType parameter to fetchAlerts |

</details>



<sub>Last reviewed commit: 5b0d05c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->