### PR TITLE
feat: WebSocket live updates — push device state changes to UI without polling (#168)

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Activity,
   AlertTriangle,
@@ -27,6 +27,7 @@ import type { Alert, DashboardStats, TrafficHistoryPoint, Device } from "@/lib/t
 import { formatBps, timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
+import { toast } from "sonner";
 import { useWsEvent } from "@/lib/ws";
 import { getDeviceIcon } from "@/lib/device-icons";
 import type { DeviceType } from "@/lib/device-type";
@@ -297,9 +298,28 @@ export default function DashboardPage() {
     return () => clearInterval(interval);
   }, [loadAll]);
 
+  // Keep a ref to current devices so WS handler can look up names without stale closure
+  const devicesRef = useRef(devices);
+  devicesRef.current = devices;
+
   useWsEvent(
     ["device_online", "device_offline", "new_device", "agent_online", "agent_offline"],
-    loadAll
+    (msg) => {
+      if (["device_online", "device_offline", "new_device"].includes(msg.event)) {
+        const d = msg.data as { device_id?: string; mac?: string; ip?: string };
+        const dev = devicesRef.current?.find((x) => x.id === d.device_id);
+        const label = dev?.name || dev?.hostname || d.mac || "Unknown device";
+
+        if (msg.event === "device_online") {
+          toast.success(`${label} came online`, { description: d.ip });
+        } else if (msg.event === "device_offline") {
+          toast.error(`${label} went offline`);
+        } else if (msg.event === "new_device") {
+          toast.info(`New device discovered: ${d.mac}`, { description: d.ip });
+        }
+      }
+      loadAll();
+    }
   );
 
   // ── Compute device type breakdown ──────────────────────

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowDown, ArrowUp, Battery, Box, ChevronDown, CircuitBoard, Container, Cpu, Download, ExternalLink, Gamepad2, HardDrive, HelpCircle, Laptop, Loader2, LayoutGrid, List, MemoryStick, Monitor, Network, Pencil, Plus, Power, Printer, Radar, RotateCcw, Router, Search, Server, Smartphone, Tablet, Tv, VolumeX, Wifi, WifiOff } from "lucide-react";
 import { getDeviceIcon } from "@/lib/device-icons";
@@ -90,10 +90,29 @@ export default function DevicesPage() {
     return () => clearInterval(interval);
   }, [load]);
 
+  // Keep a ref to current devices so WS handler can look up names without stale closure
+  const devicesRef = useRef(devices);
+  devicesRef.current = devices;
+
   // Refetch immediately when a device or agent state change arrives via WebSocket
   useWsEvent(
     ["device_online", "device_offline", "new_device", "agent_online", "agent_offline"],
-    load
+    (msg) => {
+      if (["device_online", "device_offline", "new_device"].includes(msg.event)) {
+        const d = msg.data as { device_id?: string; mac?: string; ip?: string };
+        const dev = devicesRef.current?.find((x) => x.id === d.device_id);
+        const label = dev?.name || dev?.hostname || d.mac || "Unknown device";
+
+        if (msg.event === "device_online") {
+          toast.success(`${label} came online`, { description: d.ip });
+        } else if (msg.event === "device_offline") {
+          toast.error(`${label} went offline`);
+        } else if (msg.event === "new_device") {
+          toast.info(`New device discovered: ${d.mac}`, { description: d.ip });
+        }
+      }
+      load();
+    }
   );
 
   const filtered = useMemo(() => {


### PR DESCRIPTION
Closes #168

## Summary

The core WebSocket infrastructure for real-time device state updates was already in place:
- **Server**: `WsHub` broadcasts `device_online`, `device_offline`, `new_device` events when ARP scanner detects state changes (`server/src/ws/hub.rs`, `server/src/scanner/mod.rs`)
- **Server**: UI WebSocket endpoint at `GET /api/v1/ws` (`server/src/api/agents.rs`)
- **Frontend**: `useWebSocket` hook with exponential backoff reconnection (`web/src/lib/ws.ts`)
- **Frontend**: `WebSocketProvider` wrapping the app layout for persistent connection
- **Frontend**: Both device list and dashboard subscribe to WS events via `useWsEvent`

**What this PR adds**: Toast notifications for device state changes so users get immediate visual feedback when devices come online, go offline, or are newly discovered — making the live updates actually visible instead of silently refetching data.

### Changes
- **`web/src/app/(app)/devices/page.tsx`**: Enhanced `useWsEvent` handler to show toast notifications with device name/hostname and IP for online/offline/new_device events
- **`web/src/app/(app)/dashboard/page.tsx`**: Same toast notification enhancement

### Design decisions
- Uses `useRef` to access current devices state in the WS handler without stale closures
- Looks up device name/hostname from current state; falls back to MAC address for new devices
- `toast.success` for online, `toast.error` for offline, `toast.info` for new device discovery

## Test plan
- [ ] Open dashboard or devices page, verify WebSocket connects (green indicator in sidebar)
- [ ] When a device goes online → green success toast appears with device name and IP
- [ ] When a device goes offline → red error toast appears with device name
- [ ] When a new device is discovered → blue info toast with MAC and IP
- [ ] Data still refetches correctly after each event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds toast notifications (via `sonner`) to the dashboard and devices pages so users get immediate visual feedback when devices come online, go offline, or are newly discovered via WebSocket events. The existing `useWsEvent` infrastructure is leveraged correctly, and a `useRef` pattern avoids stale closure issues when looking up device names.

- Both `dashboard/page.tsx` and `devices/page.tsx` now show `toast.success` for online, `toast.error` for offline, and `toast.info` for new device discovery events
- Device name resolution falls back gracefully: `name` -> `hostname` -> `mac` -> `"Unknown device"`
- The `loadAll()` / `load()` refetch still fires for all subscribed events (including agent events), ensuring data stays in sync
- The toast handler logic is duplicated verbatim across both pages — extracting a shared helper would improve maintainability

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds UI-only toast notifications on top of existing, working WebSocket infrastructure with no changes to data flow or server code.
- The changes are small, well-scoped, and functionally correct. The `useRef` pattern properly handles React's stale closure issue, type casts align with the server's actual payload shape, and fallback chains handle edge cases (null devices, missing fields). The only concern is code duplication across two pages, which is a maintainability issue rather than a correctness one.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Adds toast notifications for device state changes via WebSocket events. Uses `useRef` to avoid stale closures. Logic is correct but duplicated with dashboard page. |
| web/src/app/(app)/dashboard/page.tsx | Adds identical toast notification logic for device WS events. Ref pattern and fallback chain are correctly implemented. Contains duplicated code with devices page. |

</details>



<sub>Last reviewed commit: 468ed45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->