### PR TITLE
feat: GitHub Actions — build and push to Docker Hub on release (#266)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    name: Build & Push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: befeast/panoptikon
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker.yml` — a GitHub Actions workflow that builds and pushes Docker images to Docker Hub on version tag pushes (`v*`)
- Multi-platform build: `linux/amd64` and `linux/arm64` via Docker Buildx + QEMU
- Tags images as `befeast/panoptikon:latest` and `befeast/panoptikon:vX.Y.Z`
- Uses GitHub Actions cache (`type=gha`) for layer caching across builds

## Required Setup

Add these secrets to repo Settings → Secrets → Actions:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Actions Used
- `docker/setup-qemu-action@v3`
- `docker/setup-buildx-action@v3`
- `docker/login-action@v3`
- `docker/metadata-action@v5`
- `docker/build-push-action@v6`

Closes #266

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds GitHub Actions workflow to build and push Docker images to Docker Hub on version tag releases with multi-platform support (amd64/arm64).

- Clean implementation using standard Docker actions (`setup-qemu-action`, `setup-buildx-action`, `build-push-action`)
- Proper use of GitHub Actions cache for layer caching
- Automated tagging with semver and `latest`
- **Critical issue**: ARM64 builds will fail because `Dockerfile:31` hardcodes x86_64 speedtest binary download - the Dockerfile must be updated to support multi-architecture before this workflow can function correctly
- Minor: Tag trigger pattern `v*` is more permissive than existing `release.yml` workflow which uses `v*.*.*`

<h3>Confidence Score: 2/5</h3>

- This PR will cause ARM64 Docker builds to fail immediately
- Score of 2 reflects that the workflow is syntactically correct and follows best practices, but has a critical runtime bug: the multi-platform build declares support for `linux/arm64` but the underlying Dockerfile hardcodes an x86_64 binary download for speedtest CLI, which will cause the ARM64 build to fail. This is a blocking issue that prevents the workflow from functioning as intended.
- `.github/workflows/docker.yml` declares multi-platform builds but `Dockerfile` needs updates to support ARM64 architecture

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/docker.yml | Adds Docker Hub build/push workflow with multi-platform support, but ARM64 builds will fail due to hardcoded x86_64 binary in Dockerfile |

</details>



<sub>Last reviewed commit: 1c0279d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->