### PR TITLE
feat: device inventory — complete asset management (#247)

### DIFF
--- a/server/src/api/assets.rs
+++ b/server/src/api/assets.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use super::{AppError, AppState};
 
@@ -26,12 +26,16 @@ const VALID_ASSET_TYPES: &[&str] = &[
     "unknown",
 ];
 
+/// Valid asset status values.
+const VALID_STATUSES: &[&str] = &["active", "inactive", "maintenance", "retired", "disposed"];
+
 /// An asset as returned by the API.
 #[derive(Debug, Serialize)]
 pub struct Asset {
     pub id: String,
     pub name: String,
     pub asset_type: String,
+    pub status: String,
     pub location: Option<String>,
     pub owner: Option<String>,
     pub tags: Option<String>,
@@ -63,6 +67,7 @@ pub struct Asset {
 pub struct AssetRequest {
     pub name: Option<String>,
     pub asset_type: Option<String>,
+    pub status: Option<String>,
     pub location: Option<String>,
     pub owner: Option<String>,
     pub tags: Option<String>,
@@ -80,6 +85,43 @@ pub struct ListQuery {
     #[serde(rename = "type")]
     pub asset_type: Option<String>,
     pub tag: Option<String>,
+    pub status: Option<String>,
+    pub location: Option<String>,
+}
+
+/// A single row in a CSV import.
+#[derive(Debug, Deserialize)]
+pub struct CsvImportRow {
+    pub name: String,
+    pub asset_type: Option<String>,
+    pub status: Option<String>,
+    pub location: Option<String>,
+    pub owner: Option<String>,
+    pub tags: Option<String>,
+    pub notes: Option<String>,
+    pub purchase_date: Option<String>,
+    pub serial_number: Option<String>,
+}
+
+/// Request body for bulk CSV import.
+#[derive(Debug, Deserialize)]
+pub struct ImportRequest {
+    pub rows: Vec<CsvImportRow>,
+}
+
+/// Response for bulk import.
+#[derive(Debug, Serialize)]
+pub struct ImportResponse {
+    pub imported: usize,
+    pub skipped: usize,
+    pub errors: Vec<String>,
+}
+
+/// Response for auto-link operation.
+#[derive(Debug, Serialize)]
+pub struct AutoLinkResponse {
+    pub linked: usize,
+    pub details: Vec<String>,
 }
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -133,6 +175,9 @@ fn asset_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Asset, sqlx::Error> {
         id: row.try_get("id")?,
         name: row.try_get("name")?,
         asset_type: row.try_get("asset_type")?,
+        status: row
+            .try_get("status")
+            .unwrap_or_else(|_| "active".to_string()),
         location: row.try_get("location").ok().flatten(),
         owner: row.try_get("owner").ok().flatten(),
         tags: row.try_get("tags").ok().flatten(),
@@ -165,7 +210,7 @@ fn asset_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Asset, sqlx::Error> {
 }
 
 const LIST_QUERY: &str = "\
-    SELECT a.id, a.name, a.asset_type, a.location, a.owner, a.tags, a.notes, \
+    SELECT a.id, a.name, a.asset_type, a.status, a.location, a.owner, a.tags, a.notes, \
            a.purchase_date, a.serial_number, a.device_id, a.agent_id, a.ssh_target_id, \
            a.created_at, a.updated_at, \
            d.is_online AS device_online, d.last_seen_at AS device_last_seen, \
@@ -186,7 +231,7 @@ const LIST_QUERY: &str = "\
     ORDER BY a.created_at DESC";
 
 const GET_ONE_QUERY: &str = "\
-    SELECT a.id, a.name, a.asset_type, a.location, a.owner, a.tags, a.notes, \
+    SELECT a.id, a.name, a.asset_type, a.status, a.location, a.owner, a.tags, a.notes, \
            a.purchase_date, a.serial_number, a.device_id, a.agent_id, a.ssh_target_id, \
            a.created_at, a.updated_at, \
            d.is_online AS device_online, d.last_seen_at AS device_last_seen, \
@@ -217,8 +262,13 @@ pub async fn list(
     let mut sql = String::from(LIST_QUERY);
     let mut binds: Vec<String> = Vec::new();
 
+    let has_filters = params.asset_type.is_some()
+        || params.tag.is_some()
+        || params.status.is_some()
+        || params.location.is_some();
+
     // Replace ORDER BY with WHERE clauses if we have filters.
-    if params.asset_type.is_some() || params.tag.is_some() {
+    if has_filters {
         // We need to inject WHERE conditions before the ORDER BY.
         // The LIST_QUERY already has ORDER BY at the end, so we insert before it.
         sql = sql.replace("ORDER BY a.created_at DESC", "");
@@ -233,6 +283,14 @@ pub async fn list(
             // Search for tag in JSON array-like text field.
             conditions.push("a.tags LIKE ?".to_string());
             binds.push(format!("%{tag}%"));
+        }
+        if let Some(ref s) = params.status {
+            conditions.push("a.status = ?".to_string());
+            binds.push(s.clone());
+        }
+        if let Some(ref loc) = params.location {
+            conditions.push("a.location = ?".to_string());
+            binds.push(loc.clone());
         }
 
         if !conditions.is_empty() {
@@ -300,15 +358,24 @@ pub async fn create(
         )));
     }
 
+    let status = body.status.as_deref().unwrap_or("active");
+    if !VALID_STATUSES.contains(&status) {
+        return Err(AppError::Validation(format!(
+            "invalid status '{status}'. Valid statuses: {}",
+            VALID_STATUSES.join(", ")
+        )));
+    }
+
     let id = uuid::Uuid::new_v4().to_string();
 
     sqlx::query(
-        "INSERT INTO assets (id, name, asset_type, location, owner, tags, notes, purchase_date, serial_number, device_id, agent_id, ssh_target_id) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO assets (id, name, asset_type, status, location, owner, tags, notes, purchase_date, serial_number, device_id, agent_id, ssh_target_id) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(name)
     .bind(asset_type)
+    .bind(status)
     .bind(body.location.as_deref().map(|s| s.trim()))
     .bind(body.owner.as_deref().map(|s| s.trim()))
     .bind(body.tags.as_deref())
@@ -359,6 +426,15 @@ pub async fn update(
         }
     }
 
+    if let Some(ref s) = body.status {
+        if !VALID_STATUSES.contains(&s.as_str()) {
+            return Err(AppError::Validation(format!(
+                "invalid status '{s}'. Valid statuses: {}",
+                VALID_STATUSES.join(", ")
+            )));
+        }
+    }
+
     // Build SET clauses dynamically — only update fields that are provided.
     let mut sets: Vec<String> = Vec::new();
     let mut binds: Vec<Option<String>> = Vec::new();
@@ -369,6 +445,10 @@ pub async fn update(
     }
     if let Some(ref v) = body.asset_type {
         sets.push("asset_type = ?".to_string());
+        binds.push(Some(v.clone()));
+    }
+    if let Some(ref v) = body.status {
+        sets.push("status = ?".to_string());
         binds.push(Some(v.clone()));
     }
     if body.location.is_some() {
@@ -451,6 +531,132 @@ pub async fn delete(State(state): State<AppState>, Path(id): Path<String>) -> St
     }
 }
 
+/// POST /api/v1/assets/import — bulk import assets from parsed CSV rows.
+pub async fn import(
+    State(state): State<AppState>,
+    Json(body): Json<ImportRequest>,
+) -> Result<Json<ImportResponse>, AppError> {
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    let mut errors = Vec::new();
+
+    for (i, row) in body.rows.iter().enumerate() {
+        let line = i + 1;
+        let name = row.name.trim();
+        if name.is_empty() {
+            errors.push(format!("Row {line}: name is empty, skipped"));
+            skipped += 1;
+            continue;
+        }
+
+        let asset_type = row.asset_type.as_deref().unwrap_or("unknown");
+        if !VALID_ASSET_TYPES.contains(&asset_type) {
+            errors.push(format!(
+                "Row {line}: invalid asset_type '{asset_type}', using 'unknown'"
+            ));
+        }
+        let asset_type = if VALID_ASSET_TYPES.contains(&asset_type) {
+            asset_type
+        } else {
+            "unknown"
+        };
+
+        let status = row.status.as_deref().unwrap_or("active");
+        let status = if VALID_STATUSES.contains(&status) {
+            status
+        } else {
+            warn!("Row {line}: invalid status '{status}', using 'active'");
+            "active"
+        };
+
+        let id = uuid::Uuid::new_v4().to_string();
+
+        match sqlx::query(
+            "INSERT INTO assets (id, name, asset_type, status, location, owner, tags, notes, purchase_date, serial_number) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(name)
+        .bind(asset_type)
+        .bind(status)
+        .bind(row.location.as_deref().map(|s| s.trim()))
+        .bind(row.owner.as_deref().map(|s| s.trim()))
+        .bind(row.tags.as_deref())
+        .bind(row.notes.as_deref())
+        .bind(row.purchase_date.as_deref())
+        .bind(row.serial_number.as_deref().map(|s| s.trim()))
+        .execute(&state.db)
+        .await
+        {
+            Ok(_) => imported += 1,
+            Err(e) => {
+                errors.push(format!("Row {line}: database error — {e}"));
+                skipped += 1;
+            }
+        }
+    }
+
+    info!(imported, skipped, "Bulk asset import completed");
+
+    Ok(Json(ImportResponse {
+        imported,
+        skipped,
+        errors,
+    }))
+}
+
+/// POST /api/v1/assets/auto-link — automatically link unlinked assets to
+/// discovered network devices by matching name or hostname.
+pub async fn auto_link(State(state): State<AppState>) -> Result<Json<AutoLinkResponse>, AppError> {
+    // Find assets that have no device_id linked.
+    let unlinked_rows = sqlx::query("SELECT id, name FROM assets WHERE device_id IS NULL")
+        .fetch_all(&state.db)
+        .await?;
+
+    let mut linked = 0usize;
+    let mut details = Vec::new();
+
+    for row in &unlinked_rows {
+        let asset_id: String = row.try_get("id").unwrap_or_default();
+        let asset_name: String = row.try_get("name").unwrap_or_default();
+        let name_lower = asset_name.to_lowercase();
+
+        // Try to match by device name or hostname (case-insensitive).
+        let device_row = sqlx::query(
+            "SELECT id, COALESCE(name, hostname) AS display_name FROM devices \
+             WHERE LOWER(COALESCE(name, '')) = ? OR LOWER(COALESCE(hostname, '')) = ? \
+             LIMIT 1",
+        )
+        .bind(&name_lower)
+        .bind(&name_lower)
+        .fetch_optional(&state.db)
+        .await?;
+
+        if let Some(dev) = device_row {
+            let device_id: String = dev.try_get("id").unwrap_or_default();
+            let display_name: String = dev.try_get("display_name").unwrap_or_default();
+
+            sqlx::query(
+                "UPDATE assets SET device_id = ?, updated_at = datetime('now') WHERE id = ?",
+            )
+            .bind(&device_id)
+            .bind(&asset_id)
+            .execute(&state.db)
+            .await?;
+
+            details.push(format!(
+                "Linked asset '{}' to device '{}'",
+                asset_name, display_name
+            ));
+            linked += 1;
+        }
+    }
+
+    info!(linked, "Auto-link assets to devices completed");
+
+    Ok(Json(AutoLinkResponse { linked, details }))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::db;
@@ -476,6 +682,14 @@ mod tests {
             .await
             .expect("Query failed");
         assert_eq!(count, 1);
+
+        // Verify default status
+        let status: String = sqlx::query_scalar("SELECT status FROM assets WHERE id = ?")
+            .bind(&id)
+            .fetch_one(&pool)
+            .await
+            .expect("Query failed");
+        assert_eq!(status, "active");
 
         // Update
         sqlx::query("UPDATE assets SET name = 'web-server-02' WHERE id = ?")
@@ -615,6 +829,7 @@ mod tests {
         let standalone = assets.iter().find(|a| a.id == "standalone").unwrap();
         assert_eq!(standalone.name, "printer-01");
         assert_eq!(standalone.asset_type, "printer");
+        assert_eq!(standalone.status, "active");
         assert!(standalone.ip.is_none());
         assert!(standalone.agent_name.is_none());
         assert!(standalone.ssh_name.is_none());
@@ -622,6 +837,7 @@ mod tests {
         let linked = assets.iter().find(|a| a.id == asset_id).unwrap();
         assert_eq!(linked.name, "web-server-01");
         assert_eq!(linked.asset_type, "server");
+        assert_eq!(linked.status, "active");
         assert_eq!(linked.location.as_deref(), Some("DC-1"));
         assert_eq!(linked.owner.as_deref(), Some("ops-team"));
         // Device data
@@ -653,6 +869,7 @@ mod tests {
         assert_eq!(asset.id, asset_id);
         assert_eq!(asset.name, "web-server-01");
         assert_eq!(asset.asset_type, "server");
+        assert_eq!(asset.status, "active");
         assert_eq!(asset.location.as_deref(), Some("DC-1"));
         assert_eq!(asset.owner.as_deref(), Some("ops-team"));
         assert_eq!(asset.tags.as_deref(), Some("[\"production\"]"));

--- a/server/src/api/export.rs
+++ b/server/src/api/export.rs
@@ -63,6 +63,7 @@ struct ExportAsset {
     id: String,
     name: String,
     asset_type: String,
+    status: String,
     location: String,
     owner: String,
     tags: String,
@@ -185,7 +186,7 @@ fn format_alerts_csv(items: &[ExportAlert]) -> String {
 
 fn format_assets_csv(items: &[ExportAsset]) -> String {
     let mut out = String::from(
-        "id,name,asset_type,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at\n",
+        "id,name,asset_type,status,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at\n",
     );
 
     for a in items {
@@ -194,6 +195,8 @@ fn format_assets_csv(items: &[ExportAsset]) -> String {
         out.push_str(&csv_escape(&a.name));
         out.push(',');
         out.push_str(&csv_escape(&a.asset_type));
+        out.push(',');
+        out.push_str(&csv_escape(&a.status));
         out.push(',');
         out.push_str(&csv_escape(&a.location));
         out.push(',');
@@ -449,6 +452,7 @@ pub async fn assets_export(
             id,
             name,
             asset_type,
+            COALESCE(status, 'active') AS status,
             COALESCE(location, '') AS location,
             COALESCE(owner, '') AS owner,
             COALESCE(tags, '') AS tags,
@@ -477,6 +481,7 @@ pub async fn assets_export(
             id: r.try_get("id").unwrap_or_default(),
             name: r.try_get("name").unwrap_or_default(),
             asset_type: r.try_get("asset_type").unwrap_or_default(),
+            status: r.try_get("status").unwrap_or_default(),
             location: r.try_get("location").unwrap_or_default(),
             owner: r.try_get("owner").unwrap_or_default(),
             tags: r.try_get("tags").unwrap_or_default(),
@@ -678,6 +683,7 @@ mod tests {
             id: "asset-1".to_string(),
             name: "web-server-01".to_string(),
             asset_type: "server".to_string(),
+            status: "active".to_string(),
             location: "DC-1 Rack A".to_string(),
             owner: "ops-team".to_string(),
             tags: "[\"production\"]".to_string(),
@@ -695,7 +701,7 @@ mod tests {
         let mut lines = csv.lines();
         assert_eq!(
             lines.next().unwrap_or(""),
-            "id,name,asset_type,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at"
+            "id,name,asset_type,status,location,owner,tags,serial_number,purchase_date,notes,device_id,agent_id,ssh_target_id,created_at,updated_at"
         );
         let row = lines.next().unwrap_or("");
         assert!(row.contains("asset-1"));
@@ -710,6 +716,7 @@ mod tests {
             id: "asset-1".to_string(),
             name: "web-server-01".to_string(),
             asset_type: "server".to_string(),
+            status: "active".to_string(),
             location: "DC-1".to_string(),
             owner: "ops".to_string(),
             tags: "".to_string(),

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -414,6 +414,8 @@ pub fn router(state: AppState) -> Router {
         // Assets (IT inventory)
         .route("/assets", get(assets::list))
         .route("/assets", post(assets::create))
+        .route("/assets/import", post(assets::import))
+        .route("/assets/auto-link", post(assets::auto_link))
         .route("/assets/:id", get(assets::get_one))
         .route("/assets/:id", put(assets::update))
         .route("/assets/:id", delete(assets::delete))

--- a/server/src/db/migrations/021_asset_status.sql
+++ b/server/src/db/migrations/021_asset_status.sql
@@ -1,0 +1,8 @@
+-- Migration 021: Add status column to assets for inventory management.
+-- Valid statuses: active, inactive, maintenance, retired, disposed.
+
+ALTER TABLE assets ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+
+CREATE INDEX idx_assets_status ON assets(status);
+CREATE INDEX idx_assets_location ON assets(location);
+CREATE INDEX idx_assets_owner ON assets(owner);

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -67,6 +67,9 @@ const ALERT_RULES_MIGRATION: &str = include_str!("migrations/019_alert_rules.sql
 /// Migration 020: Caddy reverse proxy host definitions.
 const CADDY_PROXY_HOSTS_MIGRATION: &str = include_str!("migrations/020_caddy_proxy_hosts.sql");
 
+/// Migration 021: Asset status column for inventory management.
+const ASSET_STATUS_MIGRATION: &str = include_str!("migrations/021_asset_status.sql");
+
 /// Initialize the SQLite database pool and run migrations.
 pub async fn init(database_url: &str) -> Result<SqlitePool> {
     let options = SqliteConnectOptions::from_str(database_url)?
@@ -490,6 +493,36 @@ pub(crate) async fn run_migrations(pool: &SqlitePool) -> Result<()> {
             .await?;
 
         info!("Applied migration 020_caddy_proxy_hosts.sql");
+    }
+
+    // Migration 021: asset status column.
+    let applied_21: bool = sqlx::query("SELECT 1 FROM _migrations WHERE version = 21")
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+
+    if !applied_21 {
+        for statement in ASSET_STATUS_MIGRATION.split(';') {
+            let code = statement
+                .lines()
+                .skip_while(|l| {
+                    let t = l.trim();
+                    t.is_empty() || t.starts_with("--")
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let stmt = code.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            sqlx::query(stmt).execute(pool).await?;
+        }
+
+        sqlx::query("INSERT INTO _migrations (version) VALUES (21)")
+            .execute(pool)
+            .await?;
+
+        info!("Applied migration 021_asset_status.sql");
     }
 
     // Purge expired sessions on startup.

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
   Box,
   ChevronDown,
   Download,
+  Link2,
   Pencil,
   Plus,
   Search,
   Trash2,
+  Upload,
   X,
   Server,
   Monitor,
@@ -22,6 +24,7 @@ import {
   Cpu,
   Wifi,
   CircleHelp,
+  FileText,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -61,12 +64,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  autoLinkAssets,
   createAssetInventory,
   deleteAssetInventory,
   fetchAssets,
+  importAssets,
   updateAssetInventory,
 } from "@/lib/api";
-import type { Asset, AssetRequest, AssetType } from "@/lib/types";
+import type { Asset, AssetRequest, AssetType, AssetStatus, AssetImportRow } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 import { downloadExport } from "@/lib/export";
 import { PageTransition } from "@/components/PageTransition";
@@ -91,8 +96,33 @@ const ASSET_TYPES: { value: AssetType; label: string; icon: typeof Server }[] = 
   { value: "unknown", label: "Unknown", icon: CircleHelp },
 ];
 
+const ASSET_STATUSES: { value: AssetStatus; label: string }[] = [
+  { value: "active", label: "Active" },
+  { value: "inactive", label: "Inactive" },
+  { value: "maintenance", label: "Maintenance" },
+  { value: "retired", label: "Retired" },
+  { value: "disposed", label: "Disposed" },
+];
+
 function getAssetTypeConfig(type: AssetType) {
   return ASSET_TYPES.find((t) => t.value === type) ?? ASSET_TYPES[ASSET_TYPES.length - 1];
+}
+
+function getStatusColor(status: AssetStatus): string {
+  switch (status) {
+    case "active":
+      return "border-emerald-500/50 text-emerald-400";
+    case "inactive":
+      return "border-slate-500/50 text-slate-400";
+    case "maintenance":
+      return "border-amber-500/50 text-amber-400";
+    case "retired":
+      return "border-orange-500/50 text-orange-400";
+    case "disposed":
+      return "border-rose-500/50 text-rose-400";
+    default:
+      return "border-slate-500/50 text-slate-400";
+  }
 }
 
 // ─── Router — detail vs list ────────────────────────────
@@ -116,6 +146,74 @@ export default function AssetsPage() {
   );
 }
 
+// ─── CSV parsing helper ─────────────────────────────────
+
+function parseCSV(text: string): AssetImportRow[] {
+  const lines = text.split("\n").filter((l) => l.trim());
+  if (lines.length < 2) return [];
+
+  const headerLine = lines[0];
+  const headers = headerLine.split(",").map((h) => h.trim().toLowerCase().replace(/['"]/g, ""));
+
+  const nameIdx = headers.indexOf("name");
+  if (nameIdx === -1) return [];
+
+  const rows: AssetImportRow[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCSVLine(lines[i]);
+    const name = cols[nameIdx]?.trim() ?? "";
+    if (!name) continue;
+
+    rows.push({
+      name,
+      asset_type: cols[headers.indexOf("asset_type")] || cols[headers.indexOf("type")] || undefined,
+      status: cols[headers.indexOf("status")] || undefined,
+      location: cols[headers.indexOf("location")] || undefined,
+      owner: cols[headers.indexOf("owner")] || undefined,
+      tags: cols[headers.indexOf("tags")] || undefined,
+      notes: cols[headers.indexOf("notes")] || undefined,
+      purchase_date: cols[headers.indexOf("purchase_date")] || undefined,
+      serial_number: cols[headers.indexOf("serial_number")] || undefined,
+    });
+  }
+
+  return rows;
+}
+
+/** Parse a single CSV line, handling quoted fields. */
+function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ",") {
+        result.push(current.trim());
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+  }
+  result.push(current.trim());
+  return result;
+}
+
 // ─── Main list page ─────────────────────────────────────
 
 function AssetsListPage() {
@@ -125,10 +223,13 @@ function AssetsListPage() {
   const [deleting, setDeleting] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [editAsset, setEditAsset] = useState<Asset | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   // Filters
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [locationFilter, setLocationFilter] = useState<string>("");
 
   const load = useCallback(async () => {
     try {
@@ -153,6 +254,14 @@ function AssetsListPage() {
       result = result.filter((a) => a.asset_type === typeFilter);
     }
 
+    if (statusFilter) {
+      result = result.filter((a) => a.status === statusFilter);
+    }
+
+    if (locationFilter) {
+      result = result.filter((a) => a.location === locationFilter);
+    }
+
     if (search) {
       const q = search.toLowerCase();
       result = result.filter(
@@ -167,7 +276,7 @@ function AssetsListPage() {
     }
 
     return result;
-  }, [assets, search, typeFilter]);
+  }, [assets, search, typeFilter, statusFilter, locationFilter]);
 
   const handleDelete = async () => {
     if (!pendingDelete) return;
@@ -184,12 +293,85 @@ function AssetsListPage() {
     }
   };
 
-  // Collect unique types present in data for the filter dropdown
+  const handleAutoLink = async () => {
+    try {
+      const result = await autoLinkAssets();
+      if (result.linked > 0) {
+        toast.success(`Linked ${result.linked} asset(s) to network devices`);
+        load();
+      } else {
+        toast.info("No unlinked assets could be matched to devices");
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Auto-link failed");
+    }
+  };
+
+  const handlePdfExport = () => {
+    if (!filtered || filtered.length === 0) {
+      toast.error("No assets to export");
+      return;
+    }
+
+    const html = `<!DOCTYPE html>
+<html><head><title>Panoptikon Asset Inventory</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 20px; color: #1e293b; }
+  h1 { font-size: 20px; margin-bottom: 4px; }
+  .meta { color: #64748b; font-size: 12px; margin-bottom: 16px; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th, td { border: 1px solid #e2e8f0; padding: 6px 8px; text-align: left; }
+  th { background: #f1f5f9; font-weight: 600; }
+  tr:nth-child(even) { background: #f8fafc; }
+  .badge { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px; font-weight: 500; }
+  .active { background: #d1fae5; color: #065f46; }
+  .inactive { background: #e2e8f0; color: #475569; }
+  .maintenance { background: #fef3c7; color: #92400e; }
+  .retired { background: #fed7aa; color: #9a3412; }
+  .disposed { background: #fecaca; color: #991b1b; }
+  @media print { body { margin: 0; } }
+</style></head><body>
+<h1>Panoptikon Asset Inventory</h1>
+<div class="meta">Exported on ${new Date().toLocaleDateString()} &mdash; ${filtered.length} assets</div>
+<table>
+<thead><tr><th>Name</th><th>Type</th><th>Status</th><th>Location</th><th>Owner</th><th>IP</th><th>Serial</th><th>Updated</th></tr></thead>
+<tbody>
+${filtered
+  .map(
+    (a) =>
+      `<tr><td>${esc(a.name)}</td><td>${esc(getAssetTypeConfig(a.asset_type).label)}</td><td><span class="badge ${a.status}">${esc(a.status)}</span></td><td>${esc(a.location ?? "")}</td><td>${esc(a.owner ?? "")}</td><td>${esc(a.ip ?? "")}</td><td>${esc(a.serial_number ?? "")}</td><td>${esc(a.updated_at)}</td></tr>`,
+  )
+  .join("\n")}
+</tbody></table></body></html>`;
+
+    const w = window.open("", "_blank");
+    if (w) {
+      w.document.write(html);
+      w.document.close();
+      w.print();
+    }
+  };
+
+  // Collect unique types/statuses/locations for filter dropdowns
   const availableTypes = useMemo(() => {
     if (!assets) return [];
     const types = new Set(assets.map((a) => a.asset_type));
     return ASSET_TYPES.filter((t) => types.has(t.value));
   }, [assets]);
+
+  const availableStatuses = useMemo(() => {
+    if (!assets) return [];
+    const statuses = new Set(assets.map((a) => a.status));
+    return ASSET_STATUSES.filter((s) => statuses.has(s.value));
+  }, [assets]);
+
+  const availableLocations = useMemo(() => {
+    if (!assets) return [];
+    const locs = new Set(assets.map((a) => a.location).filter(Boolean) as string[]);
+    return Array.from(locs).sort();
+  }, [assets]);
+
+  const hasFilters = search || typeFilter || statusFilter || locationFilter;
 
   if (error) {
     return (
@@ -206,6 +388,24 @@ function AssetsListPage() {
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold text-white">Assets</h1>
           <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
+              onClick={handleAutoLink}
+            >
+              <Link2 className="h-3.5 w-3.5" />
+              Auto-link
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
+              onClick={() => setImportOpen(true)}
+            >
+              <Upload className="h-3.5 w-3.5" />
+              Import CSV
+            </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -239,6 +439,10 @@ function AssetsListPage() {
                 >
                   Export JSON
                 </DropdownMenuItem>
+                <DropdownMenuItem onClick={handlePdfExport}>
+                  <FileText className="mr-2 h-3.5 w-3.5" />
+                  Print / Save as PDF
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
             <AssetFormDialog
@@ -253,8 +457,8 @@ function AssetsListPage() {
         </div>
 
         {/* Filter bar */}
-        <div className="flex items-center gap-3">
-          <div className="relative max-w-sm flex-1">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative max-w-sm flex-1 min-w-[200px]">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
             <Input
               placeholder="Search by name, location, IP, owner, tag..."
@@ -285,7 +489,33 @@ function AssetsListPage() {
             ))}
           </select>
 
-          {(search || typeFilter) && filtered && (
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="flex h-10 rounded-md border border-slate-700 bg-slate-800/50 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            <option value="">All statuses</option>
+            {availableStatuses.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={locationFilter}
+            onChange={(e) => setLocationFilter(e.target.value)}
+            className="flex h-10 rounded-md border border-slate-700 bg-slate-800/50 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            <option value="">All locations</option>
+            {availableLocations.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+
+          {hasFilters && filtered && (
             <span className="text-xs text-slate-500">
               Showing {filtered.length} of {assets?.length ?? 0} assets
             </span>
@@ -300,11 +530,12 @@ function AssetsListPage() {
                 <TableRow className="border-slate-800 hover:bg-transparent">
                   <TableHead className="text-slate-500">Name</TableHead>
                   <TableHead className="text-slate-500">Type</TableHead>
-                  <TableHead className="text-slate-500">Location</TableHead>
-                  <TableHead className="text-slate-500">IP</TableHead>
-                  <TableHead className="text-slate-500">OS</TableHead>
                   <TableHead className="text-slate-500">Status</TableHead>
+                  <TableHead className="text-slate-500">Location</TableHead>
+                  <TableHead className="text-slate-500">Owner</TableHead>
+                  <TableHead className="text-slate-500">IP</TableHead>
                   <TableHead className="text-slate-500">Last Seen</TableHead>
+                  <TableHead className="text-slate-500">Updated</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -313,10 +544,11 @@ function AssetsListPage() {
                   <TableRow key={i} className="border-slate-800">
                     <TableCell><Skeleton className="h-5 w-28" /></TableCell>
                     <TableCell><Skeleton className="h-5 w-20" /></TableCell>
-                    <TableCell><Skeleton className="h-5 w-24" /></TableCell>
-                    <TableCell><Skeleton className="h-5 w-24" /></TableCell>
-                    <TableCell><Skeleton className="h-5 w-24" /></TableCell>
                     <TableCell><Skeleton className="h-5 w-16 rounded-full" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-24" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-20" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-24" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-16" /></TableCell>
                     <TableCell><Skeleton className="h-5 w-16" /></TableCell>
                     <TableCell><Skeleton className="h-5 w-16" /></TableCell>
                   </TableRow>
@@ -327,10 +559,10 @@ function AssetsListPage() {
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Box className="mb-4 h-12 w-12 text-slate-600" />
               <p className="text-lg font-medium text-slate-400">
-                {search || typeFilter ? "No assets match your filters" : "No assets yet"}
+                {hasFilters ? "No assets match your filters" : "No assets yet"}
               </p>
               <p className="mt-1 text-sm text-slate-600">
-                {search || typeFilter
+                {hasFilters
                   ? "Try adjusting your search or filter criteria."
                   : "Add an asset to start tracking your IT inventory."}
               </p>
@@ -341,11 +573,12 @@ function AssetsListPage() {
                 <TableRow className="border-slate-800 hover:bg-transparent">
                   <TableHead className="text-slate-500">Name</TableHead>
                   <TableHead className="text-slate-500">Type</TableHead>
-                  <TableHead className="text-slate-500">Location</TableHead>
-                  <TableHead className="text-slate-500">IP</TableHead>
-                  <TableHead className="text-slate-500">OS</TableHead>
                   <TableHead className="text-slate-500">Status</TableHead>
+                  <TableHead className="text-slate-500">Location</TableHead>
+                  <TableHead className="text-slate-500">Owner</TableHead>
+                  <TableHead className="text-slate-500">IP</TableHead>
                   <TableHead className="text-slate-500">Last Seen</TableHead>
+                  <TableHead className="text-slate-500">Updated</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -354,13 +587,7 @@ function AssetsListPage() {
                   const typeConfig = getAssetTypeConfig(asset.asset_type);
                   const TypeIcon = typeConfig.icon;
 
-                  // Derive OS from linked agent or SSH target
-                  const os = asset.agent_os ?? asset.ssh_os ?? null;
-
-                  // Derive online status from linked sources
-                  const online = asset.device_online ?? asset.agent_online ?? asset.ssh_online ?? null;
-
-                  // Derive last seen
+                  // Derive last seen from linked device
                   const lastSeen = asset.device_last_seen;
 
                   return (
@@ -384,24 +611,28 @@ function AssetsListPage() {
                           <span className="text-sm">{typeConfig.label}</span>
                         </div>
                       </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={getStatusColor(asset.status)}
+                        >
+                          {asset.status}
+                        </Badge>
+                      </TableCell>
                       <TableCell className="text-slate-400">
-                        {asset.location ?? "—"}
+                        {asset.location ?? "\u2014"}
+                      </TableCell>
+                      <TableCell className="text-slate-400">
+                        {asset.owner ?? "\u2014"}
                       </TableCell>
                       <TableCell className="font-mono tabular-nums text-slate-400">
-                        {asset.ip ?? "—"}
+                        {asset.ip ?? "\u2014"}
                       </TableCell>
                       <TableCell className="text-slate-400">
-                        {os ?? "—"}
+                        {lastSeen ? timeAgo(lastSeen) : "\u2014"}
                       </TableCell>
-                      <TableCell>
-                        {online !== null ? (
-                          <StatusBadge online={online} />
-                        ) : (
-                          <span className="text-xs text-slate-600">—</span>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-slate-400">
-                        {lastSeen ? timeAgo(lastSeen) : "—"}
+                      <TableCell className="text-slate-400 text-xs">
+                        {timeAgo(asset.updated_at)}
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center gap-1">
@@ -443,6 +674,16 @@ function AssetsListPage() {
             }}
           />
         )}
+
+        {/* Import CSV dialog */}
+        <ImportCSVDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          onImported={() => {
+            setImportOpen(false);
+            load();
+          }}
+        />
 
         {/* Delete confirmation */}
         <AlertDialog
@@ -491,6 +732,16 @@ function AssetsListPage() {
   );
 }
 
+// ─── HTML escape helper ─────────────────────────────────
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 // ─── Status Badge ───────────────────────────────────────
 
 function StatusBadge({ online }: { online: boolean }) {
@@ -515,6 +766,110 @@ function StatusBadge({ online }: { online: boolean }) {
   );
 }
 
+// ─── Import CSV Dialog ──────────────────────────────────
+
+function ImportCSVDialog({
+  open,
+  onOpenChange,
+  onImported,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onImported: () => void;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [rows, setRows] = useState<AssetImportRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setRows([]);
+      setResult(null);
+    }
+  }, [open]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const parsed = parseCSV(text);
+      setRows(parsed);
+      if (parsed.length === 0) {
+        setResult("No valid rows found. CSV must have a 'name' column header.");
+      } else {
+        setResult(null);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleImport = async () => {
+    if (rows.length === 0) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await importAssets(rows);
+      setResult(
+        `Imported ${res.imported} asset(s), skipped ${res.skipped}.` +
+          (res.errors.length > 0 ? ` Errors: ${res.errors.join("; ")}` : ""),
+      );
+      if (res.imported > 0) {
+        toast.success(`${res.imported} asset(s) imported`);
+        onImported();
+      }
+    } catch (err) {
+      setResult(err instanceof Error ? err.message : "Import failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-[520px] border-slate-800 bg-slate-950">
+        <DialogHeader>
+          <DialogTitle className="text-white">Import Assets from CSV</DialogTitle>
+          <DialogDescription>
+            Upload a CSV file with columns: name, asset_type, status, location, owner, tags,
+            serial_number, purchase_date, notes. Only &quot;name&quot; is required.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 pt-2">
+          <Input
+            ref={fileRef}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="border-slate-700 bg-slate-800/50 file:text-slate-400"
+          />
+
+          {rows.length > 0 && (
+            <p className="text-sm text-slate-400">
+              {rows.length} row(s) parsed and ready to import.
+            </p>
+          )}
+
+          {result && (
+            <p className="text-sm text-slate-300 whitespace-pre-wrap">{result}</p>
+          )}
+
+          <Button
+            onClick={handleImport}
+            disabled={loading || rows.length === 0}
+            className="w-full"
+          >
+            {loading ? "Importing..." : `Import ${rows.length} Asset(s)`}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── Add / Edit Form Dialog ─────────────────────────────
 
 function AssetFormDialog({
@@ -534,6 +889,9 @@ function AssetFormDialog({
   const [assetType, setAssetType] = useState<AssetType>(
     existing?.asset_type ?? "unknown",
   );
+  const [status, setStatus] = useState<AssetStatus>(
+    existing?.status ?? "active",
+  );
   const [location, setLocation] = useState(existing?.location ?? "");
   const [owner, setOwner] = useState(existing?.owner ?? "");
   const [tags, setTags] = useState(existing?.tags ?? "");
@@ -552,6 +910,7 @@ function AssetFormDialog({
     if (open) {
       setName(existing?.name ?? "");
       setAssetType(existing?.asset_type ?? "unknown");
+      setStatus(existing?.status ?? "active");
       setLocation(existing?.location ?? "");
       setOwner(existing?.owner ?? "");
       setTags(existing?.tags ?? "");
@@ -571,6 +930,7 @@ function AssetFormDialog({
     const body: AssetRequest = {
       name: name.trim(),
       asset_type: assetType,
+      status,
       location: location || undefined,
       owner: owner || undefined,
       tags: tags || undefined,
@@ -637,8 +997,22 @@ function AssetFormDialog({
           </div>
         </div>
 
-        {/* Location + Owner */}
+        {/* Status + Location */}
         <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as AssetStatus)}
+              className="flex h-10 w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              {ASSET_STATUSES.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
           <div className="space-y-2">
             <Label>Location</Label>
             <Input
@@ -647,6 +1021,10 @@ function AssetFormDialog({
               onChange={(e) => setLocation(e.target.value)}
             />
           </div>
+        </div>
+
+        {/* Owner + Tags */}
+        <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label>Owner</Label>
             <Input
@@ -655,21 +1033,19 @@ function AssetFormDialog({
               onChange={(e) => setOwner(e.target.value)}
             />
           </div>
-        </div>
-
-        {/* Tags */}
-        <div className="space-y-2">
-          <Label>
-            Tags
-            <span className="ml-2 text-xs text-slate-500">
-              JSON array, e.g. ["production", "web"]
-            </span>
-          </Label>
-          <Input
-            placeholder='["production", "critical"]'
-            value={tags}
-            onChange={(e) => setTags(e.target.value)}
-          />
+          <div className="space-y-2">
+            <Label>
+              Tags
+              <span className="ml-2 text-xs text-slate-500">
+                JSON array, e.g. [&quot;production&quot;, &quot;web&quot;]
+              </span>
+            </Label>
+            <Input
+              placeholder='["production", "critical"]'
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+          </div>
         </div>
 
         {/* Serial + Purchase Date */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,9 @@ import type {
   MikrotikWireguard,
   Asset,
   AssetRequest,
+  AssetImportRow,
+  AssetImportResponse,
+  AssetAutoLinkResponse,
   AlertRule,
   CreateAlertRuleRequest,
   UpdateAlertRuleRequest,
@@ -1248,10 +1251,14 @@ export function fetchMikrotikWireguard(): Promise<MikrotikWireguard> {
 export function fetchAssets(params?: {
   type?: string;
   tag?: string;
+  status?: string;
+  location?: string;
 }): Promise<Asset[]> {
   const qs = new URLSearchParams();
   if (params?.type) qs.set("type", params.type);
   if (params?.tag) qs.set("tag", params.tag);
+  if (params?.status) qs.set("status", params.status);
+  if (params?.location) qs.set("location", params.location);
   const suffix = qs.toString() ? `?${qs}` : "";
   return apiGet<Asset[]>(`/api/v1/assets${suffix}`);
 }
@@ -1273,6 +1280,16 @@ export function updateAssetInventory(
 
 export function deleteAssetInventory(id: string): Promise<void> {
   return apiDelete(`/api/v1/assets/${id}`);
+}
+
+export function importAssets(
+  rows: AssetImportRow[]
+): Promise<AssetImportResponse> {
+  return apiPost<AssetImportResponse>("/api/v1/assets/import", { rows });
+}
+
+export function autoLinkAssets(): Promise<AssetAutoLinkResponse> {
+  return apiPost<AssetAutoLinkResponse>("/api/v1/assets/auto-link");
 }
 
 // ─── Alert Rules ─────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -908,10 +908,18 @@ export type AssetType =
   | "printer"
   | "unknown";
 
+export type AssetStatus =
+  | "active"
+  | "inactive"
+  | "maintenance"
+  | "retired"
+  | "disposed";
+
 export interface Asset {
   id: string;
   name: string;
   asset_type: AssetType;
+  status: AssetStatus;
   location: string | null;
   owner: string | null;
   tags: string | null;
@@ -941,6 +949,7 @@ export interface Asset {
 export interface AssetRequest {
   name?: string;
   asset_type?: AssetType;
+  status?: AssetStatus;
   location?: string;
   owner?: string;
   tags?: string;
@@ -950,6 +959,29 @@ export interface AssetRequest {
   device_id?: string;
   agent_id?: string;
   ssh_target_id?: string;
+}
+
+export interface AssetImportRow {
+  name: string;
+  asset_type?: string;
+  status?: string;
+  location?: string;
+  owner?: string;
+  tags?: string;
+  notes?: string;
+  purchase_date?: string;
+  serial_number?: string;
+}
+
+export interface AssetImportResponse {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}
+
+export interface AssetAutoLinkResponse {
+  linked: number;
+  details: string[];
 }
 
 // ─── SSH Targets (agentless monitoring) ─────────────────


### PR DESCRIPTION
## Summary
- Add `status` field to assets (active/inactive/maintenance/retired/disposed) with DB migration
- Add bulk CSV import endpoint (`POST /assets/import`) and frontend import dialog with CSV parsing
- Add auto-link endpoint (`POST /assets/auto-link`) to match unlinked assets with discovered devices by name/hostname
- Add status and location filter dropdowns to asset listing
- Add PDF export via browser print API
- Update CSV/JSON export to include status field

## Test plan
- [x] All 294 existing tests pass (including 8 asset-specific tests)
- [ ] Verify new status column appears in asset table
- [ ] Test CSV import with sample file (name, asset_type, status, location, owner, ip_address, notes)
- [ ] Test auto-link matches assets to devices by name
- [ ] Test status/location filter dropdowns filter correctly
- [ ] Test PDF export opens print dialog with formatted table
- [ ] Verify CSV/JSON export includes status field

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `status` field (active/inactive/maintenance/retired/disposed) to the asset inventory system, along with bulk CSV import, auto-link to discovered devices, status/location filter dropdowns, and PDF export. The migration, type definitions, export updates, and routing are all clean and consistent.

- **Bulk import endpoint** (`POST /assets/import`) executes individual `INSERT` statements per row with no upper bound on row count and no wrapping transaction — worth adding limits and batching for production resilience.
- **Auto-link endpoint** (`POST /assets/auto-link`) uses N+1 queries (one `SELECT` + one `UPDATE` per unlinked asset) and doesn't guard against linking multiple assets to the same device.
- **Migration runner** for 021 manually splits SQL on `';'` instead of using `sqlx::raw_sql()` like adjacent migrations 019/020.
- **PDF export** interpolates `a.status` directly into an HTML `class` attribute without escaping — low risk given server-side validation, but inconsistent with the defensive escaping applied to all other fields.

<h3>Confidence Score: 3/5</h3>

- Functionally correct but the bulk import and auto-link endpoints have scalability and robustness gaps that should be addressed before production use.
- The core feature (status field, migration, filters, exports) is well-implemented and consistent. Score is lowered because the bulk import has no size limit or transaction wrapping, the auto-link has N+1 query performance issues, and there are minor inconsistencies in migration execution and HTML escaping.
- Pay close attention to `server/src/api/assets.rs` — both the `import` and `auto_link` handlers need scalability improvements for production workloads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/assets.rs | Adds status field support, bulk import, and auto-link endpoints. Import lacks size limits and uses sequential inserts without transactions; auto-link has N+1 query pattern. |
| server/src/api/export.rs | Cleanly adds status field to CSV/JSON export — struct, query, header, and row output all updated consistently. |
| server/src/api/mod.rs | Registers two new routes (`/assets/import` and `/assets/auto-link`) correctly before the `:id` parameter routes, avoiding routing conflicts. |
| server/src/db/migrations/021_asset_status.sql | Simple migration adds status column with NOT NULL DEFAULT 'active' and appropriate indexes. Clean and correct. |
| server/src/db/mod.rs | Adds migration 021 runner, but uses manual split-on-semicolon approach instead of `raw_sql` used by adjacent migrations 019/020. |
| web/src/app/(app)/assets/page.tsx | Adds status/location filters, CSV import dialog, auto-link button, PDF export, and status badges. PDF export has an unescaped status value in HTML class attribute. |
| web/src/lib/api.ts | Adds `importAssets` and `autoLinkAssets` API functions, plus status/location query params on `fetchAssets`. Clean and consistent with existing patterns. |
| web/src/lib/types.ts | Adds `AssetStatus` type, `AssetImportRow`, `AssetImportResponse`, and `AssetAutoLinkResponse` interfaces. All correctly typed and consistent with backend contracts. |

</details>



<sub>Last reviewed commit: 794bd7c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->