### PR TITLE
feat: feat: MikroTik VLAN management — list, create, edit, delete VLANs (#230)

### DIFF
--- a/server/src/api/mikrotik.rs
+++ b/server/src/api/mikrotik.rs
@@ -3,11 +3,16 @@
 //! These endpoints proxy requests to a MikroTik router via its REST API,
 //! using cached responses to avoid redundant network calls.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
 use crate::mikrotik::client::MikrotikClient;
+use crate::mikrotik::types::VlanWriteRequest;
 
 // ── Helper: build a MikroTik client from DB settings ───────
 
@@ -88,6 +93,23 @@ pub struct MikrotikRouteResponse {
     pub dynamic: bool,
     pub disabled: bool,
     pub comment: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MikrotikVlanResponse {
+    pub id: Option<String>,
+    pub vlan_id: Option<String>,
+    pub name: Option<String>,
+    pub interface: Option<String>,
+    pub mtu: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikVlanUpsertRequest {
+    pub vlan_id: u16,
+    pub name: String,
+    pub interface: String,
+    pub mtu: Option<u16>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -178,6 +200,19 @@ pub struct MikrotikWgPeer {
 
 fn is_true(val: &Option<String>) -> bool {
     val.as_deref() == Some("true")
+}
+
+fn validate_vlan_upsert(body: &MikrotikVlanUpsertRequest) -> Result<(), StatusCode> {
+    if !(1..=4094).contains(&body.vlan_id) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if body.name.trim().is_empty() || body.interface.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if matches!(body.mtu, Some(0)) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(())
 }
 
 // ── Endpoints ──────────────────────────────────────────────
@@ -294,6 +329,121 @@ pub async fn interfaces(
         state.mikrotik_cache.set("interfaces".into(), val);
     }
     Ok(Json(result))
+}
+
+/// GET /api/v1/mikrotik/vlans
+pub async fn vlans(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<MikrotikVlanResponse>>, StatusCode> {
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    if let Some(cached) = state.mikrotik_cache.get("vlans") {
+        if let Ok(resp) = serde_json::from_value(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    let vlans = client.vlans().await.map_err(|e| {
+        tracing::error!("MikroTik VLAN list error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let result: Vec<MikrotikVlanResponse> = vlans
+        .into_iter()
+        .map(|vlan| MikrotikVlanResponse {
+            id: vlan.id,
+            vlan_id: vlan.vlan_id,
+            name: vlan.name,
+            interface: vlan.interface,
+            mtu: vlan.mtu,
+        })
+        .collect();
+
+    if let Ok(val) = serde_json::to_value(&result) {
+        state.mikrotik_cache.set("vlans".into(), val);
+    }
+    Ok(Json(result))
+}
+
+/// POST /api/v1/mikrotik/vlans
+pub async fn create_vlan(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikVlanUpsertRequest>,
+) -> Result<StatusCode, StatusCode> {
+    validate_vlan_upsert(&body)?;
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let req = VlanWriteRequest {
+        name: body.name.trim().to_string(),
+        interface: body.interface.trim().to_string(),
+        vlan_id: body.vlan_id.to_string(),
+        mtu: body.mtu.map(|v| v.to_string()),
+    };
+
+    client.create_vlan(&req).await.map_err(|e| {
+        tracing::error!("MikroTik VLAN create error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// PUT /api/v1/mikrotik/vlans/:id
+pub async fn update_vlan(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikVlanUpsertRequest>,
+) -> Result<StatusCode, StatusCode> {
+    validate_vlan_upsert(&body)?;
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let req = VlanWriteRequest {
+        name: body.name.trim().to_string(),
+        interface: body.interface.trim().to_string(),
+        vlan_id: body.vlan_id.to_string(),
+        mtu: body.mtu.map(|v| v.to_string()),
+    };
+
+    client.update_vlan(id, &req).await.map_err(|e| {
+        tracing::error!("MikroTik VLAN update error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /api/v1/mikrotik/vlans/:id
+pub async fn delete_vlan(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client.delete_vlan(id).await.map_err(|e| {
+        tracing::error!("MikroTik VLAN delete error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// GET /api/v1/mikrotik/routes

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -380,6 +380,10 @@ pub fn router(state: AppState) -> Router {
         // MikroTik router proxy
         .route("/mikrotik/status", get(mikrotik::status))
         .route("/mikrotik/interfaces", get(mikrotik::interfaces))
+        .route("/mikrotik/vlans", get(mikrotik::vlans))
+        .route("/mikrotik/vlans", post(mikrotik::create_vlan))
+        .route("/mikrotik/vlans/:id", put(mikrotik::update_vlan))
+        .route("/mikrotik/vlans/:id", delete(mikrotik::delete_vlan))
         .route("/mikrotik/routes", get(mikrotik::routes))
         .route("/mikrotik/dhcp-leases", get(mikrotik::dhcp_leases))
         .route("/mikrotik/firewall", get(mikrotik::firewall))

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -5,6 +5,8 @@
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
+use reqwest::Method;
+use serde::Serialize;
 use serde_json::Value;
 use std::time::{Duration, Instant};
 
@@ -141,6 +143,82 @@ impl MikrotikClient {
         Ok(parsed)
     }
 
+    /// Send a mutating request with a JSON body.
+    async fn send_json<B: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: &B,
+    ) -> Result<()> {
+        let url = format!("{}/rest{}", self.base_url, path);
+
+        let start = Instant::now();
+        let resp = self
+            .http
+            .request(method.clone(), &url)
+            .basic_auth(&self.username, Some(&self.password))
+            .json(body)
+            .send()
+            .await
+            .context("MikroTik API request failed")?;
+
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .context("failed to read MikroTik API response body")?;
+        let elapsed = start.elapsed();
+
+        tracing::info!(
+            method = %method,
+            path,
+            http_status = %status,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "MikroTik API response"
+        );
+
+        if !status.is_success() {
+            anyhow::bail!("MikroTik API returned HTTP {status}: {text}");
+        }
+
+        Ok(())
+    }
+
+    /// Send a mutating request without a JSON body.
+    async fn send_no_body(&self, method: Method, path: &str) -> Result<()> {
+        let url = format!("{}/rest{}", self.base_url, path);
+
+        let start = Instant::now();
+        let resp = self
+            .http
+            .request(method.clone(), &url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await
+            .context("MikroTik API request failed")?;
+
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .context("failed to read MikroTik API response body")?;
+        let elapsed = start.elapsed();
+
+        tracing::info!(
+            method = %method,
+            path,
+            http_status = %status,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "MikroTik API response"
+        );
+
+        if !status.is_success() {
+            anyhow::bail!("MikroTik API returned HTTP {status}: {text}");
+        }
+
+        Ok(())
+    }
+
     /// Fetch system resource info (CPU, RAM, uptime, version).
     pub async fn system_resource(&self) -> Result<SystemResource> {
         let val = self.get("/system/resource").await?;
@@ -154,6 +232,14 @@ impl MikrotikClient {
         let val = self.get("/interface").await?;
         let res: Vec<MtInterface> =
             serde_json::from_value(val).context("failed to parse interfaces")?;
+        Ok(res)
+    }
+
+    /// Fetch all VLAN interfaces.
+    pub async fn vlans(&self) -> Result<Vec<VlanInterface>> {
+        let val = self.get("/interface/vlan").await?;
+        let res: Vec<VlanInterface> =
+            serde_json::from_value(val).context("failed to parse VLAN interfaces")?;
         Ok(res)
     }
 
@@ -217,6 +303,23 @@ impl MikrotikClient {
         let res: Vec<WgPeer> =
             serde_json::from_value(val).context("failed to parse WireGuard peers")?;
         Ok(res)
+    }
+
+    /// Create a VLAN interface.
+    pub async fn create_vlan(&self, req: &VlanWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/interface/vlan", req).await
+    }
+
+    /// Update a VLAN interface by RouterOS `.id`.
+    pub async fn update_vlan(&self, id: &str, req: &VlanWriteRequest) -> Result<()> {
+        self.send_json(Method::PATCH, &format!("/interface/vlan/{id}"), req)
+            .await
+    }
+
+    /// Delete a VLAN interface by RouterOS `.id`.
+    pub async fn delete_vlan(&self, id: &str) -> Result<()> {
+        self.send_no_body(Method::DELETE, &format!("/interface/vlan/{id}"))
+            .await
     }
 }
 

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -50,6 +50,31 @@ pub struct MtInterface {
     pub last_link_up_time: Option<String>,
 }
 
+/// MikroTik VLAN interface (`/rest/interface/vlan`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VlanInterface {
+    #[serde(rename = ".id")]
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub interface: Option<String>,
+    #[serde(rename = "vlan-id")]
+    pub vlan_id: Option<String>,
+    pub mtu: Option<String>,
+    pub disabled: Option<String>,
+    pub comment: Option<String>,
+}
+
+/// MikroTik VLAN write payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct VlanWriteRequest {
+    pub name: String,
+    pub interface: String,
+    #[serde(rename = "vlan-id")]
+    pub vlan_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtu: Option<String>,
+}
+
 /// MikroTik IP address (`/rest/ip/address`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpAddress {

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -16,23 +16,55 @@ import {
   MemoryStick,
   Monitor,
   HardDrive,
+  Layers,
+  Plus,
+  Pencil,
+  Trash2,
 } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   fetchMikrotikStatus,
   fetchMikrotikInterfaces,
+  fetchMikrotikVlans,
   fetchMikrotikRoutes,
   fetchMikrotikDhcpLeases,
   fetchMikrotikFirewall,
   fetchMikrotikDns,
   fetchMikrotikWireguard,
+  createMikrotikVlan,
+  updateMikrotikVlan,
+  deleteMikrotikVlan,
 } from "@/lib/api";
 import type {
   MikrotikStatus,
   MikrotikInterface,
+  MikrotikVlan,
+  MikrotikVlanRequest,
   MikrotikRoute,
   MikrotikDhcpLease,
   MikrotikFirewall,
@@ -362,6 +394,367 @@ function InterfacesTable({
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+type VlanFormState = {
+  vlan_id: string;
+  name: string;
+  interface: string;
+  mtu: string;
+};
+
+const EMPTY_VLAN_FORM: VlanFormState = {
+  vlan_id: "",
+  name: "",
+  interface: "",
+  mtu: "",
+};
+
+function vlanToForm(vlan: MikrotikVlan): VlanFormState {
+  return {
+    vlan_id: vlan.vlan_id ?? "",
+    name: vlan.name ?? "",
+    interface: vlan.interface ?? "",
+    mtu: vlan.mtu ?? "",
+  };
+}
+
+function VlansPanel({
+  data,
+  loading,
+  error,
+  reload,
+}: {
+  data: MikrotikVlan[] | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+}) {
+  const [form, setForm] = useState<VlanFormState>(EMPTY_VLAN_FORM);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<MikrotikVlan | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<MikrotikVlan | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm(EMPTY_VLAN_FORM);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (vlan: MikrotikVlan) => {
+    setEditing(vlan);
+    setForm(vlanToForm(vlan));
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    const vlanId = Number(form.vlan_id.trim());
+    if (!Number.isInteger(vlanId) || vlanId < 1 || vlanId > 4094) {
+      toast.error("VLAN ID must be an integer between 1 and 4094.");
+      return;
+    }
+
+    const name = form.name.trim();
+    const iface = form.interface.trim();
+    if (!name || !iface) {
+      toast.error("Name and interface are required.");
+      return;
+    }
+
+    let mtu: number | null = null;
+    const mtuValue = form.mtu.trim();
+    if (mtuValue) {
+      const parsedMtu = Number(mtuValue);
+      if (!Number.isInteger(parsedMtu) || parsedMtu <= 0) {
+        toast.error("MTU must be a positive integer.");
+        return;
+      }
+      mtu = parsedMtu;
+    }
+
+    const payload: MikrotikVlanRequest = {
+      vlan_id: vlanId,
+      name,
+      interface: iface,
+      mtu,
+    };
+
+    setSaving(true);
+    try {
+      if (editing) {
+        if (!editing.id) {
+          toast.error("Missing VLAN id for update.");
+          return;
+        }
+        await updateMikrotikVlan(editing.id, payload);
+        toast.success(`VLAN ${name} updated.`);
+      } else {
+        await createMikrotikVlan(payload);
+        toast.success(`VLAN ${name} created.`);
+      }
+
+      await reload();
+      setDialogOpen(false);
+      setEditing(null);
+      setForm(EMPTY_VLAN_FORM);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save VLAN.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    if (!confirmDelete.id) {
+      toast.error("Missing VLAN id for delete.");
+      setConfirmDelete(null);
+      return;
+    }
+
+    setDeleting(true);
+    try {
+      await deleteMikrotikVlan(confirmDelete.id);
+      await reload();
+      toast.success(`VLAN ${confirmDelete.name ?? confirmDelete.vlan_id ?? ""} deleted.`);
+      setConfirmDelete(null);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete VLAN.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const headerCols = (
+    <tr className="border-b border-slate-800 bg-slate-950 text-left">
+      <th className="px-4 py-3 font-medium text-slate-400">VLAN ID</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Name</th>
+      <th className="px-4 py-3 font-medium text-slate-400">Interface</th>
+      <th className="px-4 py-3 font-medium text-slate-400">MTU</th>
+      <th className="px-4 py-3 text-right font-medium text-slate-400">Actions</th>
+    </tr>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-end">
+        <Button
+          onClick={openCreate}
+          className="bg-pink-600 text-white hover:bg-pink-700"
+          size="sm"
+        >
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Add VLAN
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="overflow-x-auto rounded-md border border-slate-800">
+          <table className="w-full text-sm">
+            <thead>{headerCols}</thead>
+            <tbody>
+              {Array.from({ length: 4 }).map((_, i) => (
+                <tr key={i} className="border-b border-slate-800 last:border-b-0">
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-16" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-28" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-20" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-12" />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="ml-auto flex w-fit items-center gap-2">
+                      <Skeleton className="h-8 w-8 rounded-md" />
+                      <Skeleton className="h-8 w-8 rounded-md" />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : error ? (
+        <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+          <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+          <p className="text-xs text-rose-400">{error}</p>
+        </div>
+      ) : !data || data.length === 0 ? (
+        <p className="py-4 text-sm text-slate-500">No VLAN interfaces configured.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-slate-800">
+          <table className="w-full text-sm">
+            <thead>{headerCols}</thead>
+            <tbody>
+              {data.map((vlan, idx) => (
+                <tr
+                  key={vlan.id ?? `${vlan.name ?? "vlan"}-${vlan.vlan_id ?? idx}`}
+                  className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <span className="font-mono tabular-nums font-medium text-white">
+                      {vlan.vlan_id ?? "\u2014"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="text-slate-300">{vlan.name ?? "\u2014"}</span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="font-mono tabular-nums text-slate-300">
+                      {vlan.interface ?? "\u2014"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="text-slate-300">{vlan.mtu ?? "\u2014"}</span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-slate-400 hover:bg-slate-800 hover:text-white"
+                        onClick={() => openEdit(vlan)}
+                        disabled={!vlan.id}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-rose-400 hover:bg-rose-500/10 hover:text-rose-300"
+                        onClick={() => setConfirmDelete(vlan)}
+                        disabled={!vlan.id}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) {
+            setEditing(null);
+            setForm(EMPTY_VLAN_FORM);
+          }
+        }}
+      >
+        <DialogContent className="border-slate-800 bg-slate-900 text-slate-100">
+          <DialogHeader>
+            <DialogTitle className="text-white">
+              {editing ? "Edit VLAN" : "Create VLAN"}
+            </DialogTitle>
+            <DialogDescription className="text-slate-400">
+              Configure a VLAN interface on your MikroTik router.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="vlan-id">VLAN ID</Label>
+              <Input
+                id="vlan-id"
+                value={form.vlan_id}
+                onChange={(e) => setForm((prev) => ({ ...prev, vlan_id: e.target.value }))}
+                placeholder="10"
+                inputMode="numeric"
+                className="border-slate-700 bg-slate-950 text-slate-100"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vlan-name">Name</Label>
+              <Input
+                id="vlan-name"
+                value={form.name}
+                onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="vlan10-office"
+                className="border-slate-700 bg-slate-950 text-slate-100"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vlan-interface">Interface</Label>
+              <Input
+                id="vlan-interface"
+                value={form.interface}
+                onChange={(e) => setForm((prev) => ({ ...prev, interface: e.target.value }))}
+                placeholder="bridge"
+                className="border-slate-700 bg-slate-950 text-slate-100"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vlan-mtu">MTU (optional)</Label>
+              <Input
+                id="vlan-mtu"
+                value={form.mtu}
+                onChange={(e) => setForm((prev) => ({ ...prev, mtu: e.target.value }))}
+                placeholder="1500"
+                inputMode="numeric"
+                className="border-slate-700 bg-slate-950 text-slate-100"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              className="border-slate-700 text-slate-300 hover:bg-slate-800"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-pink-600 text-white hover:bg-pink-700"
+            >
+              {saving ? "Saving..." : editing ? "Save Changes" : "Create VLAN"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!confirmDelete}
+        onOpenChange={(open) => !open && setConfirmDelete(null)}
+      >
+        <AlertDialogContent className="border-slate-800 bg-slate-900">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">Delete VLAN</AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-400">
+              This will remove VLAN{" "}
+              <span className="font-mono text-slate-200">{confirmDelete?.name ?? ""}</span>{" "}
+              (ID {confirmDelete?.vlan_id ?? "\u2014"}). This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-slate-700 text-slate-300 hover:bg-slate-800">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleting}
+              className="bg-rose-600 text-white hover:bg-rose-700"
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -1027,6 +1420,7 @@ export default function MikrotikRouter() {
   }, []);
 
   const ifaces = useData(useCallback(() => fetchMikrotikInterfaces(), []));
+  const vlans = useData(useCallback(() => fetchMikrotikVlans(), []));
   const routes = useData(useCallback(() => fetchMikrotikRoutes(), []));
   const dhcp = useData(useCallback(() => fetchMikrotikDhcpLeases(), []));
   const fw = useData(useCallback(() => fetchMikrotikFirewall(), []));
@@ -1074,6 +1468,13 @@ export default function MikrotikRouter() {
           >
             <Network className="mr-1.5 h-3.5 w-3.5" />
             Interfaces
+          </TabsTrigger>
+          <TabsTrigger
+            value="vlans"
+            className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+          >
+            <Layers className="mr-1.5 h-3.5 w-3.5" />
+            VLANs
           </TabsTrigger>
           <TabsTrigger
             value="routes"
@@ -1128,6 +1529,24 @@ export default function MikrotikRouter() {
                 data={ifaces.data}
                 loading={ifaces.loading}
                 error={ifaces.error}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="vlans">
+          <Card className="border-slate-800 bg-slate-900">
+            <CardHeader>
+              <CardTitle className="text-base text-white">
+                VLAN Interfaces
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <VlansPanel
+                data={vlans.data}
+                loading={vlans.loading}
+                error={vlans.error}
+                reload={vlans.reload}
               />
             </CardContent>
           </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,6 +65,8 @@ import type {
   RemoveServiceResponse,
   MikrotikStatus,
   MikrotikInterface,
+  MikrotikVlan,
+  MikrotikVlanRequest,
   MikrotikRoute,
   MikrotikDhcpLease,
   MikrotikFirewall,
@@ -1193,6 +1195,25 @@ export function fetchMikrotikStatus(): Promise<MikrotikStatus> {
 
 export function fetchMikrotikInterfaces(): Promise<MikrotikInterface[]> {
   return apiGet<MikrotikInterface[]>("/api/v1/mikrotik/interfaces");
+}
+
+export function fetchMikrotikVlans(): Promise<MikrotikVlan[]> {
+  return apiGet<MikrotikVlan[]>("/api/v1/mikrotik/vlans");
+}
+
+export function createMikrotikVlan(body: MikrotikVlanRequest): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/vlans", body);
+}
+
+export function updateMikrotikVlan(
+  id: string,
+  body: MikrotikVlanRequest
+): Promise<void> {
+  return apiPut<void>(`/api/v1/mikrotik/vlans/${encodeURIComponent(id)}`, body);
+}
+
+export function deleteMikrotikVlan(id: string): Promise<void> {
+  return apiDelete(`/api/v1/mikrotik/vlans/${encodeURIComponent(id)}`);
 }
 
 export function fetchMikrotikRoutes(): Promise<MikrotikRoute[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -973,6 +973,21 @@ export interface MikrotikInterface {
   rx_bytes: string | null;
 }
 
+export interface MikrotikVlan {
+  id: string | null;
+  vlan_id: string | null;
+  name: string | null;
+  interface: string | null;
+  mtu: string | null;
+}
+
+export interface MikrotikVlanRequest {
+  vlan_id: number;
+  name: string;
+  interface: string;
+  mtu: number | null;
+}
+
 export interface MikrotikRoute {
   dst_address: string;
   gateway: string | null;


### PR DESCRIPTION
Closes #230

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds complete VLAN management functionality to MikroTik integration, enabling users to list, create, edit, and delete VLAN interfaces through the web UI.

- Backend implements four new REST endpoints (GET, POST, PUT, DELETE) with input validation (VLAN ID range 1-4094, required fields, MTU validation)
- Frontend provides a comprehensive management interface with form dialogs, confirmation modals, and proper loading/error states
- Cache invalidation handled automatically by existing middleware for mutating requests
- Code follows established patterns for both Rust backend and React frontend
- One bug identified: `setSaving` state not reset on early return in edit flow

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor bug fix needed in the frontend
- Implementation is solid with proper validation, error handling, and follows existing patterns. One logical bug in the frontend where `setSaving` state is not reset on early return, which will leave the save button disabled if a VLAN is missing an id during edit. Otherwise, the backend implementation is robust with proper input validation and cache handling.
- Pay close attention to `web/src/components/MikrotikRouter.tsx` line 490 - fix the state reset issue before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mikrotik.rs | Added VLAN endpoints (GET, POST, PUT, DELETE) with proper validation and caching. Code follows existing patterns. |
| server/src/mikrotik/client.rs | Added `vlans()`, `create_vlan()`, `update_vlan()`, and `delete_vlan()` methods with proper HTTP verb handling and error logging. |
| web/src/components/MikrotikRouter.tsx | Added comprehensive VLAN management UI with create, edit, and delete functionality. One issue: `setSaving` state not reset on early return (line 490). |

</details>



<sub>Last reviewed commit: 6af3647</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->