### PR TITLE
feat: dashboard — device status sparklines (online/offline history) (#219)

### DIFF
--- a/server/src/api/devices.rs
+++ b/server/src/api/devices.rs
@@ -118,6 +118,10 @@ pub struct Device {
     /// Serial number (manual entry)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub serial_number: Option<String>,
+    /// 24-hour online/offline status timeline (one boolean per hour, oldest first).
+    /// Only populated on the list endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_timeline: Option<Vec<bool>>,
 }
 
 /// Request body for creating a device.
@@ -233,6 +237,7 @@ impl Device {
             purchase_date: row.try_get("purchase_date").unwrap_or(None),
             warranty_expiry: row.try_get("warranty_expiry").unwrap_or(None),
             serial_number: row.try_get("serial_number").unwrap_or(None),
+            status_timeline: None,
         })
     }
 }
@@ -294,6 +299,92 @@ pub async fn list(State(state): State<AppState>) -> Result<Json<Vec<Device>>, St
             if let Some(dev) = devices.iter_mut().find(|d| d.id == device_id) {
                 dev.ips.push(ip);
             }
+        }
+    }
+
+    // Compute 24-hour status timeline (24 hourly buckets) for all devices.
+    if !devices.is_empty() {
+        let now = chrono::Utc::now();
+        let cutoff = now - chrono::Duration::hours(24);
+        let cutoff_str = cutoff.to_rfc3339();
+
+        // Fetch all events in the 24h window
+        let event_rows = sqlx::query(
+            r#"SELECT device_id, event_type, occurred_at
+               FROM device_events
+               WHERE occurred_at >= ?
+               ORDER BY device_id, occurred_at ASC"#,
+        )
+        .bind(&cutoff_str)
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+
+        // Fetch the last event before the 24h window for each device (initial state)
+        let prior_rows = sqlx::query(
+            r#"SELECT e.device_id, e.event_type
+               FROM device_events e
+               INNER JOIN (
+                   SELECT device_id, MAX(occurred_at) AS max_at
+                   FROM device_events
+                   WHERE occurred_at < ?
+                   GROUP BY device_id
+               ) latest ON e.device_id = latest.device_id AND e.occurred_at = latest.max_at"#,
+        )
+        .bind(&cutoff_str)
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+
+        // Build maps
+        let mut prior_state: std::collections::HashMap<String, bool> =
+            std::collections::HashMap::new();
+        for row in &prior_rows {
+            let did: String = row.try_get("device_id").unwrap_or_default();
+            let etype: String = row.try_get("event_type").unwrap_or_default();
+            prior_state.insert(did, etype == "online");
+        }
+
+        let mut events_by_device: std::collections::HashMap<
+            String,
+            Vec<(chrono::DateTime<chrono::Utc>, bool)>,
+        > = std::collections::HashMap::new();
+        for row in &event_rows {
+            let did: String = row.try_get("device_id").unwrap_or_default();
+            let etype: String = row.try_get("event_type").unwrap_or_default();
+            let occurred_str: String = row.try_get("occurred_at").unwrap_or_default();
+            let occurred = chrono::DateTime::parse_from_rfc3339(&occurred_str)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .or_else(|_| {
+                    chrono::NaiveDateTime::parse_from_str(&occurred_str, "%Y-%m-%d %H:%M:%S")
+                        .map(|ndt| ndt.and_utc())
+                })
+                .unwrap_or(now);
+            events_by_device
+                .entry(did)
+                .or_default()
+                .push((occurred, etype == "online"));
+        }
+
+        // Compute 24 hourly buckets per device
+        for dev in devices.iter_mut() {
+            let mut current = *prior_state.get(&dev.id).unwrap_or(&false);
+            let events = events_by_device.get(&dev.id);
+            let mut timeline = Vec::with_capacity(24);
+            let mut event_idx = 0usize;
+
+            for hour in 0..24 {
+                let bucket_start = cutoff + chrono::Duration::hours(hour);
+                // Advance through events up to bucket_start
+                if let Some(evts) = events {
+                    while event_idx < evts.len() && evts[event_idx].0 <= bucket_start {
+                        current = evts[event_idx].1;
+                        event_idx += 1;
+                    }
+                }
+                timeline.push(current);
+            }
+            dev.status_timeline = Some(timeline);
         }
     }
 
@@ -486,6 +577,7 @@ pub async fn create(
         purchase_date: body.purchase_date,
         warranty_expiry: body.warranty_expiry,
         serial_number: body.serial_number,
+        status_timeline: None,
     };
 
     Ok((StatusCode::CREATED, Json(device)))

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -52,6 +52,7 @@ import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
 import { MotionCard } from "@/components/MotionCard";
 import { DeviceTrafficChart } from "@/components/DeviceTrafficChart";
+import { StatusSparkline } from "@/components/StatusSparkline";
 
 import { downloadExport } from "@/lib/export";
 
@@ -578,6 +579,13 @@ function DeviceCard({
           <p className="font-mono tabular-nums text-xs text-slate-600">{device.mac}</p>
         </div>
 
+        {/* 24-hour status sparkline */}
+        {device.status_timeline && device.status_timeline.length > 0 && (
+          <div className="mt-2">
+            <StatusSparkline timeline={device.status_timeline} width={160} height={12} />
+          </div>
+        )}
+
         {/* mDNS service badges */}
         {device.mdns_services && (
           <div className="mt-2 flex flex-wrap gap-1">
@@ -692,6 +700,7 @@ function DevicesTable({
             <TableHead className="text-slate-400">MAC</TableHead>
             <TableHead className="text-slate-400">Vendor</TableHead>
             <TableHead className="text-slate-400">Agent</TableHead>
+            <TableHead className="text-slate-400">24h Status</TableHead>
             <TableHead
               className="cursor-pointer select-none text-slate-400 hover:text-white"
               onClick={() => onSort("last_seen_at")}
@@ -766,6 +775,13 @@ function DevicesTable({
                   {device.agent && device.agent.cpu_percent != null && device.agent.memory_percent != null
                     ? `${formatPercent(device.agent.cpu_percent)} / ${formatPercent(device.agent.memory_percent)}`
                     : "—"}
+                </TableCell>
+                <TableCell>
+                  {device.status_timeline && device.status_timeline.length > 0 ? (
+                    <StatusSparkline timeline={device.status_timeline} width={72} height={10} />
+                  ) : (
+                    <span className="text-xs text-slate-600">—</span>
+                  )}
                 </TableCell>
                 <TableCell className="text-xs text-slate-500">
                   {timeAgo(device.last_seen_at)}

--- a/web/src/components/StatusSparkline.tsx
+++ b/web/src/components/StatusSparkline.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * StatusSparkline — 24 vertical bars showing device online/offline history.
+ * Green (#10b981) = online, red/slate (#334155) = offline.
+ */
+export function StatusSparkline({
+  timeline,
+  width = 96,
+  height = 16,
+}: {
+  timeline: boolean[];
+  width?: number;
+  height?: number;
+}) {
+  if (timeline.length === 0) return null;
+
+  const bars = timeline.length;
+  const gap = 1;
+  const barWidth = (width - gap * (bars - 1)) / bars;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="block"
+      aria-label="24-hour status history"
+    >
+      {timeline.map((online, i) => (
+        <rect
+          key={i}
+          x={i * (barWidth + gap)}
+          y={0}
+          width={barWidth}
+          height={height}
+          rx={1}
+          fill={online ? "#10b981" : "#334155"}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -73,6 +73,8 @@ export interface Device {
   warranty_expiry?: string | null;
   /** Serial number (manual entry). */
   serial_number?: string | null;
+  /** 24-hour online/offline timeline (one boolean per hour, oldest first). */
+  status_timeline?: boolean[] | null;
 }
 
 // ─── Device Sysinfo (hardware inventory from agent) ───


### PR DESCRIPTION
Closes #219

## Summary
- Added `status_timeline` field to the `GET /api/v1/devices` response — an array of 24 booleans (one per hour, oldest first) indicating whether the device was online or offline during each hour of the last 24 hours
- Created `StatusSparkline` SVG component rendering 24 vertical bars (green = online, slate = offline)
- Integrated the sparkline into both the **grid card** and **table** views on the devices page

## Implementation details
- The backend computes the timeline efficiently with two SQL queries: one for all events in the 24h window, one for the prior state per device
- No extra API calls needed — timeline data is included in the existing `/api/v1/devices` response
- Pure SVG rendering (no additional chart library dependencies)

## Test plan
- [ ] Verify devices page loads and sparklines render in grid view
- [ ] Verify sparklines render in table view under "24h Status" column
- [ ] Verify green bars for online hours, dark slate bars for offline hours
- [ ] Verify devices with no event history show gracefully (no sparkline displayed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 24-hour device status sparkline feature: the backend computes a per-device boolean timeline (24 hourly buckets) from `device_events` and includes it in the existing `/api/v1/devices` list response, while the frontend renders it as a compact SVG bar chart in both grid and table views.

- Backend adds two SQL queries to the list endpoint to compute hourly online/offline buckets from event history, with a prior-state lookup for initial state
- New `StatusSparkline` SVG component renders 24 green/slate bars — no external chart library needed
- Frontend integration checks for null/empty timeline gracefully in both card and table views
- The prior-state SQL subquery can produce duplicate rows per device when events share the same timestamp, leading to non-deterministic initial state

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge; the frontend is clean but the backend timeline computation has an edge case that could produce non-deterministic results.
- The frontend changes are straightforward and well-guarded. The backend has a prior-state query that can return duplicate rows per device when events share timestamps (non-deterministic initial state), and the timeline bucketing off-by-one was already flagged in a prior review thread. These issues reduce confidence but are unlikely to cause visible bugs in most scenarios.
- `server/src/api/devices.rs` — the prior-state subquery and timeline bucketing logic need attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/devices.rs | Adds `status_timeline` field to `Device` struct and computes 24-hour bucketed online/offline timeline using two SQL queries. Prior state subquery may return duplicate rows for devices with simultaneous events; timeline bucketing off-by-one was flagged in prior review. |
| web/src/components/StatusSparkline.tsx | New pure SVG sparkline component rendering 24 vertical bars for device status history. Clean, self-contained implementation with proper empty-state handling and accessibility label. |
| web/src/app/(app)/devices/page.tsx | Integrates StatusSparkline into both grid card and table views with proper null/empty guards. Table view adds a new "24h Status" column. Clean integration. |
| web/src/lib/types.ts | Adds optional `status_timeline` field to Device interface, correctly typed as `boolean[] | null` to match the Rust backend's `Option<Vec<bool>>`. |

</details>



<sub>Last reviewed commit: 192326a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->