### PR TITLE
feat: MikroTik firewall rule management (CRUD) (#253)

### DIFF
--- a/server/src/api/mikrotik.rs
+++ b/server/src/api/mikrotik.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use super::AppState;
 use crate::mikrotik::client::MikrotikClient;
-use crate::mikrotik::types::VlanWriteRequest;
+use crate::mikrotik::types::{
+    AddressListWriteRequest, FirewallFilterWriteRequest, FirewallNatWriteRequest, VlanWriteRequest,
+};
 
 // ── Helper: build a MikroTik client from DB settings ───────
 
@@ -129,16 +131,24 @@ pub struct MikrotikDhcpLeaseResponse {
 pub struct MikrotikFirewallResponse {
     pub filter_rules: Vec<MikrotikFirewallRule>,
     pub nat_rules: Vec<MikrotikNatRule>,
+    pub address_lists: Vec<MikrotikAddressListEntry>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MikrotikFirewallRule {
+    pub id: Option<String>,
     pub chain: Option<String>,
     pub action: Option<String>,
     pub protocol: Option<String>,
     pub src_address: Option<String>,
     pub dst_address: Option<String>,
+    pub src_port: Option<String>,
     pub dst_port: Option<String>,
+    pub in_interface: Option<String>,
+    pub out_interface: Option<String>,
+    pub connection_state: Option<String>,
+    pub src_address_list: Option<String>,
+    pub dst_address_list: Option<String>,
     pub comment: Option<String>,
     pub disabled: bool,
     pub bytes: Option<String>,
@@ -147,6 +157,7 @@ pub struct MikrotikFirewallRule {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MikrotikNatRule {
+    pub id: Option<String>,
     pub chain: Option<String>,
     pub action: Option<String>,
     pub protocol: Option<String>,
@@ -158,6 +169,65 @@ pub struct MikrotikNatRule {
     pub out_interface: Option<String>,
     pub comment: Option<String>,
     pub disabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MikrotikAddressListEntry {
+    pub id: Option<String>,
+    pub list: Option<String>,
+    pub address: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikFirewallRuleRequest {
+    pub chain: String,
+    pub action: String,
+    pub protocol: Option<String>,
+    pub src_address: Option<String>,
+    pub dst_address: Option<String>,
+    pub src_port: Option<String>,
+    pub dst_port: Option<String>,
+    pub in_interface: Option<String>,
+    pub out_interface: Option<String>,
+    pub connection_state: Option<String>,
+    pub src_address_list: Option<String>,
+    pub dst_address_list: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikNatRuleRequest {
+    pub chain: String,
+    pub action: String,
+    pub protocol: Option<String>,
+    pub src_address: Option<String>,
+    pub dst_address: Option<String>,
+    pub dst_port: Option<String>,
+    pub to_addresses: Option<String>,
+    pub to_ports: Option<String>,
+    pub out_interface: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikAddressListRequest {
+    pub list: String,
+    pub address: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikToggleRequest {
+    pub disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikMoveRequest {
+    pub destination: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -541,16 +611,24 @@ pub async fn firewall(
 
     let filter = client.firewall_filter().await.unwrap_or_default();
     let nat = client.firewall_nat().await.unwrap_or_default();
+    let addr_list = client.firewall_address_list().await.unwrap_or_default();
 
     let filter_rules: Vec<MikrotikFirewallRule> = filter
         .into_iter()
         .map(|f| MikrotikFirewallRule {
+            id: f.id,
             chain: f.chain,
             action: f.action,
             protocol: f.protocol,
             src_address: f.src_address,
             dst_address: f.dst_address,
+            src_port: f.src_port,
             dst_port: f.dst_port,
+            in_interface: f.in_interface,
+            out_interface: f.out_interface,
+            connection_state: f.connection_state,
+            src_address_list: f.src_address_list,
+            dst_address_list: f.dst_address_list,
             comment: f.comment,
             disabled: is_true(&f.disabled),
             bytes: f.bytes,
@@ -561,6 +639,7 @@ pub async fn firewall(
     let nat_rules: Vec<MikrotikNatRule> = nat
         .into_iter()
         .map(|n| MikrotikNatRule {
+            id: n.id,
             chain: n.chain,
             action: n.action,
             protocol: n.protocol,
@@ -575,9 +654,21 @@ pub async fn firewall(
         })
         .collect();
 
+    let address_lists: Vec<MikrotikAddressListEntry> = addr_list
+        .into_iter()
+        .map(|a| MikrotikAddressListEntry {
+            id: a.id,
+            list: a.list,
+            address: a.address,
+            comment: a.comment,
+            disabled: is_true(&a.disabled),
+        })
+        .collect();
+
     let result = MikrotikFirewallResponse {
         filter_rules,
         nat_rules,
+        address_lists,
     };
 
     if let Ok(val) = serde_json::to_value(&result) {
@@ -687,4 +778,308 @@ pub async fn wireguard(
         state.mikrotik_cache.set("wireguard".into(), val);
     }
     Ok(Json(result))
+}
+
+// ── Firewall filter CRUD ─────────────────────────────────
+
+fn to_filter_write(body: &MikrotikFirewallRuleRequest) -> FirewallFilterWriteRequest {
+    FirewallFilterWriteRequest {
+        chain: body.chain.clone(),
+        action: body.action.clone(),
+        protocol: body.protocol.clone(),
+        src_address: body.src_address.clone(),
+        dst_address: body.dst_address.clone(),
+        src_port: body.src_port.clone(),
+        dst_port: body.dst_port.clone(),
+        comment: body.comment.clone(),
+        disabled: body
+            .disabled
+            .map(|d| if d { "true" } else { "false" }.to_string()),
+        src_address_list: body.src_address_list.clone(),
+        dst_address_list: body.dst_address_list.clone(),
+        in_interface: body.in_interface.clone(),
+        out_interface: body.out_interface.clone(),
+        connection_state: body.connection_state.clone(),
+    }
+}
+
+/// POST /api/v1/mikrotik/firewall/filter
+pub async fn create_firewall_filter(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikFirewallRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .create_firewall_filter(&to_filter_write(&body))
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall filter create error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// PUT /api/v1/mikrotik/firewall/filter/:id
+pub async fn update_firewall_filter(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikFirewallRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .update_firewall_filter(id, &to_filter_write(&body))
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall filter update error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /api/v1/mikrotik/firewall/filter/:id
+pub async fn delete_firewall_filter(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client.delete_firewall_filter(id).await.map_err(|e| {
+        tracing::error!("MikroTik firewall filter delete error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// PATCH /api/v1/mikrotik/firewall/filter/:id/toggle
+pub async fn toggle_firewall_filter(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikToggleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .toggle_firewall_filter(id, body.disabled)
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall filter toggle error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// POST /api/v1/mikrotik/firewall/filter/:id/move
+pub async fn move_firewall_filter(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikMoveRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .move_firewall_filter(id, body.destination.as_deref())
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall filter move error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Firewall NAT CRUD ────────────────────────────────────
+
+fn to_nat_write(body: &MikrotikNatRuleRequest) -> FirewallNatWriteRequest {
+    FirewallNatWriteRequest {
+        chain: body.chain.clone(),
+        action: body.action.clone(),
+        protocol: body.protocol.clone(),
+        src_address: body.src_address.clone(),
+        dst_address: body.dst_address.clone(),
+        dst_port: body.dst_port.clone(),
+        to_addresses: body.to_addresses.clone(),
+        to_ports: body.to_ports.clone(),
+        out_interface: body.out_interface.clone(),
+        comment: body.comment.clone(),
+        disabled: body
+            .disabled
+            .map(|d| if d { "true" } else { "false" }.to_string()),
+    }
+}
+
+/// POST /api/v1/mikrotik/firewall/nat
+pub async fn create_firewall_nat(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikNatRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .create_firewall_nat(&to_nat_write(&body))
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall NAT create error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// PUT /api/v1/mikrotik/firewall/nat/:id
+pub async fn update_firewall_nat(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikNatRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .update_firewall_nat(id, &to_nat_write(&body))
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall NAT update error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /api/v1/mikrotik/firewall/nat/:id
+pub async fn delete_firewall_nat(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client.delete_firewall_nat(id).await.map_err(|e| {
+        tracing::error!("MikroTik firewall NAT delete error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// PATCH /api/v1/mikrotik/firewall/nat/:id/toggle
+pub async fn toggle_firewall_nat(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikToggleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client
+        .toggle_firewall_nat(id, body.disabled)
+        .await
+        .map_err(|e| {
+            tracing::error!("MikroTik firewall NAT toggle error: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Address list CRUD ────────────────────────────────────
+
+/// POST /api/v1/mikrotik/firewall/address-list
+pub async fn create_address_list_entry(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikAddressListRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let req = AddressListWriteRequest {
+        list: body.list,
+        address: body.address,
+        comment: body.comment,
+    };
+
+    client.create_address_list_entry(&req).await.map_err(|e| {
+        tracing::error!("MikroTik address list create error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /api/v1/mikrotik/firewall/address-list/:id
+pub async fn delete_address_list_entry(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    client.delete_address_list_entry(id).await.map_err(|e| {
+        tracing::error!("MikroTik address list delete error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -421,6 +421,53 @@ pub fn router(state: AppState) -> Router {
         .route("/mikrotik/routes", get(mikrotik::routes))
         .route("/mikrotik/dhcp-leases", get(mikrotik::dhcp_leases))
         .route("/mikrotik/firewall", get(mikrotik::firewall))
+        // MikroTik firewall filter CRUD
+        .route(
+            "/mikrotik/firewall/filter",
+            post(mikrotik::create_firewall_filter),
+        )
+        .route(
+            "/mikrotik/firewall/filter/:id",
+            put(mikrotik::update_firewall_filter),
+        )
+        .route(
+            "/mikrotik/firewall/filter/:id",
+            delete(mikrotik::delete_firewall_filter),
+        )
+        .route(
+            "/mikrotik/firewall/filter/:id/toggle",
+            patch(mikrotik::toggle_firewall_filter),
+        )
+        .route(
+            "/mikrotik/firewall/filter/:id/move",
+            post(mikrotik::move_firewall_filter),
+        )
+        // MikroTik firewall NAT CRUD
+        .route(
+            "/mikrotik/firewall/nat",
+            post(mikrotik::create_firewall_nat),
+        )
+        .route(
+            "/mikrotik/firewall/nat/:id",
+            put(mikrotik::update_firewall_nat),
+        )
+        .route(
+            "/mikrotik/firewall/nat/:id",
+            delete(mikrotik::delete_firewall_nat),
+        )
+        .route(
+            "/mikrotik/firewall/nat/:id/toggle",
+            patch(mikrotik::toggle_firewall_nat),
+        )
+        // MikroTik address list CRUD
+        .route(
+            "/mikrotik/firewall/address-list",
+            post(mikrotik::create_address_list_entry),
+        )
+        .route(
+            "/mikrotik/firewall/address-list/:id",
+            delete(mikrotik::delete_address_list_entry),
+        )
         .route("/mikrotik/dns", get(mikrotik::dns))
         .route("/mikrotik/wireguard", get(mikrotik::wireguard))
         // Assets (IT inventory)

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -382,6 +382,95 @@ impl MikrotikClient {
         self.send_no_body(Method::DELETE, &format!("/interface/vlan/{id}"))
             .await
     }
+
+    // ── Firewall filter CRUD ────────────────────────────────
+
+    /// Create a firewall filter rule.
+    pub async fn create_firewall_filter(&self, req: &FirewallFilterWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/ip/firewall/filter", req)
+            .await
+    }
+
+    /// Update a firewall filter rule by RouterOS `.id`.
+    pub async fn update_firewall_filter(
+        &self,
+        id: &str,
+        req: &FirewallFilterWriteRequest,
+    ) -> Result<()> {
+        self.send_json(Method::PATCH, &format!("/ip/firewall/filter/{id}"), req)
+            .await
+    }
+
+    /// Delete a firewall filter rule by RouterOS `.id`.
+    pub async fn delete_firewall_filter(&self, id: &str) -> Result<()> {
+        self.send_no_body(Method::DELETE, &format!("/ip/firewall/filter/{id}"))
+            .await
+    }
+
+    /// Enable or disable a firewall filter rule by RouterOS `.id`.
+    pub async fn toggle_firewall_filter(&self, id: &str, disabled: bool) -> Result<()> {
+        let body = serde_json::json!({ "disabled": if disabled { "true" } else { "false" } });
+        self.send_json(Method::PATCH, &format!("/ip/firewall/filter/{id}"), &body)
+            .await
+    }
+
+    /// Move a firewall filter rule to a new position.
+    pub async fn move_firewall_filter(&self, id: &str, destination: Option<&str>) -> Result<()> {
+        let mut body = serde_json::json!({ "numbers": id });
+        if let Some(dest) = destination {
+            body["destination"] = serde_json::Value::String(dest.to_string());
+        }
+        self.post("/ip/firewall/filter/move", &body).await?;
+        Ok(())
+    }
+
+    // ── Firewall NAT CRUD ───────────────────────────────────
+
+    /// Create a firewall NAT rule.
+    pub async fn create_firewall_nat(&self, req: &FirewallNatWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/ip/firewall/nat", req).await
+    }
+
+    /// Update a firewall NAT rule by RouterOS `.id`.
+    pub async fn update_firewall_nat(&self, id: &str, req: &FirewallNatWriteRequest) -> Result<()> {
+        self.send_json(Method::PATCH, &format!("/ip/firewall/nat/{id}"), req)
+            .await
+    }
+
+    /// Delete a firewall NAT rule by RouterOS `.id`.
+    pub async fn delete_firewall_nat(&self, id: &str) -> Result<()> {
+        self.send_no_body(Method::DELETE, &format!("/ip/firewall/nat/{id}"))
+            .await
+    }
+
+    /// Enable or disable a firewall NAT rule by RouterOS `.id`.
+    pub async fn toggle_firewall_nat(&self, id: &str, disabled: bool) -> Result<()> {
+        let body = serde_json::json!({ "disabled": if disabled { "true" } else { "false" } });
+        self.send_json(Method::PATCH, &format!("/ip/firewall/nat/{id}"), &body)
+            .await
+    }
+
+    // ── Address list CRUD ───────────────────────────────────
+
+    /// Fetch firewall address list entries.
+    pub async fn firewall_address_list(&self) -> Result<Vec<AddressListEntry>> {
+        let val = self.get("/ip/firewall/address-list").await?;
+        let res: Vec<AddressListEntry> =
+            serde_json::from_value(val).context("failed to parse firewall address list")?;
+        Ok(res)
+    }
+
+    /// Create a firewall address list entry.
+    pub async fn create_address_list_entry(&self, req: &AddressListWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/ip/firewall/address-list", req)
+            .await
+    }
+
+    /// Delete a firewall address list entry by RouterOS `.id`.
+    pub async fn delete_address_list_entry(&self, id: &str) -> Result<()> {
+        self.send_no_body(Method::DELETE, &format!("/ip/firewall/address-list/{id}"))
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -143,6 +143,16 @@ pub struct FirewallFilter {
     pub dst_port: Option<String>,
     #[serde(rename = "src-port")]
     pub src_port: Option<String>,
+    #[serde(rename = "in-interface")]
+    pub in_interface: Option<String>,
+    #[serde(rename = "out-interface")]
+    pub out_interface: Option<String>,
+    #[serde(rename = "connection-state")]
+    pub connection_state: Option<String>,
+    #[serde(rename = "src-address-list")]
+    pub src_address_list: Option<String>,
+    #[serde(rename = "dst-address-list")]
+    pub dst_address_list: Option<String>,
     pub comment: Option<String>,
     pub disabled: Option<String>,
     pub bytes: Option<String>,
@@ -171,6 +181,82 @@ pub struct FirewallNat {
     pub out_interface: Option<String>,
     pub comment: Option<String>,
     pub disabled: Option<String>,
+}
+
+/// MikroTik firewall address list entry (`/rest/ip/firewall/address-list`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddressListEntry {
+    #[serde(rename = ".id")]
+    pub id: Option<String>,
+    pub list: Option<String>,
+    pub address: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: Option<String>,
+}
+
+/// Write payload for creating/updating a firewall filter rule.
+#[derive(Debug, Clone, Serialize)]
+pub struct FirewallFilterWriteRequest {
+    pub chain: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    #[serde(rename = "src-address", skip_serializing_if = "Option::is_none")]
+    pub src_address: Option<String>,
+    #[serde(rename = "dst-address", skip_serializing_if = "Option::is_none")]
+    pub dst_address: Option<String>,
+    #[serde(rename = "src-port", skip_serializing_if = "Option::is_none")]
+    pub src_port: Option<String>,
+    #[serde(rename = "dst-port", skip_serializing_if = "Option::is_none")]
+    pub dst_port: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<String>,
+    #[serde(rename = "src-address-list", skip_serializing_if = "Option::is_none")]
+    pub src_address_list: Option<String>,
+    #[serde(rename = "dst-address-list", skip_serializing_if = "Option::is_none")]
+    pub dst_address_list: Option<String>,
+    #[serde(rename = "in-interface", skip_serializing_if = "Option::is_none")]
+    pub in_interface: Option<String>,
+    #[serde(rename = "out-interface", skip_serializing_if = "Option::is_none")]
+    pub out_interface: Option<String>,
+    #[serde(rename = "connection-state", skip_serializing_if = "Option::is_none")]
+    pub connection_state: Option<String>,
+}
+
+/// Write payload for creating/updating a firewall NAT rule.
+#[derive(Debug, Clone, Serialize)]
+pub struct FirewallNatWriteRequest {
+    pub chain: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    #[serde(rename = "src-address", skip_serializing_if = "Option::is_none")]
+    pub src_address: Option<String>,
+    #[serde(rename = "dst-address", skip_serializing_if = "Option::is_none")]
+    pub dst_address: Option<String>,
+    #[serde(rename = "dst-port", skip_serializing_if = "Option::is_none")]
+    pub dst_port: Option<String>,
+    #[serde(rename = "to-addresses", skip_serializing_if = "Option::is_none")]
+    pub to_addresses: Option<String>,
+    #[serde(rename = "to-ports", skip_serializing_if = "Option::is_none")]
+    pub to_ports: Option<String>,
+    #[serde(rename = "out-interface", skip_serializing_if = "Option::is_none")]
+    pub out_interface: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<String>,
+}
+
+/// Write payload for creating an address list entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct AddressListWriteRequest {
+    pub list: String,
+    pub address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 /// MikroTik DNS settings (`/rest/ip/dns`).

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -21,6 +21,9 @@ import {
   Pencil,
   Trash2,
   BarChart3,
+  ChevronUp,
+  ChevronDown,
+  Power,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -70,6 +73,17 @@ import {
   createMikrotikVlan,
   updateMikrotikVlan,
   deleteMikrotikVlan,
+  createMikrotikFirewallFilter,
+  updateMikrotikFirewallFilter,
+  deleteMikrotikFirewallFilter,
+  toggleMikrotikFirewallFilter,
+  moveMikrotikFirewallFilter,
+  createMikrotikFirewallNat,
+  updateMikrotikFirewallNat,
+  deleteMikrotikFirewallNat,
+  toggleMikrotikFirewallNat,
+  createMikrotikAddressListEntry,
+  deleteMikrotikAddressListEntry,
   fetchTrafficHistory,
 } from "@/lib/api";
 import { formatBps } from "@/lib/format";
@@ -81,6 +95,12 @@ import type {
   MikrotikRoute,
   MikrotikDhcpLease,
   MikrotikFirewall,
+  MikrotikFirewallRule,
+  MikrotikNatRule,
+  MikrotikFirewallRuleRequest,
+  MikrotikNatRuleRequest,
+  MikrotikAddressListEntry,
+  MikrotikAddressListRequest,
   MikrotikDns,
   MikrotikWireguard,
   TrafficHistoryPoint,
@@ -1009,42 +1029,526 @@ function DhcpLeasesTable({
   );
 }
 
-// ── Firewall Tables ───────────────────────────────────────
+// ── Firewall Filter Rule Dialog ───────────────────────────
+
+const selectClass =
+  "h-9 w-full rounded-md border border-slate-800 bg-slate-950 px-3 text-sm text-white focus:outline-none focus:ring-1 focus:ring-blue-500";
+
+function FilterRuleDialog({
+  open,
+  onOpenChange,
+  rule,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rule: MikrotikFirewallRule | null;
+  onSave: (body: MikrotikFirewallRuleRequest, id?: string) => void;
+}) {
+  const [form, setForm] = useState<MikrotikFirewallRuleRequest>({
+    chain: "forward",
+    action: "accept",
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (rule) {
+      setForm({
+        chain: rule.chain ?? "forward",
+        action: rule.action ?? "accept",
+        protocol: rule.protocol ?? undefined,
+        src_address: rule.src_address ?? undefined,
+        dst_address: rule.dst_address ?? undefined,
+        src_port: rule.src_port ?? undefined,
+        dst_port: rule.dst_port ?? undefined,
+        in_interface: rule.in_interface ?? undefined,
+        out_interface: rule.out_interface ?? undefined,
+        connection_state: rule.connection_state ?? undefined,
+        src_address_list: rule.src_address_list ?? undefined,
+        dst_address_list: rule.dst_address_list ?? undefined,
+        comment: rule.comment ?? undefined,
+        disabled: rule.disabled,
+      });
+    } else {
+      setForm({ chain: "forward", action: "accept" });
+    }
+  }, [rule, open]);
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    try {
+      onSave(form, rule?.id ?? undefined);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const showPorts = form.protocol === "tcp" || form.protocol === "udp" || form.protocol === "tcp,udp";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto border-slate-800 bg-slate-900 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {rule ? "Edit Filter Rule" : "Add Filter Rule"}
+          </DialogTitle>
+          <DialogDescription>
+            {rule ? "Update the firewall filter rule." : "Create a new firewall filter rule."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">Chain</Label>
+              <select value={form.chain} onChange={(e) => setForm({ ...form, chain: e.target.value })} className={selectClass}>
+                <option value="forward">forward</option>
+                <option value="input">input</option>
+                <option value="output">output</option>
+              </select>
+            </div>
+            <div>
+              <Label className="text-slate-300">Action</Label>
+              <select value={form.action} onChange={(e) => setForm({ ...form, action: e.target.value })} className={selectClass}>
+                <option value="accept">accept</option>
+                <option value="drop">drop</option>
+                <option value="reject">reject</option>
+                <option value="jump">jump</option>
+                <option value="log">log</option>
+                <option value="passthrough">passthrough</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <Label className="text-slate-300">Protocol</Label>
+            <select value={form.protocol ?? ""} onChange={(e) => setForm({ ...form, protocol: e.target.value || undefined })} className={selectClass}>
+              <option value="">any</option>
+              <option value="tcp">tcp</option>
+              <option value="udp">udp</option>
+              <option value="icmp">icmp</option>
+              <option value="tcp,udp">tcp+udp</option>
+              <option value="gre">gre</option>
+              <option value="esp">esp</option>
+              <option value="ah">ah</option>
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">Src Address</Label>
+              <Input value={form.src_address ?? ""} onChange={(e) => setForm({ ...form, src_address: e.target.value || undefined })} placeholder="e.g. 192.168.1.0/24" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+            <div>
+              <Label className="text-slate-300">Dst Address</Label>
+              <Input value={form.dst_address ?? ""} onChange={(e) => setForm({ ...form, dst_address: e.target.value || undefined })} placeholder="e.g. 10.0.0.1" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          </div>
+          {showPorts && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label className="text-slate-300">Src Port</Label>
+                <Input value={form.src_port ?? ""} onChange={(e) => setForm({ ...form, src_port: e.target.value || undefined })} placeholder="e.g. 1024-65535" className="border-slate-800 bg-slate-950 text-white" />
+              </div>
+              <div>
+                <Label className="text-slate-300">Dst Port</Label>
+                <Input value={form.dst_port ?? ""} onChange={(e) => setForm({ ...form, dst_port: e.target.value || undefined })} placeholder="e.g. 80,443" className="border-slate-800 bg-slate-950 text-white" />
+              </div>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">In Interface</Label>
+              <Input value={form.in_interface ?? ""} onChange={(e) => setForm({ ...form, in_interface: e.target.value || undefined })} placeholder="e.g. ether1" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+            <div>
+              <Label className="text-slate-300">Out Interface</Label>
+              <Input value={form.out_interface ?? ""} onChange={(e) => setForm({ ...form, out_interface: e.target.value || undefined })} placeholder="e.g. ether2" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          </div>
+          <div>
+            <Label className="text-slate-300">Connection State</Label>
+            <Input value={form.connection_state ?? ""} onChange={(e) => setForm({ ...form, connection_state: e.target.value || undefined })} placeholder="e.g. established,related" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">Src Address List</Label>
+              <Input value={form.src_address_list ?? ""} onChange={(e) => setForm({ ...form, src_address_list: e.target.value || undefined })} placeholder="Address list name" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+            <div>
+              <Label className="text-slate-300">Dst Address List</Label>
+              <Input value={form.dst_address_list ?? ""} onChange={(e) => setForm({ ...form, dst_address_list: e.target.value || undefined })} placeholder="Address list name" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          </div>
+          <div>
+            <Label className="text-slate-300">Comment</Label>
+            <Input value={form.comment ?? ""} onChange={(e) => setForm({ ...form, comment: e.target.value || undefined })} placeholder="Rule description" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="border-slate-700 text-slate-300">
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving} className="bg-blue-600 hover:bg-blue-700">
+            {saving ? "Saving..." : rule ? "Update" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── NAT Rule Dialog ──────────────────────────────────────
+
+function NatRuleDialog({
+  open,
+  onOpenChange,
+  rule,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rule: MikrotikNatRule | null;
+  onSave: (body: MikrotikNatRuleRequest, id?: string) => void;
+}) {
+  const [form, setForm] = useState<MikrotikNatRuleRequest>({
+    chain: "dstnat",
+    action: "dst-nat",
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (rule) {
+      setForm({
+        chain: rule.chain ?? "dstnat",
+        action: rule.action ?? "dst-nat",
+        protocol: rule.protocol ?? undefined,
+        src_address: rule.src_address ?? undefined,
+        dst_address: rule.dst_address ?? undefined,
+        dst_port: rule.dst_port ?? undefined,
+        to_addresses: rule.to_addresses ?? undefined,
+        to_ports: rule.to_ports ?? undefined,
+        out_interface: rule.out_interface ?? undefined,
+        comment: rule.comment ?? undefined,
+        disabled: rule.disabled,
+      });
+    } else {
+      setForm({ chain: "dstnat", action: "dst-nat" });
+    }
+  }, [rule, open]);
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    try {
+      onSave(form, rule?.id ?? undefined);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const showPorts = form.protocol === "tcp" || form.protocol === "udp" || form.protocol === "tcp,udp";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto border-slate-800 bg-slate-900 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {rule ? "Edit NAT Rule" : "Add NAT Rule"}
+          </DialogTitle>
+          <DialogDescription>
+            {rule ? "Update the NAT rule." : "Create a new NAT rule."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">Chain</Label>
+              <select value={form.chain} onChange={(e) => setForm({ ...form, chain: e.target.value })} className={selectClass}>
+                <option value="dstnat">dstnat</option>
+                <option value="srcnat">srcnat</option>
+              </select>
+            </div>
+            <div>
+              <Label className="text-slate-300">Action</Label>
+              <select value={form.action} onChange={(e) => setForm({ ...form, action: e.target.value })} className={selectClass}>
+                <option value="dst-nat">dst-nat</option>
+                <option value="masquerade">masquerade</option>
+                <option value="src-nat">src-nat</option>
+                <option value="accept">accept</option>
+                <option value="redirect">redirect</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <Label className="text-slate-300">Protocol</Label>
+            <select value={form.protocol ?? ""} onChange={(e) => setForm({ ...form, protocol: e.target.value || undefined })} className={selectClass}>
+              <option value="">any</option>
+              <option value="tcp">tcp</option>
+              <option value="udp">udp</option>
+              <option value="icmp">icmp</option>
+              <option value="tcp,udp">tcp+udp</option>
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">Src Address</Label>
+              <Input value={form.src_address ?? ""} onChange={(e) => setForm({ ...form, src_address: e.target.value || undefined })} placeholder="e.g. 192.168.1.0/24" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+            <div>
+              <Label className="text-slate-300">Dst Address</Label>
+              <Input value={form.dst_address ?? ""} onChange={(e) => setForm({ ...form, dst_address: e.target.value || undefined })} placeholder="e.g. 10.0.0.1" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          </div>
+          {showPorts && (
+            <div>
+              <Label className="text-slate-300">Dst Port</Label>
+              <Input value={form.dst_port ?? ""} onChange={(e) => setForm({ ...form, dst_port: e.target.value || undefined })} placeholder="e.g. 80,443" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-slate-300">To Addresses</Label>
+              <Input value={form.to_addresses ?? ""} onChange={(e) => setForm({ ...form, to_addresses: e.target.value || undefined })} placeholder="e.g. 192.168.1.100" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+            <div>
+              <Label className="text-slate-300">To Ports</Label>
+              <Input value={form.to_ports ?? ""} onChange={(e) => setForm({ ...form, to_ports: e.target.value || undefined })} placeholder="e.g. 8080" className="border-slate-800 bg-slate-950 text-white" />
+            </div>
+          </div>
+          <div>
+            <Label className="text-slate-300">Out Interface</Label>
+            <Input value={form.out_interface ?? ""} onChange={(e) => setForm({ ...form, out_interface: e.target.value || undefined })} placeholder="e.g. ether1" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+          <div>
+            <Label className="text-slate-300">Comment</Label>
+            <Input value={form.comment ?? ""} onChange={(e) => setForm({ ...form, comment: e.target.value || undefined })} placeholder="Rule description" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="border-slate-700 text-slate-300">
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving} className="bg-blue-600 hover:bg-blue-700">
+            {saving ? "Saving..." : rule ? "Update" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Address List Entry Dialog ────────────────────────────
+
+function AddressListDialog({
+  open,
+  onOpenChange,
+  existingLists,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingLists: string[];
+  onSave: (body: MikrotikAddressListRequest) => void;
+}) {
+  const [form, setForm] = useState<MikrotikAddressListRequest>({
+    list: "",
+    address: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm({ list: existingLists[0] ?? "", address: "" });
+    }
+  }, [open, existingLists]);
+
+  const handleSubmit = async () => {
+    if (!form.list.trim() || !form.address.trim()) return;
+    setSaving(true);
+    try {
+      onSave(form);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="border-slate-800 bg-slate-900 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-white">Add Address List Entry</DialogTitle>
+          <DialogDescription>Add a new entry to a firewall address list.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div>
+            <Label className="text-slate-300">List Name</Label>
+            <Input value={form.list} onChange={(e) => setForm({ ...form, list: e.target.value })} placeholder="e.g. blocked-ips" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+          <div>
+            <Label className="text-slate-300">Address</Label>
+            <Input value={form.address} onChange={(e) => setForm({ ...form, address: e.target.value })} placeholder="e.g. 10.0.0.1 or 10.0.0.0/24" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+          <div>
+            <Label className="text-slate-300">Comment</Label>
+            <Input value={form.comment ?? ""} onChange={(e) => setForm({ ...form, comment: e.target.value || undefined })} placeholder="Optional description" className="border-slate-800 bg-slate-950 text-white" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="border-slate-700 text-slate-300">
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving || !form.list.trim() || !form.address.trim()} className="bg-blue-600 hover:bg-blue-700">
+            {saving ? "Adding..." : "Add Entry"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Firewall Panel (full CRUD) ───────────────────────────
 
 function FirewallPanel({
   data,
   loading,
   error,
+  onReload,
 }: {
   data: MikrotikFirewall | null;
   loading: boolean;
   error: string | null;
+  onReload: () => void;
 }) {
-  const filterHeaderCols = (
-    <tr className="border-b border-slate-800 bg-slate-950 text-left">
-      <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Action</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Src</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Port</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Status</th>
-    </tr>
-  );
+  // Filter rule dialog state
+  const [filterDialogOpen, setFilterDialogOpen] = useState(false);
+  const [editingFilter, setEditingFilter] = useState<MikrotikFirewallRule | null>(null);
+  const [confirmDeleteFilter, setConfirmDeleteFilter] = useState<string | null>(null);
 
-  const natHeaderCols = (
-    <tr className="border-b border-slate-800 bg-slate-950 text-left">
-      <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Action</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Port</th>
-      <th className="px-4 py-3 font-medium text-slate-400">To</th>
-      <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
-    </tr>
-  );
+  // NAT rule dialog state
+  const [natDialogOpen, setNatDialogOpen] = useState(false);
+  const [editingNat, setEditingNat] = useState<MikrotikNatRule | null>(null);
+  const [confirmDeleteNat, setConfirmDeleteNat] = useState<string | null>(null);
 
+  // Address list dialog state
+  const [addrDialogOpen, setAddrDialogOpen] = useState(false);
+  const [confirmDeleteAddr, setConfirmDeleteAddr] = useState<string | null>(null);
+
+  // ── Filter CRUD handlers ─────
+  const handleSaveFilter = async (body: MikrotikFirewallRuleRequest, id?: string) => {
+    try {
+      if (id) {
+        await updateMikrotikFirewallFilter(id, body);
+        toast.success("Filter rule updated");
+      } else {
+        await createMikrotikFirewallFilter(body);
+        toast.success("Filter rule created");
+      }
+      setFilterDialogOpen(false);
+      setEditingFilter(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save filter rule");
+    }
+  };
+
+  const handleDeleteFilter = async (id: string) => {
+    try {
+      await deleteMikrotikFirewallFilter(id);
+      toast.success("Filter rule deleted");
+      setConfirmDeleteFilter(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete filter rule");
+    }
+  };
+
+  const handleToggleFilter = async (rule: MikrotikFirewallRule) => {
+    if (!rule.id) return;
+    try {
+      await toggleMikrotikFirewallFilter(rule.id, !rule.disabled);
+      toast.success(rule.disabled ? "Rule enabled" : "Rule disabled");
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to toggle rule");
+    }
+  };
+
+  const handleMoveFilter = async (rule: MikrotikFirewallRule, direction: "up" | "down") => {
+    if (!rule.id || !data) return;
+    const idx = data.filter_rules.findIndex((r) => r.id === rule.id);
+    if (idx < 0) return;
+    const targetIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= data.filter_rules.length) return;
+    const destId = data.filter_rules[targetIdx].id ?? undefined;
+    try {
+      await moveMikrotikFirewallFilter(rule.id, direction === "up" ? destId : undefined);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to move rule");
+    }
+  };
+
+  // ── NAT CRUD handlers ─────
+  const handleSaveNat = async (body: MikrotikNatRuleRequest, id?: string) => {
+    try {
+      if (id) {
+        await updateMikrotikFirewallNat(id, body);
+        toast.success("NAT rule updated");
+      } else {
+        await createMikrotikFirewallNat(body);
+        toast.success("NAT rule created");
+      }
+      setNatDialogOpen(false);
+      setEditingNat(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save NAT rule");
+    }
+  };
+
+  const handleDeleteNat = async (id: string) => {
+    try {
+      await deleteMikrotikFirewallNat(id);
+      toast.success("NAT rule deleted");
+      setConfirmDeleteNat(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete NAT rule");
+    }
+  };
+
+  const handleToggleNat = async (rule: MikrotikNatRule) => {
+    if (!rule.id) return;
+    try {
+      await toggleMikrotikFirewallNat(rule.id, !rule.disabled);
+      toast.success(rule.disabled ? "NAT rule enabled" : "NAT rule disabled");
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to toggle NAT rule");
+    }
+  };
+
+  // ── Address list handlers ─────
+  const handleSaveAddr = async (body: MikrotikAddressListRequest) => {
+    try {
+      await createMikrotikAddressListEntry(body);
+      toast.success("Address list entry added");
+      setAddrDialogOpen(false);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to add address list entry");
+    }
+  };
+
+  const handleDeleteAddr = async (id: string) => {
+    try {
+      await deleteMikrotikAddressListEntry(id);
+      toast.success("Address list entry removed");
+      setConfirmDeleteAddr(null);
+      onReload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete address list entry");
+    }
+  };
+
+  // ── Loading / error states ─────
   if (loading) {
     return (
       <Card className="border-slate-800 bg-slate-900">
@@ -1052,24 +1556,10 @@ function FirewallPanel({
           <CardTitle className="text-base text-white">Filter Rules</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto rounded-md border border-slate-800">
-            <table className="w-full text-sm">
-              <thead>{filterHeaderCols}</thead>
-              <tbody>
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <tr key={i} className="border-b border-slate-800 last:border-b-0">
-                    <td className="px-4 py-3"><Skeleton className="h-4 w-14" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-4 w-10" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-3 w-20" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-3 w-20" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-4 w-10" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-3 w-24" /></td>
-                    <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
           </div>
         </CardContent>
       </Card>
@@ -1089,11 +1579,86 @@ function FirewallPanel({
     );
   }
 
+  // Collect unique address list names
+  const addrListNames = [...new Set((data?.address_lists ?? []).map((a) => a.list).filter(Boolean) as string[])];
+
+  // Group address list entries by list name
+  const addrListsByName: Record<string, MikrotikAddressListEntry[]> = {};
+  for (const entry of data?.address_lists ?? []) {
+    const name = entry.list ?? "unknown";
+    if (!addrListsByName[name]) addrListsByName[name] = [];
+    addrListsByName[name].push(entry);
+  }
+
   return (
     <div className="space-y-4">
+      {/* Dialogs */}
+      <FilterRuleDialog
+        open={filterDialogOpen}
+        onOpenChange={(o) => { setFilterDialogOpen(o); if (!o) setEditingFilter(null); }}
+        rule={editingFilter}
+        onSave={handleSaveFilter}
+      />
+      <NatRuleDialog
+        open={natDialogOpen}
+        onOpenChange={(o) => { setNatDialogOpen(o); if (!o) setEditingNat(null); }}
+        rule={editingNat}
+        onSave={handleSaveNat}
+      />
+      <AddressListDialog
+        open={addrDialogOpen}
+        onOpenChange={setAddrDialogOpen}
+        existingLists={addrListNames}
+        onSave={handleSaveAddr}
+      />
+
+      {/* Delete confirmations */}
+      <AlertDialog open={confirmDeleteFilter !== null} onOpenChange={(o) => { if (!o) setConfirmDeleteFilter(null); }}>
+        <AlertDialogContent className="border-slate-800 bg-slate-900">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">Delete filter rule?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone. The rule will be permanently removed from the router.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-slate-700 text-slate-300">Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-rose-600 hover:bg-rose-700" onClick={() => confirmDeleteFilter && handleDeleteFilter(confirmDeleteFilter)}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmDeleteNat !== null} onOpenChange={(o) => { if (!o) setConfirmDeleteNat(null); }}>
+        <AlertDialogContent className="border-slate-800 bg-slate-900">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">Delete NAT rule?</AlertDialogTitle>
+            <AlertDialogDescription>This action cannot be undone. The NAT rule will be permanently removed from the router.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-slate-700 text-slate-300">Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-rose-600 hover:bg-rose-700" onClick={() => confirmDeleteNat && handleDeleteNat(confirmDeleteNat)}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={confirmDeleteAddr !== null} onOpenChange={(o) => { if (!o) setConfirmDeleteAddr(null); }}>
+        <AlertDialogContent className="border-slate-800 bg-slate-900">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">Remove address list entry?</AlertDialogTitle>
+            <AlertDialogDescription>This entry will be permanently removed from the address list.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="border-slate-700 text-slate-300">Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-rose-600 hover:bg-rose-700" onClick={() => confirmDeleteAddr && handleDeleteAddr(confirmDeleteAddr)}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* ── Filter Rules Card ─────────────────────────── */}
       <Card className="border-slate-800 bg-slate-900">
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-base text-white">Filter Rules</CardTitle>
+          <Button size="sm" onClick={() => { setEditingFilter(null); setFilterDialogOpen(true); }} className="bg-blue-600 hover:bg-blue-700">
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Add Rule
+          </Button>
         </CardHeader>
         <CardContent>
           {!data?.filter_rules.length ? (
@@ -1101,12 +1666,24 @@ function FirewallPanel({
           ) : (
             <div className="overflow-x-auto rounded-md border border-slate-800">
               <table className="w-full text-sm">
-                <thead>{filterHeaderCols}</thead>
+                <thead>
+                  <tr className="border-b border-slate-800 bg-slate-950 text-left">
+                    <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Action</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Src</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Port</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Status</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Actions</th>
+                  </tr>
+                </thead>
                 <tbody>
                   {data.filter_rules.map((rule, i) => (
                     <tr
-                      key={i}
-                      className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+                      key={rule.id ?? i}
+                      className={`border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors ${rule.disabled ? "opacity-50" : ""}`}
                     >
                       <td className="px-4 py-3 text-slate-300">{rule.chain ?? "\u2014"}</td>
                       <td className="px-4 py-3">
@@ -1117,7 +1694,9 @@ function FirewallPanel({
                               ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
                               : rule.action === "drop"
                                 ? "border-rose-500/30 bg-rose-500/10 text-rose-400 text-xs"
-                                : "border-slate-700 text-slate-400 text-xs"
+                                : rule.action === "reject"
+                                  ? "border-amber-500/30 bg-amber-500/10 text-amber-400 text-xs"
+                                  : "border-slate-700 text-slate-400 text-xs"
                           }
                         >
                           {rule.action ?? "\u2014"}
@@ -1126,12 +1705,12 @@ function FirewallPanel({
                       <td className="px-4 py-3 text-slate-300">{rule.protocol ?? "any"}</td>
                       <td className="px-4 py-3">
                         <span className="font-mono tabular-nums text-xs text-slate-400">
-                          {rule.src_address ?? "any"}
+                          {rule.src_address ?? rule.src_address_list ?? "any"}
                         </span>
                       </td>
                       <td className="px-4 py-3">
                         <span className="font-mono tabular-nums text-xs text-slate-400">
-                          {rule.dst_address ?? "any"}
+                          {rule.dst_address ?? rule.dst_address_list ?? "any"}
                         </span>
                       </td>
                       <td className="px-4 py-3 text-slate-300">{rule.dst_port ?? "\u2014"}</td>
@@ -1150,6 +1729,25 @@ function FirewallPanel({
                           {rule.disabled ? "disabled" : "enabled"}
                         </Badge>
                       </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-1">
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => handleMoveFilter(rule, "up")} disabled={i === 0} title="Move up">
+                            <ChevronUp className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => handleMoveFilter(rule, "down")} disabled={i === data.filter_rules.length - 1} title="Move down">
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => handleToggleFilter(rule)} title={rule.disabled ? "Enable" : "Disable"}>
+                            <Power className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => { setEditingFilter(rule); setFilterDialogOpen(true); }} title="Edit">
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-rose-400" onClick={() => rule.id && setConfirmDeleteFilter(rule.id)} title="Delete">
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -1159,9 +1757,13 @@ function FirewallPanel({
         </CardContent>
       </Card>
 
+      {/* ── NAT Rules Card ────────────────────────────── */}
       <Card className="border-slate-800 bg-slate-900">
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-base text-white">NAT Rules</CardTitle>
+          <Button size="sm" onClick={() => { setEditingNat(null); setNatDialogOpen(true); }} className="bg-blue-600 hover:bg-blue-700">
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Add Rule
+          </Button>
         </CardHeader>
         <CardContent>
           {!data?.nat_rules.length ? (
@@ -1169,12 +1771,24 @@ function FirewallPanel({
           ) : (
             <div className="overflow-x-auto rounded-md border border-slate-800">
               <table className="w-full text-sm">
-                <thead>{natHeaderCols}</thead>
+                <thead>
+                  <tr className="border-b border-slate-800 bg-slate-950 text-left">
+                    <th className="px-4 py-3 font-medium text-slate-400">Chain</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Action</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Protocol</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Dst</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Port</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">To</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Comment</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Status</th>
+                    <th className="px-4 py-3 font-medium text-slate-400">Actions</th>
+                  </tr>
+                </thead>
                 <tbody>
                   {data.nat_rules.map((rule, i) => (
                     <tr
-                      key={i}
-                      className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+                      key={rule.id ?? i}
+                      className={`border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors ${rule.disabled ? "opacity-50" : ""}`}
                     >
                       <td className="px-4 py-3 text-slate-300">{rule.chain ?? "\u2014"}</td>
                       <td className="px-4 py-3 text-slate-300">{rule.action ?? "\u2014"}</td>
@@ -1194,10 +1808,74 @@ function FirewallPanel({
                       <td className="px-4 py-3">
                         <span className="text-slate-500">{rule.comment ?? ""}</span>
                       </td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant="outline"
+                          className={
+                            rule.disabled
+                              ? "border-slate-700 text-slate-500 text-xs"
+                              : "border-emerald-500/30 text-emerald-400 text-xs"
+                          }
+                        >
+                          {rule.disabled ? "disabled" : "enabled"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-1">
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => handleToggleNat(rule)} title={rule.disabled ? "Enable" : "Disable"}>
+                            <Power className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-white" onClick={() => { setEditingNat(rule); setNatDialogOpen(true); }} title="Edit">
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-rose-400" onClick={() => rule.id && setConfirmDeleteNat(rule.id)} title="Delete">
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </td>
                     </tr>
                   ))}
                 </tbody>
               </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Address Lists Card ────────────────────────── */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-base text-white">Address Lists</CardTitle>
+          <Button size="sm" onClick={() => setAddrDialogOpen(true)} className="bg-blue-600 hover:bg-blue-700">
+            <Plus className="mr-1.5 h-3.5 w-3.5" /> Add Entry
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {Object.keys(addrListsByName).length === 0 ? (
+            <p className="py-4 text-sm text-slate-500">No address lists configured.</p>
+          ) : (
+            <div className="space-y-3">
+              {Object.entries(addrListsByName).map(([listName, entries]) => (
+                <div key={listName} className="rounded-md border border-slate-800">
+                  <div className="border-b border-slate-800 bg-slate-950 px-4 py-2">
+                    <span className="text-sm font-medium text-white">{listName}</span>
+                    <span className="ml-2 text-xs text-slate-500">({entries.length} entries)</span>
+                  </div>
+                  <div className="divide-y divide-slate-800">
+                    {entries.map((entry) => (
+                      <div key={entry.id} className="flex items-center justify-between px-4 py-2">
+                        <div className="flex items-center gap-3">
+                          <span className="font-mono text-xs text-slate-300">{entry.address ?? "\u2014"}</span>
+                          {entry.comment && <span className="text-xs text-slate-500">{entry.comment}</span>}
+                        </div>
+                        <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-slate-400 hover:text-rose-400" onClick={() => entry.id && setConfirmDeleteAddr(entry.id)} title="Remove">
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           )}
         </CardContent>
@@ -1791,6 +2469,7 @@ export default function MikrotikRouter() {
             data={fw.data}
             loading={fw.loading}
             error={fw.error}
+            onReload={fw.reload}
           />
         </TabsContent>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -76,6 +76,9 @@ import type {
   MikrotikRoute,
   MikrotikDhcpLease,
   MikrotikFirewall,
+  MikrotikFirewallRuleRequest,
+  MikrotikNatRuleRequest,
+  MikrotikAddressListRequest,
   MikrotikDns,
   MikrotikWireguard,
   Asset,
@@ -1248,6 +1251,95 @@ export function fetchMikrotikDhcpLeases(): Promise<MikrotikDhcpLease[]> {
 
 export function fetchMikrotikFirewall(): Promise<MikrotikFirewall> {
   return apiGet<MikrotikFirewall>("/api/v1/mikrotik/firewall");
+}
+
+// MikroTik firewall filter CRUD
+export function createMikrotikFirewallFilter(
+  body: MikrotikFirewallRuleRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/firewall/filter", body);
+}
+
+export function updateMikrotikFirewallFilter(
+  id: string,
+  body: MikrotikFirewallRuleRequest
+): Promise<void> {
+  return apiPut<void>(
+    `/api/v1/mikrotik/firewall/filter/${encodeURIComponent(id)}`,
+    body
+  );
+}
+
+export function deleteMikrotikFirewallFilter(id: string): Promise<void> {
+  return apiDelete(
+    `/api/v1/mikrotik/firewall/filter/${encodeURIComponent(id)}`
+  );
+}
+
+export function toggleMikrotikFirewallFilter(
+  id: string,
+  disabled: boolean
+): Promise<void> {
+  return apiPatch<void>(
+    `/api/v1/mikrotik/firewall/filter/${encodeURIComponent(id)}/toggle`,
+    { disabled }
+  );
+}
+
+export function moveMikrotikFirewallFilter(
+  id: string,
+  destination?: string
+): Promise<void> {
+  return apiPost<void>(
+    `/api/v1/mikrotik/firewall/filter/${encodeURIComponent(id)}/move`,
+    { destination }
+  );
+}
+
+// MikroTik firewall NAT CRUD
+export function createMikrotikFirewallNat(
+  body: MikrotikNatRuleRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/firewall/nat", body);
+}
+
+export function updateMikrotikFirewallNat(
+  id: string,
+  body: MikrotikNatRuleRequest
+): Promise<void> {
+  return apiPut<void>(
+    `/api/v1/mikrotik/firewall/nat/${encodeURIComponent(id)}`,
+    body
+  );
+}
+
+export function deleteMikrotikFirewallNat(id: string): Promise<void> {
+  return apiDelete(
+    `/api/v1/mikrotik/firewall/nat/${encodeURIComponent(id)}`
+  );
+}
+
+export function toggleMikrotikFirewallNat(
+  id: string,
+  disabled: boolean
+): Promise<void> {
+  return apiPatch<void>(
+    `/api/v1/mikrotik/firewall/nat/${encodeURIComponent(id)}/toggle`,
+    { disabled }
+  );
+}
+
+// MikroTik address list CRUD
+export function createMikrotikAddressListEntry(
+  body: MikrotikAddressListRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/firewall/address-list", body);
+}
+
+export function deleteMikrotikAddressListEntry(id: string): Promise<void> {
+  return apiDelete(
+    `/api/v1/mikrotik/firewall/address-list/${encodeURIComponent(id)}`
+  );
 }
 
 export function fetchMikrotikDns(): Promise<MikrotikDns> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1099,12 +1099,19 @@ export interface MikrotikDhcpLease {
 }
 
 export interface MikrotikFirewallRule {
+  id: string | null;
   chain: string | null;
   action: string | null;
   protocol: string | null;
   src_address: string | null;
   dst_address: string | null;
+  src_port: string | null;
   dst_port: string | null;
+  in_interface: string | null;
+  out_interface: string | null;
+  connection_state: string | null;
+  src_address_list: string | null;
+  dst_address_list: string | null;
   comment: string | null;
   disabled: boolean;
   bytes: string | null;
@@ -1112,6 +1119,7 @@ export interface MikrotikFirewallRule {
 }
 
 export interface MikrotikNatRule {
+  id: string | null;
   chain: string | null;
   action: string | null;
   protocol: string | null;
@@ -1125,9 +1133,55 @@ export interface MikrotikNatRule {
   disabled: boolean;
 }
 
+export interface MikrotikAddressListEntry {
+  id: string | null;
+  list: string | null;
+  address: string | null;
+  comment: string | null;
+  disabled: boolean;
+}
+
 export interface MikrotikFirewall {
   filter_rules: MikrotikFirewallRule[];
   nat_rules: MikrotikNatRule[];
+  address_lists: MikrotikAddressListEntry[];
+}
+
+export interface MikrotikFirewallRuleRequest {
+  chain: string;
+  action: string;
+  protocol?: string;
+  src_address?: string;
+  dst_address?: string;
+  src_port?: string;
+  dst_port?: string;
+  in_interface?: string;
+  out_interface?: string;
+  connection_state?: string;
+  src_address_list?: string;
+  dst_address_list?: string;
+  comment?: string;
+  disabled?: boolean;
+}
+
+export interface MikrotikNatRuleRequest {
+  chain: string;
+  action: string;
+  protocol?: string;
+  src_address?: string;
+  dst_address?: string;
+  dst_port?: string;
+  to_addresses?: string;
+  to_ports?: string;
+  out_interface?: string;
+  comment?: string;
+  disabled?: boolean;
+}
+
+export interface MikrotikAddressListRequest {
+  list: string;
+  address: string;
+  comment?: string;
 }
 
 export interface MikrotikDns {


### PR DESCRIPTION
## Summary

Closes #253

- **Filter Rules CRUD**: Create, edit, delete, toggle (enable/disable), and reorder MikroTik firewall filter rules. Supports chain (forward/input/output), action (accept/drop/reject/jump/log/passthrough), protocol, source/destination addresses and ports, interfaces, connection state, and address list matching.
- **NAT Rules CRUD**: Create, edit, delete, and toggle NAT rules including dstnat (port forwards), srcnat, masquerade, and redirect actions.
- **Address Lists**: View address lists grouped by name, add new entries with address and comment, and remove existing entries. Address lists can be referenced in filter rules via src/dst address list fields.

### Backend
- New CRUD endpoints under `/api/v1/mikrotik/firewall/filter`, `/api/v1/mikrotik/firewall/nat`, and `/api/v1/mikrotik/firewall/address-list`
- MikroTik REST API client methods for all firewall operations (create, update, delete, toggle, move/reorder)
- Extended firewall read response to include rule IDs, address lists, and additional fields (in/out interface, connection state, address lists)
- Cache invalidation middleware already handles clearing MikroTik cache on mutating requests

### Frontend
- Replaced read-only FirewallPanel with full CRUD version including:
  - Filter rule dialog with all MikroTik fields (chain, action, protocol, addresses, ports, interfaces, connection state, address lists)
  - NAT rule dialog with dstnat/srcnat chain and dst-nat/masquerade/src-nat actions
  - Address list entry dialog
  - Inline action buttons: edit, delete, toggle enable/disable, move up/down (reorder)
  - AlertDialog confirmations for all destructive operations
  - Toast notifications for success/error feedback
- Follows existing VyOS firewall UI patterns (dark theme, badge styling, dialog patterns)

### Files Changed
- `server/src/api/mikrotik.rs` — Added CRUD handlers and request/response types
- `server/src/api/mod.rs` — Registered 12 new routes
- `server/src/mikrotik/client.rs` — Added firewall CRUD client methods
- `server/src/mikrotik/types.rs` — Added write request types and address list type
- `web/src/components/MikrotikRouter.tsx` — Extended FirewallPanel with full CRUD UI
- `web/src/lib/api.ts` — Added 11 new API client functions
- `web/src/lib/types.ts` — Added request types and extended response types with IDs

## Test plan
- [ ] Verify filter rules CRUD: create, edit, delete, toggle, reorder
- [ ] Verify NAT rules CRUD: create port forward (dstnat), masquerade, edit, delete, toggle
- [ ] Verify address lists: add entries, remove entries, view grouped by list name
- [ ] Verify filter rules can reference address lists
- [ ] Verify cache invalidation after mutations (rules refresh correctly)
- [ ] Verify error handling (toast messages on failure)
- [ ] `cargo check` and `cargo test` pass
- [ ] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive CRUD functionality for MikroTik firewall management, including filter rules, NAT rules, and address lists. The implementation follows existing patterns from the VyOS firewall UI and includes proper error handling, confirmation dialogs, and toast notifications.

**Key changes:**
- Backend: 12 new REST API endpoints for creating, updating, deleting, toggling, and reordering firewall rules
- Frontend: Full CRUD UI with dialogs supporting all MikroTik firewall fields (chains, actions, protocols, addresses, ports, interfaces, connection states, address lists)
- Address list management: View grouped entries and add/remove list entries that can be referenced in filter rules
- Rule reordering: Move up/down functionality for filter rules to control evaluation order
- Cache invalidation: Existing middleware handles cache clearing on mutations

**Issues found:**
- The move-down logic passes `undefined` as destination, which may not work correctly with MikroTik's REST API move endpoint

<h3>Confidence Score: 3/5</h3>

- This PR has one critical logic issue with rule reordering that needs verification
- The implementation is well-structured and follows existing patterns, but the move-down logic appears incorrect and could fail at runtime. All other CRUD operations look solid with proper error handling, type safety, and user confirmations for destructive actions.
- Pay close attention to `web/src/components/MikrotikRouter.tsx` - verify the move logic works correctly with actual MikroTik devices

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mikrotik.rs | Adds 12 CRUD handlers for firewall filter, NAT rules, and address lists with proper error handling |
| server/src/mikrotik/client.rs | Implements MikroTik REST API client methods for firewall operations including move/reorder functionality |
| web/src/components/MikrotikRouter.tsx | Large component update adding full CRUD UI with dialogs, confirmation flows, and inline actions |

</details>



<sub>Last reviewed commit: 24699f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->