### PR TITLE
feat: device list — icons by device type (router, switch, AP, server, mobile) (#220)

### DIFF
--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -82,6 +82,7 @@ const ASSET_TYPES: { value: AssetType; label: string; icon: typeof Server }[] = 
   { value: "container", label: "Container", icon: Container },
   { value: "nas", label: "NAS", icon: HardDrive },
   { value: "router", label: "Router", icon: Router },
+  { value: "access_point", label: "Access Point", icon: Wifi },
   { value: "switch", label: "Switch", icon: Wifi },
   { value: "iot", label: "IoT", icon: Cpu },
   { value: "phone", label: "Phone", icon: Smartphone },

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -674,6 +674,7 @@ export default function DashboardPage() {
 function getCategoryLabel(type: DeviceType): string {
   const labels: Record<DeviceType, string> = {
     router: "Routers",
+    access_point: "Access Points",
     laptop: "Laptops",
     desktop: "Desktops",
     phone: "Phones",

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -1688,7 +1688,7 @@ function DevicePortsTab({ deviceId }: { deviceId: string }) {
 
 const DEVICE_TYPE_OPTIONS = [
   "", "server", "workstation", "desktop", "laptop", "vm", "container", "nas",
-  "router", "switch", "phone", "tablet", "printer", "iot", "ups", "tv", "gaming", "other",
+  "router", "access_point", "switch", "phone", "tablet", "printer", "iot", "ups", "tv", "gaming", "other",
 ];
 
 const OS_OPTIONS = [

--- a/web/src/components/DeviceTypeIcon.tsx
+++ b/web/src/components/DeviceTypeIcon.tsx
@@ -17,12 +17,14 @@ import {
   Smartphone,
   Tablet,
   Tv,
+  Wifi,
 } from "lucide-react";
 import type { DeviceType } from "@/lib/device-type";
 import { cn } from "@/lib/utils";
 
 const ICON_MAP: Record<DeviceType, typeof Router> = {
   router: Router,
+  access_point: Wifi,
   laptop: Laptop,
   desktop: Monitor,
   phone: Smartphone,
@@ -44,6 +46,7 @@ const ICON_MAP: Record<DeviceType, typeof Router> = {
 
 const COLOR_MAP: Record<DeviceType, string> = {
   router: "text-blue-400",
+  access_point: "text-cyan-300",
   laptop: "text-sky-400",
   desktop: "text-indigo-400",
   phone: "text-violet-400",
@@ -85,6 +88,7 @@ export function DeviceTypeIcon({ type, size = "md", className }: DeviceTypeIconP
 export function DeviceTypeLabel({ type }: { type: DeviceType }) {
   const labels: Record<DeviceType, string> = {
     router: "Router",
+    access_point: "Access Point",
     laptop: "Laptop",
     desktop: "Desktop",
     phone: "Phone",

--- a/web/src/lib/device-icons.ts
+++ b/web/src/lib/device-icons.ts
@@ -22,11 +22,13 @@ import {
   Smartphone,
   Tablet,
   Tv,
+  Wifi,
 } from "lucide-react";
 import { inferDeviceType, type DeviceType } from "./device-type";
 
 const ICON_MAP: Record<DeviceType, LucideIcon> = {
   router: Router,
+  access_point: Wifi,
   laptop: Laptop,
   desktop: Monitor,
   phone: Smartphone,
@@ -48,6 +50,7 @@ const ICON_MAP: Record<DeviceType, LucideIcon> = {
 
 const LABEL_MAP: Record<DeviceType, string> = {
   router: "Router",
+  access_point: "Access Point",
   laptop: "Laptop",
   desktop: "Desktop",
   phone: "Phone",

--- a/web/src/lib/device-type.ts
+++ b/web/src/lib/device-type.ts
@@ -5,6 +5,7 @@
 
 export type DeviceType =
   | "router"
+  | "access_point"
   | "laptop"
   | "desktop"
   | "phone"
@@ -130,8 +131,11 @@ const HOSTNAME_PATTERNS: Array<[RegExp, DeviceType]> = [
   // Printers
   [/printer|laserjet|deskjet|officejet/i, "printer"],
 
+  // Access points
+  [/\bap[-_]|access[-_]?point|eap[-_]/i, "access_point"],
+
   // Router
-  [/router|gateway|firewall|switch|ap-|unifi|ubnt/i, "router"],
+  [/router|gateway|firewall|switch|unifi|ubnt/i, "router"],
 
   // Generic computers
   [/desktop|workstation|pc-/i, "desktop"],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -833,6 +833,7 @@ export type AssetType =
   | "container"
   | "nas"
   | "router"
+  | "access_point"
   | "switch"
   | "iot"
   | "phone"


### PR DESCRIPTION
Closes #220

## Summary

- Added `access_point` as a new device type across the full frontend stack
- All device types (router, switch, access_point, server, mobile/phone, laptop/desktop, unknown) now have Lucide icon mappings displayed in the devices table, grid cards, device detail sheet, and asset detail header

## Changes

- **`web/src/lib/device-type.ts`** — Added `access_point` to `DeviceType` union; added AP-specific hostname patterns (`ap-`, `eap-`, `access_point`) separated from the router pattern
- **`web/src/lib/device-icons.ts`** — Added `Wifi` icon and "Access Point" label for `access_point` type
- **`web/src/components/DeviceTypeIcon.tsx`** — Added `access_point` to icon, color (`text-cyan-300`), and label maps
- **`web/src/lib/types.ts`** — Added `access_point` to the `AssetType` union
- **`web/src/app/(app)/assets/page.tsx`** — Added `access_point` entry to `ASSET_TYPES` config
- **`web/src/app/(app)/devices/page.tsx`** — Added `access_point` to `DEVICE_TYPE_OPTIONS` dropdown
- **`web/src/app/(app)/dashboard/page.tsx`** — Added `access_point` → "Access Points" to category labels

## Notes

The existing icon infrastructure (`getDeviceIcon()`, `DeviceTypeIcon` component) was already wired into the devices table, grid cards, device detail sheet, and asset detail header. This PR completes the feature by adding the missing `access_point` device type requested in the issue.

## Test plan

- [ ] Verify devices table shows correct icons for each device type
- [ ] Verify device grid cards display type icons in the icon container
- [ ] Verify device detail sheet header shows the type icon and label
- [ ] Verify asset detail page header shows the device icon
- [ ] Verify `access_point` appears in the device edit type dropdown
- [ ] Verify `access_point` appears in the asset type filter on the assets page
- [ ] Verify TypeScript builds cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `access_point` as a new device type across the full stack with proper icon mappings. The implementation correctly separates access point detection patterns (`ap-`, `eap-`, `access_point`) from router patterns, and consistently adds the new type to all relevant locations including type definitions, icon maps, UI dropdowns, and category labels.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — straightforward type addition with complete implementation
- All changes are well-structured and consistent. The `access_point` type is added systematically across all relevant files (type definitions, icon mappings, UI components). The hostname pattern extraction from router to access_point is correct. No logical errors, security issues, or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/device-type.ts | Added `access_point` type and hostname patterns (`ap-`, `eap-`, `access_point`), correctly separated from router patterns |
| web/src/lib/device-icons.ts | Added `Wifi` icon and "Access Point" label for `access_point` type in both maps |
| web/src/components/DeviceTypeIcon.tsx | Added `access_point` to icon map (`Wifi`), color map (`text-cyan-300`), and label map ("Access Point") |
| web/src/lib/types.ts | Added `access_point` to `AssetType` union type |
| web/src/app/(app)/assets/page.tsx | Added `access_point` entry to `ASSET_TYPES` config with `Wifi` icon |
| web/src/app/(app)/devices/page.tsx | Added `access_point` to `DEVICE_TYPE_OPTIONS` dropdown for device editing |
| web/src/app/(app)/dashboard/page.tsx | Added "Access Points" category label for `access_point` device type |

</details>



<sub>Last reviewed commit: 089eb9e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->