### PR TITLE
feat: global search — devices by IP, MAC, name, hostname (#169)

### DIFF
--- a/server/src/api/search.rs
+++ b/server/src/api/search.rs
@@ -21,6 +21,7 @@ pub struct SearchDevice {
     pub id: String,
     pub ip_address: Option<String>,
     pub hostname: Option<String>,
+    pub name: Option<String>,
     pub mac_address: String,
     pub vendor: Option<String>,
     pub is_online: bool,
@@ -44,12 +45,34 @@ pub struct SearchAlert {
     pub created_at: String,
 }
 
+/// An SSH target in search results.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SearchSshTarget {
+    pub id: String,
+    pub name: String,
+    pub host: String,
+    pub username: String,
+    pub is_online: bool,
+}
+
+/// An asset in search results.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SearchAsset {
+    pub id: String,
+    pub name: String,
+    pub asset_type: String,
+    pub location: Option<String>,
+    pub serial_number: Option<String>,
+}
+
 /// Combined search response grouped by entity type.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SearchResponse {
     pub devices: Vec<SearchDevice>,
     pub agents: Vec<SearchAgent>,
     pub alerts: Vec<SearchAlert>,
+    pub ssh_targets: Vec<SearchSshTarget>,
+    pub assets: Vec<SearchAsset>,
 }
 
 impl SearchResponse {
@@ -58,6 +81,8 @@ impl SearchResponse {
             devices: Vec::new(),
             agents: Vec::new(),
             alerts: Vec::new(),
+            ssh_targets: Vec::new(),
+            assets: Vec::new(),
         }
     }
 }
@@ -76,9 +101,10 @@ pub async fn search(
 
     let like_term = format!("%{q}%");
 
-    // Search devices by IP (via device_ips), hostname, MAC, or vendor
+    // Search devices by IP (via device_ips), hostname, name, custom_name, MAC, or vendor
     let device_rows = sqlx::query(
         r#"SELECT DISTINCT d.id, d.hostname, d.mac, d.vendor, d.is_online,
+                  COALESCE(d.custom_name, d.name) AS display_name,
                   (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id AND di.is_current = 1 LIMIT 1) AS ip_address
            FROM devices d
            LEFT JOIN device_ips di ON di.device_id = d.id AND di.is_current = 1
@@ -86,6 +112,8 @@ pub async fn search(
               OR d.hostname LIKE ?1
               OR d.mac LIKE ?1
               OR d.vendor LIKE ?1
+              OR d.name LIKE ?1
+              OR d.custom_name LIKE ?1
            LIMIT 5"#,
     )
     .bind(&like_term)
@@ -102,6 +130,7 @@ pub async fn search(
             id: row.try_get("id").unwrap_or_default(),
             ip_address: row.try_get("ip_address").unwrap_or(None),
             hostname: row.try_get("hostname").unwrap_or(None),
+            name: row.try_get("display_name").unwrap_or(None),
             mac_address: row.try_get("mac").unwrap_or_default(),
             vendor: row.try_get("vendor").unwrap_or(None),
             is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
@@ -168,10 +197,77 @@ pub async fn search(
         })
         .collect();
 
+    // Search SSH targets by name, host, or username
+    let ssh_rows = sqlx::query(
+        r#"SELECT st.id, st.name, st.host, st.username,
+                  CASE WHEN sr.reported_at IS NOT NULL
+                            AND sr.reported_at > datetime('now', '-120 seconds')
+                       THEN 1 ELSE 0 END AS is_online
+           FROM ssh_targets st
+           LEFT JOIN ssh_reports sr ON sr.target_id = st.id
+                AND sr.id = (SELECT MAX(sr2.id) FROM ssh_reports sr2 WHERE sr2.target_id = st.id)
+           WHERE st.name LIKE ?1
+              OR st.host LIKE ?1
+              OR st.username LIKE ?1
+           LIMIT 5"#,
+    )
+    .bind(&like_term)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("Search SSH targets failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let ssh_targets: Vec<SearchSshTarget> = ssh_rows
+        .into_iter()
+        .map(|row| SearchSshTarget {
+            id: row.try_get("id").unwrap_or_default(),
+            name: row.try_get("name").unwrap_or_default(),
+            host: row.try_get("host").unwrap_or_default(),
+            username: row.try_get("username").unwrap_or_default(),
+            is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+        })
+        .collect();
+
+    // Search assets by name, location, owner, serial_number, or tags
+    let asset_rows = sqlx::query(
+        r#"SELECT id, name, asset_type, location, serial_number
+           FROM assets
+           WHERE name LIKE ?1
+              OR location LIKE ?1
+              OR owner LIKE ?1
+              OR serial_number LIKE ?1
+              OR tags LIKE ?1
+           LIMIT 5"#,
+    )
+    .bind(&like_term)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        tracing::error!("Search assets failed: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let assets: Vec<SearchAsset> = asset_rows
+        .into_iter()
+        .map(|row| SearchAsset {
+            id: row.try_get("id").unwrap_or_default(),
+            name: row.try_get("name").unwrap_or_default(),
+            asset_type: row
+                .try_get::<String, _>("asset_type")
+                .unwrap_or_else(|_| "unknown".to_string()),
+            location: row.try_get("location").unwrap_or(None),
+            serial_number: row.try_get("serial_number").unwrap_or(None),
+        })
+        .collect();
+
     Ok(Json(SearchResponse {
         devices,
         agents,
         alerts,
+        ssh_targets,
+        assets,
     }))
 }
 
@@ -184,6 +280,7 @@ pub async fn search_devices(
 
     let rows = sqlx::query(
         r#"SELECT DISTINCT d.id, d.hostname, d.mac, d.vendor, d.is_online,
+                  COALESCE(d.custom_name, d.name) AS display_name,
                   (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id AND di.is_current = 1 LIMIT 1) AS ip_address
            FROM devices d
            LEFT JOIN device_ips di ON di.device_id = d.id AND di.is_current = 1
@@ -191,6 +288,8 @@ pub async fn search_devices(
               OR d.hostname LIKE ?1
               OR d.mac LIKE ?1
               OR d.vendor LIKE ?1
+              OR d.name LIKE ?1
+              OR d.custom_name LIKE ?1
            LIMIT 5"#,
     )
     .bind(&like_term)
@@ -203,6 +302,7 @@ pub async fn search_devices(
             id: row.try_get("id").unwrap_or_default(),
             ip_address: row.try_get("ip_address").unwrap_or(None),
             hostname: row.try_get("hostname").unwrap_or(None),
+            name: row.try_get("display_name").unwrap_or(None),
             mac_address: row.try_get("mac").unwrap_or_default(),
             vendor: row.try_get("vendor").unwrap_or(None),
             is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
@@ -272,6 +372,77 @@ pub async fn search_alerts(
                 .try_get::<String, _>("severity")
                 .unwrap_or_else(|_| "WARNING".to_string()),
             created_at: row.try_get("created_at").unwrap_or_default(),
+        })
+        .collect())
+}
+
+/// Search SSH targets directly from pool (for unit tests).
+pub async fn search_ssh_targets(
+    pool: &sqlx::SqlitePool,
+    term: &str,
+) -> Result<Vec<SearchSshTarget>, sqlx::Error> {
+    let like_term = format!("%{term}%");
+
+    let rows = sqlx::query(
+        r#"SELECT st.id, st.name, st.host, st.username,
+                  CASE WHEN sr.reported_at IS NOT NULL
+                            AND sr.reported_at > datetime('now', '-120 seconds')
+                       THEN 1 ELSE 0 END AS is_online
+           FROM ssh_targets st
+           LEFT JOIN ssh_reports sr ON sr.target_id = st.id
+                AND sr.id = (SELECT MAX(sr2.id) FROM ssh_reports sr2 WHERE sr2.target_id = st.id)
+           WHERE st.name LIKE ?1
+              OR st.host LIKE ?1
+              OR st.username LIKE ?1
+           LIMIT 5"#,
+    )
+    .bind(&like_term)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| SearchSshTarget {
+            id: row.try_get("id").unwrap_or_default(),
+            name: row.try_get("name").unwrap_or_default(),
+            host: row.try_get("host").unwrap_or_default(),
+            username: row.try_get("username").unwrap_or_default(),
+            is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+        })
+        .collect())
+}
+
+/// Search assets directly from pool (for unit tests).
+pub async fn search_assets(
+    pool: &sqlx::SqlitePool,
+    term: &str,
+) -> Result<Vec<SearchAsset>, sqlx::Error> {
+    let like_term = format!("%{term}%");
+
+    let rows = sqlx::query(
+        r#"SELECT id, name, asset_type, location, serial_number
+           FROM assets
+           WHERE name LIKE ?1
+              OR location LIKE ?1
+              OR owner LIKE ?1
+              OR serial_number LIKE ?1
+              OR tags LIKE ?1
+           LIMIT 5"#,
+    )
+    .bind(&like_term)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| SearchAsset {
+            id: row.try_get("id").unwrap_or_default(),
+            name: row.try_get("name").unwrap_or_default(),
+            asset_type: row
+                .try_get::<String, _>("asset_type")
+                .unwrap_or_else(|_| "unknown".to_string()),
+            location: row.try_get("location").unwrap_or(None),
+            serial_number: row.try_get("serial_number").unwrap_or(None),
         })
         .collect())
 }
@@ -439,6 +610,108 @@ mod tests {
         assert!(results[0].message.contains("offline"));
     }
 
+    /// Helper: insert a test SSH target and return its id.
+    async fn insert_ssh_target(
+        pool: &sqlx::SqlitePool,
+        name: &str,
+        host: &str,
+        username: &str,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO ssh_targets (id, name, host, username, created_at)
+               VALUES (?, ?, ?, ?, datetime('now'))"#,
+        )
+        .bind(&id)
+        .bind(name)
+        .bind(host)
+        .bind(username)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Helper: insert a test asset and return its id.
+    async fn insert_asset(
+        pool: &sqlx::SqlitePool,
+        name: &str,
+        asset_type: &str,
+        location: Option<&str>,
+        serial_number: Option<&str>,
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO assets (id, name, asset_type, location, serial_number, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))"#,
+        )
+        .bind(&id)
+        .bind(name)
+        .bind(asset_type)
+        .bind(location)
+        .bind(serial_number)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_search_ssh_targets_by_name() {
+        let pool = test_db().await;
+        insert_ssh_target(&pool, "prod-web", "10.0.1.10", "admin").await;
+        insert_ssh_target(&pool, "staging-db", "10.0.2.20", "deploy").await;
+
+        let results = search_ssh_targets(&pool, "prod").await.unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "Should find exactly one SSH target by name"
+        );
+        assert_eq!(results[0].name, "prod-web");
+    }
+
+    #[tokio::test]
+    async fn test_search_ssh_targets_by_host() {
+        let pool = test_db().await;
+        insert_ssh_target(&pool, "server-a", "192.168.10.5", "root").await;
+        insert_ssh_target(&pool, "server-b", "10.0.0.1", "root").await;
+
+        let results = search_ssh_targets(&pool, "192.168").await.unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "Should find exactly one SSH target by host"
+        );
+        assert_eq!(results[0].host, "192.168.10.5");
+    }
+
+    #[tokio::test]
+    async fn test_search_assets_by_name() {
+        let pool = test_db().await;
+        insert_asset(&pool, "Dell PowerEdge R740", "server", Some("DC-1"), None).await;
+        insert_asset(&pool, "HP LaserJet Pro", "printer", Some("Office"), None).await;
+
+        let results = search_assets(&pool, "PowerEdge").await.unwrap();
+        assert_eq!(results.len(), 1, "Should find exactly one asset by name");
+        assert_eq!(results[0].name, "Dell PowerEdge R740");
+    }
+
+    #[tokio::test]
+    async fn test_search_assets_by_serial() {
+        let pool = test_db().await;
+        insert_asset(&pool, "Server A", "server", None, Some("SN-ABC-12345")).await;
+        insert_asset(&pool, "Server B", "server", None, Some("SN-XYZ-67890")).await;
+
+        let results = search_assets(&pool, "ABC-123").await.unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "Should find exactly one asset by serial number"
+        );
+        assert_eq!(results[0].serial_number.as_deref(), Some("SN-ABC-12345"));
+    }
+
     #[tokio::test]
     async fn test_search_empty_query() {
         let pool = test_db().await;
@@ -461,6 +734,8 @@ mod tests {
             assert!(response.devices.is_empty());
             assert!(response.agents.is_empty());
             assert!(response.alerts.is_empty());
+            assert!(response.ssh_targets.is_empty());
+            assert!(response.assets.is_empty());
         }
 
         // Single char query

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -7,13 +7,16 @@ import {
   Bell,
   Cpu,
   LayoutDashboard,
+  Monitor,
   MonitorSmartphone,
+  Package,
   Router,
   Search,
   Settings,
+  Terminal,
 } from 'lucide-react'
 import { searchAll } from '@/lib/api'
-import type { SearchDevice } from '@/lib/types'
+import type { SearchDevice, SearchAgent, SearchSshTarget, SearchAsset } from '@/lib/types'
 import type { LucideIcon } from 'lucide-react'
 
 interface PaletteItem {
@@ -42,6 +45,9 @@ export function CommandPalette() {
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
   const [deviceItems, setDeviceItems] = useState<PaletteItem[]>([])
+  const [agentItems, setAgentItems] = useState<PaletteItem[]>([])
+  const [sshItems, setSshItems] = useState<PaletteItem[]>([])
+  const [assetItems, setAssetItems] = useState<PaletteItem[]>([])
 
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
@@ -52,7 +58,7 @@ export function CommandPalette() {
     : PAGES
 
   // Flatten all items for keyboard navigation
-  const allItems: PaletteItem[] = [...filteredPages, ...deviceItems]
+  const allItems: PaletteItem[] = [...filteredPages, ...deviceItems, ...agentItems, ...sshItems, ...assetItems]
 
   // ── Global Cmd+K / Ctrl+K listener ──
   useEffect(() => {
@@ -72,6 +78,9 @@ export function CommandPalette() {
       setQuery('')
       setActiveIndex(0)
       setDeviceItems([])
+      setAgentItems([])
+      setSshItems([])
+      setAssetItems([])
       // Small delay to ensure DOM is ready
       requestAnimationFrame(() => {
         inputRef.current?.focus()
@@ -79,27 +88,59 @@ export function CommandPalette() {
     }
   }, [open])
 
-  // ── Debounced device search ──
+  // ── Debounced search across all entity types ──
   useEffect(() => {
     if (!open || query.length < 2) {
       setDeviceItems([])
+      setAgentItems([])
+      setSshItems([])
+      setAssetItems([])
       return
     }
 
     const timer = setTimeout(async () => {
       try {
         const data = await searchAll(query)
-        const devices: PaletteItem[] = data.devices.map((d: SearchDevice) => ({
+        setDeviceItems(data.devices.map((d: SearchDevice) => ({
           id: `device-${d.id}`,
-          label: d.ip_address || d.mac_address,
+          label: d.name || d.ip_address || d.mac_address,
           sublabel: d.hostname || d.vendor || undefined,
           href: `/devices?highlight=${d.id}`,
+          icon: Monitor,
           section: 'devices' as const,
           isOnline: d.is_online,
-        }))
-        setDeviceItems(devices)
+        })))
+        setAgentItems(data.agents.map((a: SearchAgent) => ({
+          id: `agent-${a.id}`,
+          label: a.name || a.id,
+          sublabel: a.hostname || undefined,
+          href: '/agents',
+          icon: Cpu,
+          section: 'devices' as const,
+          isOnline: a.is_online,
+        })))
+        setSshItems(data.ssh_targets.map((st: SearchSshTarget) => ({
+          id: `ssh-${st.id}`,
+          label: st.name,
+          sublabel: `${st.username}@${st.host}`,
+          href: '/ssh-hosts',
+          icon: Terminal,
+          section: 'devices' as const,
+          isOnline: st.is_online,
+        })))
+        setAssetItems(data.assets.map((asset: SearchAsset) => ({
+          id: `asset-${asset.id}`,
+          label: asset.name,
+          sublabel: asset.location || asset.asset_type || undefined,
+          href: '/assets',
+          icon: Package,
+          section: 'devices' as const,
+        })))
       } catch {
         setDeviceItems([])
+        setAgentItems([])
+        setSshItems([])
+        setAssetItems([])
       }
     }, 200)
 
@@ -109,7 +150,7 @@ export function CommandPalette() {
   // ── Reset active index when items change ──
   useEffect(() => {
     setActiveIndex(0)
-  }, [query, deviceItems.length])
+  }, [query, deviceItems.length, agentItems.length, sshItems.length, assetItems.length])
 
   // ── Scroll active item into view ──
   useEffect(() => {
@@ -160,6 +201,9 @@ export function CommandPalette() {
   // Build sections for rendering
   const pagesSection = filteredPages
   const devicesSection = deviceItems
+  const agentsSection = agentItems
+  const sshSection = sshItems
+  const assetsSection = assetItems
 
   let runningIdx = 0
 
@@ -181,7 +225,7 @@ export function CommandPalette() {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search devices, pages..."
+            placeholder="Search devices, agents, SSH hosts, assets..."
             className="flex-1 bg-transparent text-lg text-white placeholder-slate-500 outline-none"
           />
           <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-[11px] font-medium text-slate-400">
@@ -228,6 +272,7 @@ export function CommandPalette() {
               </div>
               {devicesSection.map((item) => {
                 const idx = runningIdx++
+                const Icon = item.icon
                 return (
                   <button
                     key={item.id}
@@ -240,6 +285,7 @@ export function CommandPalette() {
                     onClick={() => handleSelect(item)}
                     onMouseEnter={() => setActiveIndex(idx)}
                   >
+                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
                     <span
                       className={`inline-block h-2 w-2 shrink-0 rounded-full ${
                         item.isOnline
@@ -250,6 +296,116 @@ export function CommandPalette() {
                     <span className="font-mono tabular-nums">{item.label}</span>
                     {item.sublabel && (
                       <span className="text-slate-500">({item.sublabel})</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          {/* Agents section */}
+          {agentsSection.length > 0 && (
+            <div className="mt-2">
+              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Agents
+              </div>
+              {agentsSection.map((item) => {
+                const idx = runningIdx++
+                const Icon = item.icon
+                return (
+                  <button
+                    key={item.id}
+                    data-active={activeIndex === idx}
+                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                      activeIndex === idx
+                        ? 'bg-slate-800 text-white'
+                        : 'text-slate-300 hover:bg-slate-800/50'
+                    }`}
+                    onClick={() => handleSelect(item)}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                  >
+                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
+                    <span
+                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                        item.isOnline
+                          ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
+                          : 'bg-slate-500'
+                      }`}
+                    />
+                    <span>{item.label}</span>
+                    {item.sublabel && (
+                      <span className="text-slate-500">({item.sublabel})</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          {/* SSH Hosts section */}
+          {sshSection.length > 0 && (
+            <div className="mt-2">
+              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                SSH Hosts
+              </div>
+              {sshSection.map((item) => {
+                const idx = runningIdx++
+                const Icon = item.icon
+                return (
+                  <button
+                    key={item.id}
+                    data-active={activeIndex === idx}
+                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                      activeIndex === idx
+                        ? 'bg-slate-800 text-white'
+                        : 'text-slate-300 hover:bg-slate-800/50'
+                    }`}
+                    onClick={() => handleSelect(item)}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                  >
+                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
+                    <span
+                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                        item.isOnline
+                          ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
+                          : 'bg-slate-500'
+                      }`}
+                    />
+                    <span>{item.label}</span>
+                    {item.sublabel && (
+                      <span className="text-slate-500 font-mono text-xs">{item.sublabel}</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          {/* Assets section */}
+          {assetsSection.length > 0 && (
+            <div className="mt-2">
+              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Assets
+              </div>
+              {assetsSection.map((item) => {
+                const idx = runningIdx++
+                const Icon = item.icon
+                return (
+                  <button
+                    key={item.id}
+                    data-active={activeIndex === idx}
+                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                      activeIndex === idx
+                        ? 'bg-slate-800 text-white'
+                        : 'text-slate-300 hover:bg-slate-800/50'
+                    }`}
+                    onClick={() => handleSelect(item)}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                  >
+                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
+                    <span>{item.label}</span>
+                    {item.sublabel && (
+                      <span className="text-slate-500 text-xs">({item.sublabel})</span>
                     )}
                   </button>
                 )

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { Bell, Settings, Lock, LogOut } from "lucide-react";
+import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
 import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, logout } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
 import { timeAgo } from "@/lib/format";
-import type { SearchResponse, SearchDevice, SearchAgent, SearchAlert, Alert } from "@/lib/types";
+import type { SearchResponse, SearchDevice, SearchAgent, SearchAlert, SearchSshTarget, SearchAsset, Alert } from "@/lib/types";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -100,6 +100,12 @@ export function TopBar() {
     for (const a of results.agents) {
       items.push({ type: "agent", id: a.id, label: a.name || a.id });
     }
+    for (const st of results.ssh_targets) {
+      items.push({ type: "ssh_target", id: st.id, label: st.name });
+    }
+    for (const asset of results.assets) {
+      items.push({ type: "asset", id: asset.id, label: asset.name });
+    }
     for (const al of results.alerts) {
       items.push({ type: "alert", id: al.id, label: al.message });
     }
@@ -147,6 +153,10 @@ export function TopBar() {
       router.push(`/devices?highlight=${id}`);
     } else if (type === "agent") {
       router.push(`/agents`);
+    } else if (type === "ssh_target") {
+      router.push(`/ssh-hosts`);
+    } else if (type === "asset") {
+      router.push(`/assets`);
     } else if (type === "alert") {
       router.push(`/alerts`);
     }
@@ -187,7 +197,7 @@ export function TopBar() {
 
   const hasResults =
     results &&
-    (results.devices.length > 0 || results.agents.length > 0 || results.alerts.length > 0);
+    (results.devices.length > 0 || results.agents.length > 0 || results.ssh_targets.length > 0 || results.assets.length > 0 || results.alerts.length > 0);
   const noResults = results && !hasResults;
 
   // Track running index across sections for keyboard nav
@@ -238,6 +248,7 @@ export function TopBar() {
                           onClick={() => navigateTo("device", d.id)}
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
+                          <Monitor className="h-4 w-4 shrink-0 text-slate-400" />
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
                               d.is_online
@@ -246,7 +257,7 @@ export function TopBar() {
                             }`}
                           />
                           <span className="font-mono tabular-nums text-white">
-                            {d.ip_address || d.mac_address}
+                            {d.name || d.ip_address || d.mac_address}
                           </span>
                           {d.hostname && (
                             <span className="text-slate-500">({d.hostname})</span>
@@ -277,6 +288,7 @@ export function TopBar() {
                           onClick={() => navigateTo("agent", a.id)}
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
+                          <Cpu className="h-4 w-4 shrink-0 text-slate-400" />
                           <span
                             className={`inline-block h-2 w-2 rounded-full ${
                               a.is_online
@@ -287,6 +299,70 @@ export function TopBar() {
                           <span className="text-white">{a.name || a.id}</span>
                           {a.hostname && (
                             <span className="text-slate-500">({a.hostname})</span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* SSH Hosts */}
+                {results.ssh_targets.length > 0 && (
+                  <div>
+                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                      SSH Hosts
+                    </div>
+                    {results.ssh_targets.map((st: SearchSshTarget) => {
+                      const idx = runningIndex++;
+                      return (
+                        <button
+                          key={st.id}
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-800/60 ${
+                            activeIndex === idx ? "bg-slate-800/60" : ""
+                          }`}
+                          onClick={() => navigateTo("ssh_target", st.id)}
+                          onMouseEnter={() => setActiveIndex(idx)}
+                        >
+                          <Terminal className="h-4 w-4 shrink-0 text-slate-400" />
+                          <span
+                            className={`inline-block h-2 w-2 rounded-full ${
+                              st.is_online
+                                ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                                : "bg-slate-500"
+                            }`}
+                          />
+                          <span className="text-white">{st.name}</span>
+                          <span className="text-slate-500 font-mono text-xs">
+                            {st.username}@{st.host}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Assets */}
+                {results.assets.length > 0 && (
+                  <div>
+                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                      Assets
+                    </div>
+                    {results.assets.map((asset: SearchAsset) => {
+                      const idx = runningIndex++;
+                      return (
+                        <button
+                          key={asset.id}
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-slate-800/60 ${
+                            activeIndex === idx ? "bg-slate-800/60" : ""
+                          }`}
+                          onClick={() => navigateTo("asset", asset.id)}
+                          onMouseEnter={() => setActiveIndex(idx)}
+                        >
+                          <Package className="h-4 w-4 shrink-0 text-slate-400" />
+                          <span className="text-white">{asset.name}</span>
+                          <span className="text-slate-500 text-xs">{asset.asset_type}</span>
+                          {asset.location && (
+                            <span className="ml-auto text-xs text-slate-600">{asset.location}</span>
                           )}
                         </button>
                       );

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -539,6 +539,7 @@ export interface SearchDevice {
   id: string;
   ip_address: string | null;
   hostname: string | null;
+  name: string | null;
   mac_address: string;
   vendor: string | null;
   is_online: boolean;
@@ -558,10 +559,28 @@ export interface SearchAlert {
   created_at: string;
 }
 
+export interface SearchSshTarget {
+  id: string;
+  name: string;
+  host: string;
+  username: string;
+  is_online: boolean;
+}
+
+export interface SearchAsset {
+  id: string;
+  name: string;
+  asset_type: string;
+  location: string | null;
+  serial_number: string | null;
+}
+
 export interface SearchResponse {
   devices: SearchDevice[];
   agents: SearchAgent[];
   alerts: SearchAlert[];
+  ssh_targets: SearchSshTarget[];
+  assets: SearchAsset[];
 }
 
 // ─── Audit Log ─────────────────────────────────────────


### PR DESCRIPTION
Closes #169

## Summary
- Extended the global search API (`GET /api/v1/search`) to include **SSH targets** and **assets** alongside existing devices, agents, and alerts
- Added device name/custom_name to device search (previously only searched IP, MAC, hostname, vendor)
- SSH targets are searchable by name, host, and username
- Assets are searchable by name, location, owner, serial number, and tags
- Updated the **TopBar search dropdown** with type icons (Monitor, Cpu, Terminal, Package) for each entity type and new SSH Hosts / Assets sections
- Updated the **CommandPalette** (Cmd+K / Ctrl+K) to show all entity types with icons and proper navigation
- Added unit tests for SSH target and asset search

## Changes
- `server/src/api/search.rs` — Added `SearchSshTarget`, `SearchAsset` structs; extended `SearchResponse`; added SQL queries and test helpers + tests
- `web/src/lib/types.ts` — Added `SearchSshTarget`, `SearchAsset` interfaces; extended `SearchResponse`
- `web/src/components/layout/TopBar.tsx` — Added SSH Hosts and Assets sections with type icons; updated navigation and keyboard nav
- `web/src/components/CommandPalette.tsx` — Added Agents, SSH Hosts, Assets sections with type icons from search results

## Test plan
- [x] All 10 search unit tests pass (`cargo test -- search`)
- [ ] Verify search dropdown shows devices, agents, SSH hosts, assets with correct icons
- [ ] Verify Cmd+K / Ctrl+K command palette shows all entity types
- [ ] Verify keyboard navigation works across all sections
- [ ] Verify clicking results navigates to correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extended global search to include SSH targets and assets alongside existing devices, agents, and alerts. Added device `name`/`custom_name` to device search. Updated both TopBar search dropdown and CommandPalette (Cmd+K) with new entity type sections and icons (Monitor, Cpu, Terminal, Package).

**Key changes:**
- Backend: Added `SearchSshTarget` and `SearchAsset` structs with SQL queries searching by name, host, username, location, serial number, and tags
- Frontend: Added corresponding TypeScript interfaces and integrated into search UI with proper icons and navigation
- Tests: Added 4 new unit tests covering SSH target and asset search scenarios

**Issues found:**
- SSH online status query uses `MAX(id)` instead of `MAX(reported_at)`, which could select stale reports if inserts are out of order
- Keyboard navigation label fallback in TopBar uses `hostname` but display uses `name`, causing visual mismatch during arrow key navigation

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the two logic issues (SSH online status query and keyboard nav label mismatch)
- Implementation is clean with proper SQL parameter binding (no injection risk) and good type safety between frontend/backend. Two medium-severity logic bugs need fixing: the SSH online status subquery could select stale reports, and keyboard navigation labels don't match display rendering. Tests are well-written and comprehensive.
- Pay close attention to `server/src/api/search.rs` (SSH online status query) and `web/src/components/layout/TopBar.tsx` (keyboard nav label)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/search.rs | Added SSH targets and assets to search with new structs, queries, and tests. Query uses MAX(id) instead of MAX(reported_at) for SSH online status which could select stale reports. |
| web/src/components/layout/TopBar.tsx | Extended search dropdown with SSH hosts and assets sections. Keyboard nav label (line 98) uses hostname fallback but display (line 260) uses name, causing mismatch. |
| web/src/components/CommandPalette.tsx | Added agents, SSH hosts, and assets sections with proper icons and navigation. Clean implementation with consistent state management. |
| web/src/lib/types.ts | Added SearchSshTarget and SearchAsset interfaces matching backend structs perfectly. Type definitions are clean and consistent. |

</details>



<sub>Last reviewed commit: 818f3c7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->