### PR TITLE
feat: VPN status dashboard — connected clients and tunnel health (#252)

### DIFF
--- a/server/src/api/mikrotik.rs
+++ b/server/src/api/mikrotik.rs
@@ -28,7 +28,7 @@ async fn get_setting(state: &AppState, key: &str) -> Option<String> {
 
 /// Try to construct a MikroTik client from saved settings.
 /// Returns `None` if MikroTik is not configured or not enabled.
-async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
+pub(crate) async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
     let enabled = get_setting(state, "mikrotik_enabled")
         .await
         .map(|v| v == "1" || v == "true")

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -42,6 +42,7 @@ pub mod ssh_targets;
 pub mod topology;
 pub mod traffic;
 pub mod unbound;
+pub mod vpn_status;
 pub mod vyos;
 
 pub use error::AppError;
@@ -303,6 +304,8 @@ pub fn router(state: AppState) -> Router {
             "/vyos/dns/forwarding/domain-overrides/:domain",
             delete(vyos::delete_dns_domain_override),
         )
+        // VPN Status (unified across router types)
+        .route("/vpn/status", get(vpn_status::vpn_status))
         // WireGuard VPN
         .route("/vyos/wireguard", get(vyos::wireguard_list))
         .route("/vyos/wireguard", post(vyos::wireguard_create))

--- a/server/src/api/vpn_status.rs
+++ b/server/src/api/vpn_status.rs
@@ -1,0 +1,262 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Serialize;
+
+use super::AppState;
+
+/// Unified VPN peer status across router types.
+#[derive(Debug, Serialize)]
+pub struct VpnPeerStatus {
+    pub name: String,
+    pub public_key: Option<String>,
+    pub endpoint: Option<String>,
+    pub allowed_ips: Vec<String>,
+    pub last_handshake: Option<i64>,
+    pub rx_bytes: Option<u64>,
+    pub tx_bytes: Option<u64>,
+    /// Whether the peer is considered online (handshake within last 3 minutes).
+    pub is_online: bool,
+}
+
+/// Unified VPN interface status across router types.
+#[derive(Debug, Serialize)]
+pub struct VpnInterfaceStatus {
+    pub name: String,
+    /// "up", "down", or null if unknown.
+    pub status: Option<String>,
+    pub listen_port: Option<u32>,
+    pub public_key: Option<String>,
+    pub peers: Vec<VpnPeerStatus>,
+}
+
+/// Response for the VPN status dashboard endpoint.
+#[derive(Debug, Serialize)]
+pub struct VpnStatusResponse {
+    /// Which router backend provided the data: "vyos", "mikrotik", or "none".
+    pub router_type: String,
+    pub interfaces: Vec<VpnInterfaceStatus>,
+}
+
+/// Three-minute threshold for considering a peer online (in seconds).
+const ONLINE_THRESHOLD_SECS: i64 = 180;
+
+/// GET /api/v1/vpn/status — unified VPN status across VyOS and MikroTik.
+pub async fn vpn_status(
+    State(state): State<AppState>,
+) -> Result<Json<VpnStatusResponse>, StatusCode> {
+    // Try VyOS first.
+    if let Some(resp) = fetch_vyos_vpn_status(&state).await {
+        return Ok(Json(resp));
+    }
+
+    // Fall back to MikroTik.
+    if let Some(resp) = fetch_mikrotik_vpn_status(&state).await {
+        return Ok(Json(resp));
+    }
+
+    // Neither router is configured — return empty.
+    Ok(Json(VpnStatusResponse {
+        router_type: "none".to_string(),
+        interfaces: vec![],
+    }))
+}
+
+/// Fetch WireGuard status from VyOS and normalise into unified types.
+async fn fetch_vyos_vpn_status(state: &AppState) -> Option<VpnStatusResponse> {
+    let client =
+        super::vyos::get_vyos_client_from_db(&state.db, &state.config, &state.vyos_http).await?;
+
+    let config = client.retrieve(&["interfaces", "wireguard"]).await.ok()?;
+
+    let mut wg_interfaces = super::vyos::parse_wireguard_config(&config);
+
+    // Fetch interface link status.
+    if let Ok(iface_raw) = client.show(&["interfaces"]).await {
+        let iface_text = iface_raw.as_str().unwrap_or("");
+        let iface_list = super::vyos::parse_interfaces_text(iface_text);
+        for wg in &mut wg_interfaces {
+            if let Some(sys_iface) = iface_list.iter().find(|i| i.name == wg.name) {
+                wg.status = Some(sys_iface.link_state.clone());
+            }
+        }
+    }
+
+    // Fetch per-interface runtime stats.
+    for wg in &mut wg_interfaces {
+        if let Ok(raw) = client.show(&["interfaces", "wireguard", &wg.name]).await {
+            let text = raw.as_str().unwrap_or("");
+            super::vyos::merge_wireguard_runtime_stats(wg, text);
+        }
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let interfaces = wg_interfaces
+        .into_iter()
+        .map(|iface| VpnInterfaceStatus {
+            name: iface.name,
+            status: iface.status,
+            listen_port: iface.port,
+            public_key: iface.public_key,
+            peers: iface
+                .peers
+                .into_iter()
+                .map(|p| {
+                    let is_online = p
+                        .last_handshake
+                        .map(|ts| (now - ts).abs() < ONLINE_THRESHOLD_SECS)
+                        .unwrap_or(false);
+                    VpnPeerStatus {
+                        name: p.name,
+                        public_key: p.public_key,
+                        endpoint: p.endpoint,
+                        allowed_ips: p.allowed_ips,
+                        last_handshake: p.last_handshake,
+                        rx_bytes: p.rx_bytes,
+                        tx_bytes: p.tx_bytes,
+                        is_online,
+                    }
+                })
+                .collect(),
+        })
+        .collect();
+
+    Some(VpnStatusResponse {
+        router_type: "vyos".to_string(),
+        interfaces,
+    })
+}
+
+/// Fetch WireGuard status from MikroTik and normalise into unified types.
+async fn fetch_mikrotik_vpn_status(state: &AppState) -> Option<VpnStatusResponse> {
+    let client = super::mikrotik::mikrotik_client(state).await?;
+
+    let wg_ifaces = client.wireguard_interfaces().await.unwrap_or_default();
+    let wg_peers = client.wireguard_peers().await.unwrap_or_default();
+
+    let interfaces = wg_ifaces
+        .into_iter()
+        .map(|iface| {
+            let name = iface.name.clone().unwrap_or_default();
+            let running = iface
+                .running
+                .as_deref()
+                .map(|v| v == "true")
+                .unwrap_or(false);
+            let disabled = iface
+                .disabled
+                .as_deref()
+                .map(|v| v == "true")
+                .unwrap_or(false);
+            let status = if disabled {
+                Some("down".to_string())
+            } else if running {
+                Some("up".to_string())
+            } else {
+                Some("down".to_string())
+            };
+
+            let listen_port = iface
+                .listen_port
+                .as_deref()
+                .and_then(|s| s.parse::<u32>().ok());
+
+            let peers: Vec<VpnPeerStatus> = wg_peers
+                .iter()
+                .filter(|p| p.interface.as_deref() == Some(&name))
+                .map(|p| {
+                    let endpoint = match (&p.current_endpoint_address, &p.current_endpoint_port) {
+                        (Some(addr), Some(port)) => Some(format!("{addr}:{port}")),
+                        (Some(addr), None) => Some(addr.clone()),
+                        _ => None,
+                    };
+                    let rx_bytes = p.rx.as_deref().and_then(|s| s.parse::<u64>().ok());
+                    let tx_bytes = p.tx.as_deref().and_then(|s| s.parse::<u64>().ok());
+                    let last_handshake_ts = p
+                        .last_handshake
+                        .as_deref()
+                        .and_then(parse_mikrotik_handshake);
+                    let now = chrono::Utc::now().timestamp();
+                    let is_online = last_handshake_ts
+                        .map(|ts| (now - ts).abs() < ONLINE_THRESHOLD_SECS)
+                        .unwrap_or(false);
+
+                    let allowed_ips = p
+                        .allowed_address
+                        .as_deref()
+                        .map(|s| {
+                            s.split(',')
+                                .map(|a| a.trim().to_string())
+                                .filter(|a| !a.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
+                    VpnPeerStatus {
+                        name: p.comment.clone().unwrap_or_default(),
+                        public_key: p.public_key.clone(),
+                        endpoint,
+                        allowed_ips,
+                        last_handshake: last_handshake_ts,
+                        rx_bytes,
+                        tx_bytes,
+                        is_online,
+                    }
+                })
+                .collect();
+
+            VpnInterfaceStatus {
+                name,
+                status,
+                listen_port,
+                public_key: iface.public_key,
+                peers,
+            }
+        })
+        .collect();
+
+    Some(VpnStatusResponse {
+        router_type: "mikrotik".to_string(),
+        interfaces,
+    })
+}
+
+/// Parse a MikroTik relative handshake time string into a UNIX timestamp.
+///
+/// MikroTik formats like "1m30s", "2h5m12s", "3d1h2m3s", or an epoch seconds
+/// value. Returns `None` if parsing fails.
+fn parse_mikrotik_handshake(text: &str) -> Option<i64> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    // If it's a pure number, treat as epoch timestamp.
+    if let Ok(ts) = text.parse::<i64>() {
+        return Some(ts);
+    }
+
+    // Parse relative duration like "1m30s", "2h5m12s".
+    let mut total_secs: i64 = 0;
+    let mut num_buf = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_digit() {
+            num_buf.push(ch);
+        } else {
+            let n: i64 = num_buf.parse().unwrap_or(0);
+            num_buf.clear();
+            match ch {
+                'w' => total_secs += n * 7 * 86400,
+                'd' => total_secs += n * 86400,
+                'h' => total_secs += n * 3600,
+                'm' => total_secs += n * 60,
+                's' => total_secs += n,
+                _ => {}
+            }
+        }
+    }
+
+    if total_secs > 0 {
+        Some(chrono::Utc::now().timestamp() - total_secs)
+    } else {
+        None
+    }
+}

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -5714,7 +5714,7 @@ pub async fn wireguard_list(
 }
 
 /// Parse VyOS wireguard configuration JSON into a list of interfaces.
-fn parse_wireguard_config(config: &Value) -> Vec<WireguardInterface> {
+pub(crate) fn parse_wireguard_config(config: &Value) -> Vec<WireguardInterface> {
     let mut interfaces = Vec::new();
 
     let obj = match config.as_object() {
@@ -5843,7 +5843,7 @@ type WgRuntimePeerData = (
     Option<String>,
 );
 
-fn merge_wireguard_runtime_stats(iface: &mut WireguardInterface, text: &str) {
+pub(crate) fn merge_wireguard_runtime_stats(iface: &mut WireguardInterface, text: &str) {
     let mut current_pubkey: Option<String> = None;
     let mut current_handshake: Option<i64> = None;
     let mut current_rx: Option<u64> = None;

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ArrowDownUp,
+  RefreshCw,
+  Shield,
+  Wifi,
+  WifiOff,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { fetchVpnStatus } from "@/lib/api";
+import type { VpnStatusResponse, VpnInterfaceStatus, VpnPeerStatus } from "@/lib/types";
+import { formatBytes } from "@/lib/format";
+import { PageTransition } from "@/components/PageTransition";
+import { toast } from "sonner";
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+function handshakeAgo(ts: number | null): string {
+  if (ts === null) return "Never";
+  const diff = Math.max(0, Math.floor(Date.now() / 1000) - ts);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function PeerStatusDot({ isOnline }: { isOnline: boolean }) {
+  return (
+    <span
+      className={`inline-block h-2.5 w-2.5 rounded-full ${
+        isOnline
+          ? "bg-emerald-400 ring-2 ring-emerald-400/30"
+          : "bg-slate-600 ring-2 ring-slate-600/30"
+      }`}
+    />
+  );
+}
+
+function InterfaceStatusBadge({ status }: { status: string | null }) {
+  if (status === "up") {
+    return (
+      <Badge className="bg-emerald-500/15 text-emerald-400 border-emerald-500/30 hover:bg-emerald-500/15">
+        Up
+      </Badge>
+    );
+  }
+  if (status === "down") {
+    return (
+      <Badge className="bg-rose-500/15 text-rose-400 border-rose-500/30 hover:bg-rose-500/15">
+        Down
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-slate-500/15 text-slate-400 border-slate-500/30 hover:bg-slate-500/15">
+      Unknown
+    </Badge>
+  );
+}
+
+function PeerTable({ peers }: { peers: VpnPeerStatus[] }) {
+  if (peers.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-slate-500">
+        No peers configured
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="border-slate-800 hover:bg-transparent">
+          <TableHead className="text-slate-400 w-10">Status</TableHead>
+          <TableHead className="text-slate-400">Peer</TableHead>
+          <TableHead className="text-slate-400">Endpoint</TableHead>
+          <TableHead className="text-slate-400">Allowed IPs</TableHead>
+          <TableHead className="text-slate-400">Last Handshake</TableHead>
+          <TableHead className="text-slate-400 text-right">RX</TableHead>
+          <TableHead className="text-slate-400 text-right">TX</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {peers.map((peer, i) => (
+          <TableRow key={peer.public_key || i} className="border-slate-800">
+            <TableCell>
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <PeerStatusDot isOnline={peer.is_online} />
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="right"
+                    className="border-slate-800 bg-slate-900"
+                  >
+                    <p>{peer.is_online ? "Online" : "Offline"}</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-col gap-0.5">
+                {peer.name && (
+                  <span className="font-medium text-slate-200">
+                    {peer.name}
+                  </span>
+                )}
+                {peer.public_key && (
+                  <span className="font-mono text-xs text-slate-500 truncate max-w-[200px]">
+                    {peer.public_key.slice(0, 12)}...
+                  </span>
+                )}
+              </div>
+            </TableCell>
+            <TableCell className="text-slate-300 font-mono text-sm">
+              {peer.endpoint || "—"}
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-col gap-0.5">
+                {peer.allowed_ips.length > 0
+                  ? peer.allowed_ips.map((ip) => (
+                      <span
+                        key={ip}
+                        className="font-mono text-xs text-slate-400"
+                      >
+                        {ip}
+                      </span>
+                    ))
+                  : <span className="text-slate-500">—</span>}
+              </div>
+            </TableCell>
+            <TableCell className="text-slate-300">
+              {handshakeAgo(peer.last_handshake)}
+            </TableCell>
+            <TableCell className="text-right text-slate-300 tabular-nums">
+              {peer.rx_bytes != null ? formatBytes(peer.rx_bytes) : "—"}
+            </TableCell>
+            <TableCell className="text-right text-slate-300 tabular-nums">
+              {peer.tx_bytes != null ? formatBytes(peer.tx_bytes) : "—"}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
+  const onlinePeers = iface.peers.filter((p) => p.is_online).length;
+  const totalPeers = iface.peers.length;
+
+  return (
+    <Card className="border-slate-800 bg-slate-950">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
+              <Shield className="h-5 w-5 text-blue-400" />
+            </div>
+            <div>
+              <CardTitle className="text-lg text-slate-100">
+                {iface.name}
+              </CardTitle>
+              <div className="flex items-center gap-2 mt-0.5">
+                <InterfaceStatusBadge status={iface.status} />
+                {iface.listen_port && (
+                  <span className="text-xs text-slate-500">
+                    Port {iface.listen_port}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <Wifi className="h-4 w-4 text-slate-500" />
+            <span className="text-slate-400">
+              <span className="text-emerald-400 font-medium">{onlinePeers}</span>
+              <span className="text-slate-600"> / </span>
+              <span>{totalPeers}</span>
+              <span className="text-slate-500 ml-1">peers</span>
+            </span>
+          </div>
+        </div>
+        {iface.public_key && (
+          <p className="mt-2 font-mono text-xs text-slate-600 truncate">
+            Public key: {iface.public_key}
+          </p>
+        )}
+      </CardHeader>
+      <CardContent className="pt-0">
+        <PeerTable peers={iface.peers} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-6">
+      {[1, 2].map((i) => (
+        <Card key={i} className="border-slate-800 bg-slate-950">
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-9 w-9 rounded-lg" />
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-24" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {[1, 2, 3].map((j) => (
+                <Skeleton key={j} className="h-10 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export default function VpnStatusPage() {
+  const [data, setData] = useState<VpnStatusResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    else setRefreshing(true);
+    try {
+      const result = await fetchVpnStatus();
+      setData(result);
+    } catch {
+      if (!silent) toast.error("Failed to load VPN status");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    intervalRef.current = setInterval(() => load(true), REFRESH_INTERVAL_MS);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [load]);
+
+  const totalPeers = data?.interfaces.reduce((sum, i) => sum + i.peers.length, 0) ?? 0;
+  const onlinePeers = data?.interfaces.reduce(
+    (sum, i) => sum + i.peers.filter((p) => p.is_online).length,
+    0
+  ) ?? 0;
+  const totalInterfaces = data?.interfaces.length ?? 0;
+  const upInterfaces = data?.interfaces.filter((i) => i.status === "up").length ?? 0;
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">VPN Status</h1>
+            <p className="text-sm text-slate-500 mt-0.5">
+              WireGuard tunnel health and connected peers
+              {data?.router_type && data.router_type !== "none" && (
+                <> &middot; {data.router_type === "vyos" ? "VyOS" : "MikroTik"}</>
+              )}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => load(true)}
+            disabled={refreshing}
+            className="border-slate-700 text-slate-300 hover:bg-slate-800"
+          >
+            <RefreshCw
+              className={`h-4 w-4 mr-2 ${refreshing ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Summary cards */}
+        {!loading && data && (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Card className="border-slate-800 bg-slate-950">
+              <CardContent className="flex items-center gap-3 pt-6">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
+                  <Shield className="h-5 w-5 text-blue-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white tabular-nums">
+                    {upInterfaces}
+                    <span className="text-sm font-normal text-slate-500">
+                      {" "}/ {totalInterfaces}
+                    </span>
+                  </p>
+                  <p className="text-xs text-slate-500">Tunnels Up</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-slate-800 bg-slate-950">
+              <CardContent className="flex items-center gap-3 pt-6">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/10">
+                  <Wifi className="h-5 w-5 text-emerald-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white tabular-nums">
+                    {onlinePeers}
+                    <span className="text-sm font-normal text-slate-500">
+                      {" "}/ {totalPeers}
+                    </span>
+                  </p>
+                  <p className="text-xs text-slate-500">Peers Online</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-slate-800 bg-slate-950">
+              <CardContent className="flex items-center gap-3 pt-6">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10">
+                  <ArrowDownUp className="h-5 w-5 text-amber-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white tabular-nums">
+                    {formatBytes(
+                      data.interfaces.reduce(
+                        (sum, i) =>
+                          sum +
+                          i.peers.reduce(
+                            (ps, p) => ps + (p.rx_bytes ?? 0) + (p.tx_bytes ?? 0),
+                            0
+                          ),
+                        0
+                      )
+                    )}
+                  </p>
+                  <p className="text-xs text-slate-500">Total Transfer</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Interfaces */}
+        {loading ? (
+          <LoadingSkeleton />
+        ) : data?.router_type === "none" ? (
+          <Card className="border-slate-800 bg-slate-950">
+            <CardContent className="flex flex-col items-center justify-center py-16">
+              <WifiOff className="h-12 w-12 text-slate-600 mb-4" />
+              <h2 className="text-lg font-semibold text-slate-300">
+                No Router Configured
+              </h2>
+              <p className="mt-1 text-sm text-slate-500 max-w-md text-center">
+                Configure a VyOS or MikroTik router in Settings to see WireGuard
+                VPN status here.
+              </p>
+            </CardContent>
+          </Card>
+        ) : data?.interfaces.length === 0 ? (
+          <Card className="border-slate-800 bg-slate-950">
+            <CardContent className="flex flex-col items-center justify-center py-16">
+              <Shield className="h-12 w-12 text-slate-600 mb-4" />
+              <h2 className="text-lg font-semibold text-slate-300">
+                No WireGuard Interfaces
+              </h2>
+              <p className="mt-1 text-sm text-slate-500 max-w-md text-center">
+                No WireGuard interfaces are configured on your router. Create one
+                from the Router page.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {data?.interfaces.map((iface) => (
+              <InterfaceCard key={iface.name} iface={iface} />
+            ))}
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Server,
   Settings,
   Shield,
+  ShieldCheck,
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ const navItems = [
   { href: "/assets", label: "Assets", icon: Box },
   { href: "/ssh-hosts", label: "SSH Hosts", icon: Server },
   { href: "/router", label: "Router", icon: Router },
+  { href: "/vpn-status", label: "VPN Status", icon: ShieldCheck },
   { href: "/npm", label: "NPM", icon: Globe },
   { href: "/services", label: "Services", icon: Workflow },
   { href: "/topology", label: "Topology", icon: Network },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -95,6 +95,7 @@ import type {
   DnsIngestEntry,
   DnsIngestResponse,
   DnsPurgeResponse,
+  VpnStatusResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -1574,4 +1575,10 @@ export function fetchDnsQueries(params?: {
 export function fetchDnsQueryStats(hours?: number): Promise<DnsQueryStats> {
   const qs = hours ? `?hours=${hours}` : "";
   return apiGet<DnsQueryStats>(`/api/v1/dns-queries/stats${qs}`);
+}
+
+// ─── VPN Status ──────────────────────────────────────────
+
+export function fetchVpnStatus(): Promise<VpnStatusResponse> {
+  return apiGet<VpnStatusResponse>("/api/v1/vpn/status");
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1414,3 +1414,29 @@ export interface DnsUnboundConfigResponse {
   config: string;
   domain_count: number;
 }
+
+// ─── VPN Status Dashboard ────────────────────────────────
+
+export interface VpnPeerStatus {
+  name: string;
+  public_key: string | null;
+  endpoint: string | null;
+  allowed_ips: string[];
+  last_handshake: number | null;
+  rx_bytes: number | null;
+  tx_bytes: number | null;
+  is_online: boolean;
+}
+
+export interface VpnInterfaceStatus {
+  name: string;
+  status: string | null;
+  listen_port: number | null;
+  public_key: string | null;
+  peers: VpnPeerStatus[];
+}
+
+export interface VpnStatusResponse {
+  router_type: string;
+  interfaces: VpnInterfaceStatus[];
+}


### PR DESCRIPTION
Closes #252

## Summary

- **New `/api/v1/vpn/status` endpoint** — unified VPN status across VyOS and MikroTik routers, returning per-interface status (up/down, port, public key) and per-peer details (handshake, transfer RX/TX, endpoint, allowed IPs, online/offline indicator)
- **New VPN Status page** (`/vpn-status`) — dedicated dashboard with summary cards (tunnels up, peers online, total transfer), interface cards with peer tables, and auto-refresh every 30 seconds
- **Sidebar navigation** — added "VPN Status" link with ShieldCheck icon

### Design decisions
- Peer "online" threshold: 3-minute handshake recency (standard WireGuard keepalive interval is 25s, so 3 minutes covers several missed keepalives)
- VyOS takes precedence over MikroTik when both are configured (existing pattern in the codebase)
- Reuses existing `parse_wireguard_config`, `merge_wireguard_runtime_stats`, and MikroTik WireGuard client methods rather than duplicating logic
- Made `parse_wireguard_config`, `merge_wireguard_runtime_stats` (vyos.rs) and `mikrotik_client` (mikrotik.rs) `pub(crate)` to enable reuse from the new module

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo check` — compiles
- [x] `cargo test` — 294 unit + 18 integration tests pass
- [ ] Manual: configure VyOS with WireGuard, verify `/vpn-status` page shows interfaces and peer status
- [ ] Manual: configure MikroTik with WireGuard, verify fallback works
- [ ] Manual: no router configured — empty state with guidance message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a comprehensive VPN status dashboard that displays WireGuard tunnel health and connected peers across VyOS and MikroTik routers.

**Key Changes:**
- New `/api/v1/vpn/status` endpoint that unifies VPN data from VyOS and MikroTik
- Reuses existing parsing logic (`parse_wireguard_config`, `merge_wireguard_runtime_stats`) rather than duplicating code
- 3-minute handshake threshold for peer online status (matches WireGuard keepalive behavior)
- Auto-refreshing dashboard with summary cards showing tunnels up, peers online, and total transfer
- Clean separation between backend router abstraction and frontend presentation
- Proper empty states for unconfigured routers and missing WireGuard interfaces

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- Clean implementation following existing codebase patterns, proper error handling, type-safe frontend/backend integration, and successful test suite (294 unit + 18 integration tests passing)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vpn_status.rs | New unified VPN status endpoint with VyOS and MikroTik support, clean type definitions and proper error handling |
| web/src/app/(app)/vpn-status/page.tsx | Well-structured VPN status dashboard with auto-refresh, summary cards, and proper state management |
| web/src/lib/types.ts | TypeScript type definitions that correctly match backend Rust structures |

</details>



<sub>Last reviewed commit: c78ce06</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->