### PR TITLE
feat: VyOS interface toggle — fix config preview for non-ethernet types

### DIFF
--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -7252,6 +7252,30 @@ mod tests {
     }
 
     #[test]
+    fn test_interface_type_openvpn() {
+        assert_eq!(interface_type("vtun0"), Some("openvpn"));
+        assert_eq!(interface_type("vtun1"), Some("openvpn"));
+    }
+
+    #[test]
+    fn test_interface_type_tunnel() {
+        assert_eq!(interface_type("tun0"), Some("tunnel"));
+        assert_eq!(interface_type("tun1"), Some("tunnel"));
+    }
+
+    #[test]
+    fn test_interface_type_vti() {
+        assert_eq!(interface_type("vti0"), Some("vti"));
+        assert_eq!(interface_type("vti1"), Some("vti"));
+    }
+
+    #[test]
+    fn test_interface_type_pppoe() {
+        assert_eq!(interface_type("pppoe0"), Some("pppoe"));
+        assert_eq!(interface_type("pppoe1"), Some("pppoe"));
+    }
+
+    #[test]
     fn test_interface_type_unknown() {
         assert_eq!(interface_type("unknown0"), None);
         assert_eq!(interface_type("xyz"), None);

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -1493,6 +1493,20 @@ function InterfacesTable({
     return false;
   };
 
+  // Derive VyOS interface type prefix from the interface name (mirrors backend logic)
+  const interfaceType = (name: string): string => {
+    if (name.startsWith("eth")) return "ethernet";
+    if (name.startsWith("bond")) return "bonding";
+    if (name.startsWith("br")) return "bridge";
+    if (name.startsWith("wg")) return "wireguard";
+    if (name === "lo" || name.startsWith("lo")) return "loopback";
+    if (name.startsWith("vtun")) return "openvpn";
+    if (name.startsWith("tun")) return "tunnel";
+    if (name.startsWith("vti")) return "vti";
+    if (name.startsWith("pppoe")) return "pppoe";
+    return "ethernet";
+  };
+
   // Loopback interfaces shouldn't be toggled
   const canToggle = (name: string) => name !== "lo";
 
@@ -1607,9 +1621,11 @@ function InterfacesTable({
           <div className="rounded-md border border-slate-800 bg-slate-950 p-3">
             <p className="text-xs font-medium text-slate-500">Config change:</p>
             <code className="mt-1 block text-xs text-blue-400">
-              {confirmToggle?.disable
-                ? `set interfaces ethernet ${confirmToggle?.iface.name} disable`
-                : `delete interfaces ethernet ${confirmToggle?.iface.name} disable`}
+              {confirmToggle
+                ? confirmToggle.disable
+                  ? `set interfaces ${interfaceType(confirmToggle.iface.name)} ${confirmToggle.iface.name} disable`
+                  : `delete interfaces ${interfaceType(confirmToggle.iface.name)} ${confirmToggle.iface.name} disable`
+                : null}
             </code>
           </div>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary
- Fix the interface enable/disable confirmation dialog which was hardcoding `ethernet` in the config change preview, causing incorrect previews for non-ethernet interfaces (bridge, wireguard, bonding, openvpn, tunnel, vti, pppoe)
- Add `interfaceType()` helper on the frontend mirroring the backend `interface_type()` logic so the preview accurately shows the VyOS command that will be executed (e.g. `set interfaces bridge br0 disable` instead of `set interfaces ethernet br0 disable`)
- Add missing unit tests for openvpn (`vtun*`), tunnel (`tun*`), vti (`vti*`), and pppoe (`pppoe*`) interface type detection

Closes #178

## Test plan
- [x] All 266 unit tests pass (`cargo test --all-targets`)
- [x] All 12 integration tests pass
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] Frontend builds successfully (`bun run build`)
- [ ] Manually verify toggle switch appears on interface rows in router page
- [ ] Manually verify confirmation dialog shows correct interface type for each interface
- [ ] Manually verify enable/disable actually works via VyOS API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the interface toggle confirmation dialog to show the correct VyOS interface type in the config change preview, instead of hardcoding `ethernet` for all interface types. It adds a frontend `interfaceType()` helper that mirrors the backend `interface_type()` function, correctly mapping interface name prefixes (e.g., `br*` → bridge, `wg*` → wireguard, `vtun*` → openvpn) to their VyOS config types. The backend changes are limited to adding missing unit tests for openvpn, tunnel, vti, and pppoe interface type detection.

- The prefix matching order is correct — `vtun` is checked before `tun`, preventing misclassification of OpenVPN interfaces as tunnel interfaces
- The null-safety improvement in the JSX template (`confirmToggle ? ... : null`) is a good defensive change
- Minor divergence: the frontend defaults to `"ethernet"` for unknown interface names, while the backend returns `None` and rejects with a 400 — low risk but worth noting for consistency

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a targeted bug fix with correct logic and no behavioral regressions.
- The changes are straightforward and well-scoped. The frontend helper correctly mirrors the backend logic with proper prefix ordering. The only minor concern is the fallback behavior divergence for unknown interface types, which is low-risk in practice since all known VyOS interface prefixes are covered.
- No files require special attention. The frontend change in `web/src/app/(app)/router/page.tsx` has one minor style suggestion but no critical issues.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vyos.rs | Adds unit tests for openvpn, tunnel, vti, and pppoe interface type detection — straightforward and correct. |
| web/src/app/(app)/router/page.tsx | Adds frontend `interfaceType()` helper mirroring backend logic and fixes config preview for non-ethernet interfaces. Minor concern: defaults to "ethernet" for unknown types, diverging from backend which returns None/400. |

</details>



<sub>Last reviewed commit: a4b6e1c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->