### PR TITLE
feat: traffic monitoring — historical bandwidth graphs per device (1h/24h/7d/30d) (#173)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -127,6 +127,7 @@ pub fn router(state: AppState) -> Router {
         .route("/devices/:id/enrichment", patch(devices::update_enrichment))
         .route("/devices/:id/custom", delete(devices::reset_custom))
         .route("/devices/:id/sysinfo", get(devices::get_sysinfo))
+        .route("/devices/:id/traffic", get(traffic::device_traffic))
         // Agents
         .route("/agents", get(agents::list))
         .route("/agents", post(agents::register))

--- a/server/src/api/traffic.rs
+++ b/server/src/api/traffic.rs
@@ -1,6 +1,6 @@
 use crate::api::AppState;
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     Json,
 };
 use serde::{Deserialize, Serialize};
@@ -51,6 +51,162 @@ pub async fn history(
             })
             .collect(),
     )
+}
+
+// ── Per-device traffic history ──────────────────────────────────────────
+
+/// A single data point in the per-device traffic history response.
+#[derive(Serialize)]
+pub struct DeviceTrafficPoint {
+    /// Time bucket label (ISO 8601).
+    pub time: String,
+    pub avg_rx_bps: i64,
+    pub avg_tx_bps: i64,
+    pub max_rx_bps: i64,
+    pub max_tx_bps: i64,
+}
+
+#[derive(Deserialize)]
+pub struct DeviceTrafficQuery {
+    /// Time range: "1h", "24h", "7d", "30d". Defaults to "1h".
+    pub range: Option<String>,
+}
+
+/// GET /api/v1/devices/:id/traffic?range=1h|24h|7d|30d
+///
+/// Returns historical traffic data for a specific device.
+/// - 1h  → per-minute from traffic_samples (last 60 min)
+/// - 24h → per-hour from traffic_hourly   (last 24 hours)
+/// - 7d  → per-hour from traffic_hourly   (last 7 days)
+/// - 30d → per-day from traffic_daily     (last 30 days)
+pub async fn device_traffic(
+    State(state): State<AppState>,
+    Path(device_id): Path<String>,
+    Query(q): Query<DeviceTrafficQuery>,
+) -> Json<Vec<DeviceTrafficPoint>> {
+    let range = q.range.as_deref().unwrap_or("1h");
+
+    let rows = match range {
+        "1h" => query_samples_minutes(&state.db, &device_id, 60).await,
+        "24h" => query_hourly(&state.db, &device_id, 24).await,
+        "7d" => query_hourly(&state.db, &device_id, 168).await,
+        "30d" => query_daily(&state.db, &device_id, 30).await,
+        _ => query_samples_minutes(&state.db, &device_id, 60).await,
+    };
+
+    Json(rows)
+}
+
+/// Query traffic_samples grouped by minute for short time ranges.
+async fn query_samples_minutes(
+    pool: &sqlx::SqlitePool,
+    device_id: &str,
+    minutes: i64,
+) -> Vec<DeviceTrafficPoint> {
+    let rows: Vec<(String, i64, i64, i64, i64)> = sqlx::query_as(
+        r#"SELECT
+               strftime('%Y-%m-%dT%H:%M:00', sampled_at) AS time,
+               CAST(AVG(rx_bps) AS INTEGER) AS avg_rx,
+               CAST(AVG(tx_bps) AS INTEGER) AS avg_tx,
+               MAX(rx_bps) AS max_rx,
+               MAX(tx_bps) AS max_tx
+           FROM traffic_samples
+           WHERE device_id = ?
+             AND sampled_at >= datetime('now', '-' || CAST(? AS TEXT) || ' minutes')
+           GROUP BY time
+           ORDER BY time ASC"#,
+    )
+    .bind(device_id)
+    .bind(minutes)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    rows.into_iter()
+        .map(
+            |(time, avg_rx, avg_tx, max_rx, max_tx)| DeviceTrafficPoint {
+                time,
+                avg_rx_bps: avg_rx,
+                avg_tx_bps: avg_tx,
+                max_rx_bps: max_rx,
+                max_tx_bps: max_tx,
+            },
+        )
+        .collect()
+}
+
+/// Query traffic_hourly for medium time ranges.
+async fn query_hourly(
+    pool: &sqlx::SqlitePool,
+    device_id: &str,
+    hours: i64,
+) -> Vec<DeviceTrafficPoint> {
+    let rows: Vec<(String, i64, i64, i64, i64)> = sqlx::query_as(
+        r#"SELECT
+               hour AS time,
+               COALESCE(avg_rx_bps, 0),
+               COALESCE(avg_tx_bps, 0),
+               COALESCE(max_rx_bps, 0),
+               COALESCE(max_tx_bps, 0)
+           FROM traffic_hourly
+           WHERE device_id = ?
+             AND hour >= datetime('now', '-' || CAST(? AS TEXT) || ' hours')
+           ORDER BY hour ASC"#,
+    )
+    .bind(device_id)
+    .bind(hours)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    rows.into_iter()
+        .map(
+            |(time, avg_rx, avg_tx, max_rx, max_tx)| DeviceTrafficPoint {
+                time,
+                avg_rx_bps: avg_rx,
+                avg_tx_bps: avg_tx,
+                max_rx_bps: max_rx,
+                max_tx_bps: max_tx,
+            },
+        )
+        .collect()
+}
+
+/// Query traffic_daily for long time ranges.
+async fn query_daily(
+    pool: &sqlx::SqlitePool,
+    device_id: &str,
+    days: i64,
+) -> Vec<DeviceTrafficPoint> {
+    let rows: Vec<(String, i64, i64, i64, i64)> = sqlx::query_as(
+        r#"SELECT
+               day AS time,
+               COALESCE(avg_rx_bps, 0),
+               COALESCE(avg_tx_bps, 0),
+               COALESCE(max_rx_bps, 0),
+               COALESCE(max_tx_bps, 0)
+           FROM traffic_daily
+           WHERE device_id = ?
+             AND day >= date('now', '-' || CAST(? AS TEXT) || ' days')
+           ORDER BY day ASC"#,
+    )
+    .bind(device_id)
+    .bind(days)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    rows.into_iter()
+        .map(
+            |(time, avg_rx, avg_tx, max_rx, max_tx)| DeviceTrafficPoint {
+                time,
+                avg_rx_bps: avg_rx,
+                avg_tx_bps: avg_tx,
+                max_rx_bps: max_rx,
+                max_tx_bps: max_tx,
+            },
+        )
+        .collect()
 }
 
 #[cfg(test)]

--- a/server/src/db/migrations/018_traffic_rollup_indexes.sql
+++ b/server/src/db/migrations/018_traffic_rollup_indexes.sql
@@ -1,0 +1,8 @@
+-- Migration 018: Add unique indexes on traffic_hourly and traffic_daily
+-- for the background rollup task (upsert support) and query performance.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_traffic_hourly_device_hour
+    ON traffic_hourly(device_id, hour);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_traffic_daily_device_day
+    ON traffic_daily(device_id, day);

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -57,6 +57,10 @@ const MANUAL_ASSETS_MIGRATION: &str = include_str!("migrations/016_manual_assets
 /// Migration 017: IT asset inventory table.
 const ASSETS_MIGRATION: &str = include_str!("migrations/017_assets.sql");
 
+/// Migration 018: unique indexes on traffic_hourly / traffic_daily for rollup upserts.
+const TRAFFIC_ROLLUP_INDEXES_MIGRATION: &str =
+    include_str!("migrations/018_traffic_rollup_indexes.sql");
+
 /// Initialize the SQLite database pool and run migrations.
 pub async fn init(database_url: &str) -> Result<SqlitePool> {
     let options = SqliteConnectOptions::from_str(database_url)?
@@ -428,6 +432,24 @@ pub(crate) async fn run_migrations(pool: &SqlitePool) -> Result<()> {
             .await?;
 
         info!("Applied migration 017_assets.sql");
+    }
+
+    // Migration 018: traffic rollup indexes.
+    let applied_18: bool = sqlx::query("SELECT 1 FROM _migrations WHERE version = 18")
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+
+    if !applied_18 {
+        sqlx::raw_sql(TRAFFIC_ROLLUP_INDEXES_MIGRATION)
+            .execute(pool)
+            .await?;
+
+        sqlx::query("INSERT INTO _migrations (version) VALUES (18)")
+            .execute(pool)
+            .await?;
+
+        info!("Applied migration 018_traffic_rollup_indexes.sql");
     }
 
     // Purge expired sessions on startup.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -14,6 +14,7 @@ pub mod speedtest_scheduler;
 pub mod ssdp;
 pub mod ssh;
 pub mod static_files;
+pub mod traffic_rollup;
 pub mod vyos;
 pub mod webhook;
 pub mod ws;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use panoptikon_server::{
     api, config, db, dhcp, mdns, netflow, retention, scanner, speedtest_scheduler, ssdp, ssh,
+    traffic_rollup,
 };
 use std::net::SocketAddr;
 use tracing::info;
@@ -135,6 +136,9 @@ async fn main() -> Result<()> {
 
     // Start the SSH agentless monitoring poller.
     ssh::start_ssh_poller(state.db.clone(), state.ws_hub.clone());
+
+    // Start traffic rollup background task (samples → hourly → daily, every 5 min).
+    traffic_rollup::start_traffic_rollup_task(state.db.clone());
 
     // Build the application router.
     let app = api::router(state);

--- a/server/src/traffic_rollup.rs
+++ b/server/src/traffic_rollup.rs
@@ -1,0 +1,233 @@
+use sqlx::SqlitePool;
+use std::time::Duration;
+use tracing::{error, info};
+
+/// Aggregate traffic_samples into traffic_hourly for completed hours.
+/// Uses INSERT ... ON CONFLICT to be idempotent.
+async fn rollup_hourly(pool: &SqlitePool) -> u64 {
+    // Aggregate all completed hours (not the current partial hour).
+    let result = sqlx::query(
+        r#"INSERT INTO traffic_hourly (device_id, hour, avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps, samples)
+           SELECT
+               device_id,
+               strftime('%Y-%m-%dT%H:00:00', sampled_at) AS hour,
+               CAST(AVG(rx_bps) AS INTEGER),
+               CAST(AVG(tx_bps) AS INTEGER),
+               MAX(rx_bps),
+               MAX(tx_bps),
+               COUNT(*)
+           FROM traffic_samples
+           WHERE sampled_at < strftime('%Y-%m-%dT%H:00:00', 'now')
+           GROUP BY device_id, hour
+           ON CONFLICT(device_id, hour) DO UPDATE SET
+               avg_rx_bps = excluded.avg_rx_bps,
+               avg_tx_bps = excluded.avg_tx_bps,
+               max_rx_bps = excluded.max_rx_bps,
+               max_tx_bps = excluded.max_tx_bps,
+               samples    = excluded.samples"#,
+    )
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(r) => r.rows_affected(),
+        Err(e) => {
+            error!("traffic_rollup: hourly aggregation failed: {e}");
+            0
+        }
+    }
+}
+
+/// Aggregate traffic_hourly into traffic_daily for completed days.
+async fn rollup_daily(pool: &SqlitePool) -> u64 {
+    let result = sqlx::query(
+        r#"INSERT INTO traffic_daily (device_id, day, avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps, total_rx_bytes, total_tx_bytes, samples)
+           SELECT
+               device_id,
+               strftime('%Y-%m-%d', hour) AS day,
+               CAST(AVG(avg_rx_bps) AS INTEGER),
+               CAST(AVG(avg_tx_bps) AS INTEGER),
+               MAX(max_rx_bps),
+               MAX(max_tx_bps),
+               -- Estimate total bytes: avg bps * 3600 seconds per hour * number of hours / 8 bits
+               CAST(SUM(avg_rx_bps) * 3600 / 8 AS INTEGER),
+               CAST(SUM(avg_tx_bps) * 3600 / 8 AS INTEGER),
+               SUM(samples)
+           FROM traffic_hourly
+           WHERE hour < strftime('%Y-%m-%dT00:00:00', 'now')
+           GROUP BY device_id, day
+           ON CONFLICT(device_id, day) DO UPDATE SET
+               avg_rx_bps     = excluded.avg_rx_bps,
+               avg_tx_bps     = excluded.avg_tx_bps,
+               max_rx_bps     = excluded.max_rx_bps,
+               max_tx_bps     = excluded.max_tx_bps,
+               total_rx_bytes = excluded.total_rx_bytes,
+               total_tx_bytes = excluded.total_tx_bytes,
+               samples        = excluded.samples"#,
+    )
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(r) => r.rows_affected(),
+        Err(e) => {
+            error!("traffic_rollup: daily aggregation failed: {e}");
+            0
+        }
+    }
+}
+
+/// Run one cycle of traffic rollup: samples → hourly → daily.
+pub async fn run_rollup(pool: &SqlitePool) -> (u64, u64) {
+    let hourly = rollup_hourly(pool).await;
+    let daily = rollup_daily(pool).await;
+    (hourly, daily)
+}
+
+/// Start the background traffic rollup task that runs every 5 minutes.
+pub fn start_traffic_rollup_task(pool: SqlitePool) {
+    tokio::spawn(async move {
+        // Run an initial rollup shortly after startup.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        let (h, d) = run_rollup(&pool).await;
+        if h + d > 0 {
+            info!(
+                hourly = h,
+                daily = d,
+                "traffic_rollup: initial rollup completed"
+            );
+        }
+
+        let mut interval = tokio::time::interval(Duration::from_secs(300));
+        interval.tick().await; // skip immediate tick
+        loop {
+            interval.tick().await;
+            let (h, d) = run_rollup(&pool).await;
+            if h + d > 0 {
+                info!(hourly = h, daily = d, "traffic_rollup: rollup completed");
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    async fn test_db() -> SqlitePool {
+        db::init(":memory:")
+            .await
+            .expect("in-memory DB init failed")
+    }
+
+    async fn insert_device(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            r#"INSERT INTO devices (id, mac, first_seen_at, last_seen_at)
+               VALUES (?, 'AA:BB:CC:DD:EE:FF', datetime('now'), datetime('now'))"#,
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_sample(pool: &SqlitePool, device_id: &str, ts: &str, rx: i64, tx: i64) {
+        sqlx::query(
+            r#"INSERT INTO traffic_samples (device_id, sampled_at, rx_bps, tx_bps, source)
+               VALUES (?, ?, ?, ?, 'test')"#,
+        )
+        .bind(device_id)
+        .bind(ts)
+        .bind(rx)
+        .bind(tx)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hourly_rollup() {
+        let pool = test_db().await;
+        insert_device(&pool, "dev1").await;
+
+        // Insert samples for a completed hour (2 hours ago).
+        insert_sample(&pool, "dev1", "2024-01-01T10:05:00", 1000, 500).await;
+        insert_sample(&pool, "dev1", "2024-01-01T10:15:00", 2000, 1000).await;
+        insert_sample(&pool, "dev1", "2024-01-01T10:45:00", 3000, 1500).await;
+
+        let (hourly, _) = run_rollup(&pool).await;
+        assert!(hourly > 0, "Should produce hourly rollup rows");
+
+        let row: (i64, i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps, samples FROM traffic_hourly WHERE device_id = 'dev1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            row.0, 2000,
+            "avg_rx_bps should be (1000+2000+3000)/3 = 2000"
+        );
+        assert_eq!(row.1, 1000, "avg_tx_bps should be (500+1000+1500)/3 = 1000");
+        assert_eq!(row.2, 3000, "max_rx_bps");
+        assert_eq!(row.3, 1500, "max_tx_bps");
+        assert_eq!(row.4, 3, "3 samples");
+    }
+
+    #[tokio::test]
+    async fn test_daily_rollup() {
+        let pool = test_db().await;
+        insert_device(&pool, "dev1").await;
+
+        // Insert hourly rows for a completed day.
+        sqlx::query(
+            r#"INSERT INTO traffic_hourly (device_id, hour, avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps, samples)
+               VALUES ('dev1', '2024-01-01T10:00:00', 1000, 500, 2000, 1000, 10)"#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"INSERT INTO traffic_hourly (device_id, hour, avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps, samples)
+               VALUES ('dev1', '2024-01-01T14:00:00', 3000, 1500, 4000, 2000, 20)"#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (_, daily) = run_rollup(&pool).await;
+        assert!(daily > 0, "Should produce daily rollup rows");
+
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT avg_rx_bps, avg_tx_bps, max_rx_bps, max_tx_bps FROM traffic_daily WHERE device_id = 'dev1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row.0, 2000, "avg_rx_bps should be (1000+3000)/2 = 2000");
+        assert_eq!(row.1, 1000, "avg_tx_bps should be (500+1500)/2 = 1000");
+        assert_eq!(row.2, 4000, "max_rx_bps");
+        assert_eq!(row.3, 2000, "max_tx_bps");
+    }
+
+    #[tokio::test]
+    async fn test_rollup_idempotent() {
+        let pool = test_db().await;
+        insert_device(&pool, "dev1").await;
+        insert_sample(&pool, "dev1", "2024-01-01T10:05:00", 1000, 500).await;
+
+        // Run twice — should not create duplicates.
+        run_rollup(&pool).await;
+        run_rollup(&pool).await;
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM traffic_hourly WHERE device_id = 'dev1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count.0, 1, "Should have exactly 1 hourly row (idempotent)");
+    }
+}

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -53,6 +53,7 @@ import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
 import { MotionCard } from "@/components/MotionCard";
 
 import { downloadExport } from "@/lib/export";
+import { DeviceTrafficChart } from "@/components/DeviceTrafficChart";
 
 type Filter = "all" | "online" | "offline" | "unknown";
 type ViewMode = "grid" | "table";
@@ -886,6 +887,7 @@ function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => vo
       <Tabs defaultValue="info" className="w-full">
         <TabsList className="mb-4 w-full bg-slate-800">
           <TabsTrigger value="info" className="flex-1">Info</TabsTrigger>
+          <TabsTrigger value="traffic" className="flex-1">Traffic</TabsTrigger>
           <TabsTrigger value="edit" className="flex-1">Edit</TabsTrigger>
           <TabsTrigger value="system" className="flex-1">System</TabsTrigger>
           <TabsTrigger value="ports" className="flex-1">Ports</TabsTrigger>
@@ -894,6 +896,10 @@ function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => vo
 
         <TabsContent value="info">
           <DeviceInfoTab device={device} ips={ips} primaryIp={primaryIp} />
+        </TabsContent>
+
+        <TabsContent value="traffic">
+          <DeviceTrafficChart deviceId={device.id} />
         </TabsContent>
 
         <TabsContent value="edit">

--- a/web/src/components/DeviceTrafficChart.tsx
+++ b/web/src/components/DeviceTrafficChart.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Activity } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchDeviceTrafficHistory } from "@/lib/api";
+import { formatBps } from "@/lib/format";
+import type { DeviceTrafficPoint, TrafficRange } from "@/lib/types";
+
+const RANGES: { label: string; value: TrafficRange }[] = [
+  { label: "1h", value: "1h" },
+  { label: "24h", value: "24h" },
+  { label: "7d", value: "7d" },
+  { label: "30d", value: "30d" },
+];
+
+function formatTimeLabel(iso: string, range: TrafficRange): string {
+  try {
+    const d = new Date(iso);
+    if (range === "30d") {
+      return d.toLocaleDateString([], { month: "short", day: "numeric" });
+    }
+    if (range === "7d") {
+      return d.toLocaleDateString([], {
+        weekday: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    }
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+export function DeviceTrafficChart({ deviceId }: { deviceId: string }) {
+  const [range, setRange] = useState<TrafficRange>("1h");
+  const [data, setData] = useState<DeviceTrafficPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const points = await fetchDeviceTrafficHistory(deviceId, range);
+      setData(points);
+    } catch {
+      // silently ignore — empty state shown
+    } finally {
+      setLoading(false);
+    }
+  }, [deviceId, range]);
+
+  useEffect(() => {
+    load();
+    // Auto-refresh for 1h view
+    if (range === "1h") {
+      const interval = setInterval(load, 30_000);
+      return () => clearInterval(interval);
+    }
+  }, [load, range]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-blue-400" />
+          <span className="text-sm font-medium text-slate-400">
+            Bandwidth History
+          </span>
+        </div>
+        <div className="flex gap-1">
+          {RANGES.map((r) => (
+            <Button
+              key={r.value}
+              variant={range === r.value ? "secondary" : "ghost"}
+              size="sm"
+              className={`h-7 px-2.5 text-xs ${
+                range === r.value
+                  ? "bg-slate-700 text-white"
+                  : "text-slate-500 hover:text-slate-300"
+              }`}
+              onClick={() => setRange(r.value)}
+            >
+              {r.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {loading && data.length === 0 ? (
+        <Skeleton className="h-[200px] w-full rounded-xl" />
+      ) : data.length > 0 ? (
+        <div className="h-[200px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data}>
+              <defs>
+                <linearGradient id="dtcRx" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="dtcTx" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <XAxis
+                dataKey="time"
+                tickFormatter={(v: string) => formatTimeLabel(v, range)}
+                tick={{ fill: "#6b7280", fontSize: 10 }}
+                stroke="#1e293b"
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tickFormatter={(v: number) => formatBps(v)}
+                tick={{ fill: "#6b7280", fontSize: 10 }}
+                stroke="#1e293b"
+                width={65}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#0f172a",
+                  border: "1px solid #1e293b",
+                  borderRadius: "6px",
+                  color: "#fff",
+                  fontSize: "12px",
+                }}
+                labelFormatter={(v: string) => formatTimeLabel(v, range)}
+                formatter={(value: number, name: string) => [
+                  formatBps(value),
+                  name === "avg_rx_bps" ? "Avg Inbound" : "Avg Outbound",
+                ]}
+              />
+              <Legend
+                formatter={(value: string) =>
+                  value === "avg_rx_bps" ? "Avg Inbound" : "Avg Outbound"
+                }
+                wrapperStyle={{ fontSize: "11px", color: "#9ca3af" }}
+              />
+              <Area
+                type="monotone"
+                dataKey="avg_rx_bps"
+                stroke="#3b82f6"
+                fillOpacity={1}
+                fill="url(#dtcRx)"
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+              <Area
+                type="monotone"
+                dataKey="avg_tx_bps"
+                stroke="#22c55e"
+                fillOpacity={1}
+                fill="url(#dtcTx)"
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="flex h-[200px] items-center justify-center">
+          <p className="text-sm text-slate-500">
+            No traffic data for this device.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -51,6 +51,8 @@ import type {
   SyslogResponse,
   TopDevice,
   TrafficHistoryPoint,
+  TrafficRange,
+  DeviceTrafficPoint,
   VyosDhcpLease,
   VyosInterface,
   VyosRoute,
@@ -372,6 +374,15 @@ export function fetchTrafficHistory(minutes = 60): Promise<TrafficHistoryPoint[]
   return apiGet<TrafficHistoryPoint[]>(`/api/v1/traffic/history?minutes=${minutes}`, {
     timeoutMs: DASHBOARD_TIMEOUT_MS,
   });
+}
+
+export function fetchDeviceTrafficHistory(
+  deviceId: string,
+  range: TrafficRange = "1h"
+): Promise<DeviceTrafficPoint[]> {
+  return apiGet<DeviceTrafficPoint[]>(
+    `/api/v1/devices/${deviceId}/traffic?range=${range}`
+  );
 }
 
 // ─── Auth ───────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -188,6 +188,16 @@ export interface TrafficHistoryPoint {
   tx_bps: number;
 }
 
+export type TrafficRange = "1h" | "24h" | "7d" | "30d";
+
+export interface DeviceTrafficPoint {
+  time: string;
+  avg_rx_bps: number;
+  avg_tx_bps: number;
+  max_rx_bps: number;
+  max_tx_bps: number;
+}
+
 // ─── NetFlow ────────────────────────────────────────────
 
 export interface NetflowStatus {


### PR DESCRIPTION
## Summary

- **Background rollup task** aggregates `traffic_samples` → `traffic_hourly` → `traffic_daily` every 5 minutes with idempotent upserts
- **Per-device traffic API** at `GET /devices/:id/traffic?range=1h|24h|7d|30d` — queries the appropriate aggregation table based on time range
- **Recharts area chart component** with time range selector (1h/24h/7d/30d) showing avg inbound/outbound bandwidth
- **New "Traffic" tab** in the device detail sheet for per-device bandwidth history
- **Migration 018**: unique indexes on `traffic_hourly(device_id, hour)` and `traffic_daily(device_id, day)` for upsert support

### Data resolution by range
| Range | Source | Granularity |
|-------|--------|-------------|
| 1h | `traffic_samples` | per-minute |
| 24h | `traffic_hourly` | per-hour |
| 7d | `traffic_hourly` | per-hour |
| 30d | `traffic_daily` | per-day |

## Test plan
- [x] All 272 unit tests pass (including 3 new rollup tests)
- [x] All 12 integration tests pass
- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo check` — no compile errors
- [x] TypeScript compiles without errors in modified files
- [ ] Manual: open device detail → Traffic tab shows chart with range buttons
- [ ] Manual: verify rollup populates hourly/daily tables after traffic data flows

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a comprehensive traffic monitoring system with multi-level aggregation and visualization.

**Implementation highlights:**
- Background rollup task aggregates `traffic_samples` into `traffic_hourly` and `traffic_daily` tables every 5 minutes using idempotent upserts
- New unique indexes on `(device_id, hour)` and `(device_id, day)` enable efficient upsert operations via `ON CONFLICT`
- Per-device API endpoint dynamically selects appropriate data source based on time range (samples for 1h, hourly for 24h/7d, daily for 30d)
- Recharts-based visualization component with time range selector and auto-refresh for real-time 1h view
- All queries use parameterized bindings for SQL injection prevention
- Comprehensive test coverage with 3 new rollup tests (hourly, daily, idempotency)

**Considerations:**
- No retention policy for `traffic_hourly` or `traffic_daily` tables — these will grow indefinitely while `traffic_samples` are cleaned up after 48 hours (default). Consider adding retention for aggregated tables in future work.
- Rollup aggregates ALL historical samples on every run, which is idempotent but could become expensive with large datasets. Current implementation is acceptable for typical usage.
- Frontend silently catches API errors, showing empty state — appropriate UX choice.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows best practices with parameterized queries preventing SQL injection, idempotent upsert operations preventing duplicates, comprehensive test coverage (3 new tests covering key rollup scenarios), and proper error handling throughout. The migration adds indexes safely with IF NOT EXISTS guards, and the background task has appropriate error handling that logs failures without crashing.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/db/migrations/018_traffic_rollup_indexes.sql | Adds unique indexes on traffic_hourly and traffic_daily for upsert support |
| server/src/traffic_rollup.rs | Implements idempotent traffic aggregation with proper error handling and comprehensive tests |
| server/src/api/traffic.rs | Adds per-device traffic endpoint with range selection, uses parameterized queries |
| web/src/components/DeviceTrafficChart.tsx | Recharts-based bandwidth visualization with range selector and auto-refresh for 1h view |

</details>



<sub>Last reviewed commit: 3c88221</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->