### PR TITLE
feat: per-device bandwidth charts — traffic history from MikroTik (#229)

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dhcp;
 pub mod enrichment;
 pub mod mdns;
 pub mod mikrotik;
+pub mod mikrotik_traffic;
 pub mod netflow;
 pub mod npm;
 pub mod oui;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 use panoptikon_server::{
-    api, config, db, dhcp, mdns, netflow, retention, scanner, speedtest_scheduler, ssdp, ssh,
+    api, config, db, dhcp, mdns, mikrotik_traffic, netflow, retention, scanner,
+    speedtest_scheduler, ssdp, ssh,
 };
 use std::net::SocketAddr;
 use tracing::info;
@@ -135,6 +136,9 @@ async fn main() -> Result<()> {
 
     // Start the SSH agentless monitoring poller.
     ssh::start_ssh_poller(state.db.clone(), state.ws_hub.clone());
+
+    // Start the MikroTik interface traffic poller (1-min samples).
+    mikrotik_traffic::start_mikrotik_traffic_poller(state.db.clone(), state.mikrotik_http.clone());
 
     // Build the application router.
     let app = api::router(state);

--- a/server/src/mikrotik_traffic.rs
+++ b/server/src/mikrotik_traffic.rs
@@ -1,0 +1,203 @@
+//! MikroTik interface traffic poller.
+//!
+//! Periodically fetches interface byte counters from MikroTik via REST API,
+//! computes per-interval deltas, maps interfaces to devices by MAC address,
+//! and inserts traffic samples into `traffic_samples` with `source = 'mikrotik'`.
+//!
+//! Resolution: 1-minute polling interval.
+
+use sqlx::SqlitePool;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tracing::{debug, error, info, warn};
+
+use crate::mikrotik::client::MikrotikClient;
+
+/// Polling interval in seconds.
+const POLL_INTERVAL_SECS: u64 = 60;
+
+/// Previous snapshot of interface byte counters.
+struct InterfaceSnapshot {
+    tx_bytes: u64,
+    rx_bytes: u64,
+    timestamp: Instant,
+}
+
+/// Read a string setting from the settings table.
+async fn get_setting(pool: &SqlitePool, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+/// Try to construct a MikroTik client from DB settings.
+/// Returns `None` if MikroTik is not enabled/configured.
+async fn build_client(pool: &SqlitePool, http: &reqwest::Client) -> Option<MikrotikClient> {
+    let enabled = get_setting(pool, "mikrotik_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let url = get_setting(pool, "mikrotik_url").await?;
+    let user = get_setting(pool, "mikrotik_user")
+        .await
+        .unwrap_or_else(|| "admin".to_string());
+    let password = get_setting(pool, "mikrotik_password")
+        .await
+        .unwrap_or_default();
+
+    Some(MikrotikClient::with_http(
+        &url,
+        &user,
+        &password,
+        http.clone(),
+    ))
+}
+
+/// Look up device_id by MAC address (case-insensitive).
+async fn device_id_by_mac(pool: &SqlitePool, mac: &str) -> Option<String> {
+    let mac_upper = mac.to_uppercase();
+    sqlx::query_scalar::<_, String>("SELECT id FROM devices WHERE UPPER(mac) = ?")
+        .bind(&mac_upper)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Insert a traffic sample for a device.
+async fn insert_sample(pool: &SqlitePool, device_id: &str, tx_bps: i64, rx_bps: i64) {
+    let result = sqlx::query(
+        r#"INSERT INTO traffic_samples (device_id, sampled_at, tx_bps, rx_bps, source)
+           VALUES (?, datetime('now'), ?, ?, 'mikrotik')"#,
+    )
+    .bind(device_id)
+    .bind(tx_bps)
+    .bind(rx_bps)
+    .execute(pool)
+    .await;
+
+    if let Err(e) = result {
+        error!(device_id, "Failed to insert MikroTik traffic sample: {e}");
+    }
+}
+
+/// Start the MikroTik traffic polling task.
+///
+/// Runs in the background, polling every 60 seconds.
+/// Skips silently if MikroTik is not configured/enabled.
+pub fn start_mikrotik_traffic_poller(pool: SqlitePool, http: reqwest::Client) {
+    tokio::spawn(async move {
+        info!("MikroTik traffic poller started (interval: {POLL_INTERVAL_SECS}s)");
+
+        let mut prev_counters: HashMap<String, InterfaceSnapshot> = HashMap::new();
+        let mut interval = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
+
+        loop {
+            interval.tick().await;
+
+            // Try to build a client — skip this cycle if not configured.
+            let Some(client) = build_client(&pool, &http).await else {
+                // Clear previous counters so we don't compute stale deltas
+                // when MikroTik gets re-enabled.
+                if !prev_counters.is_empty() {
+                    prev_counters.clear();
+                }
+                continue;
+            };
+
+            // Fetch interfaces from MikroTik.
+            let ifaces = match client.interfaces().await {
+                Ok(ifaces) => ifaces,
+                Err(e) => {
+                    warn!("MikroTik traffic poll failed: {e}");
+                    continue;
+                }
+            };
+
+            let now = Instant::now();
+            let mut new_counters: HashMap<String, InterfaceSnapshot> = HashMap::new();
+            let mut samples_inserted = 0u32;
+
+            for iface in &ifaces {
+                let name = match &iface.name {
+                    Some(n) => n.clone(),
+                    None => continue,
+                };
+
+                // Parse current byte counters.
+                let tx_bytes: u64 = iface
+                    .tx_byte
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let rx_bytes: u64 = iface
+                    .rx_byte
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+
+                // Store current counters for next iteration.
+                new_counters.insert(
+                    name.clone(),
+                    InterfaceSnapshot {
+                        tx_bytes,
+                        rx_bytes,
+                        timestamp: now,
+                    },
+                );
+
+                // Compute delta from previous poll.
+                let Some(prev) = prev_counters.get(&name) else {
+                    // First poll — no delta to compute.
+                    continue;
+                };
+
+                let elapsed_secs = prev.timestamp.elapsed().as_secs_f64();
+                if elapsed_secs < 1.0 {
+                    continue;
+                }
+
+                // Handle counter wraparound (unlikely but safe).
+                let tx_delta = tx_bytes.saturating_sub(prev.tx_bytes);
+                let rx_delta = rx_bytes.saturating_sub(prev.rx_bytes);
+
+                // Skip if no traffic.
+                if tx_delta == 0 && rx_delta == 0 {
+                    continue;
+                }
+
+                // Convert bytes delta to bits per second.
+                let tx_bps = ((tx_delta as f64 * 8.0) / elapsed_secs) as i64;
+                let rx_bps = ((rx_delta as f64 * 8.0) / elapsed_secs) as i64;
+
+                // Find the device by interface MAC address.
+                let mac = match &iface.mac_address {
+                    Some(m) if !m.is_empty() => m,
+                    _ => continue,
+                };
+
+                if let Some(device_id) = device_id_by_mac(&pool, mac).await {
+                    insert_sample(&pool, &device_id, tx_bps, rx_bps).await;
+                    samples_inserted += 1;
+                }
+            }
+
+            if samples_inserted > 0 {
+                debug!(
+                    samples = samples_inserted,
+                    "MikroTik traffic poller: inserted samples"
+                );
+            }
+
+            prev_counters = new_counters;
+        }
+    });
+}

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -20,13 +20,24 @@ import {
   Plus,
   Pencil,
   Trash2,
+  BarChart3,
 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -59,7 +70,9 @@ import {
   createMikrotikVlan,
   updateMikrotikVlan,
   deleteMikrotikVlan,
+  fetchTrafficHistory,
 } from "@/lib/api";
+import { formatBps } from "@/lib/format";
 import type {
   MikrotikStatus,
   MikrotikInterface,
@@ -70,6 +83,7 @@ import type {
   MikrotikFirewall,
   MikrotikDns,
   MikrotikWireguard,
+  TrafficHistoryPoint,
 } from "@/lib/types";
 
 function formatBytes(bytes: string | null): string {
@@ -1392,6 +1406,168 @@ function WireGuardPanel({
   );
 }
 
+// ── Traffic Tab ───────────────────────────────────────────
+
+type TimeRange = "1h" | "24h" | "7d";
+
+const RANGE_LABELS: Record<TimeRange, string> = {
+  "1h": "1 Hour",
+  "24h": "24 Hours",
+  "7d": "7 Days",
+};
+
+const RANGE_MINUTES: Record<TimeRange, number> = {
+  "1h": 60,
+  "24h": 1440,
+  "7d": 10080,
+};
+
+function formatTrafficTime(iso: string, range: TimeRange): string {
+  try {
+    const d = new Date(iso);
+    if (range === "7d") {
+      return d.toLocaleDateString([], { weekday: "short", hour: "2-digit", minute: "2-digit" });
+    }
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+function TrafficTab() {
+  const [data, setData] = useState<TrafficHistoryPoint[]>([]);
+  const [range, setRange] = useState<TimeRange>("1h");
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      const points = await fetchTrafficHistory(RANGE_MINUTES[range]);
+      setData(points);
+    } catch {
+      // Keep stale data on error
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+    const intervalMs = range === "1h" ? 30_000 : 60_000;
+    const interval = setInterval(load, intervalMs);
+    return () => clearInterval(interval);
+  }, [load, range]);
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base text-white">
+            Bandwidth History
+          </CardTitle>
+          <div className="flex gap-1">
+            {(Object.keys(RANGE_LABELS) as TimeRange[]).map((r) => (
+              <Button
+                key={r}
+                variant={range === r ? "secondary" : "ghost"}
+                size="sm"
+                className={`h-7 px-2.5 text-xs ${
+                  range === r
+                    ? "bg-slate-700 text-white"
+                    : "text-slate-500 hover:text-slate-300"
+                }`}
+                onClick={() => setRange(r)}
+              >
+                {r}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading && data.length === 0 ? (
+          <Skeleton className="h-[300px] w-full rounded-xl" />
+        ) : data.length > 0 ? (
+          <div style={{ height: 300 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={data}>
+                <defs>
+                  <linearGradient id="mtColorRx" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="mtColorTx" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                <XAxis
+                  dataKey="minute"
+                  tickFormatter={(v: string) => formatTrafficTime(v, range)}
+                  tick={{ fill: "#6b7280", fontSize: 11 }}
+                  stroke="#1e293b"
+                  interval="preserveStartEnd"
+                />
+                <YAxis
+                  tickFormatter={(v: number) => formatBps(v)}
+                  tick={{ fill: "#6b7280", fontSize: 11 }}
+                  stroke="#1e293b"
+                  width={70}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "#0f172a",
+                    border: "1px solid #1e293b",
+                    borderRadius: "6px",
+                    color: "#fff",
+                    fontSize: "12px",
+                  }}
+                  labelFormatter={(v: string) => formatTrafficTime(v, range)}
+                  formatter={(value: number, name: string) => [
+                    formatBps(value),
+                    name === "rx_bps" ? "Inbound" : "Outbound",
+                  ]}
+                />
+                <Legend
+                  formatter={(value: string) =>
+                    value === "rx_bps" ? "Inbound" : "Outbound"
+                  }
+                  wrapperStyle={{ fontSize: "12px", color: "#9ca3af" }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="rx_bps"
+                  stroke="#3b82f6"
+                  fillOpacity={1}
+                  fill="url(#mtColorRx)"
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="tx_bps"
+                  stroke="#22c55e"
+                  fillOpacity={1}
+                  fill="url(#mtColorTx)"
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <div className="flex h-[300px] items-center justify-center">
+            <p className="text-sm text-slate-500">
+              No traffic data yet. The poller collects samples every 60 seconds.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ── Main component ────────────────────────────────────────
 
 export default function MikrotikRouter() {
@@ -1511,6 +1687,13 @@ export default function MikrotikRouter() {
             <Lock className="mr-1.5 h-3.5 w-3.5" />
             VPN
           </TabsTrigger>
+          <TabsTrigger
+            value="traffic"
+            className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+          >
+            <BarChart3 className="mr-1.5 h-3.5 w-3.5" />
+            Traffic
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="system">
@@ -1626,6 +1809,10 @@ export default function MikrotikRouter() {
               />
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="traffic">
+          <TrafficTab />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
Closes #229

## Summary

- **MikroTik traffic poller**: New background task (`mikrotik_traffic.rs`) polls MikroTik interface byte counters every 60 seconds via the existing REST API client. Computes byte deltas between polls, converts to bits-per-second, and stores per-device samples in `traffic_samples` (matched by MAC address). Handles counter wraparound, skips zero-traffic interfaces, and gracefully handles MikroTik being unconfigured.

- **Traffic tab on MikroTik router page**: Added a "Traffic" tab to the MikroTik router page with an interactive bandwidth history chart (AreaChart from recharts). Supports 1h/24h/7d time range selection with auto-refresh (30s for 1h, 60s for longer ranges). Shows inbound/outbound traffic with gradient fills matching the existing DeviceTrafficChart style.

- **Per-device charts**: The existing `DeviceTrafficChart` component (already on device detail pages) now has data to display — the poller feeds `traffic_samples` which the existing `/api/v1/devices/:id/traffic` endpoint queries.

## Design decisions

- Used the existing `/rest/interface` endpoint (cumulative `tx-byte`/`rx-byte` counters) rather than `/rest/interface/monitor-traffic` (streaming endpoint) for simpler, more reliable polling
- Matches interfaces to devices by MAC address lookup
- Reuses the existing `traffic_samples` table and rollup infrastructure (hourly/daily aggregation handled by the existing retention task)
- Source field set to `'mikrotik'` for traceability

## Test plan

- [x] All 290 existing tests pass (`cargo test --lib`)
- [x] Traffic-specific tests pass (history, aggregation, ordering)
- [ ] Manual: Enable MikroTik in settings, verify traffic data appears after ~2 minutes
- [ ] Manual: Check Traffic tab on MikroTik router page shows chart
- [ ] Manual: Check device detail page traffic tab shows per-device data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added MikroTik traffic monitoring with per-minute interface polling and interactive bandwidth charts. The implementation reuses the existing `traffic_samples` infrastructure and adds a new Traffic tab to the MikroTik router page.

**Key Changes:**
- New background poller (`mikrotik_traffic.rs`) fetches interface byte counters every 60 seconds via REST API, computes deltas, maps interfaces to devices by MAC address, and stores samples with `source = 'mikrotik'`
- Traffic tab on MikroTik router page displays bandwidth history with 1h/24h/7d time range selection and auto-refresh
- Handles counter wraparound, skips zero-traffic interfaces, and gracefully handles MikroTik being disabled

**Issues Found:**
- The 7-day time range is broken - the history endpoint clamps requests to 1,440 minutes (24 hours) maximum, but the frontend requests 10,080 minutes for 7d view. This causes the 7d range to only display 24 hours of data instead of a full week.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the 7-day range limit - the broken limit is the only functional issue
- The implementation is well-designed and reuses existing infrastructure correctly. The traffic poller properly handles edge cases (wraparound, disabled state, missing MACs). All 290 existing tests pass. The only issue is the 7d time range being clamped to 24h, which is a simple one-line fix.
- `server/src/api/traffic.rs` - fix the clamp limit on line 30 to support 7-day queries

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/traffic.rs | Added global traffic history endpoint with aggregation, but 7d time range is incorrectly clamped to 24h maximum |
| server/src/mikrotik_traffic.rs | New traffic poller - fetches interface counters every 60s, computes byte deltas, maps by MAC to devices, handles wraparound and disabled state correctly |
| web/src/components/MikrotikRouter.tsx | Added Traffic tab with bandwidth history chart, supports 1h/24h/7d ranges with auto-refresh, uses existing fetchTrafficHistory endpoint |

</details>



<sub>Last reviewed commit: 72ada75</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->