### PR TITLE
feat: router page — MikroTik as default tab, VyOS lazy-loaded (#218)

### DIFF
--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -163,6 +163,36 @@ function NotConfigured() {
   );
 }
 
+function VyosNotConfigured() {
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center">
+      <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+        <CardContent className="flex flex-col items-center gap-4 py-12">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-800">
+            <Router className="h-8 w-8 text-slate-500" />
+          </div>
+          <h1 className="text-xl font-semibold text-white">
+            VyOS Not Configured
+          </h1>
+          <p className="text-center text-sm text-slate-500">
+            VyOS is optional. To enable it, add the VyOS URL and API key in
+            Settings.
+          </p>
+          <Link href="/settings/vyos">
+            <Button
+              variant="outline"
+              className="border-slate-800 text-slate-300 hover:bg-slate-800"
+            >
+              <Settings className="mr-2 h-4 w-4" />
+              Configure VyOS
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 // ── Status Header ───────────────────────────────────────
 
 function StatusHeader({ status }: { status: RouterStatus }) {
@@ -5043,16 +5073,15 @@ export default function RouterPage() {
     loadVyosSummary();
   }, [routerType, summary]);
 
-  const bothConfigured = settingsLoaded && vyosConfigured && mikrotikEnabled;
   const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, buttons if both configured */}
+        {/* Router type selector — skeleton while settings load, tabs when MikroTik is enabled */}
         {!settingsLoaded ? (
           <Skeleton className="h-9 w-48" />
-        ) : bothConfigured ? (
+        ) : mikrotikEnabled ? (
           <div className="flex gap-2">
             <Button
               variant={routerType === "mikrotik" ? "default" : "outline"}
@@ -5093,6 +5122,8 @@ export default function RouterPage() {
           <NotConfigured />
         ) : routerType === "mikrotik" && mikrotikEnabled ? (
           <MikrotikRouter />
+        ) : routerType === "vyos" && !vyosConfigured ? (
+          <VyosNotConfigured />
         ) : routerType === "vyos" && !summary ? (
           <div className="space-y-6">
             <Skeleton className="h-10 w-64" />
@@ -5103,7 +5134,7 @@ export default function RouterPage() {
             <RouterTabs summary={summary} />
           </Suspense>
         ) : routerType === "vyos" ? (
-          <NotConfigured />
+          <VyosNotConfigured />
         ) : null}
       </div>
     </PageTransition>


### PR DESCRIPTION
## Summary
- Always show MikroTik/VyOS tab selector when MikroTik is enabled (not only when both are configured)
- VyOS tab shows a graceful "VyOS Not Configured" empty state with link to `/settings/vyos` when VyOS isn't set up
- MikroTik remains first tab and default selection
- VyOS data still lazy-loaded only when VyOS tab is clicked

## Test plan
- [ ] With MikroTik enabled + VyOS configured: both tabs visible, MikroTik loads first, VyOS loads on click
- [ ] With MikroTik enabled + VyOS NOT configured: both tabs visible, VyOS tab shows "VyOS Not Configured" card
- [ ] With neither configured: shows generic "Router Not Configured" card
- [ ] With only VyOS configured: shows VyOS content directly (no tabs)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements graceful empty state for VyOS by adding a new `VyosNotConfigured` component and updating the router tab logic to always display MikroTik/VyOS tabs when MikroTik is enabled (previously only shown when both were configured).

**Key Changes:**
- Added `VyosNotConfigured` component with link to `/settings/vyos` for optional VyOS configuration
- Changed tab display condition from `bothConfigured` to `mikrotikEnabled` — tabs now show when only MikroTik is enabled
- VyOS tab shows empty state when clicked without VyOS configured
- Updated conditional rendering logic to handle new VyOS-not-configured scenario

**Issues Found:**
- Lazy-load `useEffect` (line 5049) doesn't check `vyosConfigured` before attempting API call — will make unnecessary failing request when VyOS tab is clicked without VyOS configured

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logic fix needed — unnecessary API call when VyOS unconfigured
- The implementation correctly adds the VyOS empty state UI and updates tab display logic, but contains a logical flaw where the lazy-load effect will trigger API calls even when VyOS is not configured, causing unnecessary network requests and error handling
- Pay attention to `web/src/app/(app)/router/page.tsx` — fix lazy-load effect to check `vyosConfigured` before API call

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/router/page.tsx | Added `VyosNotConfigured` component and updated tab logic to always show MikroTik/VyOS tabs when MikroTik is enabled. Critical issue: lazy-load effect makes unnecessary API call when VyOS isn't configured. |

</details>



<sub>Last reviewed commit: 03e44d3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->