### PR TITLE
feat: improve DHCP static mappings UX with network/subnet dropdowns

### DIFF
--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -2208,11 +2208,13 @@ function StaticMappingsTable({
   loading,
   error,
   onReload,
+  dhcpConfig,
 }: {
   mappings: DhcpStaticMapping[] | null;
   loading: boolean;
   error: string | null;
   onReload: () => void;
+  dhcpConfig: DhcpServerConfig | null;
 }) {
   const [confirmDelete, setConfirmDelete] = useState<DhcpStaticMapping | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -2293,16 +2295,30 @@ function StaticMappingsTable({
     }
   };
 
-  // Pre-fill subnet from existing mappings
+  // Build available networks/subnets from DHCP server config
+  const availableNetworks = dhcpConfig?.shared_networks ?? [];
+  const selectedNetworkObj = availableNetworks.find((n) => n.name === addForm.network);
+  const availableSubnets = selectedNetworkObj?.subnets ?? [];
+
+  // Pre-fill network/subnet from config or existing mappings
   useEffect(() => {
-    if (mappings && mappings.length > 0 && !addForm.subnet) {
+    if (addForm.subnet) return;
+    if (availableNetworks.length > 0) {
+      const firstNet = availableNetworks[0];
+      const firstSub = firstNet.subnets[0]?.subnet ?? "";
+      setAddForm((prev) => ({
+        ...prev,
+        network: prev.network && availableNetworks.some((n) => n.name === prev.network) ? prev.network : firstNet.name,
+        subnet: firstSub,
+      }));
+    } else if (mappings && mappings.length > 0) {
       setAddForm((prev) => ({
         ...prev,
         network: mappings[0].network,
         subnet: mappings[0].subnet,
       }));
     }
-  }, [mappings, addForm.subnet]);
+  }, [mappings, addForm.subnet, availableNetworks]);
 
   return (
     <>
@@ -2330,21 +2346,52 @@ function StaticMappingsTable({
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label className="text-slate-300">Network Name</Label>
-                  <Input
-                    value={addForm.network}
-                    onChange={(e) => setAddForm({ ...addForm, network: e.target.value })}
-                    placeholder="LAN"
-                    className="border-slate-800 bg-slate-950 text-white"
-                  />
+                  {availableNetworks.length > 0 ? (
+                    <select
+                      value={addForm.network}
+                      onChange={(e) => {
+                        const net = availableNetworks.find((n) => n.name === e.target.value);
+                        setAddForm({
+                          ...addForm,
+                          network: e.target.value,
+                          subnet: net?.subnets[0]?.subnet ?? "",
+                        });
+                      }}
+                      className={selectClass}
+                    >
+                      {availableNetworks.map((n) => (
+                        <option key={n.name} value={n.name}>{n.name}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      value={addForm.network}
+                      onChange={(e) => setAddForm({ ...addForm, network: e.target.value })}
+                      placeholder="LAN"
+                      className="border-slate-800 bg-slate-950 text-white"
+                    />
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label className="text-slate-300">Subnet</Label>
-                  <Input
-                    value={addForm.subnet}
-                    onChange={(e) => setAddForm({ ...addForm, subnet: e.target.value })}
-                    placeholder="10.10.0.0/24"
-                    className="border-slate-800 bg-slate-950 text-white"
-                  />
+                  {availableSubnets.length > 0 ? (
+                    <select
+                      value={addForm.subnet}
+                      onChange={(e) => setAddForm({ ...addForm, subnet: e.target.value })}
+                      className={selectClass}
+                    >
+                      {availableSubnets.map((s) => (
+                        <option key={s.subnet} value={s.subnet}>{s.subnet}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      value={addForm.subnet}
+                      onChange={(e) => setAddForm({ ...addForm, subnet: e.target.value })}
+                      placeholder="10.10.0.0/24"
+                      className="border-slate-800 bg-slate-950 text-white"
+                    />
+                  )}
                 </div>
               </div>
               <div className="space-y-2">
@@ -5249,6 +5296,7 @@ function RouterTabs({ summary }: { summary: RouterSummary }) {
                 loading={staticMappings.loading}
                 error={staticMappings.error}
                 onReload={staticMappings.reload}
+                dhcpConfig={dhcpConfig.data ?? null}
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- Replaces manual text inputs for Network Name and Subnet in the "Add Static Mapping" dialog with dropdown `<select>` elements populated from the DHCP server configuration
- When a network is selected, the subnet dropdown auto-filters to show only subnets belonging to that network
- Falls back gracefully to text inputs if the DHCP config hasn't loaded yet
- Passes `dhcpConfig` from the parent `RouterTabs` component to `StaticMappingsTable`

## Context
The DHCP static mappings CRUD feature (issue #179 / PRD F10) was already fully implemented with:
- Backend: GET/POST/PUT/DELETE endpoints with validation, audit logging, and atomic rollback
- Frontend: `StaticMappingsTable` component with add/edit/delete dialogs, config preview, and confirmation dialogs

This PR improves the UX by eliminating the need for users to manually type network names and subnet CIDRs when creating new static mappings, reducing input errors.

Closes #179

## Test plan
- [x] `cargo test --lib` — 262 unit tests pass (including DHCP static mapping parsing tests)
- [x] `cargo test` — 12 integration tests pass
- [x] `next build` — compiles without errors
- [ ] Manual: open Router → DHCP tab → Static Mappings → click "Add Static Mapping" → verify dropdowns are populated from DHCP config
- [ ] Manual: select different network → verify subnet dropdown updates accordingly
- [ ] Manual: verify fallback to text inputs when DHCP config is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced manual text inputs with dropdowns for network/subnet selection in DHCP static mappings, improving UX by reducing input errors. The subnet dropdown automatically filters based on the selected network, and the implementation gracefully falls back to text inputs when config isn't available.

- Improved UX with network/subnet dropdowns that auto-populate from DHCP server config
- Subnet dropdown dynamically filters based on selected network
- Graceful fallback to text inputs when `dhcpConfig` is unavailable
- **Critical bug**: `useEffect` dependency array includes `availableNetworks`, which is recalculated on every render, causing infinite render loop

<h3>Confidence Score: 2/5</h3>

- This PR contains a critical infinite render loop bug that will cause performance issues
- The `useEffect` hook has a dependency on `availableNetworks`, which is derived from props/state and recalculated on every render. This creates an infinite loop that will cause excessive re-renders and poor performance. While the feature implementation is otherwise solid, this bug needs to be fixed before merging.
- `web/src/app/(app)/router/page.tsx` requires attention - fix the useEffect dependency on line 2321

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/router/page.tsx | Added network/subnet dropdowns to DHCP static mappings with dynamic filtering, but contains infinite render loop bug in useEffect |

</details>



<sub>Last reviewed commit: de38436</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->