### PR TITLE
feat: unified topology graph endpoint with DHCP/bridge enrichment (#228)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -312,7 +312,8 @@ pub fn router(state: AppState) -> Router {
             "/vyos/wireguard/:name/peers/:peer/generate-config",
             post(vyos::wireguard_generate_client_config),
         )
-        // Topology positions
+        // Topology
+        .route("/topology/graph", get(topology::graph))
         .route("/topology/positions", get(topology::get_positions))
         .route("/topology/positions", put(topology::save_positions))
         .route("/topology/positions", delete(topology::delete_positions))

--- a/server/src/api/topology.rs
+++ b/server/src/api/topology.rs
@@ -1,8 +1,10 @@
 use axum::{extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
+use sqlx::Row;
 use tracing::error;
 
 use super::AppState;
+use crate::mikrotik::client::MikrotikClient;
 
 /// A single node's persisted position.
 #[derive(Debug, Serialize, Deserialize)]
@@ -82,4 +84,358 @@ pub async fn delete_positions(State(state): State<AppState>) -> Result<StatusCod
         })?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Topology Graph endpoint ─────────────────────────────────────────
+
+/// A lightweight device node for the topology graph.
+#[derive(Debug, Serialize)]
+pub struct TopologyDevice {
+    pub id: String,
+    pub mac: String,
+    pub name: Option<String>,
+    pub hostname: Option<String>,
+    pub vendor: Option<String>,
+    pub is_online: bool,
+    pub ips: Vec<String>,
+    pub custom_name: Option<String>,
+    pub custom_type: Option<String>,
+    pub custom_vendor: Option<String>,
+    pub device_type: Option<String>,
+    pub device_model: Option<String>,
+    pub device_brand: Option<String>,
+    pub mdns_services: Option<String>,
+    pub icon: String,
+    pub first_seen_at: String,
+    pub last_seen_at: String,
+    pub os_family: Option<String>,
+    pub os_version: Option<String>,
+    pub location: Option<String>,
+    pub owner: Option<String>,
+    pub tags: Option<String>,
+    pub rx_bps: i64,
+    pub tx_bps: i64,
+    /// DHCP lease status (e.g. "bound", "waiting") — enriched from router DHCP
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dhcp_lease_status: Option<String>,
+    /// DHCP server name that issued the lease
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dhcp_server: Option<String>,
+    /// DHCP lease expiry / remaining time
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dhcp_expires: Option<String>,
+    /// DHCP hostname (reported by the client to the DHCP server)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dhcp_hostname: Option<String>,
+    /// Bridge port this device was last seen on (from MikroTik bridge host table)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_port: Option<String>,
+    /// Bridge name (from MikroTik bridge host table)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_name: Option<String>,
+}
+
+/// Router info for the topology hub node.
+#[derive(Debug, Serialize)]
+pub struct TopologyRouter {
+    pub router_type: String, // "vyos" | "mikrotik" | "unknown"
+    pub is_online: bool,
+    pub wan_ip: Option<String>,
+    pub hostname: Option<String>,
+    pub version: Option<String>,
+}
+
+/// The complete topology graph response — all data needed for the visualization.
+#[derive(Debug, Serialize)]
+pub struct TopologyGraph {
+    pub devices: Vec<TopologyDevice>,
+    pub router: TopologyRouter,
+    pub positions: Vec<NodePosition>,
+}
+
+/// Try to construct a MikroTik client from saved settings.
+async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
+    let get_setting = |key: &str| {
+        let db = state.db.clone();
+        let key = key.to_string();
+        async move {
+            sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+                .bind(&key)
+                .fetch_optional(&db)
+                .await
+                .ok()
+                .flatten()
+                .filter(|v| !v.is_empty())
+        }
+    };
+
+    let enabled = get_setting("mikrotik_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let url = get_setting("mikrotik_url").await?;
+    let user = get_setting("mikrotik_user")
+        .await
+        .unwrap_or_else(|| "admin".to_string());
+    let password = get_setting("mikrotik_password").await.unwrap_or_default();
+
+    Some(MikrotikClient::with_http(
+        &url,
+        &user,
+        &password,
+        state.mikrotik_http.clone(),
+    ))
+}
+
+/// GET /api/v1/topology/graph — return the complete topology graph in a single call.
+///
+/// Aggregates devices (from DB), traffic data, DHCP leases and bridge hosts
+/// (from MikroTik/VyOS, if configured), router interfaces, and saved positions.
+pub async fn graph(State(state): State<AppState>) -> Result<Json<TopologyGraph>, StatusCode> {
+    // 1. Fetch devices with traffic data from the database
+    let rows = sqlx::query(
+        r#"
+        SELECT d.id, d.mac, d.name, d.hostname, d.vendor,
+               COALESCE(d.icon, 'device') AS icon,
+               d.is_online,
+               d.mdns_services,
+               d.custom_name, d.custom_type, d.custom_vendor,
+               d.device_type, d.device_model, d.device_brand,
+               d.first_seen_at, d.last_seen_at,
+               d.os_family, d.os_version,
+               d.location, d.owner, d.tags,
+               COALESCE(ts.rx_bps, 0) AS rx_bps,
+               COALESCE(ts.tx_bps, 0) AS tx_bps
+        FROM devices d
+        LEFT JOIN (
+            SELECT device_id, rx_bps, tx_bps,
+                   ROW_NUMBER() OVER (PARTITION BY device_id ORDER BY sampled_at DESC) AS rn
+            FROM traffic_samples
+        ) ts ON ts.device_id = d.id AND ts.rn = 1
+        ORDER BY d.last_seen_at DESC
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        error!("Failed to fetch topology devices: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Fetch current IPs
+    let ip_rows = sqlx::query("SELECT device_id, ip FROM device_ips WHERE is_current = 1")
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    // Group IPs by device_id
+    let mut ip_map: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for row in &ip_rows {
+        let device_id: String = row.try_get("device_id").unwrap_or_default();
+        let ip: String = row.try_get("ip").unwrap_or_default();
+        ip_map.entry(device_id).or_default().push(ip);
+    }
+
+    // Build device MAC → index map for DHCP/bridge enrichment
+    let mut mac_to_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    let mut devices: Vec<TopologyDevice> = rows
+        .into_iter()
+        .enumerate()
+        .map(|(idx, r)| {
+            let id: String = r.try_get("id").unwrap_or_default();
+            let mac: String = r.try_get("mac").unwrap_or_default();
+            let mac_lower = mac.to_lowercase();
+            mac_to_idx.insert(mac_lower, idx);
+
+            TopologyDevice {
+                ips: ip_map.remove(&id).unwrap_or_default(),
+                id,
+                mac,
+                name: r.try_get("name").unwrap_or(None),
+                hostname: r.try_get("hostname").unwrap_or(None),
+                vendor: r.try_get("vendor").unwrap_or(None),
+                icon: r
+                    .try_get::<String, _>("icon")
+                    .unwrap_or_else(|_| "device".to_string()),
+                is_online: r.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+                mdns_services: r.try_get("mdns_services").unwrap_or(None),
+                custom_name: r.try_get("custom_name").unwrap_or(None),
+                custom_type: r.try_get("custom_type").unwrap_or(None),
+                custom_vendor: r.try_get("custom_vendor").unwrap_or(None),
+                device_type: r.try_get("device_type").unwrap_or(None),
+                device_model: r.try_get("device_model").unwrap_or(None),
+                device_brand: r.try_get("device_brand").unwrap_or(None),
+                first_seen_at: r.try_get("first_seen_at").unwrap_or_default(),
+                last_seen_at: r.try_get("last_seen_at").unwrap_or_default(),
+                os_family: r.try_get("os_family").unwrap_or(None),
+                os_version: r.try_get("os_version").unwrap_or(None),
+                location: r.try_get("location").unwrap_or(None),
+                owner: r.try_get("owner").unwrap_or(None),
+                tags: r.try_get("tags").unwrap_or(None),
+                rx_bps: r.try_get("rx_bps").unwrap_or(0),
+                tx_bps: r.try_get("tx_bps").unwrap_or(0),
+                dhcp_lease_status: None,
+                dhcp_server: None,
+                dhcp_expires: None,
+                dhcp_hostname: None,
+                bridge_port: None,
+                bridge_name: None,
+            }
+        })
+        .collect();
+
+    // 2. Fetch saved positions
+    let positions = sqlx::query_as::<_, (String, f64, f64, i32)>(
+        "SELECT node_id, x, y, pinned FROM topology_positions",
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default()
+    .into_iter()
+    .map(|(node_id, x, y, pinned)| NodePosition {
+        node_id,
+        x,
+        y,
+        pinned: pinned != 0,
+    })
+    .collect();
+
+    // 3. Build router info and enrich with DHCP/bridge data from MikroTik or VyOS
+    let mut router = TopologyRouter {
+        router_type: "unknown".to_string(),
+        is_online: false,
+        wan_ip: None,
+        hostname: None,
+        version: None,
+    };
+
+    // Try MikroTik first
+    if let Some(mt_client) = mikrotik_client(&state).await {
+        // Router status
+        if let Ok(res) = mt_client.system_resource().await {
+            router = TopologyRouter {
+                router_type: "mikrotik".to_string(),
+                is_online: true,
+                wan_ip: None, // populated below from interfaces
+                hostname: res.board_name.clone(),
+                version: res.version,
+            };
+        }
+
+        // MikroTik interfaces — find WAN IP
+        if let Ok(addrs) = mt_client.ip_addresses().await {
+            // Use the first non-loopback address, prefer one on ether1
+            for addr in &addrs {
+                if let Some(ip) = &addr.address {
+                    if router.wan_ip.is_none() || addr.interface.as_deref() == Some("ether1") {
+                        // Strip CIDR prefix if present (e.g. "10.0.0.1/24" → "10.0.0.1")
+                        router.wan_ip = Some(ip.split('/').next().unwrap_or(ip).to_string());
+                    }
+                }
+            }
+        }
+
+        // Enrich with DHCP leases
+        if let Ok(leases) = mt_client.dhcp_leases().await {
+            for lease in leases {
+                if let Some(mac) = &lease.mac_address {
+                    let mac_lower = mac.to_lowercase();
+                    if let Some(&idx) = mac_to_idx.get(&mac_lower) {
+                        devices[idx].dhcp_lease_status = lease.status;
+                        devices[idx].dhcp_server = lease.server;
+                        devices[idx].dhcp_expires = lease.expires_after;
+                        devices[idx].dhcp_hostname = lease.host_name;
+                    }
+                }
+            }
+        }
+
+        // Enrich with bridge hosts
+        if let Ok(hosts) = mt_client.bridge_hosts().await {
+            for host in hosts {
+                if let Some(mac) = &host.mac_address {
+                    let mac_lower = mac.to_lowercase();
+                    if let Some(&idx) = mac_to_idx.get(&mac_lower) {
+                        devices[idx].bridge_port = host.on_interface.or(host.interface);
+                        devices[idx].bridge_name = host.bridge;
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall back to VyOS if MikroTik didn't provide router info
+    if router.router_type == "unknown" {
+        if let Some(vyos_client) =
+            super::vyos::get_vyos_client_from_db(&state.db, &state.config, &state.vyos_http).await
+        {
+            // Check VyOS reachability
+            if vyos_client.show(&["system", "uptime"]).await.is_ok() {
+                router.router_type = "vyos".to_string();
+                router.is_online = true;
+
+                // Try to get hostname
+                if let Ok(val) = vyos_client.show(&["system", "host-name"]).await {
+                    if let Some(s) = val.as_str() {
+                        let trimmed = s.trim();
+                        if !trimmed.is_empty() {
+                            router.hostname = Some(trimmed.to_string());
+                        }
+                    }
+                }
+
+                // Try to get interfaces for WAN IP
+                if let Ok(val) = vyos_client.show(&["interfaces"]).await {
+                    let text = val.as_str().unwrap_or("");
+                    let ifaces = super::vyos::parse_interfaces_text(text);
+                    // Find WAN interface
+                    let wan = ifaces.iter().find(|i| {
+                        i.name == "eth0"
+                            || i.name.starts_with("pppoe")
+                            || i.description
+                                .as_ref()
+                                .map(|d| d.to_lowercase().contains("wan"))
+                                .unwrap_or(false)
+                    });
+                    if let Some(iface) = wan {
+                        router.wan_ip = iface
+                            .ip_address
+                            .as_ref()
+                            .map(|ip| ip.split('/').next().unwrap_or(ip).to_string());
+                    }
+                }
+
+                // Enrich with VyOS DHCP leases
+                if let Ok(val) = vyos_client.show(&["dhcp", "server", "leases"]).await {
+                    let text = val.as_str().unwrap_or("");
+                    let leases = super::vyos::parse_dhcp_leases_text(text);
+                    for lease in leases {
+                        let mac_lower = lease.mac.to_lowercase();
+                        if let Some(&idx) = mac_to_idx.get(&mac_lower) {
+                            devices[idx].dhcp_lease_status = Some(lease.state);
+                            devices[idx].dhcp_server = lease.pool;
+                            devices[idx].dhcp_expires = lease.remaining;
+                            if let Some(h) = lease.hostname {
+                                if h != "-" {
+                                    devices[idx].dhcp_hostname = Some(h);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(Json(TopologyGraph {
+        devices,
+        router,
+        positions,
+    }))
 }

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -6776,7 +6776,7 @@ async fn get_vyos_settings(
     (url, key)
 }
 
-async fn get_vyos_client_from_db(
+pub(crate) async fn get_vyos_client_from_db(
     db: &SqlitePool,
     config: &crate::config::AppConfig,
     http: &reqwest::Client,

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -289,6 +289,14 @@ impl MikrotikClient {
         Ok(res)
     }
 
+    /// Fetch bridge host table (MAC forwarding database).
+    pub async fn bridge_hosts(&self) -> Result<Vec<BridgeHost>> {
+        let val = self.get("/interface/bridge/host").await?;
+        let res: Vec<BridgeHost> =
+            serde_json::from_value(val).context("failed to parse bridge hosts")?;
+        Ok(res)
+    }
+
     /// Fetch WireGuard interfaces.
     pub async fn wireguard_interfaces(&self) -> Result<Vec<WgInterface>> {
         let val = self.get("/interface/wireguard").await?;

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -185,6 +185,20 @@ pub struct DnsSettings {
     pub cache_used: Option<String>,
 }
 
+/// MikroTik bridge host entry (`/rest/interface/bridge/host`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHost {
+    #[serde(rename = ".id")]
+    pub id: Option<String>,
+    #[serde(rename = "mac-address")]
+    pub mac_address: Option<String>,
+    pub interface: Option<String>,
+    pub bridge: Option<String>,
+    pub on_interface: Option<String>,
+    pub dynamic: Option<String>,
+    pub disabled: Option<String>,
+}
+
 /// MikroTik WireGuard interface (`/rest/interface/wireguard`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WgInterface {

--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -38,15 +38,11 @@ import {
   Check,
 } from 'lucide-react'
 import {
-  fetchDevices,
-  fetchTopDevices,
-  fetchRouterInterfaces,
-  fetchTopologyPositions,
+  fetchTopologyGraph,
   saveTopologyPositions,
   deleteTopologyPositions,
-  type NodePosition,
 } from '@/lib/api'
-import type { Device, TopDevice, VyosInterface } from '@/lib/types'
+import type { TopologyDevice, TopologyRouter } from '@/lib/types'
 import { getDeviceIcon } from '@/lib/device-icons'
 import { PageTransition } from '@/components/PageTransition'
 import {
@@ -65,12 +61,13 @@ import Link from 'next/link'
 
 type RouterNodeData = {
   label: string
+  routerType: string
   wanIp: string | null
   isOnline: boolean
 }
 
 type DeviceNodeData = {
-  device: Device
+  device: TopologyDevice
   trafficBps: number
   subnet: string
 }
@@ -240,6 +237,13 @@ function computeForceLayout(
 // ─── Custom Nodes ───────────────────────────────────────
 
 function RouterNode({ data }: NodeProps<RouterNodeType>) {
+  const routerLabel =
+    data.routerType === 'mikrotik'
+      ? 'MikroTik'
+      : data.routerType === 'vyos'
+        ? 'VyOS'
+        : 'Router'
+
   return (
     <div
       className="flex items-center gap-3 rounded-xl border border-blue-500/30 bg-gradient-to-br from-slate-800 to-slate-900 px-5 py-4 shadow-lg shadow-blue-500/10"
@@ -253,7 +257,7 @@ function RouterNode({ data }: NodeProps<RouterNodeType>) {
         <Network className="h-5 w-5 text-blue-400" />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-semibold text-white">Router</p>
+        <p className="truncate text-sm font-semibold text-white">{routerLabel}</p>
         {data.wanIp && (
           <p className="truncate text-xs text-slate-400">{data.wanIp}</p>
         )}
@@ -286,6 +290,7 @@ function DeviceNode({ data }: NodeProps<DeviceNodeType>) {
     device.custom_name || device.name || device.hostname || device.mac
   const primaryIp = device.ips?.[0] || '—'
   const subnetColor = getSubnetColor(data.subnet)
+  const hasDhcp = !!device.dhcp_lease_status
 
   return (
     <div
@@ -305,7 +310,12 @@ function DeviceNode({ data }: NodeProps<DeviceNodeType>) {
       </div>
       <div className="min-w-0 flex-1">
         <p className="truncate text-xs font-medium text-white">{displayName}</p>
-        <p className="truncate text-[10px] text-slate-400">{primaryIp}</p>
+        <div className="flex items-center gap-1">
+          <p className="truncate text-[10px] text-slate-400">{primaryIp}</p>
+          {hasDhcp && (
+            <span className="inline-block h-1 w-1 rounded-full bg-blue-400" title="DHCP lease" />
+          )}
+        </div>
       </div>
       <span
         className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
@@ -359,7 +369,7 @@ function getEdgeStrokeWidth(bps: number): number {
 
 // ─── Device Detail Panel ────────────────────────────────
 
-function DeviceDetailPanel({ device }: { device: Device }) {
+function DeviceDetailPanel({ device }: { device: TopologyDevice }) {
   const [copied, setCopied] = useState<string | null>(null)
   const ips = device.ips ?? []
   const primaryIp = ips[0] ?? '—'
@@ -497,6 +507,33 @@ function DeviceDetailPanel({ device }: { device: Device }) {
           </>
         )}
 
+        {(device.dhcp_lease_status || device.bridge_port) && (
+          <>
+            <Separator className="bg-slate-800" />
+            <p className="text-xs font-medium uppercase tracking-wider text-slate-500">
+              Network
+            </p>
+            {device.dhcp_lease_status && (
+              <InfoRow label="DHCP Status" value={device.dhcp_lease_status} />
+            )}
+            {device.dhcp_hostname && (
+              <InfoRow label="DHCP Hostname" value={device.dhcp_hostname} />
+            )}
+            {device.dhcp_server && (
+              <InfoRow label="DHCP Server" value={device.dhcp_server} />
+            )}
+            {device.dhcp_expires && (
+              <InfoRow label="Lease Expires" value={device.dhcp_expires} />
+            )}
+            {device.bridge_port && (
+              <InfoRow label="Bridge Port" value={device.bridge_port} />
+            )}
+            {device.bridge_name && (
+              <InfoRow label="Bridge" value={device.bridge_name} />
+            )}
+          </>
+        )}
+
         {device.mdns_services && (
           <>
             <Separator className="bg-slate-800" />
@@ -596,57 +633,30 @@ export default function TopologyPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
-  const [selectedDevice, setSelectedDevice] = useState<Device | null>(null)
+  const [selectedDevice, setSelectedDevice] = useState<TopologyDevice | null>(null)
 
   // Track pinned positions locally so refreshes preserve them
   const pinnedRef = useRef<Map<string, { x: number; y: number }>>(new Map())
+  // Store the latest router info for display
+  const routerInfoRef = useRef<TopologyRouter | null>(null)
 
   const buildGraph = useCallback(
     async (isInitial: boolean) => {
       try {
-        const fetches: [
-          Promise<Device[]>,
-          Promise<TopDevice[]>,
-          Promise<VyosInterface[]>,
-          Promise<NodePosition[]>?,
-        ] = [
-          fetchDevices(),
-          fetchTopDevices(100),
-          fetchRouterInterfaces().catch(() => [] as VyosInterface[]),
-        ]
+        const graph = await fetchTopologyGraph()
+        const { devices, router, positions } = graph
 
-        if (isInitial) {
-          fetches.push(
-            fetchTopologyPositions().catch(() => [] as NodePosition[]),
-          )
-        }
-
-        const [devices, topDevices, interfaces, savedPositions] =
-          await Promise.all(fetches)
+        // Store router info
+        routerInfoRef.current = router
 
         // Populate pinned map from server on initial load
-        if (isInitial && savedPositions) {
+        if (isInitial) {
           pinnedRef.current = new Map(
-            savedPositions
+            positions
               .filter((p) => p.pinned)
               .map((p) => [p.node_id, { x: p.x, y: p.y }]),
           )
         }
-
-        // Find WAN IP from router interfaces
-        const wanIf = interfaces.find(
-          (i) =>
-            i.name === 'eth0' ||
-            i.description?.toLowerCase().includes('wan') ||
-            i.name?.startsWith('pppoe'),
-        )
-        const wanIp = wanIf?.ip_address ?? null
-
-        // Build traffic map
-        const trafficMap = new Map<string, number>()
-        topDevices.forEach((td: TopDevice) => {
-          trafficMap.set(td.id, (td.rx_bps || 0) + (td.tx_bps || 0))
-        })
 
         // Derive subnet for each device
         const deviceSubnets = new Map<string, string>()
@@ -656,7 +666,7 @@ export default function TopologyPage() {
         })
 
         // Collect subnet groups
-        const subnetDevices = new Map<string, Device[]>()
+        const subnetDevices = new Map<string, TopologyDevice[]>()
         devices.forEach((d) => {
           const subnet = deviceSubnets.get(d.id) || 'unknown'
           const existing = subnetDevices.get(subnet) || []
@@ -697,6 +707,7 @@ export default function TopologyPage() {
         // Build device nodes
         const deviceNodes: TopologyNode[] = devices.map((device) => {
           const subnet = deviceSubnets.get(device.id) || 'unknown'
+          const totalBps = (device.rx_bps || 0) + (device.tx_bps || 0)
           const pos = positionMap.get(device.id)
           return {
             id: device.id,
@@ -706,7 +717,7 @@ export default function TopologyPage() {
               : { x: 0, y: 0 },
             data: {
               device,
-              trafficBps: trafficMap.get(device.id) || 0,
+              trafficBps: totalBps,
               subnet,
             },
             draggable: true,
@@ -726,9 +737,10 @@ export default function TopologyPage() {
               }
             : { x: -ROUTER_WIDTH / 2, y: -ROUTER_HEIGHT / 2 },
           data: {
-            label: 'Router',
-            wanIp,
-            isOnline: true,
+            label: router.hostname || 'Router',
+            routerType: router.router_type,
+            wanIp: router.wan_ip,
+            isOnline: router.is_online,
           },
           draggable: true,
           zIndex: 10,
@@ -785,7 +797,7 @@ export default function TopologyPage() {
 
         // Build edges
         const allEdges: Edge[] = devices.map((device) => {
-          const totalBps = trafficMap.get(device.id) || 0
+          const totalBps = (device.rx_bps || 0) + (device.tx_bps || 0)
           return {
             id: `router-${device.id}`,
             source: 'router',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,8 @@ import type {
   AlertRule,
   CreateAlertRuleRequest,
   UpdateAlertRuleRequest,
+  TopologyGraph,
+  NodePosition,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -880,13 +882,12 @@ export function generateWireguardClientConfig(
   );
 }
 
-// ─── Topology Positions ──────────────────────────────────
+// ─── Topology ───────────────────────────────────────────
 
-export interface NodePosition {
-  node_id: string;
-  x: number;
-  y: number;
-  pinned: boolean;
+export type { NodePosition };
+
+export function fetchTopologyGraph(): Promise<TopologyGraph> {
+  return apiGet<TopologyGraph>("/api/v1/topology/graph");
 }
 
 export function fetchTopologyPositions(): Promise<NodePosition[]> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -182,6 +182,72 @@ export interface TopDevice {
   tx_bps: number;
 }
 
+// ─── Topology Graph ─────────────────────────────────────
+
+/** A device node in the topology graph (lighter than full Device). */
+export interface TopologyDevice {
+  id: string;
+  mac: string;
+  name: string | null;
+  hostname: string | null;
+  vendor: string | null;
+  is_online: boolean;
+  ips: string[];
+  custom_name: string | null;
+  custom_type: string | null;
+  custom_vendor: string | null;
+  device_type: string | null;
+  device_model: string | null;
+  device_brand: string | null;
+  mdns_services: string | null;
+  icon: string;
+  first_seen_at: string;
+  last_seen_at: string;
+  os_family: string | null;
+  os_version: string | null;
+  location: string | null;
+  owner: string | null;
+  tags: string | null;
+  rx_bps: number;
+  tx_bps: number;
+  /** DHCP lease status (e.g. "bound", "active") */
+  dhcp_lease_status?: string | null;
+  /** DHCP server / pool that issued the lease */
+  dhcp_server?: string | null;
+  /** DHCP lease expiry / remaining time */
+  dhcp_expires?: string | null;
+  /** DHCP hostname (reported by the client) */
+  dhcp_hostname?: string | null;
+  /** Bridge port the device was last seen on */
+  bridge_port?: string | null;
+  /** Bridge name (from MikroTik bridge host table) */
+  bridge_name?: string | null;
+}
+
+/** Router hub node in the topology graph. */
+export interface TopologyRouter {
+  router_type: string; // "vyos" | "mikrotik" | "unknown"
+  is_online: boolean;
+  wan_ip: string | null;
+  hostname: string | null;
+  version: string | null;
+}
+
+/** Saved node position for the topology layout. */
+export interface NodePosition {
+  node_id: string;
+  x: number;
+  y: number;
+  pinned: boolean;
+}
+
+/** Complete topology graph response from /api/v1/topology/graph. */
+export interface TopologyGraph {
+  devices: TopologyDevice[];
+  router: TopologyRouter;
+  positions: NodePosition[];
+}
+
 // ─── Traffic ────────────────────────────────────────────
 
 export interface TrafficHistoryPoint {


### PR DESCRIPTION
## Summary
- Adds a unified `/api/v1/topology/graph` backend endpoint that returns devices, router info, and traffic data in a single request — replacing 3-4 separate frontend API calls
- Enriches topology devices with MikroTik DHCP lease data (status, hostname, server, expiry) and bridge host data (port, bridge name) via MAC address matching
- Supports both MikroTik and VyOS routers as the central hub node in the topology graph
- Updates the topology page to consume the new unified endpoint, showing DHCP lease indicators on device nodes and a "Network" section in the device detail panel

## Changes
**Backend (Rust/Axum)**
- `server/src/api/topology.rs`: New `graph()` handler with `TopologyDevice`, `TopologyRouter`, `TopologyGraph` types; fetches devices + traffic from DB, enriches with DHCP/bridge data from MikroTik or VyOS
- `server/src/api/mod.rs`: Wired `/topology/graph` route
- `server/src/api/vyos.rs`: Made `get_vyos_client_from_db` pub(crate) for cross-module reuse
- `server/src/mikrotik/client.rs`: Added `bridge_hosts()` method
- `server/src/mikrotik/types.rs`: Added `BridgeHost` struct

**Frontend (Next.js/React)**
- `web/src/lib/types.ts`: Added `TopologyDevice`, `TopologyRouter`, `NodePosition`, `TopologyGraph` types
- `web/src/lib/api.ts`: Added `fetchTopologyGraph()` function
- `web/src/app/(app)/topology/page.tsx`: Switched from multiple API calls to single `fetchTopologyGraph()`, added DHCP indicator dot on device nodes, added Network section in detail panel, shows router type (MikroTik/VyOS)

## Test plan
- [ ] Verify topology page loads and displays devices as nodes with router as central hub
- [ ] Verify DHCP-leased devices show a blue indicator dot
- [ ] Verify clicking a device shows detail panel with Network section (DHCP/bridge info)
- [ ] Verify MikroTik router shows "MikroTik" label; VyOS router shows "VyOS"
- [ ] Verify `cargo check` and `bun run build` pass

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates multiple API calls into a single unified `/api/v1/topology/graph` endpoint that returns devices, router info, and traffic data in one request. The backend enriches device data with DHCP lease information and bridge host details from MikroTik or VyOS routers via MAC address matching. The frontend refactors the topology page to consume this unified endpoint, displaying DHCP indicators on device nodes and showing network details in the device panel.

**Key improvements:**
- Reduces network round-trips from 3-4 API calls to 1 on topology page load
- Enriches topology with real-time DHCP lease status and bridge port information
- Supports both MikroTik and VyOS routers as central hub nodes
- Displays router type (MikroTik/VyOS) in the topology visualization
- Shows DHCP-leased devices with blue indicator dot
- Adds "Network" section in device detail panel with DHCP/bridge info

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Well-structured refactoring that consolidates API calls without changing core logic. Backend properly handles optional router data with fallbacks. Frontend gracefully handles missing DHCP/bridge enrichment fields. Type definitions match between Rust and TypeScript. Minor concern: MAC address matching uses lowercase normalization which should work but could have edge cases with different MAC formats
- Pay close attention to `server/src/api/topology.rs` for the MAC address matching logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/topology.rs | Adds unified `/topology/graph` endpoint with DHCP/bridge enrichment; properly handles MikroTik and VyOS router discovery with MAC-based device matching |
| server/src/mikrotik/client.rs | Adds `bridge_hosts()` method to fetch MAC forwarding database from MikroTik |
| web/src/lib/types.ts | Adds TypeScript interfaces for unified topology graph response with DHCP/bridge fields |
| web/src/app/(app)/topology/page.tsx | Refactors to use unified endpoint, adds DHCP indicator dot and Network section in device panel; displays router type label |

</details>



<sub>Last reviewed commit: 73c9563</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->