### PR TITLE
feat: standalone port forwarding / NAT management UI (#249)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -32,6 +32,7 @@ pub mod error;
 pub mod export;
 pub mod metrics;
 pub mod mikrotik;
+pub mod nat;
 pub mod npm;
 pub mod qos;
 pub mod scanner;
@@ -517,6 +518,16 @@ pub fn router(state: AppState) -> Router {
         .route("/qos/mikrotik/queue-tree", get(qos::mikrotik_queue_tree))
         // VPN Status Dashboard
         .route("/vpn-status", get(vpn_status::vpn_status))
+        // NAT / Port Forwarding
+        .route("/nat/summary", get(nat::summary))
+        .route("/nat/vyos/rules", get(nat::vyos_list))
+        .route("/nat/vyos/rules", post(nat::vyos_create))
+        .route("/nat/vyos/rules/:rule_number", put(nat::vyos_update))
+        .route("/nat/vyos/rules/:rule_number", delete(nat::vyos_delete))
+        .route("/nat/mikrotik/rules", get(nat::mikrotik_list))
+        .route("/nat/mikrotik/rules", post(nat::mikrotik_create))
+        .route("/nat/mikrotik/rules/:id", put(nat::mikrotik_update))
+        .route("/nat/mikrotik/rules/:id", delete(nat::mikrotik_delete))
         // Assets (IT inventory)
         .route("/assets", get(assets::list))
         .route("/assets", post(assets::create))

--- a/server/src/api/nat.rs
+++ b/server/src/api/nat.rs
@@ -1,0 +1,630 @@
+//! NAT (port forwarding) management endpoints.
+//!
+//! Provides CRUD operations for VyOS destination NAT rules and MikroTik
+//! firewall NAT rules, allowing users to manage port forwarding without
+//! going through the unified services wizard.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+
+use super::AppState;
+use crate::mikrotik::client::MikrotikClient;
+use crate::mikrotik::types::FirewallNatWriteRequest;
+
+// ── Helpers ─────────────────────────────────────────────────
+
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
+    let enabled = get_setting(state, "mikrotik_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let url = get_setting(state, "mikrotik_url").await?;
+    let user = get_setting(state, "mikrotik_user")
+        .await
+        .unwrap_or_else(|| "admin".to_string());
+    let password = get_setting(state, "mikrotik_password")
+        .await
+        .unwrap_or_default();
+
+    Some(MikrotikClient::with_http(
+        &url,
+        &user,
+        &password,
+        state.mikrotik_http.clone(),
+    ))
+}
+
+// ── Response / Request types ────────────────────────────────
+
+/// Unified NAT rule response (covers both VyOS and MikroTik).
+#[derive(Debug, Serialize)]
+pub struct NatRuleResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+// ── VyOS NAT Destination (DNAT) ─────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct VyosNatRule {
+    pub rule: u32,
+    pub description: Option<String>,
+    pub protocol: Option<String>,
+    pub inbound_interface: Option<String>,
+    pub external_port: Option<String>,
+    pub internal_ip: Option<String>,
+    pub internal_port: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateVyosNatRuleRequest {
+    pub rule: u32,
+    pub description: Option<String>,
+    pub protocol: Option<String>,
+    pub inbound_interface: Option<String>,
+    pub external_port: String,
+    pub internal_ip: String,
+    pub internal_port: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateVyosNatRuleRequest {
+    pub description: Option<String>,
+    pub protocol: Option<String>,
+    pub inbound_interface: Option<String>,
+    pub external_port: Option<String>,
+    pub internal_ip: Option<String>,
+    pub internal_port: Option<String>,
+}
+
+/// GET /api/v1/nat/vyos/rules — list all VyOS destination NAT rules.
+pub async fn vyos_list(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<VyosNatRule>>, StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let raw = client
+        .retrieve(&["nat", "destination", "rule"])
+        .await
+        .map_err(|e| {
+            // If path doesn't exist, it means no NAT rules — return empty list.
+            tracing::debug!("VyOS NAT retrieve error (likely empty): {e}");
+            StatusCode::OK
+        });
+
+    let value = match raw {
+        Ok(v) => v,
+        Err(_) => return Ok(Json(vec![])),
+    };
+
+    // VyOS returns an object keyed by rule number.
+    let rules_map = match value.as_object() {
+        Some(m) => m,
+        None => return Ok(Json(vec![])),
+    };
+
+    let mut rules: Vec<VyosNatRule> = Vec::new();
+
+    for (rule_num_str, rule_val) in rules_map {
+        let rule_num: u32 = match rule_num_str.parse() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+
+        let description = rule_val
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let protocol = rule_val
+            .get("protocol")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let inbound_interface = rule_val
+            .get("inbound-interface")
+            .and_then(|v| v.get("name"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let external_port = rule_val
+            .get("destination")
+            .and_then(|v| v.get("port"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let internal_ip = rule_val
+            .get("translation")
+            .and_then(|v| v.get("address"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let internal_port = rule_val
+            .get("translation")
+            .and_then(|v| v.get("port"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        rules.push(VyosNatRule {
+            rule: rule_num,
+            description,
+            protocol,
+            inbound_interface,
+            external_port,
+            internal_ip,
+            internal_port,
+        });
+    }
+
+    rules.sort_by_key(|r| r.rule);
+    Ok(Json(rules))
+}
+
+/// POST /api/v1/nat/vyos/rules — create a VyOS destination NAT rule.
+pub async fn vyos_create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateVyosNatRuleRequest>,
+) -> Result<(StatusCode, Json<NatRuleResponse>), StatusCode> {
+    if body.rule == 0 || body.rule > 99999 {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(NatRuleResponse {
+                success: false,
+                message: "Rule number must be between 1 and 99999".into(),
+            }),
+        ));
+    }
+
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let rule_str = body.rule.to_string();
+    let protocol = body.protocol.as_deref().unwrap_or("tcp");
+    let description = body.description.as_deref().unwrap_or("");
+
+    let base_path = ["nat", "destination", "rule", &rule_str];
+
+    // Set description
+    if !description.is_empty() {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("description");
+        path.push(description);
+        if let Err(e) = client.configure_set(&path).await {
+            error!("Failed to set NAT rule description: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set protocol
+    {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("protocol");
+        path.push(protocol);
+        if let Err(e) = client.configure_set(&path).await {
+            let _ = client.configure_delete(&base_path).await;
+            error!("Failed to set NAT rule protocol: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set inbound interface (optional)
+    if let Some(ref iface) = body.inbound_interface {
+        if !iface.is_empty() {
+            let mut path: Vec<&str> = base_path.to_vec();
+            path.push("inbound-interface");
+            path.push("name");
+            path.push(iface);
+            if let Err(e) = client.configure_set(&path).await {
+                let _ = client.configure_delete(&base_path).await;
+                error!("Failed to set NAT rule inbound interface: {e}");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    // Set destination port (external port)
+    {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("destination");
+        path.push("port");
+        path.push(&body.external_port);
+        if let Err(e) = client.configure_set(&path).await {
+            let _ = client.configure_delete(&base_path).await;
+            error!("Failed to set NAT rule destination port: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set translation address (internal IP)
+    {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("translation");
+        path.push("address");
+        path.push(&body.internal_ip);
+        if let Err(e) = client.configure_set(&path).await {
+            let _ = client.configure_delete(&base_path).await;
+            error!("Failed to set NAT rule translation address: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set translation port (internal port)
+    {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("translation");
+        path.push("port");
+        path.push(&body.internal_port);
+        if let Err(e) = client.configure_set(&path).await {
+            let _ = client.configure_delete(&base_path).await;
+            error!("Failed to set NAT rule translation port: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    if let Err(e) = client.config_save().await {
+        tracing::warn!("config-file save failed after NAT rule create: {e}");
+    }
+
+    info!("VyOS DNAT rule {} created", body.rule);
+
+    Ok((
+        StatusCode::CREATED,
+        Json(NatRuleResponse {
+            success: true,
+            message: format!(
+                "DNAT rule {} created — port {} → {}:{}",
+                body.rule, body.external_port, body.internal_ip, body.internal_port
+            ),
+        }),
+    ))
+}
+
+/// PUT /api/v1/nat/vyos/rules/:rule_number — update an existing VyOS DNAT rule.
+pub async fn vyos_update(
+    State(state): State<AppState>,
+    Path(rule_number): Path<u32>,
+    Json(body): Json<UpdateVyosNatRuleRequest>,
+) -> Result<Json<NatRuleResponse>, StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let rule_str = rule_number.to_string();
+    let base_path = ["nat", "destination", "rule", &rule_str];
+
+    // Verify rule exists
+    if client.retrieve(&base_path).await.is_err() {
+        return Ok(Json(NatRuleResponse {
+            success: false,
+            message: format!("Rule {} not found", rule_number),
+        }));
+    }
+
+    // Delete the old rule and recreate with new values
+    // (VyOS doesn't support partial updates well for nested NAT paths)
+    if let Err(e) = client.configure_delete(&base_path).await {
+        error!("Failed to delete old NAT rule {rule_number} for update: {e}");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // Set description
+    if let Some(ref desc) = body.description {
+        if !desc.is_empty() {
+            let mut path: Vec<&str> = base_path.to_vec();
+            path.push("description");
+            path.push(desc);
+            if let Err(e) = client.configure_set(&path).await {
+                error!("Failed to set NAT rule description on update: {e}");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    // Set protocol
+    if let Some(ref proto) = body.protocol {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("protocol");
+        path.push(proto);
+        if let Err(e) = client.configure_set(&path).await {
+            error!("Failed to set NAT rule protocol on update: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set inbound interface
+    if let Some(ref iface) = body.inbound_interface {
+        if !iface.is_empty() {
+            let mut path: Vec<&str> = base_path.to_vec();
+            path.push("inbound-interface");
+            path.push("name");
+            path.push(iface);
+            if let Err(e) = client.configure_set(&path).await {
+                error!("Failed to set NAT rule inbound interface on update: {e}");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    // Set destination port
+    if let Some(ref ext_port) = body.external_port {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("destination");
+        path.push("port");
+        path.push(ext_port);
+        if let Err(e) = client.configure_set(&path).await {
+            error!("Failed to set NAT rule destination port on update: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set translation address
+    if let Some(ref ip) = body.internal_ip {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("translation");
+        path.push("address");
+        path.push(ip);
+        if let Err(e) = client.configure_set(&path).await {
+            error!("Failed to set NAT rule translation address on update: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Set translation port
+    if let Some(ref int_port) = body.internal_port {
+        let mut path: Vec<&str> = base_path.to_vec();
+        path.push("translation");
+        path.push("port");
+        path.push(int_port);
+        if let Err(e) = client.configure_set(&path).await {
+            error!("Failed to set NAT rule translation port on update: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    if let Err(e) = client.config_save().await {
+        tracing::warn!("config-file save failed after NAT rule update: {e}");
+    }
+
+    info!("VyOS DNAT rule {} updated", rule_number);
+
+    Ok(Json(NatRuleResponse {
+        success: true,
+        message: format!("DNAT rule {} updated", rule_number),
+    }))
+}
+
+/// DELETE /api/v1/nat/vyos/rules/:rule_number — delete a VyOS DNAT rule.
+pub async fn vyos_delete(
+    State(state): State<AppState>,
+    Path(rule_number): Path<u32>,
+) -> Result<Json<NatRuleResponse>, StatusCode> {
+    let client = super::vyos::get_vyos_client_or_503(&state).await?;
+
+    let rule_str = rule_number.to_string();
+    let base_path = ["nat", "destination", "rule", &rule_str];
+
+    if let Err(e) = client.configure_delete(&base_path).await {
+        error!("Failed to delete VyOS DNAT rule {rule_number}: {e}");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    if let Err(e) = client.config_save().await {
+        tracing::warn!("config-file save failed after NAT rule delete: {e}");
+    }
+
+    info!("VyOS DNAT rule {} deleted", rule_number);
+
+    Ok(Json(NatRuleResponse {
+        success: true,
+        message: format!("DNAT rule {} deleted", rule_number),
+    }))
+}
+
+// ── MikroTik NAT ────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct MikrotikNatRuleResponse {
+    pub id: Option<String>,
+    pub chain: Option<String>,
+    pub action: Option<String>,
+    pub protocol: Option<String>,
+    pub src_address: Option<String>,
+    pub dst_address: Option<String>,
+    pub dst_port: Option<String>,
+    pub to_addresses: Option<String>,
+    pub to_ports: Option<String>,
+    pub out_interface: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateMikrotikNatRuleRequest {
+    pub chain: String,
+    pub action: String,
+    pub protocol: Option<String>,
+    pub dst_port: Option<String>,
+    pub to_addresses: Option<String>,
+    pub to_ports: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: Option<bool>,
+}
+
+/// GET /api/v1/nat/mikrotik/rules — list all MikroTik NAT rules.
+pub async fn mikrotik_list(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<MikrotikNatRuleResponse>>, StatusCode> {
+    let Some(client) = mikrotik_client(&state).await else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+
+    let nat_rules = client.firewall_nat().await.map_err(|e| {
+        error!("Failed to fetch MikroTik NAT rules: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let rules: Vec<MikrotikNatRuleResponse> = nat_rules
+        .into_iter()
+        .map(|r| MikrotikNatRuleResponse {
+            id: r.id,
+            chain: r.chain,
+            action: r.action,
+            protocol: r.protocol,
+            src_address: r.src_address,
+            dst_address: r.dst_address,
+            dst_port: r.dst_port,
+            to_addresses: r.to_addresses,
+            to_ports: r.to_ports,
+            out_interface: r.out_interface,
+            comment: r.comment,
+            disabled: r.disabled.as_deref() == Some("true"),
+        })
+        .collect();
+
+    Ok(Json(rules))
+}
+
+/// POST /api/v1/nat/mikrotik/rules — create a MikroTik NAT rule.
+pub async fn mikrotik_create(
+    State(state): State<AppState>,
+    Json(body): Json<CreateMikrotikNatRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let Some(client) = mikrotik_client(&state).await else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+
+    let req = FirewallNatWriteRequest {
+        chain: body.chain,
+        action: body.action,
+        protocol: body.protocol,
+        src_address: None,
+        dst_address: None,
+        dst_port: body.dst_port,
+        to_addresses: body.to_addresses,
+        to_ports: body.to_ports,
+        in_interface: None,
+        out_interface: None,
+        comment: body.comment,
+        disabled: body
+            .disabled
+            .map(|d| if d { "true" } else { "false" }.into()),
+    };
+
+    client.create_firewall_nat(&req).await.map_err(|e| {
+        error!("Failed to create MikroTik NAT rule: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    info!("MikroTik NAT rule created");
+    Ok(StatusCode::CREATED)
+}
+
+/// PUT /api/v1/nat/mikrotik/rules/:id — update a MikroTik NAT rule.
+pub async fn mikrotik_update(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<CreateMikrotikNatRuleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let Some(client) = mikrotik_client(&state).await else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+
+    let req = FirewallNatWriteRequest {
+        chain: body.chain,
+        action: body.action,
+        protocol: body.protocol,
+        src_address: None,
+        dst_address: None,
+        dst_port: body.dst_port,
+        to_addresses: body.to_addresses,
+        to_ports: body.to_ports,
+        in_interface: None,
+        out_interface: None,
+        comment: body.comment,
+        disabled: body
+            .disabled
+            .map(|d| if d { "true" } else { "false" }.into()),
+    };
+
+    client.update_firewall_nat(&id, &req).await.map_err(|e| {
+        error!("Failed to update MikroTik NAT rule {id}: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    info!("MikroTik NAT rule {id} updated");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /api/v1/nat/mikrotik/rules/:id — delete a MikroTik NAT rule.
+pub async fn mikrotik_delete(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let Some(client) = mikrotik_client(&state).await else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+
+    client.delete_firewall_nat(&id).await.map_err(|e| {
+        error!("Failed to delete MikroTik NAT rule {id}: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    info!("MikroTik NAT rule {id} deleted");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── NAT Summary ─────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct NatSummary {
+    pub vyos_available: bool,
+    pub mikrotik_available: bool,
+    pub vyos_rule_count: usize,
+    pub mikrotik_rule_count: usize,
+}
+
+/// GET /api/v1/nat/summary — overview of NAT rule counts.
+pub async fn summary(State(state): State<AppState>) -> Json<NatSummary> {
+    let vyos_client = super::vyos::get_vyos_client_or_503(&state).await.ok();
+    let mt_client = mikrotik_client(&state).await;
+
+    let vyos_count = if let Some(ref client) = vyos_client {
+        client
+            .retrieve(&["nat", "destination", "rule"])
+            .await
+            .ok()
+            .and_then(|v| v.as_object().map(|m| m.len()))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    let mt_count = if let Some(ref client) = mt_client {
+        client.firewall_nat().await.map(|v| v.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
+    Json(NatSummary {
+        vyos_available: vyos_client.is_some(),
+        mikrotik_available: mt_client.is_some(),
+        vyos_rule_count: vyos_count,
+        mikrotik_rule_count: mt_count,
+    })
+}

--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -1,0 +1,1133 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowRightLeft,
+  Loader2,
+  Network,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Router,
+  Search,
+  Trash2,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageTransition } from "@/components/PageTransition";
+import {
+  fetchNatSummary,
+  fetchVyosNatRules,
+  createVyosNatRule,
+  updateVyosNatRule,
+  deleteVyosNatRule,
+  fetchMikrotikNatRules,
+  createMikrotikNatRule,
+  updateMikrotikNatRule,
+  deleteMikrotikNatRule,
+} from "@/lib/api";
+import type {
+  NatSummary,
+  NatDestinationRule,
+  MikrotikNatRuleWithId,
+} from "@/lib/types";
+import { toast } from "sonner";
+
+export default function NatPage() {
+  const [summary, setSummary] = useState<NatSummary | null>(null);
+  const [vyosRules, setVyosRules] = useState<NatDestinationRule[] | null>(null);
+  const [mtRules, setMtRules] = useState<MikrotikNatRuleWithId[] | null>(null);
+  const [search, setSearch] = useState("");
+  const [activeTab, setActiveTab] = useState("overview");
+
+  // Dialogs
+  const [showAddVyos, setShowAddVyos] = useState(false);
+  const [editVyosRule, setEditVyosRule] = useState<NatDestinationRule | null>(
+    null
+  );
+  const [pendingDeleteVyos, setPendingDeleteVyos] =
+    useState<NatDestinationRule | null>(null);
+  const [showAddMt, setShowAddMt] = useState(false);
+  const [editMtRule, setEditMtRule] = useState<MikrotikNatRuleWithId | null>(
+    null
+  );
+  const [pendingDeleteMt, setPendingDeleteMt] =
+    useState<MikrotikNatRuleWithId | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const s = await fetchNatSummary();
+      setSummary(s);
+    } catch {
+      // summary is best-effort
+    }
+  }, []);
+
+  const loadVyos = useCallback(async () => {
+    try {
+      const data = await fetchVyosNatRules();
+      setVyosRules(data);
+    } catch {
+      setVyosRules([]);
+    }
+  }, []);
+
+  const loadMt = useCallback(async () => {
+    try {
+      const data = await fetchMikrotikNatRules();
+      setMtRules(data);
+    } catch {
+      setMtRules([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (activeTab === "vyos") loadVyos();
+    if (activeTab === "mikrotik") loadMt();
+  }, [activeTab, loadVyos, loadMt]);
+
+  // -- Filter helpers --
+  const filteredVyos = useMemo(() => {
+    if (!vyosRules) return null;
+    if (!search.trim()) return vyosRules;
+    const q = search.toLowerCase();
+    return vyosRules.filter(
+      (r) =>
+        (r.description ?? "").toLowerCase().includes(q) ||
+        (r.internal_ip ?? "").toLowerCase().includes(q) ||
+        (r.external_port ?? "").toLowerCase().includes(q) ||
+        (r.protocol ?? "").toLowerCase().includes(q)
+    );
+  }, [vyosRules, search]);
+
+  const filteredMt = useMemo(() => {
+    if (!mtRules) return null;
+    if (!search.trim()) return mtRules;
+    const q = search.toLowerCase();
+    return mtRules.filter(
+      (r) =>
+        (r.comment ?? "").toLowerCase().includes(q) ||
+        (r.to_addresses ?? "").toLowerCase().includes(q) ||
+        (r.dst_port ?? "").toLowerCase().includes(q) ||
+        (r.action ?? "").toLowerCase().includes(q)
+    );
+  }, [mtRules, search]);
+
+  // -- VyOS Handlers --
+  async function handleDeleteVyos() {
+    if (!pendingDeleteVyos) return;
+    try {
+      await deleteVyosNatRule(pendingDeleteVyos.rule);
+      setVyosRules(
+        (prev) =>
+          prev?.filter((r) => r.rule !== pendingDeleteVyos.rule) ?? null
+      );
+      toast.success(`Deleted DNAT rule ${pendingDeleteVyos.rule}`);
+      load();
+    } catch {
+      toast.error("Failed to delete DNAT rule");
+    } finally {
+      setPendingDeleteVyos(null);
+    }
+  }
+
+  // -- MikroTik Handlers --
+  async function handleDeleteMt() {
+    if (!pendingDeleteMt || !pendingDeleteMt.id) return;
+    try {
+      await deleteMikrotikNatRule(pendingDeleteMt.id);
+      setMtRules(
+        (prev) => prev?.filter((r) => r.id !== pendingDeleteMt.id) ?? null
+      );
+      toast.success("Deleted MikroTik NAT rule");
+      load();
+    } catch {
+      toast.error("Failed to delete MikroTik NAT rule");
+    } finally {
+      setPendingDeleteMt(null);
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-6xl space-y-6 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <ArrowRightLeft className="h-6 w-6 text-blue-500" />
+            <h1 className="text-2xl font-semibold text-white">
+              NAT / Port Forwarding
+            </h1>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              load();
+              if (activeTab === "vyos") loadVyos();
+              if (activeTab === "mikrotik") loadMt();
+            }}
+            className="border-slate-800 text-slate-300 hover:bg-slate-800"
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Summary Cards */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SummaryCard
+            title="VyOS DNAT Rules"
+            value={summary?.vyos_rule_count ?? null}
+            available={summary?.vyos_available ?? null}
+            icon={<Router className="h-4 w-4 text-blue-400" />}
+          />
+          <SummaryCard
+            title="MikroTik NAT Rules"
+            value={summary?.mikrotik_rule_count ?? null}
+            available={summary?.mikrotik_available ?? null}
+            icon={<Network className="h-4 w-4 text-orange-400" />}
+          />
+        </div>
+
+        {/* Tabs */}
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList className="bg-slate-900 border border-slate-800">
+            <TabsTrigger
+              value="overview"
+              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+            >
+              Overview
+            </TabsTrigger>
+            {summary?.vyos_available && (
+              <TabsTrigger
+                value="vyos"
+                className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+              >
+                VyOS DNAT
+              </TabsTrigger>
+            )}
+            {summary?.mikrotik_available && (
+              <TabsTrigger
+                value="mikrotik"
+                className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+              >
+                MikroTik NAT
+              </TabsTrigger>
+            )}
+          </TabsList>
+
+          {/* Search */}
+          {activeTab !== "overview" && (
+            <div className="relative mt-4 max-w-sm">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-500" />
+              <Input
+                placeholder="Filter rules..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9 bg-slate-900 border-slate-800 text-slate-300"
+              />
+            </div>
+          )}
+
+          {/* Overview Tab */}
+          <TabsContent value="overview">
+            <Card className="bg-slate-900/50 border-slate-800">
+              <CardHeader>
+                <CardTitle className="text-white">
+                  NAT / Port Forwarding Overview
+                </CardTitle>
+                <CardDescription className="text-slate-400">
+                  Manage destination NAT (port forwarding) rules on your VyOS
+                  and MikroTik routers. Select a tab above to view and manage
+                  rules for each router type.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {summary === null ? (
+                  <div className="space-y-3">
+                    <Skeleton className="h-4 w-64 bg-slate-800" />
+                    <Skeleton className="h-4 w-48 bg-slate-800" />
+                  </div>
+                ) : (
+                  <div className="text-sm text-slate-400 space-y-2">
+                    <p>
+                      {summary.vyos_available
+                        ? `VyOS router connected with ${summary.vyos_rule_count} DNAT rule(s).`
+                        : "VyOS router not configured."}
+                    </p>
+                    <p>
+                      {summary.mikrotik_available
+                        ? `MikroTik router connected with ${summary.mikrotik_rule_count} NAT rule(s).`
+                        : "MikroTik router not configured."}
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* VyOS Tab */}
+          <TabsContent value="vyos">
+            <Card className="bg-slate-900/50 border-slate-800">
+              <CardHeader className="flex flex-row items-center justify-between">
+                <div>
+                  <CardTitle className="text-white">
+                    VyOS Destination NAT Rules
+                  </CardTitle>
+                  <CardDescription className="text-slate-400">
+                    Port forwarding rules on the VyOS router.
+                  </CardDescription>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => setShowAddVyos(true)}
+                  className="bg-blue-600 hover:bg-blue-700"
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Add Rule
+                </Button>
+              </CardHeader>
+              <CardContent>
+                {filteredVyos === null ? (
+                  <div className="space-y-2">
+                    {[...Array(3)].map((_, i) => (
+                      <Skeleton key={i} className="h-10 bg-slate-800" />
+                    ))}
+                  </div>
+                ) : filteredVyos.length === 0 ? (
+                  <p className="text-sm text-slate-500 py-8 text-center">
+                    {search
+                      ? "No matching rules."
+                      : "No DNAT rules configured."}
+                  </p>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="border-slate-800">
+                        <TableHead className="text-slate-400">Rule</TableHead>
+                        <TableHead className="text-slate-400">
+                          Description
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Protocol
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Ext. Port
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Internal IP
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Int. Port
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Interface
+                        </TableHead>
+                        <TableHead className="text-slate-400 text-right">
+                          Actions
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredVyos.map((rule) => (
+                        <TableRow
+                          key={rule.rule}
+                          className="border-slate-800 hover:bg-slate-800/50"
+                        >
+                          <TableCell className="text-slate-200 font-mono">
+                            {rule.rule}
+                          </TableCell>
+                          <TableCell className="text-slate-300">
+                            {rule.description || "-"}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="secondary"
+                              className="bg-slate-800 text-slate-300"
+                            >
+                              {rule.protocol ?? "any"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.external_port ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.internal_ip ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.internal_port ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-400">
+                            {rule.inbound_interface ?? "any"}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex justify-end gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setEditVyosRule(rule)}
+                                className="h-7 w-7 p-0 text-slate-400 hover:text-white"
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setPendingDeleteVyos(rule)}
+                                className="h-7 w-7 p-0 text-slate-400 hover:text-red-400"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* MikroTik Tab */}
+          <TabsContent value="mikrotik">
+            <Card className="bg-slate-900/50 border-slate-800">
+              <CardHeader className="flex flex-row items-center justify-between">
+                <div>
+                  <CardTitle className="text-white">
+                    MikroTik NAT Rules
+                  </CardTitle>
+                  <CardDescription className="text-slate-400">
+                    Firewall NAT rules on the MikroTik router.
+                  </CardDescription>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => setShowAddMt(true)}
+                  className="bg-blue-600 hover:bg-blue-700"
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Add Rule
+                </Button>
+              </CardHeader>
+              <CardContent>
+                {filteredMt === null ? (
+                  <div className="space-y-2">
+                    {[...Array(3)].map((_, i) => (
+                      <Skeleton key={i} className="h-10 bg-slate-800" />
+                    ))}
+                  </div>
+                ) : filteredMt.length === 0 ? (
+                  <p className="text-sm text-slate-500 py-8 text-center">
+                    {search
+                      ? "No matching rules."
+                      : "No NAT rules configured."}
+                  </p>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="border-slate-800">
+                        <TableHead className="text-slate-400">Chain</TableHead>
+                        <TableHead className="text-slate-400">
+                          Action
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Protocol
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Dst Port
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          To Address
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          To Port
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Comment
+                        </TableHead>
+                        <TableHead className="text-slate-400">
+                          Status
+                        </TableHead>
+                        <TableHead className="text-slate-400 text-right">
+                          Actions
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredMt.map((rule, idx) => (
+                        <TableRow
+                          key={rule.id ?? idx}
+                          className="border-slate-800 hover:bg-slate-800/50"
+                        >
+                          <TableCell className="text-slate-300">
+                            {rule.chain ?? "-"}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="secondary"
+                              className={
+                                rule.action === "dst-nat"
+                                  ? "bg-blue-900/50 text-blue-300"
+                                  : rule.action === "masquerade"
+                                    ? "bg-green-900/50 text-green-300"
+                                    : "bg-slate-800 text-slate-300"
+                              }
+                            >
+                              {rule.action ?? "-"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-slate-300">
+                            {rule.protocol ?? "any"}
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.dst_port ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.to_addresses ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-300 font-mono">
+                            {rule.to_ports ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-slate-400 max-w-[200px] truncate">
+                            {rule.comment ?? "-"}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="secondary"
+                              className={
+                                rule.disabled
+                                  ? "bg-slate-800 text-slate-500"
+                                  : "bg-green-900/50 text-green-300"
+                              }
+                            >
+                              {rule.disabled ? "Disabled" : "Active"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex justify-end gap-1">
+                              {rule.id && (
+                                <>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setEditMtRule(rule)}
+                                    className="h-7 w-7 p-0 text-slate-400 hover:text-white"
+                                  >
+                                    <Pencil className="h-3.5 w-3.5" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setPendingDeleteMt(rule)}
+                                    className="h-7 w-7 p-0 text-slate-400 hover:text-red-400"
+                                  >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                  </Button>
+                                </>
+                              )}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* VyOS Add Dialog */}
+        <VyosNatDialog
+          open={showAddVyos}
+          onOpenChange={setShowAddVyos}
+          onSave={async (data) => {
+            try {
+              await createVyosNatRule(data);
+              toast.success(`DNAT rule ${data.rule} created`);
+              loadVyos();
+              load();
+              setShowAddVyos(false);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? err.message : "Failed to create rule"
+              );
+            }
+          }}
+        />
+
+        {/* VyOS Edit Dialog */}
+        <VyosNatDialog
+          open={!!editVyosRule}
+          onOpenChange={(open) => {
+            if (!open) setEditVyosRule(null);
+          }}
+          existing={editVyosRule}
+          onSave={async (data) => {
+            if (!editVyosRule) return;
+            try {
+              await updateVyosNatRule(editVyosRule.rule, {
+                description: data.description,
+                protocol: data.protocol,
+                inbound_interface: data.inbound_interface,
+                external_port: data.external_port,
+                internal_ip: data.internal_ip,
+                internal_port: data.internal_port,
+              });
+              toast.success(`DNAT rule ${editVyosRule.rule} updated`);
+              loadVyos();
+              load();
+              setEditVyosRule(null);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? err.message : "Failed to update rule"
+              );
+            }
+          }}
+        />
+
+        {/* VyOS Delete Confirm */}
+        <AlertDialog
+          open={!!pendingDeleteVyos}
+          onOpenChange={(open) => {
+            if (!open) setPendingDeleteVyos(null);
+          }}
+        >
+          <AlertDialogContent className="bg-slate-900 border-slate-800">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-white">
+                Delete DNAT Rule
+              </AlertDialogTitle>
+              <AlertDialogDescription className="text-slate-400">
+                Are you sure you want to delete DNAT rule{" "}
+                {pendingDeleteVyos?.rule}? This will remove the port forwarding
+                from the VyOS router.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="border-slate-700 text-slate-300">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDeleteVyos}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        {/* MikroTik Add Dialog */}
+        <MikrotikNatDialog
+          open={showAddMt}
+          onOpenChange={setShowAddMt}
+          onSave={async (data) => {
+            try {
+              await createMikrotikNatRule(data);
+              toast.success("MikroTik NAT rule created");
+              loadMt();
+              load();
+              setShowAddMt(false);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? err.message : "Failed to create rule"
+              );
+            }
+          }}
+        />
+
+        {/* MikroTik Edit Dialog */}
+        <MikrotikNatDialog
+          open={!!editMtRule}
+          onOpenChange={(open) => {
+            if (!open) setEditMtRule(null);
+          }}
+          existing={editMtRule}
+          onSave={async (data) => {
+            if (!editMtRule?.id) return;
+            try {
+              await updateMikrotikNatRule(editMtRule.id, data);
+              toast.success("MikroTik NAT rule updated");
+              loadMt();
+              load();
+              setEditMtRule(null);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? err.message : "Failed to update rule"
+              );
+            }
+          }}
+        />
+
+        {/* MikroTik Delete Confirm */}
+        <AlertDialog
+          open={!!pendingDeleteMt}
+          onOpenChange={(open) => {
+            if (!open) setPendingDeleteMt(null);
+          }}
+        >
+          <AlertDialogContent className="bg-slate-900 border-slate-800">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-white">
+                Delete MikroTik NAT Rule
+              </AlertDialogTitle>
+              <AlertDialogDescription className="text-slate-400">
+                Are you sure you want to delete this NAT rule
+                {pendingDeleteMt?.comment
+                  ? ` (${pendingDeleteMt.comment})`
+                  : ""}
+                ? This will remove it from the MikroTik router.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="border-slate-700 text-slate-300">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDeleteMt}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </PageTransition>
+  );
+}
+
+// ─── Summary Card ────────────────────────────────────────────
+
+function SummaryCard({
+  title,
+  value,
+  available,
+  icon,
+}: {
+  title: string;
+  value: number | null;
+  available: boolean | null;
+  icon: React.ReactNode;
+}) {
+  return (
+    <Card className="bg-slate-900/50 border-slate-800">
+      <CardContent className="flex items-center gap-3 pt-6">
+        {icon}
+        <div>
+          <p className="text-xs text-slate-500">{title}</p>
+          {available === null ? (
+            <Skeleton className="h-5 w-10 mt-1 bg-slate-800" />
+          ) : available ? (
+            <p className="text-lg font-semibold text-white">{value ?? 0}</p>
+          ) : (
+            <p className="text-sm text-slate-500">Not configured</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── VyOS NAT Dialog ─────────────────────────────────────────
+
+function VyosNatDialog({
+  open,
+  onOpenChange,
+  existing,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existing?: NatDestinationRule | null;
+  onSave: (data: {
+    rule: number;
+    description?: string;
+    protocol?: string;
+    inbound_interface?: string;
+    external_port: string;
+    internal_ip: string;
+    internal_port: string;
+  }) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [rule, setRule] = useState("");
+  const [description, setDescription] = useState("");
+  const [protocol, setProtocol] = useState("tcp");
+  const [externalPort, setExternalPort] = useState("");
+  const [internalIp, setInternalIp] = useState("");
+  const [internalPort, setInternalPort] = useState("");
+  const [inboundInterface, setInboundInterface] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      if (existing) {
+        setRule(String(existing.rule));
+        setDescription(existing.description ?? "");
+        setProtocol(existing.protocol ?? "tcp");
+        setExternalPort(existing.external_port ?? "");
+        setInternalIp(existing.internal_ip ?? "");
+        setInternalPort(existing.internal_port ?? "");
+        setInboundInterface(existing.inbound_interface ?? "");
+      } else {
+        setRule("");
+        setDescription("");
+        setProtocol("tcp");
+        setExternalPort("");
+        setInternalIp("");
+        setInternalPort("");
+        setInboundInterface("");
+      }
+    }
+  }, [open, existing]);
+
+  const handleSubmit = async () => {
+    if (!rule || !externalPort || !internalIp || !internalPort) return;
+    setSaving(true);
+    try {
+      await onSave({
+        rule: Number(rule),
+        description: description || undefined,
+        protocol: protocol || undefined,
+        inbound_interface: inboundInterface || undefined,
+        external_port: externalPort,
+        internal_ip: internalIp,
+        internal_port: internalPort,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-800 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {existing ? "Edit DNAT Rule" : "Add DNAT Rule"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Rule Number</Label>
+              <Input
+                type="number"
+                value={rule}
+                onChange={(e) => setRule(e.target.value)}
+                disabled={!!existing}
+                placeholder="e.g. 100"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Protocol</Label>
+              <Input
+                value={protocol}
+                onChange={(e) => setProtocol(e.target.value)}
+                placeholder="tcp, udp, tcp_udp"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-slate-400">Description</Label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Web server port forward"
+              className="bg-slate-800 border-slate-700 text-slate-200"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">External Port</Label>
+              <Input
+                value={externalPort}
+                onChange={(e) => setExternalPort(e.target.value)}
+                placeholder="8080"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Internal IP</Label>
+              <Input
+                value={internalIp}
+                onChange={(e) => setInternalIp(e.target.value)}
+                placeholder="192.168.1.100"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Internal Port</Label>
+              <Input
+                value={internalPort}
+                onChange={(e) => setInternalPort(e.target.value)}
+                placeholder="80"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-slate-400">Inbound Interface (optional)</Label>
+            <Input
+              value={inboundInterface}
+              onChange={(e) => setInboundInterface(e.target.value)}
+              placeholder="eth0"
+              className="bg-slate-800 border-slate-700 text-slate-200"
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="border-slate-700 text-slate-300"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={
+                saving || !rule || !externalPort || !internalIp || !internalPort
+              }
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+              {existing ? "Update" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── MikroTik NAT Dialog ─────────────────────────────────────
+
+function MikrotikNatDialog({
+  open,
+  onOpenChange,
+  existing,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existing?: MikrotikNatRuleWithId | null;
+  onSave: (data: {
+    chain: string;
+    action: string;
+    protocol?: string;
+    dst_port?: string;
+    to_addresses?: string;
+    to_ports?: string;
+    comment?: string;
+    disabled?: boolean;
+  }) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [chain, setChain] = useState("dstnat");
+  const [action, setAction] = useState("dst-nat");
+  const [protocol, setProtocol] = useState("tcp");
+  const [dstPort, setDstPort] = useState("");
+  const [toAddresses, setToAddresses] = useState("");
+  const [toPorts, setToPorts] = useState("");
+  const [comment, setComment] = useState("");
+  const [disabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      if (existing) {
+        setChain(existing.chain ?? "dstnat");
+        setAction(existing.action ?? "dst-nat");
+        setProtocol(existing.protocol ?? "");
+        setDstPort(existing.dst_port ?? "");
+        setToAddresses(existing.to_addresses ?? "");
+        setToPorts(existing.to_ports ?? "");
+        setComment(existing.comment ?? "");
+        setDisabled(existing.disabled);
+      } else {
+        setChain("dstnat");
+        setAction("dst-nat");
+        setProtocol("tcp");
+        setDstPort("");
+        setToAddresses("");
+        setToPorts("");
+        setComment("");
+        setDisabled(false);
+      }
+    }
+  }, [open, existing]);
+
+  const handleSubmit = async () => {
+    if (!chain || !action) return;
+    setSaving(true);
+    try {
+      await onSave({
+        chain,
+        action,
+        protocol: protocol || undefined,
+        dst_port: dstPort || undefined,
+        to_addresses: toAddresses || undefined,
+        to_ports: toPorts || undefined,
+        comment: comment || undefined,
+        disabled,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-800 sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            {existing ? "Edit MikroTik NAT Rule" : "Add MikroTik NAT Rule"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Chain</Label>
+              <Input
+                value={chain}
+                onChange={(e) => setChain(e.target.value)}
+                placeholder="dstnat"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Action</Label>
+              <Input
+                value={action}
+                onChange={(e) => setAction(e.target.value)}
+                placeholder="dst-nat"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Protocol</Label>
+              <Input
+                value={protocol}
+                onChange={(e) => setProtocol(e.target.value)}
+                placeholder="tcp"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">Dst Port</Label>
+              <Input
+                value={dstPort}
+                onChange={(e) => setDstPort(e.target.value)}
+                placeholder="8080"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">To Addresses</Label>
+              <Input
+                value={toAddresses}
+                onChange={(e) => setToAddresses(e.target.value)}
+                placeholder="192.168.1.100"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-slate-400">To Ports</Label>
+              <Input
+                value={toPorts}
+                onChange={(e) => setToPorts(e.target.value)}
+                placeholder="80"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-slate-400">Comment</Label>
+            <Input
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Web server"
+              className="bg-slate-800 border-slate-700 text-slate-200"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="mt-nat-disabled"
+              checked={disabled}
+              onChange={(e) => setDisabled(e.target.checked)}
+              className="rounded border-slate-700 bg-slate-800"
+            />
+            <Label htmlFor="mt-nat-disabled" className="text-slate-400">
+              Disabled
+            </Label>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="border-slate-700 text-slate-300"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={saving || !chain || !action}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+              {existing ? "Update" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   Activity,
+  ArrowRightLeft,
   Bell,
   Box,
   ChevronLeft,
@@ -43,6 +44,7 @@ const navItems = [
   { href: "/topology", label: "Topology", icon: Network },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/vpn-status", label: "VPN Status", icon: Shield },
+  { href: "/nat", label: "NAT", icon: ArrowRightLeft },
   { href: "/qos", label: "QoS", icon: Gauge },
   { href: "/dns-logs", label: "DNS Logs", icon: Search },
   { href: "/dns-queries", label: "DNS Queries", icon: Search },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1864,3 +1864,74 @@ export function fetchVyosDdnsConfig(): Promise<
 > {
   return apiGet<import("./types").VyosDdnsConfig>("/api/v1/ddns/vyos");
 }
+
+// ─── NAT / Port Forwarding ───────────────────────────────────
+
+export function fetchNatSummary(): Promise<import("./types").NatSummary> {
+  return apiGet<import("./types").NatSummary>("/api/v1/nat/summary");
+}
+
+export function fetchVyosNatRules(): Promise<
+  import("./types").NatDestinationRule[]
+> {
+  return apiGet<import("./types").NatDestinationRule[]>(
+    "/api/v1/nat/vyos/rules"
+  );
+}
+
+export function createVyosNatRule(
+  body: import("./types").CreateVyosNatRuleRequest
+): Promise<import("./types").NatRuleResponse> {
+  return apiPost<import("./types").NatRuleResponse>(
+    "/api/v1/nat/vyos/rules",
+    body
+  );
+}
+
+export function updateVyosNatRule(
+  ruleNumber: number,
+  body: import("./types").UpdateVyosNatRuleRequest
+): Promise<import("./types").NatRuleResponse> {
+  return apiPut<import("./types").NatRuleResponse>(
+    `/api/v1/nat/vyos/rules/${ruleNumber}`,
+    body
+  );
+}
+
+export function deleteVyosNatRule(
+  ruleNumber: number
+): Promise<import("./types").NatRuleResponse> {
+  return apiDelete(
+    `/api/v1/nat/vyos/rules/${ruleNumber}`
+  ) as unknown as Promise<import("./types").NatRuleResponse>;
+}
+
+export function fetchMikrotikNatRules(): Promise<
+  import("./types").MikrotikNatRuleWithId[]
+> {
+  return apiGet<import("./types").MikrotikNatRuleWithId[]>(
+    "/api/v1/nat/mikrotik/rules"
+  );
+}
+
+export function createMikrotikNatRule(
+  body: import("./types").CreateMikrotikNatRuleRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/nat/mikrotik/rules", body);
+}
+
+export function updateMikrotikNatRule(
+  id: string,
+  body: import("./types").CreateMikrotikNatRuleRequest
+): Promise<void> {
+  return apiPut<void>(
+    `/api/v1/nat/mikrotik/rules/${encodeURIComponent(id)}`,
+    body
+  );
+}
+
+export function deleteMikrotikNatRule(id: string): Promise<void> {
+  return apiDelete(
+    `/api/v1/nat/mikrotik/rules/${encodeURIComponent(id)}`
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1745,3 +1745,62 @@ export interface VyosDdnsService {
 export interface VyosDdnsConfig {
   services: VyosDdnsService[];
 }
+
+// ─── NAT Management ─────────────────────────────────────────
+
+export interface NatSummary {
+  vyos_available: boolean;
+  mikrotik_available: boolean;
+  vyos_rule_count: number;
+  mikrotik_rule_count: number;
+}
+
+export interface CreateVyosNatRuleRequest {
+  rule: number;
+  description?: string;
+  protocol?: string;
+  inbound_interface?: string;
+  external_port: string;
+  internal_ip: string;
+  internal_port: string;
+}
+
+export interface UpdateVyosNatRuleRequest {
+  description?: string;
+  protocol?: string;
+  inbound_interface?: string;
+  external_port?: string;
+  internal_ip?: string;
+  internal_port?: string;
+}
+
+export interface NatRuleResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface MikrotikNatRuleWithId {
+  id: string | null;
+  chain: string | null;
+  action: string | null;
+  protocol: string | null;
+  src_address: string | null;
+  dst_address: string | null;
+  dst_port: string | null;
+  to_addresses: string | null;
+  to_ports: string | null;
+  out_interface: string | null;
+  comment: string | null;
+  disabled: boolean;
+}
+
+export interface CreateMikrotikNatRuleRequest {
+  chain: string;
+  action: string;
+  protocol?: string;
+  dst_port?: string;
+  to_addresses?: string;
+  to_ports?: string;
+  comment?: string;
+  disabled?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add standalone NAT / port forwarding management page with full CRUD for both VyOS destination NAT rules and MikroTik firewall NAT rules
- Backend: new `server/src/api/nat.rs` module with VyOS DNAT endpoints (list/create/update/delete) and MikroTik NAT endpoints (list/create/update/delete), plus a summary endpoint
- Frontend: new `/nat` page with tabbed UI (Overview, VyOS DNAT, MikroTik NAT), search/filter, create/edit dialogs, delete confirmation, and loading skeletons
- Adds NAT navigation item to the sidebar

## Test plan
- [ ] Verify VyOS DNAT rules list, create, edit, and delete work correctly
- [ ] Verify MikroTik NAT rules list, create, edit, and delete work correctly
- [ ] Verify NAT summary endpoint returns correct counts for both router types
- [ ] Verify the NAT page loads correctly and tabs switch between Overview, VyOS, and MikroTik views
- [ ] Verify the sidebar shows the NAT navigation link
- [ ] Verify `cargo check` and `cargo fmt` pass cleanly

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements standalone NAT/port forwarding management UI and API endpoints for VyOS DNAT and MikroTik firewall NAT rules.

**Key Changes:**
- Backend adds `nat.rs` module with full CRUD operations for both VyOS and MikroTik NAT rules
- Frontend adds `/nat` page with tabbed interface (Overview, VyOS DNAT, MikroTik NAT) including search, create/edit dialogs, and delete confirmation
- Adds NAT navigation item to sidebar
- Includes summary endpoint to show rule counts and router availability

**Issues Found:**
- Critical design flaw in VyOS update endpoint: deletes entire rule then recreates from optional fields, risking incomplete rules if required fields are omitted
- No input validation for ports, IPs, or protocol values (relies on underlying router clients)

The frontend currently mitigates the update issue by always sending all fields, but the API contract allows dangerous usage patterns.

<h3>Confidence Score: 3/5</h3>

- This PR has a critical logic flaw in the VyOS update endpoint that could create broken NAT rules
- Score reflects the dangerous delete-then-recreate pattern in `vyos_update` that relies on optional fields being present. While the current frontend sends all fields, the API design permits incomplete updates that would break NAT rules. This is a logic error that should be fixed before merge.
- Pay close attention to `server/src/api/nat.rs` (update logic) and `web/src/lib/types.ts` (API contract)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/nat.rs | Implements NAT/port forwarding CRUD endpoints for VyOS and MikroTik. Critical issue: `vyos_update` deletes rule then only sets optional fields, potentially creating incomplete rules if frontend omits required fields. |
| web/src/app/(app)/nat/page.tsx | Implements NAT management UI with tabbed interface for VyOS DNAT and MikroTik NAT rules. Frontend always sends required fields during updates, mitigating backend API design flaw. |
| web/src/lib/types.ts | Defines TypeScript types for NAT API. `UpdateVyosNatRuleRequest` marks critical fields as optional, creating potential for incomplete rule updates. |

</details>



<sub>Last reviewed commit: 0f48b15</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->