### PR TITLE
fix(e2e): fix device filter and agent page selectors

### DIFF
--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -60,7 +60,7 @@ export async function login(page: Page) {
   await page.locator("#password").fill(PASSWORD);
   await page.getByRole('button', { name: 'Sign In' }).click();
   
-  await page.waitForURL(/\/(dashboard|agents|devices)/, { timeout: 15000 });
+  await page.waitForURL(/\/(dashboard|agents|devices)/, { timeout: 30000 });
 }
 
 /** Returns bounding rect of an element. */

--- a/web/tests/e2e/devices.spec.ts
+++ b/web/tests/e2e/devices.spec.ts
@@ -12,10 +12,12 @@ test.describe('Devices page', () => {
   });
 
   test('devices page has filter buttons', async ({ page }) => {
-    await expect(page.getByRole('button', { name: 'All', exact: true })).toBeVisible({ timeout: 15000 });
-    await expect(page.getByRole('button', { name: 'Online' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Offline' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Unknown' })).toBeVisible();
+    // Button accessible names include counts once devices load (e.g. "All 42"),
+    // so use regex to match the label prefix.
+    await expect(page.getByRole('button', { name: /^All\b/ })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: /^Online\b/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Offline\b/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Unknown\b/ })).toBeVisible();
   });
 
   test('devices page has search input', async ({ page }) => {
@@ -44,16 +46,16 @@ test.describe('Devices page', () => {
   });
 
   test('filter buttons work', async ({ page }) => {
-    // Wait for devices to load
+    // Wait for devices to load (buttons include counts like "All 42")
     await page.waitForTimeout(2000);
     
-    // Click Online filter
-    await page.getByRole('button', { name: 'Online' }).click();
+    // Click Online filter — use regex since accessible name includes count
+    await page.getByRole('button', { name: /^Online\b/ }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: 'tests/screenshots/devices-online-filter.png', fullPage: true });
     
     // Click All filter to go back
-    await page.getByRole('button', { name: 'All', exact: true }).click();
+    await page.getByRole('button', { name: /^All\b/ }).click();
     await page.waitForTimeout(500);
     await page.screenshot({ path: 'tests/screenshots/devices-all-filter.png', fullPage: true });
   });


### PR DESCRIPTION
Fixes E2E test failures on main branch that block all feature PRs.

## Changes
- **Device filter buttons**: Use regex selectors (`/^All\b/`, `/^Online\b/`, etc.) instead of exact name match. Once devices load, button accessible names include counts (e.g. "All 42"), causing `{ name: 'All', exact: true }` to never match.
- **Login fixture**: Increase `waitForURL` timeout from 15s to 30s to handle slower CI environments during initial setup/login phase.

## Root Cause
The filter buttons render a count badge inside the button element:
```tsx
<Button>All<span className="...">42</span></Button>
```
This makes the accessible name `All 42` instead of `All`, breaking `exact: true` selectors.

## Failing Tests Fixed
1. `devices › filter buttons work` — `locator.click` timeout (consistent failure)
2. `devices › devices page has filter buttons` — elements not found (flaky)
3. `agents › agents page loads with heading` — `page.waitForURL` timeout (flaky)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes E2E test failures caused by dynamic count badges in filter buttons and slow CI login redirects. The filter button selectors now use regex patterns (`/^All\b/`, `/^Online\b/`, etc.) to match button labels regardless of count badges (e.g., "All 42"), and the login fixture timeout was doubled to 30s to handle slower CI environments during initial authentication flows.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- Both changes are well-targeted test fixes with clear rationale: regex selectors properly handle the documented UI behavior where buttons include count badges, and the timeout increase is a standard practice for accommodating CI environment variability. The changes are isolated to E2E tests with no impact on production code.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/tests/e2e/devices.spec.ts | Replaced exact button name selectors with regex patterns to handle dynamic count badges in filter buttons |
| web/e2e/fixtures.ts | Increased login redirect timeout from 15s to 30s to accommodate slower CI environments |

</details>



<sub>Last reviewed commit: fb6f865</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->