### PR TITLE
feat: add MikroTik to settings nav, mark VyOS as optional

### DIFF
--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -32,11 +32,18 @@ const settingsGroups: SettingsGroup[] = [
     label: "Integrations",
     items: [
       {
+        href: "/settings/mikrotik",
+        icon: <Router className="h-4 w-4 text-red-400" />,
+        iconBg: "bg-red-500/10",
+        title: "MikroTik",
+        description: "Configure MikroTik router integration.",
+      },
+      {
         href: "/settings/router",
         icon: <Router className="h-4 w-4 text-blue-400" />,
         iconBg: "bg-blue-500/10",
-        title: "Router",
-        description: "Configure VyOS or MikroTik router integration.",
+        title: "VyOS Router",
+        description: "Optional: configure VyOS router integration.",
       },
       {
         href: "/settings/npm",

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -481,15 +481,8 @@ export default function RouterSettingsPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <Tabs defaultValue="vyos">
+            <Tabs defaultValue="mikrotik">
               <TabsList className="mb-4 w-full border-slate-800 bg-slate-950">
-                <TabsTrigger
-                  value="vyos"
-                  className="flex-1 data-[state=active]:bg-blue-600 data-[state=active]:text-white"
-                >
-                  <Router className="mr-1.5 h-3.5 w-3.5" />
-                  VyOS
-                </TabsTrigger>
                 <TabsTrigger
                   value="mikrotik"
                   className="flex-1 data-[state=active]:bg-pink-600 data-[state=active]:text-white"
@@ -497,12 +490,19 @@ export default function RouterSettingsPage() {
                   <Router className="mr-1.5 h-3.5 w-3.5" />
                   MikroTik
                 </TabsTrigger>
+                <TabsTrigger
+                  value="vyos"
+                  className="flex-1 data-[state=active]:bg-blue-600 data-[state=active]:text-white"
+                >
+                  <Router className="mr-1.5 h-3.5 w-3.5" />
+                  VyOS (Optional)
+                </TabsTrigger>
               </TabsList>
-              <TabsContent value="vyos">
-                <VyosPanel />
-              </TabsContent>
               <TabsContent value="mikrotik">
                 <MikrotikPanel />
+              </TabsContent>
+              <TabsContent value="vyos">
+                <VyosPanel />
               </TabsContent>
             </Tabs>
           </CardContent>

--- a/web/src/app/(app)/settings/vyos/page.tsx
+++ b/web/src/app/(app)/settings/vyos/page.tsx
@@ -126,7 +126,12 @@ export default function VyosSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">VyOS Router</h1>
+          <h1 className="text-2xl font-semibold text-white">
+            VyOS Router
+            <span className="ml-2 rounded-full bg-slate-700 px-2 py-0.5 text-xs text-slate-400">
+              Optional
+            </span>
+          </h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">


### PR DESCRIPTION
- Add MikroTik card to Settings > Integrations grid (was only accessible via direct URL)
- MikroTik is now primary/default router integration (shown first, no Optional label)
- VyOS marked as Optional everywhere: settings card description, router page tab label, standalone VyOS settings page badge
- Router page (`/settings/router`): MikroTik tab is now default, VyOS tab labeled "VyOS (Optional)"
- No changes to backend or MikroTik settings page functionality

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repositions MikroTik as the primary router integration in the UI, demoting VyOS to optional status. The changes add a dedicated MikroTik card to the settings page (previously only accessible via direct URL), reorder the router settings tabs to show MikroTik first as the default, and consistently label VyOS as "Optional" across all three affected pages.

**Key changes:**
- Settings page: new MikroTik integration card added to grid, VyOS router card renamed and marked optional
- Router settings page: tab order swapped (MikroTik now default), VyOS tab labeled "(Optional)"
- VyOS settings page: "Optional" badge added to page title

**Minor inconsistency:** The Audit Log and Config Backup descriptions in `settings/page.tsx` still reference only VyOS ("View all VyOS configuration changes" and "restore VyOS router configurations"), which may become outdated as MikroTik becomes the primary integration.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with very low risk - purely UI/labeling changes
- The changes are straightforward UI modifications with no logic changes or backend impact. The only concern is minor inconsistency in descriptions that still reference VyOS specifically when other features may support MikroTik in the future.
- No files require special attention - all changes are simple UI updates

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/page.tsx | Added MikroTik card to settings grid, marked VyOS as optional; note that Audit Log and Config Backup descriptions still reference only VyOS |
| web/src/app/(app)/settings/router/page.tsx | Swapped tab order to make MikroTik default, added (Optional) label to VyOS tab - clean implementation |
| web/src/app/(app)/settings/vyos/page.tsx | Added Optional badge to VyOS Router page title - simple, clean change |

</details>



<sub>Last reviewed commit: 6719d66</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->