### PR TITLE
feat: per-device bandwidth charts — traffic history from MikroTik (#229)

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -137,7 +137,7 @@ async fn main() -> Result<()> {
     // Start the SSH agentless monitoring poller.
     ssh::start_ssh_poller(state.db.clone(), state.ws_hub.clone());
 
-    // Start the MikroTik interface traffic poller (1-min samples).
+    // Start the MikroTik interface traffic poller (polls every 60s when enabled).
     mikrotik_traffic::start_mikrotik_traffic_poller(state.db.clone(), state.mikrotik_http.clone());
 
     // Build the application router.

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -219,6 +219,44 @@ impl MikrotikClient {
         Ok(())
     }
 
+    /// POST a MikroTik REST command with a JSON body, returning parsed JSON.
+    async fn post(&self, path: &str, body: &Value) -> Result<Value> {
+        let url = format!("{}/rest{}", self.base_url, path);
+
+        let start = Instant::now();
+        let resp = self
+            .http
+            .post(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .json(body)
+            .send()
+            .await
+            .context("MikroTik API POST request failed")?;
+
+        let status = resp.status();
+        let resp_body = resp
+            .text()
+            .await
+            .context("failed to read MikroTik API POST response body")?;
+
+        let elapsed = start.elapsed();
+        tracing::debug!(
+            path,
+            http_status = %status,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "MikroTik API POST response"
+        );
+
+        if !status.is_success() {
+            anyhow::bail!("MikroTik API POST returned HTTP {status}: {resp_body}");
+        }
+
+        let parsed: Value = serde_json::from_str(&resp_body)
+            .context("failed to parse MikroTik API POST response JSON")?;
+
+        Ok(parsed)
+    }
+
     /// Fetch system resource info (CPU, RAM, uptime, version).
     pub async fn system_resource(&self) -> Result<SystemResource> {
         let val = self.get("/system/resource").await?;
@@ -302,6 +340,21 @@ impl MikrotikClient {
         let val = self.get("/interface/wireguard").await?;
         let res: Vec<WgInterface> =
             serde_json::from_value(val).context("failed to parse WireGuard interfaces")?;
+        Ok(res)
+    }
+
+    /// Monitor traffic on a specific interface (returns instantaneous bps).
+    ///
+    /// Uses `POST /rest/interface/monitor-traffic` with `once` to get a single
+    /// snapshot of rx/tx bits-per-second.
+    pub async fn monitor_traffic(&self, interface: &str) -> Result<Vec<MonitorTrafficResult>> {
+        let body = serde_json::json!({
+            "interface": interface,
+            "once": ""
+        });
+        let val = self.post("/interface/monitor-traffic", &body).await?;
+        let res: Vec<MonitorTrafficResult> =
+            serde_json::from_value(val).context("failed to parse monitor-traffic result")?;
         Ok(res)
     }
 

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -216,6 +216,15 @@ pub struct WgInterface {
     pub running: Option<String>,
 }
 
+/// MikroTik interface monitor-traffic result (`/rest/interface/monitor-traffic`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorTrafficResult {
+    #[serde(rename = "rx-bits-per-second")]
+    pub rx_bits_per_second: Option<String>,
+    #[serde(rename = "tx-bits-per-second")]
+    pub tx_bits_per_second: Option<String>,
+}
+
 /// MikroTik WireGuard peer (`/rest/interface/wireguard/peers`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WgPeer {

--- a/server/src/mikrotik_traffic.rs
+++ b/server/src/mikrotik_traffic.rs
@@ -1,29 +1,44 @@
 //! MikroTik interface traffic poller.
 //!
-//! Periodically fetches interface byte counters from MikroTik via REST API,
-//! computes per-interval deltas, maps interfaces to devices by MAC address,
-//! and inserts traffic samples into `traffic_samples` with `source = 'mikrotik'`.
-//!
-//! Resolution: 1-minute polling interval.
+//! Polls MikroTik router interface traffic counters every 60 seconds using
+//! `/rest/interface/monitor-traffic`, maps the data to the router device in
+//! the devices table, and inserts samples into `traffic_samples`.
+
+use std::time::Duration;
 
 use sqlx::SqlitePool;
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::mikrotik::client::MikrotikClient;
 
-/// Polling interval in seconds.
-const POLL_INTERVAL_SECS: u64 = 60;
+/// Polling interval: 1 minute.
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Previous snapshot of interface byte counters.
-struct InterfaceSnapshot {
-    tx_bytes: u64,
-    rx_bytes: u64,
-    timestamp: Instant,
+/// Start the MikroTik traffic polling background task.
+///
+/// Spawns a tokio task that runs every 60 seconds:
+/// 1. Reads MikroTik connection settings from the `settings` table.
+/// 2. Fetches running interface list.
+/// 3. Calls `monitor-traffic` on each running interface to get instantaneous bps.
+/// 4. Finds the router device by its IP in `device_ips`.
+/// 5. Inserts aggregated traffic into `traffic_samples` with `source = 'mikrotik'`.
+pub fn start_mikrotik_traffic_poller(pool: SqlitePool, http: reqwest::Client) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(POLL_INTERVAL);
+        // Skip the immediate first tick to let the system initialize.
+        interval.tick().await;
+        info!("MikroTik traffic poller started (60s interval)");
+
+        loop {
+            interval.tick().await;
+            if let Err(e) = poll_once(&pool, &http).await {
+                debug!("MikroTik traffic poll skipped: {e}");
+            }
+        }
+    });
 }
 
-/// Read a string setting from the settings table.
+/// Read a setting value from the `settings` table.
 async fn get_setting(pool: &SqlitePool, key: &str) -> Option<String> {
     sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
         .bind(key)
@@ -34,18 +49,45 @@ async fn get_setting(pool: &SqlitePool, key: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-/// Try to construct a MikroTik client from DB settings.
-/// Returns `None` if MikroTik is not enabled/configured.
-async fn build_client(pool: &SqlitePool, http: &reqwest::Client) -> Option<MikrotikClient> {
+/// Extract the host/IP from a URL string (e.g. "https://192.168.1.1" → "192.168.1.1").
+fn extract_host_from_url(url: &str) -> Option<String> {
+    // Require a scheme (http:// or https://).
+    let after_scheme = url.split("://").nth(1)?;
+    // Strip path and port.
+    let host = after_scheme.split('/').next()?;
+    let host = host.split(':').next()?;
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
+/// Look up a device_id by IP address.
+async fn lookup_device_by_ip(pool: &SqlitePool, ip: &str) -> Option<String> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT device_id FROM device_ips WHERE ip = ? AND is_current = 1 LIMIT 1")
+            .bind(ip)
+            .fetch_optional(pool)
+            .await
+            .ok()?;
+    row.map(|(id,)| id)
+}
+
+/// Run a single poll cycle.
+async fn poll_once(pool: &SqlitePool, http: &reqwest::Client) -> anyhow::Result<()> {
+    // Check if MikroTik integration is enabled.
     let enabled = get_setting(pool, "mikrotik_enabled")
         .await
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
     if !enabled {
-        return None;
+        return Ok(());
     }
 
-    let url = get_setting(pool, "mikrotik_url").await?;
+    let url = get_setting(pool, "mikrotik_url")
+        .await
+        .ok_or_else(|| anyhow::anyhow!("mikrotik_url not configured"))?;
     let user = get_setting(pool, "mikrotik_user")
         .await
         .unwrap_or_else(|| "admin".to_string());
@@ -53,151 +95,130 @@ async fn build_client(pool: &SqlitePool, http: &reqwest::Client) -> Option<Mikro
         .await
         .unwrap_or_default();
 
-    Some(MikrotikClient::with_http(
-        &url,
-        &user,
-        &password,
-        http.clone(),
-    ))
-}
+    let client = MikrotikClient::with_http(&url, &user, &password, http.clone());
 
-/// Look up device_id by MAC address (case-insensitive).
-async fn device_id_by_mac(pool: &SqlitePool, mac: &str) -> Option<String> {
-    let mac_upper = mac.to_uppercase();
-    sqlx::query_scalar::<_, String>("SELECT id FROM devices WHERE UPPER(mac) = ?")
-        .bind(&mac_upper)
-        .fetch_optional(pool)
+    // Find the router device by its IP address.
+    let router_ip = extract_host_from_url(&url)
+        .ok_or_else(|| anyhow::anyhow!("cannot extract IP from mikrotik_url"))?;
+    let device_id = lookup_device_by_ip(pool, &router_ip)
         .await
-        .ok()
-        .flatten()
-}
+        .ok_or_else(|| anyhow::anyhow!("router device not found for IP {router_ip}"))?;
 
-/// Insert a traffic sample for a device.
-async fn insert_sample(pool: &SqlitePool, device_id: &str, tx_bps: i64, rx_bps: i64) {
-    let result = sqlx::query(
-        r#"INSERT INTO traffic_samples (device_id, sampled_at, tx_bps, rx_bps, source)
-           VALUES (?, datetime('now'), ?, ?, 'mikrotik')"#,
-    )
-    .bind(device_id)
-    .bind(tx_bps)
-    .bind(rx_bps)
-    .execute(pool)
-    .await;
+    // Get list of interfaces to find running ones.
+    let interfaces = client.interfaces().await?;
 
-    if let Err(e) = result {
-        error!(device_id, "Failed to insert MikroTik traffic sample: {e}");
-    }
-}
+    let mut total_rx_bps: i64 = 0;
+    let mut total_tx_bps: i64 = 0;
+    let mut polled_count = 0u32;
 
-/// Start the MikroTik traffic polling task.
-///
-/// Runs in the background, polling every 60 seconds.
-/// Skips silently if MikroTik is not configured/enabled.
-pub fn start_mikrotik_traffic_poller(pool: SqlitePool, http: reqwest::Client) {
-    tokio::spawn(async move {
-        info!("MikroTik traffic poller started (interval: {POLL_INTERVAL_SECS}s)");
-
-        let mut prev_counters: HashMap<String, InterfaceSnapshot> = HashMap::new();
-        let mut interval = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
-
-        loop {
-            interval.tick().await;
-
-            // Try to build a client — skip this cycle if not configured.
-            let Some(client) = build_client(&pool, &http).await else {
-                // Clear previous counters so we don't compute stale deltas
-                // when MikroTik gets re-enabled.
-                if !prev_counters.is_empty() {
-                    prev_counters.clear();
-                }
-                continue;
-            };
-
-            // Fetch interfaces from MikroTik.
-            let ifaces = match client.interfaces().await {
-                Ok(ifaces) => ifaces,
-                Err(e) => {
-                    warn!("MikroTik traffic poll failed: {e}");
-                    continue;
-                }
-            };
-
-            let now = Instant::now();
-            let mut new_counters: HashMap<String, InterfaceSnapshot> = HashMap::new();
-            let mut samples_inserted = 0u32;
-
-            for iface in &ifaces {
-                let name = match &iface.name {
-                    Some(n) => n.clone(),
-                    None => continue,
-                };
-
-                // Parse current byte counters.
-                let tx_bytes: u64 = iface
-                    .tx_byte
-                    .as_deref()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0);
-                let rx_bytes: u64 = iface
-                    .rx_byte
-                    .as_deref()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0);
-
-                // Store current counters for next iteration.
-                new_counters.insert(
-                    name.clone(),
-                    InterfaceSnapshot {
-                        tx_bytes,
-                        rx_bytes,
-                        timestamp: now,
-                    },
-                );
-
-                // Compute delta from previous poll.
-                let Some(prev) = prev_counters.get(&name) else {
-                    // First poll — no delta to compute.
-                    continue;
-                };
-
-                let elapsed_secs = prev.timestamp.elapsed().as_secs_f64();
-                if elapsed_secs < 1.0 {
-                    continue;
-                }
-
-                // Handle counter wraparound (unlikely but safe).
-                let tx_delta = tx_bytes.saturating_sub(prev.tx_bytes);
-                let rx_delta = rx_bytes.saturating_sub(prev.rx_bytes);
-
-                // Skip if no traffic.
-                if tx_delta == 0 && rx_delta == 0 {
-                    continue;
-                }
-
-                // Convert bytes delta to bits per second.
-                let tx_bps = ((tx_delta as f64 * 8.0) / elapsed_secs) as i64;
-                let rx_bps = ((rx_delta as f64 * 8.0) / elapsed_secs) as i64;
-
-                // Find the device by interface MAC address.
-                let mac = match &iface.mac_address {
-                    Some(m) if !m.is_empty() => m,
-                    _ => continue,
-                };
-
-                if let Some(device_id) = device_id_by_mac(&pool, mac).await {
-                    insert_sample(&pool, &device_id, tx_bps, rx_bps).await;
-                    samples_inserted += 1;
-                }
-            }
-
-            if samples_inserted > 0 {
-                debug!(
-                    samples = samples_inserted,
-                    "MikroTik traffic poller: inserted samples"
-                );
-            }
-
-            prev_counters = new_counters;
+    for iface in &interfaces {
+        let running = iface.running.as_deref() == Some("true");
+        let disabled = iface.disabled.as_deref() == Some("true");
+        if !running || disabled {
+            continue;
         }
-    });
+
+        let name = match &iface.name {
+            Some(n) => n.as_str(),
+            None => continue,
+        };
+
+        // Skip loopback and virtual interfaces that don't carry real traffic.
+        let iface_type = iface.iface_type.as_deref().unwrap_or("");
+        if iface_type == "loopback" {
+            continue;
+        }
+
+        // Call monitor-traffic to get instantaneous bps for this interface.
+        match client.monitor_traffic(name).await {
+            Ok(results) => {
+                for r in &results {
+                    let rx: i64 = r
+                        .rx_bits_per_second
+                        .as_deref()
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
+                    let tx: i64 = r
+                        .tx_bits_per_second
+                        .as_deref()
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
+                    total_rx_bps += rx;
+                    total_tx_bps += tx;
+                }
+                polled_count += 1;
+            }
+            Err(e) => {
+                debug!(interface = name, "monitor-traffic failed: {e}");
+            }
+        }
+    }
+
+    if polled_count == 0 {
+        return Ok(());
+    }
+
+    // Skip zero-traffic samples to avoid DB bloat.
+    if total_rx_bps == 0 && total_tx_bps == 0 {
+        return Ok(());
+    }
+
+    // Insert aggregated traffic sample.
+    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+
+    sqlx::query(
+        r#"INSERT INTO traffic_samples (device_id, sampled_at, rx_bps, tx_bps, source)
+           VALUES (?, ?, ?, ?, 'mikrotik')"#,
+    )
+    .bind(&device_id)
+    .bind(&now)
+    .bind(total_rx_bps)
+    .bind(total_tx_bps)
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        error!("Failed to insert MikroTik traffic sample: {e}");
+        e
+    })?;
+
+    info!(
+        rx_bps = total_rx_bps,
+        tx_bps = total_tx_bps,
+        interfaces = polled_count,
+        "MikroTik traffic sample stored"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_host_from_url() {
+        assert_eq!(
+            extract_host_from_url("https://192.168.1.1"),
+            Some("192.168.1.1".to_string())
+        );
+        assert_eq!(
+            extract_host_from_url("https://192.168.1.1:443"),
+            Some("192.168.1.1".to_string())
+        );
+        assert_eq!(
+            extract_host_from_url("http://router.local"),
+            Some("router.local".to_string())
+        );
+        assert_eq!(extract_host_from_url("not-a-url"), None);
+    }
+
+    #[tokio::test]
+    async fn test_poll_skips_when_not_enabled() {
+        let pool = crate::db::init(":memory:").await.expect("DB init failed");
+
+        // mikrotik_enabled is not set, so poll_once should return Ok(())
+        let http = reqwest::Client::new();
+        let result = poll_once(&pool, &http).await;
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a background poller that queries MikroTik router interface traffic counters (`/rest/interface/monitor-traffic`) every 60 seconds
- Stores per-device traffic samples in SQLite (`traffic_samples` table with `source = 'mikrotik'`)
- The existing `DeviceTrafficChart` component and traffic API endpoints automatically display the collected data as line charts (bytes in/out over time)

### Implementation details

- **`MikrotikClient`**: Added `post()` method and `monitor_traffic(interface)` which uses `POST /rest/interface/monitor-traffic` with `once` parameter to get instantaneous rx/tx bits-per-second
- **`MonitorTrafficResult`** type added for deserializing the monitor-traffic response
- **`mikrotik_traffic` module**: Background task that polls every 60s when MikroTik is enabled in settings, finds the router device by its IP, queries running interfaces, and inserts aggregated bps into `traffic_samples`
- Skips disabled/loopback interfaces and zero-traffic samples
- Resolution: 1-minute samples; retention handled by existing `retention` task (48h raw samples, 90d hourly aggregates, 2y daily aggregates)

### What already existed (no changes needed)

- Database schema (`traffic_samples`, `traffic_hourly`, `traffic_daily`)
- Traffic API endpoints (`GET /devices/:id/traffic?range=1h|24h|7d|30d`)
- `DeviceTrafficChart` frontend component with time range selector
- Retention/aggregation background task

Closes #229

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored MikroTik traffic polling to use the `/rest/interface/monitor-traffic` API instead of computing deltas from byte counters. The new implementation queries instantaneous bps values every 60 seconds, aggregates traffic across all running interfaces, and stores a single sample per poll cycle for the router device (identified by its IP). This is a cleaner approach that:

- Eliminates the need to track previous counter snapshots and handle wraparound
- Uses MikroTik's native monitoring API designed for instantaneous traffic readings
- Simplifies device mapping by associating traffic with the router itself rather than per-interface MAC lookups
- Maintains compatibility with existing database schema and frontend components

The implementation is well-structured with proper error handling, test coverage, and defensive checks (skips disabled/loopback interfaces, zero-traffic samples, and missing settings).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-documented, and uses a simpler approach than the previous counter-delta method. All changes are isolated to the MikroTik traffic polling module with no breaking changes to existing APIs or database schema. The code includes unit tests, proper error handling, and defensive checks for edge cases.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/main.rs | Updated comment to clarify poller behavior (polls every 60s when enabled) |
| server/src/mikrotik/client.rs | Added `post()` method and `monitor_traffic()` API for querying instantaneous interface traffic |
| server/src/mikrotik/types.rs | Added `MonitorTrafficResult` type for deserializing monitor-traffic API responses |
| server/src/mikrotik_traffic.rs | Complete rewrite: now uses monitor-traffic API for instantaneous bps instead of counter deltas, aggregates per-router instead of per-interface |

</details>



<sub>Last reviewed commit: 11a9966</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->