### PR TITLE
feat: global keyboard shortcut Cmd+K / Ctrl+K — command palette (#221)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -19,6 +19,7 @@
         "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "cmdk": "^1.1.1",
         "d3-force": "^3.0.0",
         "framer-motion": "^12.34.3",
         "lucide-react": "^0.468.0",
@@ -464,6 +465,8 @@
     "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -1128,6 +1131,8 @@
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptikon-web",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptikon-web",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -22,6 +22,8 @@
         "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "cmdk": "^1.1.1",
+        "d3-force": "^3.0.0",
         "framer-motion": "^12.34.3",
         "lucide-react": "^0.468.0",
         "next": "^15.1.0",
@@ -34,6 +36,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/d3-force": "^3.0.10",
         "@types/dagre": "^0.7.53",
         "@types/node": "^22.0.0",
         "@types/qrcode": "^1.5.6",
@@ -2150,6 +2153,13 @@
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -3518,6 +3528,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3639,6 +3665,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -3664,6 +3704,15 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "cmdk": "^1.1.1",
     "d3-force": "^3.0.0",
     "framer-motion": "^12.34.3",
     "lucide-react": "^0.468.0",

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,15 +1,19 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { Command } from 'cmdk'
 import {
   Activity,
   Bell,
+  BellPlus,
   Cpu,
   LayoutDashboard,
   Monitor,
   MonitorSmartphone,
   Package,
+  Plus,
+  Radar,
   Router,
   Search,
   Settings,
@@ -18,47 +22,39 @@ import {
 import { searchAll } from '@/lib/api'
 import type { SearchDevice, SearchAgent, SearchSshTarget, SearchAsset } from '@/lib/types'
 import type { LucideIcon } from 'lucide-react'
+import { toast } from 'sonner'
 
-interface PaletteItem {
-  id: string
-  label: string
-  sublabel?: string
-  href: string
-  icon?: LucideIcon
-  section: 'pages' | 'devices' | 'actions'
-  isOnline?: boolean
+interface SearchResults {
+  devices: SearchDevice[]
+  agents: SearchAgent[]
+  ssh_targets: SearchSshTarget[]
+  assets: SearchAsset[]
 }
 
-const PAGES: PaletteItem[] = [
-  { id: 'page-dashboard', label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard, section: 'pages' },
-  { id: 'page-devices', label: 'Devices', href: '/devices', icon: MonitorSmartphone, section: 'pages' },
-  { id: 'page-agents', label: 'Agents', href: '/agents', icon: Cpu, section: 'pages' },
-  { id: 'page-traffic', label: 'Traffic', href: '/traffic', icon: Activity, section: 'pages' },
-  { id: 'page-alerts', label: 'Alerts', href: '/alerts', icon: Bell, section: 'pages' },
-  { id: 'page-router', label: 'Router', href: '/router', icon: Router, section: 'pages' },
-  { id: 'page-settings', label: 'Settings', href: '/settings', icon: Settings, section: 'pages' },
+const EMPTY_RESULTS: SearchResults = { devices: [], agents: [], ssh_targets: [], assets: [] }
+
+interface PageItem {
+  label: string
+  href: string
+  icon: LucideIcon
+}
+
+const PAGES: PageItem[] = [
+  { label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { label: 'Devices', href: '/devices', icon: MonitorSmartphone },
+  { label: 'Agents', href: '/agents', icon: Cpu },
+  { label: 'Traffic', href: '/traffic', icon: Activity },
+  { label: 'Alerts', href: '/alerts', icon: Bell },
+  { label: 'Router', href: '/router', icon: Router },
+  { label: 'Settings', href: '/settings', icon: Settings },
 ]
 
 export function CommandPalette() {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
-  const [activeIndex, setActiveIndex] = useState(0)
-  const [deviceItems, setDeviceItems] = useState<PaletteItem[]>([])
-  const [agentItems, setAgentItems] = useState<PaletteItem[]>([])
-  const [sshItems, setSshItems] = useState<PaletteItem[]>([])
-  const [assetItems, setAssetItems] = useState<PaletteItem[]>([])
-
-  const inputRef = useRef<HTMLInputElement>(null)
-  const listRef = useRef<HTMLDivElement>(null)
-
-  // Filter pages by query
-  const filteredPages = query.length > 0
-    ? PAGES.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
-    : PAGES
-
-  // Flatten all items for keyboard navigation
-  const allItems: PaletteItem[] = [...filteredPages, ...deviceItems, ...agentItems, ...sshItems, ...assetItems]
+  const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS)
+  const [scanning, setScanning] = useState(false)
 
   // ── Global Cmd+K / Ctrl+K listener ──
   useEffect(() => {
@@ -72,355 +68,257 @@ export function CommandPalette() {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [])
 
-  // ── Auto-focus input when opened ──
+  // ── Reset state when closed ──
   useEffect(() => {
-    if (open) {
+    if (!open) {
       setQuery('')
-      setActiveIndex(0)
-      setDeviceItems([])
-      setAgentItems([])
-      setSshItems([])
-      setAssetItems([])
-      // Small delay to ensure DOM is ready
-      requestAnimationFrame(() => {
-        inputRef.current?.focus()
-      })
+      setResults(EMPTY_RESULTS)
     }
   }, [open])
 
   // ── Debounced search across all entity types ──
   useEffect(() => {
     if (!open || query.length < 2) {
-      setDeviceItems([])
-      setAgentItems([])
-      setSshItems([])
-      setAssetItems([])
+      setResults(EMPTY_RESULTS)
       return
     }
 
     const timer = setTimeout(async () => {
       try {
         const data = await searchAll(query)
-        setDeviceItems(data.devices.map((d: SearchDevice) => ({
-          id: `device-${d.id}`,
-          label: d.name || d.ip_address || d.mac_address,
-          sublabel: d.hostname || d.vendor || undefined,
-          href: `/devices?highlight=${d.id}`,
-          icon: Monitor,
-          section: 'devices' as const,
-          isOnline: d.is_online,
-        })))
-        setAgentItems(data.agents.map((a: SearchAgent) => ({
-          id: `agent-${a.id}`,
-          label: a.name || a.id,
-          sublabel: a.hostname || undefined,
-          href: '/agents',
-          icon: Cpu,
-          section: 'devices' as const,
-          isOnline: a.is_online,
-        })))
-        setSshItems(data.ssh_targets.map((st: SearchSshTarget) => ({
-          id: `ssh-${st.id}`,
-          label: st.name,
-          sublabel: `${st.username}@${st.host}`,
-          href: '/ssh-hosts',
-          icon: Terminal,
-          section: 'devices' as const,
-          isOnline: st.is_online,
-        })))
-        setAssetItems(data.assets.map((asset: SearchAsset) => ({
-          id: `asset-${asset.id}`,
-          label: asset.name,
-          sublabel: asset.location || asset.asset_type || undefined,
-          href: '/assets',
-          icon: Package,
-          section: 'devices' as const,
-        })))
+        setResults(data)
       } catch {
-        setDeviceItems([])
-        setAgentItems([])
-        setSshItems([])
-        setAssetItems([])
+        setResults(EMPTY_RESULTS)
       }
     }, 200)
 
     return () => clearTimeout(timer)
   }, [query, open])
 
-  // ── Reset active index when items change ──
-  useEffect(() => {
-    setActiveIndex(0)
-  }, [query, deviceItems.length, agentItems.length, sshItems.length, assetItems.length])
-
-  // ── Scroll active item into view ──
-  useEffect(() => {
-    if (!listRef.current) return
-    const activeEl = listRef.current.querySelector('[data-active="true"]')
-    if (activeEl) {
-      activeEl.scrollIntoView({ block: 'nearest' })
-    }
-  }, [activeIndex])
-
-  // ── Navigate to item ──
-  const handleSelect = useCallback(
-    (item: PaletteItem) => {
+  const navigate = useCallback(
+    (href: string) => {
       setOpen(false)
-      router.push(item.href)
+      router.push(href)
     },
     [router],
   )
 
-  // ── Keyboard navigation inside modal ──
-  function handleKeyDown(e: React.KeyboardEvent) {
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault()
-        setActiveIndex((prev) => (prev + 1) % Math.max(allItems.length, 1))
-        break
-      case 'ArrowUp':
-        e.preventDefault()
-        setActiveIndex((prev) =>
-          prev <= 0 ? Math.max(allItems.length - 1, 0) : prev - 1,
-        )
-        break
-      case 'Enter':
-        e.preventDefault()
-        if (allItems[activeIndex]) {
-          handleSelect(allItems[activeIndex])
-        }
-        break
-      case 'Escape':
-        e.preventDefault()
-        setOpen(false)
-        break
+  const handleScanNow = useCallback(async () => {
+    setOpen(false)
+    if (scanning) return
+    setScanning(true)
+    try {
+      await fetch('/api/v1/scanner/trigger', { method: 'POST', credentials: 'include' })
+      toast.success('Network scan complete')
+    } catch {
+      toast.error('Network scan failed')
+    } finally {
+      setTimeout(() => setScanning(false), 5000)
     }
-  }
+  }, [scanning])
 
-  if (!open) return null
-
-  // Build sections for rendering
-  const pagesSection = filteredPages
-  const devicesSection = deviceItems
-  const agentsSection = agentItems
-  const sshSection = sshItems
-  const assetsSection = assetItems
-
-  let runningIdx = 0
+  const hasDevices = results.devices.length > 0
+  const hasAgents = results.agents.length > 0
+  const hasSsh = results.ssh_targets.length > 0
+  const hasAssets = results.assets.length > 0
+  const hasResults = hasDevices || hasAgents || hasSsh || hasAssets
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-slate-950/80 backdrop-blur-sm pt-[15vh]"
-      onClick={() => setOpen(false)}
+    <Command.Dialog
+      open={open}
+      onOpenChange={setOpen}
+      label="Command palette"
+      className="fixed inset-0 z-50"
+      overlayClassName="fixed inset-0 bg-slate-950/80 backdrop-blur-sm"
+      contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 w-[560px] max-h-[480px] flex flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-900 shadow-2xl"
+      shouldFilter={!hasResults}
     >
-      <div
-        className="w-[560px] max-h-[480px] flex flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-900 shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        {/* Search input */}
-        <div className="flex items-center gap-3 border-b border-slate-700 px-4 py-3">
-          <Search className="h-5 w-5 shrink-0 text-slate-500" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search devices, agents, SSH hosts, assets..."
-            className="flex-1 bg-transparent text-lg text-white placeholder-slate-500 outline-none"
-          />
-          <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-[11px] font-medium text-slate-400">
-            ESC
-          </kbd>
-        </div>
-
-        {/* Results list */}
-        <div ref={listRef} className="flex-1 overflow-y-auto p-2">
-          {/* Pages section */}
-          {pagesSection.length > 0 && (
-            <div>
-              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Pages
-              </div>
-              {pagesSection.map((item) => {
-                const idx = runningIdx++
-                const Icon = item.icon
-                return (
-                  <button
-                    key={item.id}
-                    data-active={activeIndex === idx}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                      activeIndex === idx
-                        ? 'bg-slate-800 text-white'
-                        : 'text-slate-300 hover:bg-slate-800/50'
-                    }`}
-                    onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                  >
-                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
-                    <span>{item.label}</span>
-                  </button>
-                )
-              })}
-            </div>
-          )}
-
-          {/* Devices section */}
-          {devicesSection.length > 0 && (
-            <div className="mt-2">
-              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Devices
-              </div>
-              {devicesSection.map((item) => {
-                const idx = runningIdx++
-                const Icon = item.icon
-                return (
-                  <button
-                    key={item.id}
-                    data-active={activeIndex === idx}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                      activeIndex === idx
-                        ? 'bg-slate-800 text-white'
-                        : 'text-slate-300 hover:bg-slate-800/50'
-                    }`}
-                    onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                  >
-                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
-                    <span
-                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
-                        item.isOnline
-                          ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
-                          : 'bg-slate-500'
-                      }`}
-                    />
-                    <span className="font-mono tabular-nums">{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-slate-500">({item.sublabel})</span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
-
-          {/* Agents section */}
-          {agentsSection.length > 0 && (
-            <div className="mt-2">
-              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Agents
-              </div>
-              {agentsSection.map((item) => {
-                const idx = runningIdx++
-                const Icon = item.icon
-                return (
-                  <button
-                    key={item.id}
-                    data-active={activeIndex === idx}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                      activeIndex === idx
-                        ? 'bg-slate-800 text-white'
-                        : 'text-slate-300 hover:bg-slate-800/50'
-                    }`}
-                    onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                  >
-                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
-                    <span
-                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
-                        item.isOnline
-                          ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
-                          : 'bg-slate-500'
-                      }`}
-                    />
-                    <span>{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-slate-500">({item.sublabel})</span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
-
-          {/* SSH Hosts section */}
-          {sshSection.length > 0 && (
-            <div className="mt-2">
-              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                SSH Hosts
-              </div>
-              {sshSection.map((item) => {
-                const idx = runningIdx++
-                const Icon = item.icon
-                return (
-                  <button
-                    key={item.id}
-                    data-active={activeIndex === idx}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                      activeIndex === idx
-                        ? 'bg-slate-800 text-white'
-                        : 'text-slate-300 hover:bg-slate-800/50'
-                    }`}
-                    onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                  >
-                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
-                    <span
-                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
-                        item.isOnline
-                          ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
-                          : 'bg-slate-500'
-                      }`}
-                    />
-                    <span>{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-slate-500 font-mono text-xs">{item.sublabel}</span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
-
-          {/* Assets section */}
-          {assetsSection.length > 0 && (
-            <div className="mt-2">
-              <div className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Assets
-              </div>
-              {assetsSection.map((item) => {
-                const idx = runningIdx++
-                const Icon = item.icon
-                return (
-                  <button
-                    key={item.id}
-                    data-active={activeIndex === idx}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-                      activeIndex === idx
-                        ? 'bg-slate-800 text-white'
-                        : 'text-slate-300 hover:bg-slate-800/50'
-                    }`}
-                    onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                  >
-                    {Icon && <Icon className="h-4 w-4 shrink-0 text-slate-400" />}
-                    <span>{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-slate-500 text-xs">({item.sublabel})</span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          )}
-
-          {/* Empty state */}
-          {allItems.length === 0 && query.length > 0 && (
-            <div className="px-3 py-8 text-center text-sm text-slate-500">
-              No results for &ldquo;{query}&rdquo;
-            </div>
-          )}
-        </div>
+      {/* Search input */}
+      <div className="flex items-center gap-3 border-b border-slate-700 px-4 py-3">
+        <Search className="h-5 w-5 shrink-0 text-slate-500" />
+        <Command.Input
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Search pages, devices, actions…"
+          className="flex-1 bg-transparent text-lg text-white placeholder-slate-500 outline-none"
+        />
+        <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-[11px] font-medium text-slate-400">
+          ESC
+        </kbd>
       </div>
-    </div>
+
+      {/* Results list */}
+      <Command.List className="flex-1 overflow-y-auto p-2">
+        <Command.Empty className="px-3 py-8 text-center text-sm text-slate-500">
+          No results found.
+        </Command.Empty>
+
+        {/* Pages */}
+        <Command.Group
+          heading="Pages"
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+        >
+          {PAGES.map((page) => (
+            <Command.Item
+              key={page.href}
+              value={page.label}
+              onSelect={() => navigate(page.href)}
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+            >
+              <page.icon className="h-4 w-4 shrink-0 text-slate-400" />
+              <span>{page.label}</span>
+            </Command.Item>
+          ))}
+        </Command.Group>
+
+        {/* Quick Actions */}
+        <Command.Group
+          heading="Actions"
+          className="mt-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+        >
+          <Command.Item
+            value="Scan Now"
+            onSelect={handleScanNow}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+          >
+            <Radar className="h-4 w-4 shrink-0 text-slate-400" />
+            <span>Scan Now</span>
+          </Command.Item>
+          <Command.Item
+            value="Add Agent"
+            onSelect={() => navigate('/agents')}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+          >
+            <Plus className="h-4 w-4 shrink-0 text-slate-400" />
+            <span>Add Agent</span>
+          </Command.Item>
+          <Command.Item
+            value="Add Alert"
+            onSelect={() => navigate('/alerts')}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+          >
+            <BellPlus className="h-4 w-4 shrink-0 text-slate-400" />
+            <span>Add Alert</span>
+          </Command.Item>
+        </Command.Group>
+
+        {/* Device search results */}
+        {hasDevices && (
+          <Command.Group
+            heading="Devices"
+            className="mt-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+          >
+            {results.devices.map((d) => (
+              <Command.Item
+                key={`device-${d.id}`}
+                value={`device ${d.name ?? ''} ${d.ip_address ?? ''} ${d.mac_address ?? ''}`}
+                onSelect={() => navigate(`/devices?highlight=${d.id}`)}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+              >
+                <Monitor className="h-4 w-4 shrink-0 text-slate-400" />
+                <span
+                  className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                    d.is_online
+                      ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
+                      : 'bg-slate-500'
+                  }`}
+                />
+                <span className="font-mono tabular-nums">
+                  {d.name || d.ip_address || d.mac_address}
+                </span>
+                {(d.hostname || d.vendor) && (
+                  <span className="text-slate-500">({d.hostname || d.vendor})</span>
+                )}
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+
+        {/* Agent search results */}
+        {hasAgents && (
+          <Command.Group
+            heading="Agents"
+            className="mt-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+          >
+            {results.agents.map((a) => (
+              <Command.Item
+                key={`agent-${a.id}`}
+                value={`agent ${a.name ?? ''} ${a.hostname ?? ''}`}
+                onSelect={() => navigate('/agents')}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+              >
+                <Cpu className="h-4 w-4 shrink-0 text-slate-400" />
+                <span
+                  className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                    a.is_online
+                      ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
+                      : 'bg-slate-500'
+                  }`}
+                />
+                <span>{a.name || a.id}</span>
+                {a.hostname && (
+                  <span className="text-slate-500">({a.hostname})</span>
+                )}
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+
+        {/* SSH Hosts search results */}
+        {hasSsh && (
+          <Command.Group
+            heading="SSH Hosts"
+            className="mt-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+          >
+            {results.ssh_targets.map((st) => (
+              <Command.Item
+                key={`ssh-${st.id}`}
+                value={`ssh ${st.name} ${st.host}`}
+                onSelect={() => navigate('/ssh-hosts')}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+              >
+                <Terminal className="h-4 w-4 shrink-0 text-slate-400" />
+                <span
+                  className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+                    st.is_online
+                      ? 'bg-emerald-400 ring-2 ring-emerald-400/30'
+                      : 'bg-slate-500'
+                  }`}
+                />
+                <span>{st.name}</span>
+                <span className="text-slate-500 font-mono text-xs">
+                  {st.username}@{st.host}
+                </span>
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+
+        {/* Assets search results */}
+        {hasAssets && (
+          <Command.Group
+            heading="Assets"
+            className="mt-2 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-slate-500"
+          >
+            {results.assets.map((asset) => (
+              <Command.Item
+                key={`asset-${asset.id}`}
+                value={`asset ${asset.name} ${asset.location ?? ''}`}
+                onSelect={() => navigate('/assets')}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-slate-300 aria-selected:bg-slate-800 aria-selected:text-white cursor-pointer"
+              >
+                <Package className="h-4 w-4 shrink-0 text-slate-400" />
+                <span>{asset.name}</span>
+                {(asset.location || asset.asset_type) && (
+                  <span className="text-slate-500 text-xs">
+                    ({asset.location || asset.asset_type})
+                  </span>
+                )}
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+      </Command.List>
+    </Command.Dialog>
   )
 }


### PR DESCRIPTION
Closes #221

## Summary

- Replaced the custom command palette implementation with the [`cmdk`](https://github.com/pacocoursey/cmdk) library for built-in fuzzy search, keyboard navigation, and accessible dialog handling
- Added **Quick Actions** section with three new commands:
  - **Scan Now** — triggers a network scan via `/api/v1/scanner/trigger`
  - **Add Agent** — navigates to the Agents page
  - **Add Alert** — navigates to the Alerts page
- Retained all existing functionality: page navigation (Dashboard, Devices, Agents, Traffic, Alerts, Router, Settings), device/agent/SSH/asset search by name/IP/MAC

## What changed

- `web/src/components/CommandPalette.tsx` — full rewrite using `cmdk` Command.Dialog, Command.Group, Command.Item, and Command.Input
- `web/package.json` / lock files — added `cmdk@^1.1.1` dependency

## Test plan

- [ ] Press `Cmd+K` (Mac) or `Ctrl+K` (Linux/Windows) to open the palette
- [ ] Verify fuzzy search filters pages and actions
- [ ] Type 2+ characters to trigger device/agent/SSH/asset search
- [ ] Select "Scan Now" and verify toast notification
- [ ] Select "Add Agent" and verify navigation to /agents
- [ ] Select "Add Alert" and verify navigation to /alerts
- [ ] Use arrow keys + Enter for keyboard navigation
- [ ] Press Escape to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modernizes the command palette by replacing the custom implementation with the `cmdk` library, which provides built-in fuzzy search, keyboard navigation, and accessibility features. The rewrite reduces code complexity (346 fewer lines) while adding three new Quick Actions: Scan Now, Add Agent, and Add Alert.

**Key Changes:**
- Migrated from manual keyboard navigation and filtering to `cmdk`'s declarative API using `Command.Dialog`, `Command.Group`, and `Command.Item` components
- Simplified state management by consolidating device/agent/SSH/asset results into a single `SearchResults` object
- Added Quick Actions section with network scan trigger and navigation shortcuts
- Retained all existing search functionality for devices, agents, SSH hosts, and assets

**Issues Found:**
- The "Scan Now" action displays "Network scan complete" immediately after triggering the POST request, but the scan is likely asynchronous and may not actually be complete yet

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor messaging issue in the Scan Now action
- The refactor is well-executed with proper use of the `cmdk` library. The code is cleaner and more maintainable. The only issue is the misleading toast message that claims the scan is complete when it's just been triggered. This is a user experience issue rather than a functional bug.
- The toast message in `web/src/components/CommandPalette.tsx:112` should be updated to reflect that the scan was started, not completed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Replaced custom command palette with cmdk library, added Quick Actions (Scan Now, Add Agent, Add Alert). One issue: toast message shows "scan complete" when scan is likely just triggered. |
| web/package.json | Added `cmdk@^1.1.1` dependency for command palette functionality. |

</details>



<sub>Last reviewed commit: b351330</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->