### PR TITLE
fix: default router tab to MikroTik, lazy-load VyOS

### DIFF
--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -4986,11 +4986,11 @@ export default function RouterPage() {
   const [loading, setLoading] = useState(true);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("vyos");
+  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("mikrotik");
 
+  // Load settings to determine which routers are configured
   useEffect(() => {
-    const loadAll = async () => {
-      // Load settings to check which routers are configured
+    const loadSettings = async () => {
       let mtEnabled = false;
       let vyosConf = false;
       try {
@@ -5003,12 +5003,24 @@ export default function RouterPage() {
       setMikrotikEnabled(mtEnabled);
       setVyosConfigured(vyosConf);
 
-      // Auto-select the right tab
-      if (mtEnabled && !vyosConf) {
+      // Default to mikrotik if enabled, fallback to vyos only if mikrotik not available
+      if (mtEnabled) {
         setRouterType("mikrotik");
+      } else if (vyosConf) {
+        setRouterType("vyos");
       }
 
-      // Load VyOS summary
+      setLoading(false);
+    };
+    loadSettings();
+  }, []);
+
+  // Lazy-load VyOS summary only when VyOS tab is selected
+  useEffect(() => {
+    if (routerType !== "vyos") return;
+    if (summary) return; // already loaded
+
+    const loadVyosSummary = async () => {
       try {
         const s = await fetchRouterSummary();
         setSummary(s);
@@ -5027,10 +5039,9 @@ export default function RouterPage() {
           wireguard: [],
         });
       }
-      setLoading(false);
     };
-    loadAll();
-  }, []);
+    loadVyosSummary();
+  }, [routerType, summary]);
 
   if (loading) {
     return (
@@ -5042,7 +5053,7 @@ export default function RouterPage() {
   }
 
   const bothConfigured = vyosConfigured && mikrotikEnabled;
-  const neitherConfigured = !summary?.status.configured && !mikrotikEnabled;
+  const neitherConfigured = !vyosConfigured && !mikrotikEnabled;
 
   if (neitherConfigured) {
     return <PageTransition><NotConfigured /></PageTransition>;
@@ -5054,19 +5065,6 @@ export default function RouterPage() {
         {/* Router type selector — only shown if both are configured */}
         {bothConfigured && (
           <div className="flex gap-2">
-            <Button
-              variant={routerType === "vyos" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("vyos")}
-              className={
-                routerType === "vyos"
-                  ? "bg-blue-600 text-white hover:bg-blue-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              VyOS
-            </Button>
             <Button
               variant={routerType === "mikrotik" ? "default" : "outline"}
               size="sm"
@@ -5080,15 +5078,33 @@ export default function RouterPage() {
               <Router className="mr-1.5 h-3.5 w-3.5" />
               MikroTik
             </Button>
+            <Button
+              variant={routerType === "vyos" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setRouterType("vyos")}
+              className={
+                routerType === "vyos"
+                  ? "bg-blue-600 text-white hover:bg-blue-500"
+                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+              }
+            >
+              <Router className="mr-1.5 h-3.5 w-3.5" />
+              VyOS (Optional)
+            </Button>
           </div>
         )}
 
-        {routerType === "vyos" && summary?.status.configured ? (
+        {routerType === "mikrotik" && mikrotikEnabled ? (
+          <MikrotikRouter />
+        ) : routerType === "vyos" && !summary ? (
+          <div className="space-y-6">
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-96 w-full" />
+          </div>
+        ) : routerType === "vyos" && summary?.status.configured ? (
           <Suspense fallback={null}>
             <RouterTabs summary={summary} />
           </Suspense>
-        ) : routerType === "mikrotik" && mikrotikEnabled ? (
-          <MikrotikRouter />
         ) : routerType === "vyos" ? (
           <NotConfigured />
         ) : null}


### PR DESCRIPTION
- MikroTik is now default/primary router tab
- VyOS data only fetches when VyOS tab is selected (fixes slow initial load)
- VyOS labeled as Optional in tab
- MikroTik button appears first in tab selector

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes MikroTik the default/primary router tab and introduces lazy-loading for VyOS data. The VyOS summary is no longer fetched on initial page load — it's deferred until the user actually selects the VyOS tab, improving load performance when MikroTik is the primary router.

- Splits the single `useEffect` into two: one for loading settings (determines which routers are configured) and a second that lazy-loads VyOS data only when the VyOS tab is active
- Changes the default `routerType` state from `"vyos"` to `"mikrotik"` and reorders tab selector buttons to put MikroTik first
- Fixes `neitherConfigured` to use `vyosConfigured` (from settings) instead of `summary?.status.configured`, which is necessary since `summary` may now be `null` when VyOS data hasn't been lazy-loaded yet
- Adds a skeleton loading state for the VyOS tab while its data is being fetched

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a focused UI/UX improvement with correct handling of all router configuration scenarios.
- The changes are well-structured and correctly handle all configuration permutations (both configured, only MikroTik, only VyOS, neither). The lazy-loading pattern is properly implemented with appropriate guard clauses and a loading skeleton. The `neitherConfigured` logic fix is a necessary consequence of the lazy-loading change. One minor note: `summary` in the second useEffect's dependency array is technically redundant (the effect early-returns when summary is truthy), but this is harmless.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/router/page.tsx | Defaults router tab to MikroTik, splits VyOS data fetching into a separate lazy-loading useEffect, reorders tab buttons, and fixes `neitherConfigured` logic to use settings-derived `vyosConfigured` instead of `summary?.status.configured`. Clean refactor with correct handling of all configuration scenarios. |

</details>



<sub>Last reviewed commit: 1fb584e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->