### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panoptikon-agent"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "panoptikon-server"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["server", "agent"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/BeFeast/panoptikon"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptikon-web",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -186,7 +186,7 @@ export function Sidebar() {
                   </TooltipContent>
                 </Tooltip>
               )}
-              <p className="text-[10px] text-slate-700">Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.1.0"}</p>
+              <p className="text-[10px] text-slate-700">Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.5.0"}</p>
             </div>
           ) : (
             <div className="mt-1 flex flex-col items-center gap-1">


### PR DESCRIPTION
Bump project version from 0.1.0 to 0.5.0 — 200+ PRs merged, actively deployed in production.

### Changes
- `Cargo.toml` workspace version: 0.1.0 → 0.5.0
- `web/package.json` version: 0.1.0 → 0.5.0
- Sidebar fallback version string: v0.1.0 → v0.5.0
- Cargo.lock updated accordingly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Version bump from 0.1.0 to 0.5.0 across Rust workspace and web frontend, reflecting 200+ merged PRs and production deployment.

- Updated workspace version in `Cargo.toml` and propagated to `Cargo.lock`
- Updated npm package version in `web/package.json`
- Updated fallback version string in Sidebar component
- `package-lock.json` needs regeneration to sync with new package version

<h3>Confidence Score: 4/5</h3>

- Safe to merge after regenerating package-lock.json to maintain consistency
- All version strings correctly updated to 0.5.0 across Rust and JavaScript ecosystems, but package-lock.json should be regenerated for complete consistency
- web/package.json requires running npm install to update package-lock.json

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Workspace version updated from 0.1.0 to 0.5.0 |
| Cargo.lock | Lock file automatically updated to reflect new workspace version |
| web/package.json | Package version updated from 0.1.0 to 0.5.0, but package-lock.json not updated |
| web/src/components/layout/Sidebar.tsx | Fallback version string updated from v0.1.0 to v0.5.0 |

</details>



<sub>Last reviewed commit: ccbcab4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->