### PR TITLE
feat: OpenVPN server and client management (#250)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -342,6 +342,12 @@ pub fn router(state: AppState) -> Router {
             "/vyos/wireguard/:name/peers/:peer/generate-config",
             post(vyos::wireguard_generate_client_config),
         )
+        // OpenVPN
+        .route("/vyos/openvpn", get(vyos::openvpn_list))
+        .route("/vyos/openvpn", post(vyos::openvpn_create))
+        .route("/vyos/openvpn/:name", delete(vyos::openvpn_delete))
+        .route("/vyos/openvpn/:name/toggle", post(vyos::openvpn_toggle))
+        .route("/vyos/openvpn/:name/clients", get(vyos::openvpn_clients))
         // Topology
         .route("/topology/graph", get(topology::graph))
         .route("/topology/positions", get(topology::get_positions))

--- a/server/src/api/vyos.rs
+++ b/server/src/api/vyos.rs
@@ -7554,6 +7554,762 @@ pub(crate) async fn get_vyos_client_or_503(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)
 }
 
+// ── OpenVPN ─────────────────────────────────────────────────────────
+
+/// A connected OpenVPN client (from runtime status).
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenVpnConnectedClient {
+    pub common_name: String,
+    pub real_address: Option<String>,
+    pub virtual_address: Option<String>,
+    pub bytes_received: Option<u64>,
+    pub bytes_sent: Option<u64>,
+    pub connected_since: Option<String>,
+}
+
+/// Represents a configured OpenVPN interface (server or client mode).
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenVpnInterface {
+    pub name: String,
+    pub mode: Option<String>,
+    pub protocol: Option<String>,
+    pub local_port: Option<u32>,
+    pub local_address: Option<String>,
+    pub remote_host: Option<String>,
+    pub remote_port: Option<u32>,
+    pub encryption: Option<String>,
+    pub hash: Option<String>,
+    pub subnet: Option<String>,
+    pub description: Option<String>,
+    pub status: Option<String>,
+    pub tls_ca_cert: Option<String>,
+    pub tls_cert: Option<String>,
+    pub tls_key: Option<String>,
+    pub tls_dh: Option<String>,
+    pub push_routes: Vec<String>,
+    pub clients: Vec<OpenVpnConnectedClient>,
+    pub disabled: bool,
+}
+
+/// Request body for creating an OpenVPN interface.
+#[derive(Debug, Deserialize)]
+pub struct CreateOpenVpnInterfaceRequest {
+    /// Interface name, e.g. "vtun0"
+    pub name: String,
+    /// Mode: "server", "client", or "site-to-site"
+    pub mode: String,
+    /// Protocol: "udp" or "tcp-passive" (server) / "tcp-active" (client)
+    pub protocol: Option<String>,
+    /// Local port (for server mode)
+    pub local_port: Option<u16>,
+    /// Local address (bind address)
+    pub local_address: Option<String>,
+    /// Remote host (for client mode)
+    pub remote_host: Option<String>,
+    /// Remote port (for client mode)
+    pub remote_port: Option<u16>,
+    /// Encryption cipher (e.g. "aes256")
+    pub encryption: Option<String>,
+    /// Hash algorithm (e.g. "sha512")
+    pub hash: Option<String>,
+    /// Server subnet in CIDR (e.g. "10.8.0.0/24"), for server mode
+    pub subnet: Option<String>,
+    /// Description
+    pub description: Option<String>,
+    /// TLS CA certificate file path on VyOS
+    pub tls_ca_cert: Option<String>,
+    /// TLS certificate file path on VyOS
+    pub tls_cert: Option<String>,
+    /// TLS key file path on VyOS
+    pub tls_key: Option<String>,
+    /// TLS DH params file path on VyOS
+    pub tls_dh: Option<String>,
+    /// Routes to push to clients
+    pub push_routes: Option<Vec<String>>,
+}
+
+/// Validate an OpenVPN interface name (vtun0, vtun1, ...).
+fn is_valid_ovpn_name(name: &str) -> bool {
+    if !name.starts_with("vtun") {
+        return false;
+    }
+    let suffix = &name[4..];
+    !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Validate OpenVPN mode.
+fn is_valid_ovpn_mode(mode: &str) -> bool {
+    matches!(mode, "server" | "client" | "site-to-site")
+}
+
+/// GET /api/v1/vyos/openvpn — list all OpenVPN interfaces with connected clients.
+pub async fn openvpn_list(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<OpenVpnInterface>>, StatusCode> {
+    let client = get_vyos_client_or_503(&state).await?;
+
+    let config = match client.retrieve(&["interfaces", "openvpn"]).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("VyOS openvpn config query failed (returning empty): {e}");
+            return Ok(Json(vec![]));
+        }
+    };
+
+    let mut interfaces = parse_openvpn_config(&config);
+
+    // Fetch interface link status from `show interfaces`
+    if let Ok(iface_raw) = client.show(&["interfaces"]).await {
+        let iface_text = iface_raw.as_str().unwrap_or("");
+        let iface_list = parse_interfaces_text(iface_text);
+        for ovpn in &mut interfaces {
+            if let Some(sys_iface) = iface_list.iter().find(|i| i.name == ovpn.name) {
+                ovpn.status = Some(sys_iface.link_state.clone());
+            }
+        }
+    }
+
+    // Fetch connected clients for server-mode interfaces
+    for ovpn in &mut interfaces {
+        if ovpn.mode.as_deref() == Some("server") {
+            if let Ok(raw) = client.show(&["interfaces", "openvpn", &ovpn.name]).await {
+                let text = raw.as_str().unwrap_or("");
+                ovpn.clients = parse_openvpn_status_clients(text);
+            }
+        }
+    }
+
+    Ok(Json(interfaces))
+}
+
+/// Parse VyOS OpenVPN configuration JSON into a list of interfaces.
+fn parse_openvpn_config(config: &Value) -> Vec<OpenVpnInterface> {
+    let mut interfaces = Vec::new();
+
+    let obj = match config.as_object() {
+        Some(o) => o,
+        None => return interfaces,
+    };
+
+    for (iface_name, iface_val) in obj {
+        let iface_obj = match iface_val.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        let mode = iface_obj
+            .get("mode")
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        let protocol = iface_obj
+            .get("protocol")
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        let local_port = iface_obj.get("local-port").and_then(|v| {
+            v.as_u64()
+                .map(|n| n as u32)
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        });
+
+        let local_address = iface_obj
+            .get("local-address")
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        let remote_host = iface_obj.get("remote-host").and_then(|v| {
+            if let Some(s) = v.as_str() {
+                Some(s.to_string())
+            } else if let Some(arr) = v.as_array() {
+                arr.first().and_then(|a| a.as_str().map(|s| s.to_string()))
+            } else {
+                None
+            }
+        });
+
+        let remote_port = iface_obj.get("remote-port").and_then(|v| {
+            v.as_u64()
+                .map(|n| n as u32)
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        });
+
+        let encryption_obj = iface_obj.get("encryption");
+        let encryption = encryption_obj
+            .and_then(|e| e.as_object())
+            .and_then(|o| o.get("cipher"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .or_else(|| encryption_obj.and_then(|v| v.as_str().map(|s| s.to_string())));
+
+        let hash = iface_obj
+            .get("hash")
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        // Server subnet: "server subnet <cidr>"
+        let subnet = iface_obj
+            .get("server")
+            .and_then(|v| v.as_object())
+            .and_then(|o| o.get("subnet"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        let description = iface_obj
+            .get("description")
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        // TLS settings
+        let tls = iface_obj.get("tls").and_then(|v| v.as_object());
+        let tls_ca_cert = tls
+            .and_then(|o| o.get("ca-cert-file"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+        let tls_cert = tls
+            .and_then(|o| o.get("cert-file"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+        let tls_key = tls
+            .and_then(|o| o.get("key-file"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+        let tls_dh = tls
+            .and_then(|o| o.get("dh-file"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        // Push routes
+        let push_routes = iface_obj
+            .get("push-route")
+            .map(|v| {
+                if let Some(s) = v.as_str() {
+                    vec![s.to_string()]
+                } else if let Some(arr) = v.as_array() {
+                    arr.iter()
+                        .filter_map(|a| a.as_str().map(|s| s.to_string()))
+                        .collect()
+                } else {
+                    Vec::new()
+                }
+            })
+            .unwrap_or_default();
+
+        // Check if disabled
+        let disabled = iface_obj.contains_key("disable");
+
+        interfaces.push(OpenVpnInterface {
+            name: iface_name.clone(),
+            mode,
+            protocol,
+            local_port,
+            local_address,
+            remote_host,
+            remote_port,
+            encryption,
+            hash,
+            subnet,
+            description,
+            status: None,
+            tls_ca_cert,
+            tls_cert,
+            tls_key,
+            tls_dh,
+            push_routes,
+            clients: Vec::new(),
+            disabled,
+        });
+    }
+
+    interfaces
+}
+
+/// Parse connected clients from `show interfaces openvpn vtunN` output.
+///
+/// VyOS OpenVPN status output for a server interface looks like:
+/// ```text
+/// Client list:
+///   Common Name     Real Address       Virtual Address   Bytes Received   Bytes Sent   Connected Since
+///   client1         1.2.3.4:12345      10.8.0.2          123456           654321       2024-01-01 12:00:00
+/// ```
+fn parse_openvpn_status_clients(text: &str) -> Vec<OpenVpnConnectedClient> {
+    let mut clients = Vec::new();
+    let mut in_client_list = false;
+    let mut header_seen = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("Client list") || trimmed.contains("CLIENT LIST") {
+            in_client_list = true;
+            header_seen = false;
+            continue;
+        }
+
+        if in_client_list && !header_seen {
+            // Skip header line
+            if trimmed.contains("Common Name") || trimmed.contains("common_name") {
+                header_seen = true;
+                continue;
+            }
+            // Also skip separator lines
+            if trimmed.starts_with("---") || trimmed.starts_with("===") {
+                continue;
+            }
+        }
+
+        if in_client_list && header_seen {
+            // End of client list
+            if trimmed.is_empty()
+                || trimmed.starts_with("ROUTING")
+                || trimmed.starts_with("GLOBAL")
+                || trimmed.starts_with("END")
+            {
+                in_client_list = false;
+                continue;
+            }
+
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let common_name = parts[0].to_string();
+                let real_address = parts.get(1).map(|s| s.to_string());
+                let virtual_address = parts.get(2).map(|s| s.to_string());
+                let bytes_received = parts.get(3).and_then(|s| s.parse().ok());
+                let bytes_sent = parts.get(4).and_then(|s| s.parse().ok());
+                let connected_since = if parts.len() >= 7 {
+                    Some(format!("{} {}", parts[5], parts[6]))
+                } else {
+                    parts.get(5).map(|s| s.to_string())
+                };
+
+                clients.push(OpenVpnConnectedClient {
+                    common_name,
+                    real_address,
+                    virtual_address,
+                    bytes_received,
+                    bytes_sent,
+                    connected_since,
+                });
+            }
+        }
+    }
+
+    clients
+}
+
+/// POST /api/v1/vyos/openvpn — create an OpenVPN interface.
+pub async fn openvpn_create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateOpenVpnInterfaceRequest>,
+) -> Result<Json<VyosWriteResponse>, (StatusCode, Json<VyosWriteResponse>)> {
+    let client = get_vyos_client_or_503(&state).await.map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Router not configured".to_string(),
+            }),
+        )
+    })?;
+
+    // Validate interface name
+    if !is_valid_ovpn_name(&body.name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid interface name. Use vtun0, vtun1, etc.".to_string(),
+            }),
+        ));
+    }
+
+    // Validate mode
+    if !is_valid_ovpn_mode(&body.mode) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid mode. Use 'server', 'client', or 'site-to-site'.".to_string(),
+            }),
+        ));
+    }
+
+    // Validate subnet if provided (server mode)
+    if let Some(ref subnet) = body.subnet {
+        if !is_valid_cidr(subnet) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(VyosWriteResponse {
+                    success: false,
+                    message: "Invalid subnet. Expected CIDR format like 10.8.0.0/24".to_string(),
+                }),
+            ));
+        }
+    }
+
+    let description = format!(
+        "Create OpenVPN interface {} (mode: {})",
+        body.name, body.mode
+    );
+    let mut commands = Vec::new();
+
+    let base = ["interfaces", "openvpn", body.name.as_str()];
+
+    // Set mode
+    commands.push(format!(
+        "set interfaces openvpn {} mode {}",
+        body.name, body.mode
+    ));
+    if let Err(e) = client
+        .configure_set(&[base[0], base[1], base[2], "mode", &body.mode])
+        .await
+    {
+        let msg = format!("Failed to set OpenVPN mode: {e}");
+        audit::log_failure(
+            &state.db,
+            "openvpn_interface_create",
+            &description,
+            &commands,
+            &msg,
+        )
+        .await;
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(VyosWriteResponse {
+                success: false,
+                message: msg,
+            }),
+        ));
+    }
+
+    // Set protocol
+    if let Some(ref proto) = body.protocol {
+        commands.push(format!(
+            "set interfaces openvpn {} protocol {}",
+            body.name, proto
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "protocol", proto])
+            .await;
+    }
+
+    // Set local port
+    if let Some(port) = body.local_port {
+        let port_str = port.to_string();
+        commands.push(format!(
+            "set interfaces openvpn {} local-port {}",
+            body.name, port
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "local-port", &port_str])
+            .await;
+    }
+
+    // Set local address
+    if let Some(ref addr) = body.local_address {
+        commands.push(format!(
+            "set interfaces openvpn {} local-address {}",
+            body.name, addr
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "local-address", addr])
+            .await;
+    }
+
+    // Set remote host (client mode)
+    if let Some(ref host) = body.remote_host {
+        commands.push(format!(
+            "set interfaces openvpn {} remote-host {}",
+            body.name, host
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "remote-host", host])
+            .await;
+    }
+
+    // Set remote port (client mode)
+    if let Some(port) = body.remote_port {
+        let port_str = port.to_string();
+        commands.push(format!(
+            "set interfaces openvpn {} remote-port {}",
+            body.name, port
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "remote-port", &port_str])
+            .await;
+    }
+
+    // Set encryption
+    if let Some(ref cipher) = body.encryption {
+        commands.push(format!(
+            "set interfaces openvpn {} encryption cipher {}",
+            body.name, cipher
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "encryption", "cipher", cipher])
+            .await;
+    }
+
+    // Set hash
+    if let Some(ref hash) = body.hash {
+        commands.push(format!(
+            "set interfaces openvpn {} hash {}",
+            body.name, hash
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "hash", hash])
+            .await;
+    }
+
+    // Set server subnet
+    if let Some(ref subnet) = body.subnet {
+        commands.push(format!(
+            "set interfaces openvpn {} server subnet {}",
+            body.name, subnet
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "server", "subnet", subnet])
+            .await;
+    }
+
+    // Set description
+    if let Some(ref desc) = body.description {
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "description", desc])
+            .await;
+    }
+
+    // Set TLS settings
+    if let Some(ref ca) = body.tls_ca_cert {
+        commands.push(format!(
+            "set interfaces openvpn {} tls ca-cert-file {}",
+            body.name, ca
+        ));
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "tls", "ca-cert-file", ca])
+            .await;
+    }
+    if let Some(ref cert) = body.tls_cert {
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "tls", "cert-file", cert])
+            .await;
+    }
+    if let Some(ref key) = body.tls_key {
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "tls", "key-file", key])
+            .await;
+    }
+    if let Some(ref dh) = body.tls_dh {
+        let _ = client
+            .configure_set(&[base[0], base[1], base[2], "tls", "dh-file", dh])
+            .await;
+    }
+
+    // Set push routes
+    if let Some(ref routes) = body.push_routes {
+        for route in routes {
+            commands.push(format!(
+                "set interfaces openvpn {} push-route {}",
+                body.name, route
+            ));
+            let _ = client
+                .configure_set(&[base[0], base[1], base[2], "push-route", route])
+                .await;
+        }
+    }
+
+    audit::log_success(
+        &state.db,
+        "openvpn_interface_create",
+        &description,
+        &commands,
+    )
+    .await;
+
+    if let Err(e) = client.config_save().await {
+        tracing::warn!("config-file save failed after OpenVPN interface create: {e}");
+    }
+
+    Ok(Json(VyosWriteResponse {
+        success: true,
+        message: format!("OpenVPN interface {} created", body.name),
+    }))
+}
+
+/// DELETE /api/v1/vyos/openvpn/:name — delete an OpenVPN interface.
+pub async fn openvpn_delete(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<VyosWriteResponse>, (StatusCode, Json<VyosWriteResponse>)> {
+    let client = get_vyos_client_or_503(&state).await.map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Router not configured".to_string(),
+            }),
+        )
+    })?;
+
+    if !is_valid_ovpn_name(&name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid interface name".to_string(),
+            }),
+        ));
+    }
+
+    let description = format!("Delete OpenVPN interface {}", name);
+    let commands = vec![format!("delete interfaces openvpn {}", name)];
+
+    tracing::info!("VyOS: deleting OpenVPN interface {}", name);
+
+    match client
+        .configure_delete(&["interfaces", "openvpn", &name])
+        .await
+    {
+        Ok(_) => {
+            audit::log_success(
+                &state.db,
+                "openvpn_interface_delete",
+                &description,
+                &commands,
+            )
+            .await;
+            if let Err(e) = client.config_save().await {
+                tracing::warn!("config-file save failed after OpenVPN interface delete: {e}");
+            }
+            Ok(Json(VyosWriteResponse {
+                success: true,
+                message: format!("OpenVPN interface {} deleted", name),
+            }))
+        }
+        Err(e) => {
+            let msg = format!("Failed to delete OpenVPN interface: {e}");
+            audit::log_failure(
+                &state.db,
+                "openvpn_interface_delete",
+                &description,
+                &commands,
+                &msg,
+            )
+            .await;
+            Err((
+                StatusCode::BAD_GATEWAY,
+                Json(VyosWriteResponse {
+                    success: false,
+                    message: msg,
+                }),
+            ))
+        }
+    }
+}
+
+/// POST /api/v1/vyos/openvpn/:name/toggle — enable or disable an OpenVPN interface.
+pub async fn openvpn_toggle(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<VyosWriteResponse>, (StatusCode, Json<VyosWriteResponse>)> {
+    let client = get_vyos_client_or_503(&state).await.map_err(|_| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Router not configured".to_string(),
+            }),
+        )
+    })?;
+
+    if !is_valid_ovpn_name(&name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(VyosWriteResponse {
+                success: false,
+                message: "Invalid interface name".to_string(),
+            }),
+        ));
+    }
+
+    let disable = body
+        .get("disable")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let (action, description) = if disable {
+        ("disable", format!("Disable OpenVPN interface {}", name))
+    } else {
+        ("enable", format!("Enable OpenVPN interface {}", name))
+    };
+
+    let commands = if disable {
+        vec![format!("set interfaces openvpn {} disable", name)]
+    } else {
+        vec![format!("delete interfaces openvpn {} disable", name)]
+    };
+
+    let result = if disable {
+        client
+            .configure_set(&["interfaces", "openvpn", &name, "disable"])
+            .await
+    } else {
+        client
+            .configure_delete(&["interfaces", "openvpn", &name, "disable"])
+            .await
+    };
+
+    match result {
+        Ok(_) => {
+            audit::log_success(
+                &state.db,
+                &format!("openvpn_interface_{}", action),
+                &description,
+                &commands,
+            )
+            .await;
+            if let Err(e) = client.config_save().await {
+                tracing::warn!("config-file save failed after OpenVPN toggle: {e}");
+            }
+            Ok(Json(VyosWriteResponse {
+                success: true,
+                message: format!("OpenVPN interface {} {}d", name, action),
+            }))
+        }
+        Err(e) => {
+            let msg = format!("Failed to {} OpenVPN interface: {e}", action);
+            audit::log_failure(
+                &state.db,
+                &format!("openvpn_interface_{}", action),
+                &description,
+                &commands,
+                &msg,
+            )
+            .await;
+            Err((
+                StatusCode::BAD_GATEWAY,
+                Json(VyosWriteResponse {
+                    success: false,
+                    message: msg,
+                }),
+            ))
+        }
+    }
+}
+
+/// GET /api/v1/vyos/openvpn/:name/clients — get connected clients for an OpenVPN server.
+pub async fn openvpn_clients(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<Vec<OpenVpnConnectedClient>>, StatusCode> {
+    let client = get_vyos_client_or_503(&state).await?;
+
+    if !is_valid_ovpn_name(&name) {
+        return Ok(Json(vec![]));
+    }
+
+    match client.show(&["interfaces", "openvpn", &name]).await {
+        Ok(raw) => {
+            let text = raw.as_str().unwrap_or("");
+            Ok(Json(parse_openvpn_status_clients(text)))
+        }
+        Err(e) => {
+            tracing::warn!("Failed to get OpenVPN clients for {}: {e}", name);
+            Ok(Json(vec![]))
+        }
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -118,6 +118,10 @@ import {
   addWireguardPeer,
   deleteWireguardPeer,
   generateWireguardClientConfig,
+  fetchOpenVpnInterfaces,
+  createOpenVpnInterface,
+  deleteOpenVpnInterface,
+  toggleOpenVpnInterface,
   fetchDnsForwarding,
   addDnsNameServer,
   deleteDnsNameServer,
@@ -129,7 +133,7 @@ import {
   fetchMikrotikStatus,
   fetchSettings,
 } from "@/lib/api";
-import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData } from "@/lib/types";
+import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
 import MikrotikRouter from "@/components/MikrotikRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
@@ -5301,6 +5305,585 @@ function GenerateClientConfigDialog({
   );
 }
 
+// ── OpenVPN Panel ────────────────────────────────────────
+
+function OpenVpnPanel({
+  interfaces,
+  loading,
+  error,
+  onReload,
+}: {
+  interfaces: OpenVpnInterface[] | null;
+  loading: boolean;
+  error: string | null;
+  onReload: () => void;
+}) {
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="py-8">
+          <div className="flex items-center justify-center gap-2 text-slate-400">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading OpenVPN interfaces…
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="py-8">
+          <div className="flex flex-col items-center gap-2 text-slate-400">
+            <AlertCircle className="h-5 w-5 text-red-400" />
+            <p className="text-sm">{error}</p>
+            <Button variant="outline" size="sm" onClick={onReload}>
+              Retry
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const ovpnInterfaces = interfaces ?? [];
+
+  return (
+    <div className="space-y-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-base text-white">
+            OpenVPN Interfaces
+          </CardTitle>
+          <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+            <DialogTrigger asChild>
+              <Button size="sm" variant="outline">
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Create Interface
+              </Button>
+            </DialogTrigger>
+            <CreateOpenVpnInterfaceDialog
+              onCreated={() => {
+                setShowCreateDialog(false);
+                onReload();
+              }}
+            />
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          {ovpnInterfaces.length === 0 ? (
+            <div className="py-8 text-center text-sm text-slate-500">
+              No OpenVPN interfaces configured. Create one to get started.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {ovpnInterfaces.map((iface) => (
+                <OpenVpnInterfaceCard
+                  key={iface.name}
+                  iface={iface}
+                  onReload={onReload}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ── Create OpenVPN Interface Dialog ──────────────────────
+
+function CreateOpenVpnInterfaceDialog({
+  onCreated,
+}: {
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("vtun0");
+  const [mode, setMode] = useState("server");
+  const [protocol, setProtocol] = useState("udp");
+  const [localPort, setLocalPort] = useState("1194");
+  const [subnet, setSubnet] = useState("10.8.0.0/24");
+  const [remoteHost, setRemoteHost] = useState("");
+  const [remotePort, setRemotePort] = useState("1194");
+  const [encryption, setEncryption] = useState("aes256");
+  const [hash, setHash] = useState("sha512");
+  const [description, setDescription] = useState("");
+  const [tlsCaCert, setTlsCaCert] = useState("");
+  const [tlsCert, setTlsCert] = useState("");
+  const [tlsKey, setTlsKey] = useState("");
+  const [tlsDh, setTlsDh] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleCreate = async () => {
+    if (!name || !mode) {
+      toast.error("Please fill in required fields");
+      return;
+    }
+    setSaving(true);
+    try {
+      await createOpenVpnInterface({
+        name,
+        mode,
+        protocol: protocol || undefined,
+        local_port: mode === "server" ? parseInt(localPort, 10) || undefined : undefined,
+        subnet: mode === "server" && subnet ? subnet : undefined,
+        remote_host: mode === "client" && remoteHost ? remoteHost : undefined,
+        remote_port: mode === "client" ? parseInt(remotePort, 10) || undefined : undefined,
+        encryption: encryption || undefined,
+        hash: hash || undefined,
+        description: description || undefined,
+        tls_ca_cert: tlsCaCert || undefined,
+        tls_cert: tlsCert || undefined,
+        tls_key: tlsKey || undefined,
+        tls_dh: mode === "server" && tlsDh ? tlsDh : undefined,
+      });
+      toast.success(`OpenVPN interface ${name} created`);
+      onCreated();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to create interface"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <DialogContent className="border-slate-800 bg-slate-900 sm:max-w-lg max-h-[80vh] overflow-y-auto">
+      <DialogHeader>
+        <DialogTitle className="text-white">
+          Create OpenVPN Interface
+        </DialogTitle>
+        <DialogDescription>
+          Configure a new OpenVPN interface. TLS certificate paths refer to
+          files on the VyOS router filesystem.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label className="text-slate-300">Interface Name</Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="vtun0"
+              className="mt-1 border-slate-700 bg-slate-800 text-white"
+            />
+          </div>
+          <div>
+            <Label className="text-slate-300">Mode</Label>
+            <select
+              value={mode}
+              onChange={(e) => setMode(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white"
+            >
+              <option value="server">Server</option>
+              <option value="client">Client</option>
+              <option value="site-to-site">Site-to-Site</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label className="text-slate-300">Protocol</Label>
+            <select
+              value={protocol}
+              onChange={(e) => setProtocol(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white"
+            >
+              <option value="udp">UDP</option>
+              <option value="tcp-passive">TCP (Server)</option>
+              <option value="tcp-active">TCP (Client)</option>
+            </select>
+          </div>
+          {mode === "server" && (
+            <div>
+              <Label className="text-slate-300">Local Port</Label>
+              <Input
+                value={localPort}
+                onChange={(e) => setLocalPort(e.target.value)}
+                placeholder="1194"
+                type="number"
+                className="mt-1 border-slate-700 bg-slate-800 text-white"
+              />
+            </div>
+          )}
+          {mode === "client" && (
+            <div>
+              <Label className="text-slate-300">Remote Port</Label>
+              <Input
+                value={remotePort}
+                onChange={(e) => setRemotePort(e.target.value)}
+                placeholder="1194"
+                type="number"
+                className="mt-1 border-slate-700 bg-slate-800 text-white"
+              />
+            </div>
+          )}
+        </div>
+
+        {mode === "client" && (
+          <div>
+            <Label className="text-slate-300">Remote Host</Label>
+            <Input
+              value={remoteHost}
+              onChange={(e) => setRemoteHost(e.target.value)}
+              placeholder="vpn.example.com"
+              className="mt-1 border-slate-700 bg-slate-800 text-white"
+            />
+          </div>
+        )}
+
+        {mode === "server" && (
+          <div>
+            <Label className="text-slate-300">Server Subnet (CIDR)</Label>
+            <Input
+              value={subnet}
+              onChange={(e) => setSubnet(e.target.value)}
+              placeholder="10.8.0.0/24"
+              className="mt-1 border-slate-700 bg-slate-800 text-white"
+            />
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label className="text-slate-300">Encryption</Label>
+            <Input
+              value={encryption}
+              onChange={(e) => setEncryption(e.target.value)}
+              placeholder="aes256"
+              className="mt-1 border-slate-700 bg-slate-800 text-white"
+            />
+          </div>
+          <div>
+            <Label className="text-slate-300">Hash</Label>
+            <Input
+              value={hash}
+              onChange={(e) => setHash(e.target.value)}
+              placeholder="sha512"
+              className="mt-1 border-slate-700 bg-slate-800 text-white"
+            />
+          </div>
+        </div>
+
+        <div>
+          <Label className="text-slate-300">Description</Label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description"
+            className="mt-1 border-slate-700 bg-slate-800 text-white"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-slate-300 text-sm font-medium">TLS Certificates (file paths on VyOS)</Label>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-xs text-slate-400">CA Certificate</Label>
+              <Input
+                value={tlsCaCert}
+                onChange={(e) => setTlsCaCert(e.target.value)}
+                placeholder="/config/auth/ca.crt"
+                className="mt-1 border-slate-700 bg-slate-800 text-white text-xs"
+              />
+            </div>
+            <div>
+              <Label className="text-xs text-slate-400">Certificate</Label>
+              <Input
+                value={tlsCert}
+                onChange={(e) => setTlsCert(e.target.value)}
+                placeholder="/config/auth/server.crt"
+                className="mt-1 border-slate-700 bg-slate-800 text-white text-xs"
+              />
+            </div>
+            <div>
+              <Label className="text-xs text-slate-400">Private Key</Label>
+              <Input
+                value={tlsKey}
+                onChange={(e) => setTlsKey(e.target.value)}
+                placeholder="/config/auth/server.key"
+                className="mt-1 border-slate-700 bg-slate-800 text-white text-xs"
+              />
+            </div>
+            {mode === "server" && (
+              <div>
+                <Label className="text-xs text-slate-400">DH Parameters</Label>
+                <Input
+                  value={tlsDh}
+                  onChange={(e) => setTlsDh(e.target.value)}
+                  placeholder="/config/auth/dh.pem"
+                  className="mt-1 border-slate-700 bg-slate-800 text-white text-xs"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleCreate} disabled={saving}>
+            {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            Create Interface
+          </Button>
+        </DialogFooter>
+      </div>
+    </DialogContent>
+  );
+}
+
+// ── OpenVPN Interface Card ──────────────────────────────
+
+function OpenVpnInterfaceCard({
+  iface,
+  onReload,
+}: {
+  iface: OpenVpnInterface;
+  onReload: () => void;
+}) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  const [showClients, setShowClients] = useState(false);
+
+  const handleDeleteInterface = async () => {
+    setDeleting(true);
+    try {
+      await deleteOpenVpnInterface(iface.name);
+      toast.success(`Interface ${iface.name} deleted`);
+      onReload();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to delete interface"
+      );
+    } finally {
+      setDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
+  const handleToggle = async () => {
+    setToggling(true);
+    try {
+      const newDisable = !iface.disabled;
+      await toggleOpenVpnInterface(iface.name, newDisable);
+      toast.success(
+        `OpenVPN interface ${iface.name} ${newDisable ? "disabled" : "enabled"}`
+      );
+      onReload();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to toggle interface"
+      );
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const modeLabel =
+    iface.mode === "server"
+      ? "Server"
+      : iface.mode === "client"
+        ? "Client"
+        : iface.mode === "site-to-site"
+          ? "Site-to-Site"
+          : iface.mode ?? "Unknown";
+
+  return (
+    <Card className="border-slate-700 bg-slate-800/50">
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
+        <div className="flex items-center gap-3">
+          <div className="rounded-md bg-orange-950/50 p-2">
+            <Globe className="h-4 w-4 text-orange-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-white">
+                {iface.name}
+              </span>
+              <Badge
+                variant="outline"
+                className="text-[10px] border-orange-800 text-orange-400"
+              >
+                {modeLabel}
+              </Badge>
+              {iface.disabled ? (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] border-red-800 text-red-400"
+                >
+                  Disabled
+                </Badge>
+              ) : iface.status === "u/u" ? (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] border-emerald-800 text-emerald-400"
+                >
+                  Up
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] border-slate-600 text-slate-400"
+                >
+                  {iface.status ?? "Unknown"}
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-3 mt-1 text-xs text-slate-400">
+              {iface.protocol && <span>Protocol: {iface.protocol}</span>}
+              {iface.local_port && <span>Port: {iface.local_port}</span>}
+              {iface.subnet && <span>Subnet: {iface.subnet}</span>}
+              {iface.remote_host && <span>Remote: {iface.remote_host}</span>}
+              {iface.encryption && <span>Cipher: {iface.encryption}</span>}
+            </div>
+            {iface.description && (
+              <p className="text-xs text-slate-500 mt-0.5">{iface.description}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-slate-400 hover:text-white"
+            onClick={handleToggle}
+            disabled={toggling}
+            title={iface.disabled ? "Enable" : "Disable"}
+          >
+            {toggling ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Power className="h-3.5 w-3.5" />
+            )}
+          </Button>
+          <AlertDialog
+            open={showDeleteConfirm}
+            onOpenChange={setShowDeleteConfirm}
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0 text-slate-400 hover:text-red-400"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+            <AlertDialogContent className="border-slate-800 bg-slate-900">
+              <AlertDialogHeader>
+                <AlertDialogTitle className="text-white">
+                  Delete {iface.name}?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will permanently remove the OpenVPN interface and all its
+                  configuration from the router.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel className="border-slate-700">
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDeleteInterface}
+                  disabled={deleting}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  {deleting && (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  )}
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </CardHeader>
+
+      {/* Connected clients for server mode */}
+      {iface.mode === "server" && (
+        <CardContent className="pt-0">
+          <div className="border-t border-slate-700 pt-3">
+            <button
+              onClick={() => setShowClients(!showClients)}
+              className="flex items-center gap-2 text-xs text-slate-400 hover:text-white transition-colors"
+            >
+              <Users className="h-3.5 w-3.5" />
+              {iface.clients.length} connected client
+              {iface.clients.length !== 1 ? "s" : ""}
+            </button>
+
+            {showClients && iface.clients.length > 0 && (
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-slate-700 text-slate-400">
+                      <th className="py-1.5 pr-3 text-left font-medium">
+                        Common Name
+                      </th>
+                      <th className="py-1.5 pr-3 text-left font-medium">
+                        Real Address
+                      </th>
+                      <th className="py-1.5 pr-3 text-left font-medium">
+                        Virtual Address
+                      </th>
+                      <th className="py-1.5 pr-3 text-right font-medium">
+                        Received
+                      </th>
+                      <th className="py-1.5 pr-3 text-right font-medium">
+                        Sent
+                      </th>
+                      <th className="py-1.5 text-left font-medium">
+                        Connected Since
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {iface.clients.map((c, i) => (
+                      <tr
+                        key={i}
+                        className="border-b border-slate-800 last:border-0"
+                      >
+                        <td className="py-1.5 pr-3 text-white">
+                          {c.common_name}
+                        </td>
+                        <td className="py-1.5 pr-3 text-slate-300">
+                          {c.real_address ?? "-"}
+                        </td>
+                        <td className="py-1.5 pr-3 text-slate-300">
+                          {c.virtual_address ?? "-"}
+                        </td>
+                        <td className="py-1.5 pr-3 text-right text-slate-300">
+                          {c.bytes_received != null
+                            ? formatBytes(c.bytes_received)
+                            : "-"}
+                        </td>
+                        <td className="py-1.5 pr-3 text-right text-slate-300">
+                          {c.bytes_sent != null
+                            ? formatBytes(c.bytes_sent)
+                            : "-"}
+                        </td>
+                        <td className="py-1.5 text-slate-400">
+                          {c.connected_since ?? "-"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
 // ── Main Page ───────────────────────────────────────────
 
 export default function RouterPage() {
@@ -5518,6 +6101,20 @@ function RouterTabs({ summary }: { summary: RouterSummary }) {
     useCallback(() => fetchWireguardInterfaces(), [])
   );
 
+  const openvpn = useSummaryData(
+    null as OpenVpnInterface[] | null,
+    useCallback(() => fetchOpenVpnInterfaces(), [])
+  );
+
+  // Auto-load OpenVPN data on VPN tab
+  const openvpnLoadedRef = useRef(false);
+  useEffect(() => {
+    if (tab === "vpn" && !openvpnLoadedRef.current) {
+      openvpnLoadedRef.current = true;
+      openvpn.reload();
+    }
+  }, [tab, openvpn]);
+
   const reloadInterfaces = useCallback(() => {
     interfaces.reload();
     configIfaces.reload();
@@ -5718,12 +6315,20 @@ function RouterTabs({ summary }: { summary: RouterSummary }) {
         </TabsContent>
 
         <TabsContent value="vpn">
-          <WireGuardPanel
-            interfaces={Array.isArray(wireguard.data) ? wireguard.data : null}
-            loading={wireguard.loading}
-            error={wireguard.error}
-            onReload={wireguard.reload}
-          />
+          <div className="space-y-6">
+            <WireGuardPanel
+              interfaces={Array.isArray(wireguard.data) ? wireguard.data : null}
+              loading={wireguard.loading}
+              error={wireguard.error}
+              onReload={wireguard.reload}
+            />
+            <OpenVpnPanel
+              interfaces={Array.isArray(openvpn.data) ? openvpn.data : null}
+              loading={openvpn.loading}
+              error={openvpn.error}
+              onReload={openvpn.reload}
+            />
+          </div>
         </TabsContent>
 
         <TabsContent value="speedtest">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -948,6 +948,46 @@ export function generateWireguardClientConfig(
   );
 }
 
+// ─── OpenVPN ─────────────────────────────────────────────
+
+export function fetchOpenVpnInterfaces(): Promise<
+  import("./types").OpenVpnInterface[]
+> {
+  return apiGet<import("./types").OpenVpnInterface[]>("/api/v1/vyos/openvpn");
+}
+
+export function createOpenVpnInterface(
+  body: import("./types").CreateOpenVpnInterfaceRequest
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>("/api/v1/vyos/openvpn", body);
+}
+
+export function deleteOpenVpnInterface(
+  name: string
+): Promise<VyosWriteResponse> {
+  return apiDelete(
+    `/api/v1/vyos/openvpn/${encodeURIComponent(name)}`
+  ) as unknown as Promise<VyosWriteResponse>;
+}
+
+export function toggleOpenVpnInterface(
+  name: string,
+  disable: boolean
+): Promise<VyosWriteResponse> {
+  return apiPost<VyosWriteResponse>(
+    `/api/v1/vyos/openvpn/${encodeURIComponent(name)}/toggle`,
+    { disable }
+  );
+}
+
+export function fetchOpenVpnClients(
+  name: string
+): Promise<import("./types").OpenVpnConnectedClient[]> {
+  return apiGet<import("./types").OpenVpnConnectedClient[]>(
+    `/api/v1/vyos/openvpn/${encodeURIComponent(name)}/clients`
+  );
+}
+
 // ─── Topology ───────────────────────────────────────────
 
 export type { NodePosition };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -804,6 +804,58 @@ export interface ClientConfigResponse {
   public_key: string;
 }
 
+// ─── OpenVPN ────────────────────────────────────────────
+
+export interface OpenVpnConnectedClient {
+  common_name: string;
+  real_address: string | null;
+  virtual_address: string | null;
+  bytes_received: number | null;
+  bytes_sent: number | null;
+  connected_since: string | null;
+}
+
+export interface OpenVpnInterface {
+  name: string;
+  mode: string | null;
+  protocol: string | null;
+  local_port: number | null;
+  local_address: string | null;
+  remote_host: string | null;
+  remote_port: number | null;
+  encryption: string | null;
+  hash: string | null;
+  subnet: string | null;
+  description: string | null;
+  status: string | null;
+  tls_ca_cert: string | null;
+  tls_cert: string | null;
+  tls_key: string | null;
+  tls_dh: string | null;
+  push_routes: string[];
+  clients: OpenVpnConnectedClient[];
+  disabled: boolean;
+}
+
+export interface CreateOpenVpnInterfaceRequest {
+  name: string;
+  mode: string;
+  protocol?: string;
+  local_port?: number;
+  local_address?: string;
+  remote_host?: string;
+  remote_port?: number;
+  encryption?: string;
+  hash?: string;
+  subnet?: string;
+  description?: string;
+  tls_ca_cert?: string;
+  tls_cert?: string;
+  tls_key?: string;
+  tls_dh?: string;
+  push_routes?: string[];
+}
+
 // ─── System Info ───────────────────────────────────────
 
 export interface CpuLoad {


### PR DESCRIPTION
## Summary

- **OpenVPN server/client management** for VyOS routers — list, create, delete, enable/disable OpenVPN interfaces
- **Connected client monitoring** — view real-time connected clients with traffic stats for server-mode interfaces
- **Full VPN tab integration** — OpenVPN panel added alongside WireGuard in the router management VPN tab

## Changes

### Backend (Rust/Axum)
- Added OpenVPN handlers in `server/src/api/vyos.rs`:
  - `openvpn_list` — GET list of all OpenVPN interfaces with config + runtime data
  - `openvpn_create` — POST create new OpenVPN interface (server/client/site-to-site)
  - `openvpn_delete` — DELETE remove an OpenVPN interface
  - `openvpn_toggle` — POST enable/disable an interface
  - `openvpn_clients` — GET connected clients for a server interface
- Registered 5 new routes in `server/src/api/mod.rs`
- Supports all OpenVPN modes: server, client, site-to-site
- Supports configuration of: protocol (UDP/TCP), port, encryption cipher, hash, TLS certificates, server subnet, push routes

### Frontend (Next.js/TypeScript)
- Added TypeScript types: `OpenVpnInterface`, `OpenVpnConnectedClient`, `CreateOpenVpnInterfaceRequest`
- Added API client functions: `fetchOpenVpnInterfaces`, `createOpenVpnInterface`, `deleteOpenVpnInterface`, `toggleOpenVpnInterface`, `fetchOpenVpnClients`
- Added `OpenVpnPanel` component with create dialog, interface cards, and connected client table
- Panel auto-loads when VPN tab is selected

## Design Decisions
- Follows exact same patterns as existing WireGuard implementation
- TLS certificate paths reference files on the VyOS filesystem (PKI/CA integration is a separate prerequisite issue)
- OpenVPN interfaces use VyOS naming convention (`vtun0`, `vtun1`, etc.)
- Audit logging for all create/delete/toggle operations

## Test plan
- [ ] Verify OpenVPN interfaces list renders correctly in VPN tab
- [ ] Test creating a server-mode OpenVPN interface
- [ ] Test creating a client-mode OpenVPN interface
- [ ] Test deleting an OpenVPN interface
- [ ] Test enable/disable toggle
- [ ] Verify connected clients display for server interfaces
- [ ] Confirm no regressions in WireGuard panel

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added comprehensive OpenVPN management functionality mirroring the existing WireGuard implementation. The PR introduces 5 new API endpoints for listing, creating, deleting, toggling, and monitoring OpenVPN interfaces on VyOS routers, along with a full-featured UI panel in the router management VPN tab.

**Key changes:**
- Backend handlers support all OpenVPN modes (server, client, site-to-site) with configuration options for protocol, encryption, TLS certificates, and subnet/route management
- Real-time connected client monitoring for server-mode interfaces with traffic statistics
- Full audit logging for all mutating operations
- Frontend components follow existing design patterns with create dialogs, interface cards, and connected client tables
- TypeScript types properly mirror Rust structs for type safety

**Minor issues identified:**
- CIDR validation only supports IPv4, will reject valid IPv6 subnets
- Optional configuration parameters fail silently during interface creation

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor caveats - functionality is sound but has limited validation edge cases
- The implementation follows established patterns from WireGuard feature and includes proper audit logging. Two non-critical issues: IPv4-only CIDR validation will reject IPv6 subnets, and silent failures on optional config parameters could create incomplete interfaces. These don't affect core functionality but should be addressed in follow-up work.
- server/src/api/vyos.rs - review CIDR validation and error handling for optional parameters

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Added 5 OpenVPN route registrations following existing patterns, properly integrated into protected routes |
| server/src/api/vyos.rs | 756 lines of OpenVPN handler implementation - validation, parsing, CRUD operations; error handling pattern differs from mode-setting validation |
| web/src/lib/types.ts | TypeScript interfaces match Rust structs exactly, proper null handling and type safety |
| web/src/lib/api.ts | 5 API client functions with proper URL encoding, consistent with existing WireGuard patterns |
| web/src/app/(app)/router/page.tsx | 612 lines of UI components for OpenVPN management - create dialog, interface cards, connected clients table; auto-loads on VPN tab selection |

</details>



<sub>Last reviewed commit: 3151e2b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->