### PR TITLE
feat: docs: update README — MikroTik as primary router, VyOS optional (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *The all-seeing eye for your home network.*
 
-**Panoptikon** is a self-hosted web application for managing a VyOS router and monitoring all devices on your local network. It combines device discovery (ARP scanning), router management (VyOS HTTP API), and lightweight agent-based telemetry into a single binary with a polished, dark-themed web UI inspired by Ubiquiti UniFi.
+**Panoptikon** is a self-hosted web application for monitoring all devices on your local network and managing MikroTik or VyOS routers. It combines device discovery (ARP scanning), router management, and lightweight agent-based telemetry into a single binary with a polished, dark-themed web UI inspired by Ubiquiti UniFi.
 
 ---
 
@@ -18,8 +18,9 @@
 ┌─────────────────────────────────────────────────────┐
 │                Rust API Server (axum)               │
 │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐  │
-│  │ REST API │ │ WS Hub   │ │ Scanner  │ │ VyOS   │  │
-│  │          │ │          │ │ (ARP)    │ │ Client │  │ 
+│  │ REST API │ │ WS Hub   │ │ Scanner  │ │ Router │  │
+│  │          │ │          │ │ (ARP)    │ │ Client │  │
+│  │          │ │          │ │          │ │MT/VyOS │  │
 │  └──────────┘ └──────────┘ └──────────┘ └────────┘  │
 │                     │                               │
 │              ┌──────┴──────┐                        │
@@ -67,8 +68,8 @@ cargo build --release -p panoptikon-agent
 
 ```bash
 cd web
-npm install
-npm run dev
+bun install
+bun run dev
 # Open http://localhost:3000
 ```
 
@@ -76,10 +77,17 @@ npm run dev
 
 ```
 panoptikon/
-├── server/     # Rust axum backend (REST API, WebSocket hub, ARP scanner, VyOS client)
+├── server/     # Rust axum backend (REST API, WebSocket hub, ARP scanner, MikroTik + VyOS router clients)
 ├── agent/      # Rust lightweight agent (system metrics collector)
 └── web/        # Next.js 15 frontend (shadcn/ui, dark theme)
 ```
+
+## Router Integration
+
+Panoptikon supports two router platforms:
+
+- **MikroTik (primary)** — connects via the RouterOS 7+ REST API. Configure in **Settings → MikroTik**.
+- **VyOS (optional)** — connects via the VyOS HTTP API. Configure in **Settings → Router**.
 
 ## Prometheus Integration
 


### PR DESCRIPTION
Closes #210

## Summary
- Updated opening description to reflect MikroTik as the primary router integration and VyOS as optional
- Updated architecture diagram: `VyOS Client` → `Router Client (MT/VyOS)`
- Updated project structure description to mention MikroTik + VyOS router clients
- Changed `npm install` / `npm run dev` → `bun install` / `bun run dev` in Quick Start
- Added new **Router Integration** section explaining both supported platforms and where to configure them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated documentation to reflect MikroTik as the primary router integration with VyOS as an optional secondary platform. Changed package manager commands from npm to bun in Quick Start section, updated architecture diagram to show unified Router Client supporting both platforms, and added new Router Integration section explaining configuration paths for both routers.

- Updated opening description to position MikroTik first, VyOS as optional
- Architecture diagram now shows `Router Client (MT/VyOS)` instead of `VyOS Client`
- Project structure comment updated to mention both MikroTik and VyOS router clients
- Quick Start commands changed from `npm` to `bun`
- New Router Integration section added with configuration paths verified against actual codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — purely documentation changes
- All changes are documentation-only updates to README.md that accurately reflect existing MikroTik implementation in the codebase. Navigation paths for settings were verified against actual code. The shift from npm to bun commands aligns with the project having bun.lock present. No code logic or functionality is modified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Documentation updated to reflect MikroTik as primary router with VyOS as optional, changed npm to bun commands, added Router Integration section |

</details>



<sub>Last reviewed commit: 22b5de6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->