### PR TITLE
feat: connect Panoptikon to Caddy Admin API — proxy host CRUD (#260)

### DIFF
--- a/server/src/api/caddy.rs
+++ b/server/src/api/caddy.rs
@@ -75,6 +75,16 @@ async fn caddy_admin_url(state: &AppState) -> String {
         .unwrap_or_else(|| "http://localhost:2019".to_string())
 }
 
+/// Sync proxy hosts to Caddy on server startup (fire-and-forget).
+pub fn start_caddy_sync_task(state: AppState) {
+    tokio::spawn(async move {
+        // Small delay to let Caddy finish starting if launched alongside Panoptikon.
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        info!("Running initial Caddy config sync");
+        sync_to_caddy(&state).await;
+    });
+}
+
 /// Build Caddy JSON config from all enabled proxy hosts and PATCH it to the admin API.
 async fn sync_to_caddy(state: &AppState) {
     let hosts: Vec<(String, String, i64, String, i64)> = match sqlx::query_as(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -140,6 +140,9 @@ async fn main() -> Result<()> {
     // Start the MikroTik interface traffic poller (polls every 60s when enabled).
     mikrotik_traffic::start_mikrotik_traffic_poller(state.db.clone(), state.mikrotik_http.clone());
 
+    // Sync proxy host config to Caddy on startup.
+    api::caddy::start_caddy_sync_task(state.clone());
+
     // Build the application router.
     let app = api::router(state);
 


### PR DESCRIPTION
## Summary

- Adds `start_caddy_sync_task()` in `server/src/api/caddy.rs` — a public startup function that syncs SQLite proxy hosts to Caddy Admin API when the server boots
- Wires the startup sync into `server/src/main.rs` alongside other background tasks
- Includes a 5-second delay to allow Caddy to finish initializing when co-deployed

The Caddy integration (CRUD endpoints, frontend page, Test Connection, settings) was implemented in prior PRs (#242, #258). This PR completes the last missing requirement from the issue: **sync to Caddy on startup**.

### Endpoints (existing, from prior PRs)
- `GET /api/v1/caddy/status` — check reachability
- `GET /api/v1/caddy/proxy-hosts` — list all hosts
- `POST /api/v1/caddy/proxy-hosts` — create host
- `PUT /api/v1/caddy/proxy-hosts/:id` — update host
- `DELETE /api/v1/caddy/proxy-hosts/:id` — delete host
- `POST /api/v1/caddy/proxy-hosts/:id/toggle` — enable/disable
- `POST /api/v1/caddy/sync` — manual sync
- `POST /api/v1/caddy/test-connection` — test connection

## Test plan
- [ ] Verify `cargo check -p panoptikon-server` passes
- [ ] Start server with Caddy proxy hosts in SQLite — confirm they sync to Caddy after 5s
- [ ] CRUD proxy hosts via UI and verify Caddy config updates
- [ ] Test Connection button returns success when Caddy is reachable

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a startup sync task that pushes SQLite proxy host configuration to the Caddy Admin API when the Panoptikon server boots. A 5-second delay accommodates co-deployment scenarios where Caddy may still be initializing.

- Adds `start_caddy_sync_task()` in `server/src/api/caddy.rs` as a fire-and-forget `tokio::spawn` wrapper around the existing `sync_to_caddy()` function
- Wires the startup call into `server/src/main.rs` alongside other background tasks, following the established pattern
- If Caddy is unreachable at startup, failures are logged as warnings without affecting server availability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a minimal, well-isolated startup task with no impact on existing functionality.
- The change is very small (13 lines total), follows established patterns in the codebase for background tasks, reuses the existing sync_to_caddy function with its built-in error handling, and introduces no new dependencies or architectural changes. Failures are handled gracefully via logging.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/caddy.rs | Adds `start_caddy_sync_task()` — a thin public wrapper that spawns a fire-and-forget tokio task with a 5-second delay before calling the existing `sync_to_caddy()`. Error handling is inherited from `sync_to_caddy` which already logs failures gracefully. |
| server/src/main.rs | Adds a single call to `api::caddy::start_caddy_sync_task(state.clone())` alongside other background task launches. Consistent with existing startup patterns in the file. |

</details>



<sub>Last reviewed commit: bf44844</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->