### PR TITLE
feat: Mesh topology page — visual map of Xiaomi BE3600 nodes (#294)

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -1,0 +1,174 @@
+//! Xiaomi Mesh topology proxy endpoint.
+//!
+//! Fetches the mesh topology from the Xiaomi router's `api/misystem/topo_graph`
+//! endpoint which requires **no authentication**. The router IP is read from the
+//! `xiaomi_mesh_ip` setting (defaults to `10.10.0.199`).
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use super::AppState;
+
+// ── Settings helper ─────────────────────────────────────────
+
+const DEFAULT_MESH_IP: &str = "10.10.0.199";
+
+async fn mesh_router_ip(state: &AppState) -> String {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind("xiaomi_mesh_ip")
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_MESH_IP.to_string())
+}
+
+// ── Raw Xiaomi topo_graph response shapes ───────────────────
+
+/// Root response from `api/misystem/topo_graph`.
+#[derive(Debug, Deserialize)]
+struct XiaomiTopoResponse {
+    code: i32,
+    #[serde(default)]
+    list: Vec<XiaomiTopoNode>,
+}
+
+/// A single node in the Xiaomi mesh topology.
+#[derive(Debug, Deserialize)]
+struct XiaomiTopoNode {
+    #[serde(default)]
+    ip: String,
+    #[serde(default)]
+    mac: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    hardware: String,
+    #[serde(default)]
+    locale: String,
+    /// 1 = main/CAP node, 0 = satellite
+    #[serde(default)]
+    is_ap: i32,
+    /// Number of online devices connected to this node.
+    #[serde(default)]
+    online: i32,
+    /// Connection type: "wire" or "wifi", etc.
+    #[serde(default, rename = "type")]
+    connection_type: String,
+    /// Parent node MAC address (empty for the main/CAP node).
+    #[serde(default)]
+    parent_mac: String,
+    /// Signal strength (for wireless backhaul, otherwise 0).
+    #[serde(default)]
+    signal: i32,
+}
+
+// ── API response types ──────────────────────────────────────
+
+/// A mesh node returned to the frontend.
+#[derive(Debug, Serialize)]
+pub struct MeshNode {
+    pub ip: String,
+    pub mac: String,
+    pub name: String,
+    pub model: String,
+    pub hardware: String,
+    pub is_main: bool,
+    pub online_devices: i32,
+    pub backhaul_type: String,
+    pub parent_mac: String,
+    pub signal: i32,
+    pub is_online: bool,
+}
+
+/// Full mesh topology response.
+#[derive(Debug, Serialize)]
+pub struct MeshTopologyResponse {
+    pub nodes: Vec<MeshNode>,
+    pub main_ip: String,
+    pub total_devices: i32,
+}
+
+// ── Handler ─────────────────────────────────────────────────
+
+/// GET /api/v1/mesh/topology
+pub async fn topology(
+    State(state): State<AppState>,
+) -> Result<Json<MeshTopologyResponse>, StatusCode> {
+    let router_ip = mesh_router_ip(&state).await;
+    let url = format!("http://{router_ip}/cgi-bin/luci/api/misystem/topo_graph");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| {
+            warn!("failed to build HTTP client for mesh: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let resp = client.get(&url).send().await.map_err(|e| {
+        warn!("failed to fetch mesh topology from {url}: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    if !resp.status().is_success() {
+        warn!(
+            "mesh topology endpoint returned HTTP {}",
+            resp.status().as_u16()
+        );
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    let raw: XiaomiTopoResponse = resp.json().await.map_err(|e| {
+        warn!("failed to parse mesh topology response: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    if raw.code != 0 {
+        warn!("mesh topology returned error code {}", raw.code);
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    let mut total_devices = 0i32;
+    let nodes: Vec<MeshNode> = raw
+        .list
+        .into_iter()
+        .map(|n| {
+            total_devices += n.online;
+            let backhaul_type = if n.is_ap == 1 {
+                "main".to_string()
+            } else if n.connection_type == "wire" {
+                "wired".to_string()
+            } else {
+                n.connection_type.clone()
+            };
+            MeshNode {
+                ip: n.ip.clone(),
+                mac: n.mac,
+                name: if n.name.is_empty() {
+                    n.locale.clone()
+                } else {
+                    n.name
+                },
+                model: n.model,
+                hardware: n.hardware,
+                is_main: n.is_ap == 1,
+                online_devices: n.online,
+                backhaul_type,
+                parent_mac: n.parent_mac,
+                signal: n.signal,
+                is_online: !n.ip.is_empty(),
+            }
+        })
+        .collect();
+
+    Ok(Json(MeshTopologyResponse {
+        main_ip: router_ip,
+        total_devices,
+        nodes,
+    }))
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -30,6 +30,7 @@ pub mod dns_logs;
 pub mod dns_query_log;
 pub mod error;
 pub mod export;
+pub mod mesh;
 pub mod metrics;
 pub mod mikrotik;
 pub mod nat;
@@ -351,6 +352,8 @@ pub fn router(state: AppState) -> Router {
         .route("/vyos/openvpn/:name", delete(vyos::openvpn_delete))
         .route("/vyos/openvpn/:name/toggle", post(vyos::openvpn_toggle))
         .route("/vyos/openvpn/:name/clients", get(vyos::openvpn_clients))
+        // Mesh topology (Xiaomi)
+        .route("/mesh/topology", get(mesh::topology))
         // Topology
         .route("/topology/graph", get(topology::graph))
         .route("/topology/positions", get(topology::get_positions))

--- a/web/src/app/(app)/mesh/page.tsx
+++ b/web/src/app/(app)/mesh/page.tsx
@@ -1,0 +1,496 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ReactFlow,
+  Controls,
+  MiniMap,
+  Background,
+  BackgroundVariant,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  type NodeProps,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import {
+  Loader2,
+  RefreshCw,
+  Wifi,
+  Cable,
+  MonitorSmartphone,
+  Crown,
+} from 'lucide-react'
+import { fetchMeshTopology } from '@/lib/api'
+import type { MeshNode, MeshTopologyResponse } from '@/lib/types'
+import { PageTransition } from '@/components/PageTransition'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+
+// ─── Types ──────────────────────────────────────────────
+
+type MeshNodeData = {
+  node: MeshNode
+}
+
+type MeshNodeType = Node<MeshNodeData, 'meshNode'>
+
+// ─── Layout ─────────────────────────────────────────────
+
+const NODE_WIDTH = 240
+const NODE_HEIGHT = 120
+
+/** Simple radial layout: main node center, satellites in a circle around it. */
+function computeLayout(nodes: MeshNode[]): Map<string, { x: number; y: number }> {
+  const positions = new Map<string, { x: number; y: number }>()
+  const main = nodes.find((n) => n.is_main)
+  const satellites = nodes.filter((n) => !n.is_main)
+
+  // Center the main node
+  if (main) {
+    positions.set(main.mac, { x: 0, y: 0 })
+  }
+
+  // Place satellites in a circle
+  const radius = 300
+  satellites.forEach((sat, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(satellites.length, 1) - Math.PI / 2
+    positions.set(sat.mac, {
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+    })
+  })
+
+  return positions
+}
+
+// ─── Custom Node ────────────────────────────────────────
+
+function MeshNodeComponent({ data }: NodeProps<MeshNodeType>) {
+  const { node } = data
+  const isMain = node.is_main
+
+  const backhaulIcon = node.backhaul_type === 'wired' || node.backhaul_type === 'main'
+    ? Cable
+    : Wifi
+
+  const BackhaulIcon = backhaulIcon
+
+  return (
+    <div
+      className={`flex flex-col gap-2 rounded-xl border px-4 py-3 shadow-lg transition-shadow hover:shadow-xl ${
+        isMain
+          ? 'border-amber-500/30 bg-gradient-to-br from-slate-800 to-slate-900 shadow-amber-500/10'
+          : node.is_online
+            ? 'border-blue-500/30 bg-gradient-to-br from-slate-800 to-slate-900 shadow-blue-500/10'
+            : 'border-slate-600/30 bg-slate-900 shadow-slate-700/10'
+      }`}
+      style={{ width: NODE_WIDTH, minHeight: NODE_HEIGHT }}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-blue-500" />
+      <Handle type="source" position={Position.Bottom} className="!bg-blue-500" />
+      <Handle type="target" position={Position.Left} id="left" className="!bg-blue-500" />
+      <Handle type="source" position={Position.Right} id="right" className="!bg-blue-500" />
+
+      {/* Header row */}
+      <div className="flex items-center gap-3">
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+            isMain ? 'bg-amber-500/20' : 'bg-blue-500/20'
+          }`}
+        >
+          {isMain ? (
+            <Crown className={`h-5 w-5 ${isMain ? 'text-amber-400' : 'text-blue-400'}`} />
+          ) : (
+            <Wifi className="h-5 w-5 text-blue-400" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-white">
+            {node.name || 'Mesh Node'}
+          </p>
+          <p className="truncate font-mono text-xs text-slate-400">{node.ip || '—'}</p>
+        </div>
+        <span
+          className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+            node.is_online
+              ? 'bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]'
+              : 'bg-rose-400 shadow-[0_0_6px_rgba(251,113,133,0.5)]'
+          }`}
+        />
+      </div>
+
+      {/* Stats row */}
+      <div className="flex items-center gap-3 text-[11px] text-slate-400">
+        <span className="flex items-center gap-1">
+          <MonitorSmartphone className="h-3 w-3" />
+          {node.online_devices} device{node.online_devices !== 1 ? 's' : ''}
+        </span>
+        <span className="flex items-center gap-1">
+          <BackhaulIcon className="h-3 w-3" />
+          {isMain ? 'Main' : node.backhaul_type}
+        </span>
+      </div>
+
+      {/* Model badge */}
+      <div className="flex items-center gap-1.5">
+        <Badge
+          variant="outline"
+          className="border-slate-700 text-[10px] text-slate-500"
+        >
+          {node.model || node.hardware || 'Unknown'}
+        </Badge>
+        {isMain && (
+          <Badge className="bg-amber-500/10 text-[10px] text-amber-400 border-amber-500/20">
+            CAP
+          </Badge>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const nodeTypes: NodeTypes = {
+  meshNode: MeshNodeComponent,
+}
+
+// ─── Node Detail Panel ──────────────────────────────────
+
+function MeshNodeDetailPanel({ node }: { node: MeshNode }) {
+  return (
+    <>
+      <SheetHeader>
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${
+              node.is_main ? 'bg-amber-500/20' : 'bg-blue-500/20'
+            }`}
+          >
+            {node.is_main ? (
+              <Crown className="h-5 w-5 text-amber-400" />
+            ) : (
+              <Wifi className="h-5 w-5 text-blue-400" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <SheetTitle className="text-white">
+              {node.name || 'Mesh Node'}
+            </SheetTitle>
+            <SheetDescription>
+              {node.is_online ? (
+                <span className="text-emerald-400">Online</span>
+              ) : (
+                <span className="text-rose-400">Offline</span>
+              )}
+              {node.is_main && ' — Main Router (CAP)'}
+            </SheetDescription>
+          </div>
+        </div>
+      </SheetHeader>
+
+      <Separator className="my-4 bg-slate-800" />
+
+      <div className="space-y-3">
+        <InfoRow label="IP Address" value={node.ip || '—'} mono />
+        <InfoRow label="MAC Address" value={node.mac} mono />
+        <InfoRow label="Model" value={node.model || '—'} />
+        <InfoRow label="Hardware" value={node.hardware || '—'} />
+        <InfoRow
+          label="Role"
+          value={node.is_main ? 'Main Router (CAP)' : 'Satellite'}
+        />
+        <InfoRow
+          label="Backhaul"
+          value={
+            node.is_main
+              ? 'N/A (Main)'
+              : node.backhaul_type === 'wired'
+                ? 'Wired'
+                : node.backhaul_type === 'wifi'
+                  ? `Wireless (signal: ${node.signal})`
+                  : node.backhaul_type
+          }
+        />
+        <InfoRow
+          label="Connected Devices"
+          value={String(node.online_devices)}
+        />
+        {node.parent_mac && (
+          <InfoRow label="Parent MAC" value={node.parent_mac} mono />
+        )}
+      </div>
+    </>
+  )
+}
+
+function InfoRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">
+        {label}
+      </span>
+      <span
+        className={`text-sm text-slate-300 ${mono ? 'font-mono tabular-nums' : ''}`}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+// ─── Main Page ──────────────────────────────────────────
+
+export default function MeshPage() {
+  const [nodes, setNodes, onNodesChange] = useNodesState<MeshNodeType>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const [selectedNode, setSelectedNode] = useState<MeshNode | null>(null)
+
+  const buildGraph = useCallback(
+    async (isInitial: boolean) => {
+      try {
+        const data: MeshTopologyResponse = await fetchMeshTopology()
+        const { nodes: meshNodes } = data
+
+        // Compute positions on initial load; preserve on refresh
+        let positionMap: Map<string, { x: number; y: number }>
+
+        if (isInitial) {
+          positionMap = computeLayout(meshNodes)
+        } else {
+          positionMap = new Map()
+        }
+
+        const flowNodes: MeshNodeType[] = meshNodes.map((mn) => {
+          const pos = positionMap.get(mn.mac)
+          return {
+            id: mn.mac,
+            type: 'meshNode' as const,
+            position: pos
+              ? { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 }
+              : { x: 0, y: 0 },
+            data: { node: mn },
+            draggable: true,
+          }
+        })
+
+        // Edges: each satellite connects to the main node (or its parent)
+        const mainNode = meshNodes.find((n) => n.is_main)
+        const allEdges: Edge[] = meshNodes
+          .filter((n) => !n.is_main)
+          .map((satellite) => {
+            const parentMac = satellite.parent_mac || mainNode?.mac || ''
+            const isWired = satellite.backhaul_type === 'wired'
+            return {
+              id: `${parentMac}-${satellite.mac}`,
+              source: parentMac,
+              target: satellite.mac,
+              type: 'default',
+              animated: !isWired,
+              label: isWired ? 'Wired' : 'Wireless',
+              labelStyle: { fill: '#64748b', fontSize: 10 },
+              labelBgStyle: { fill: '#0f172a', fillOpacity: 0.8 },
+              labelBgPadding: [4, 2] as [number, number],
+              style: {
+                stroke: satellite.is_online
+                  ? isWired
+                    ? '#3b82f6'
+                    : '#8b5cf6'
+                  : '#334155',
+                strokeWidth: isWired ? 2.5 : 1.5,
+                strokeDasharray: isWired ? undefined : '5 5',
+                opacity: satellite.is_online ? 0.7 : 0.2,
+              },
+            }
+          })
+
+        if (isInitial) {
+          setNodes(flowNodes)
+          setEdges(allEdges)
+        } else {
+          // On refresh, update data without changing positions
+          setNodes((prev) => {
+            const posMap = new Map(prev.map((n) => [n.id, n.position]))
+            return flowNodes.map((n) => ({
+              ...n,
+              position: posMap.get(n.id) ?? n.position,
+            }))
+          })
+          setEdges(allEdges)
+        }
+
+        setLastRefresh(new Date())
+        setError(null)
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to load mesh topology',
+        )
+      } finally {
+        setLoading(false)
+      }
+    },
+    [setNodes, setEdges],
+  )
+
+  // Initial load
+  useEffect(() => {
+    buildGraph(true)
+  }, [buildGraph])
+
+  // Poll every 20s (more aggressive since no auth needed)
+  useEffect(() => {
+    const interval = setInterval(() => buildGraph(false), 20_000)
+    return () => clearInterval(interval)
+  }, [buildGraph])
+
+  // Click handler — show node detail panel
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: MeshNodeType) => {
+      setSelectedNode(node.data.node)
+    },
+    [],
+  )
+
+  // Count stats for header
+  const stats = useMemo(() => {
+    const meshNodes = nodes.map((n) => n.data.node)
+    const online = meshNodes.filter((n) => n.is_online).length
+    const totalDevices = meshNodes.reduce((sum, n) => sum + n.online_devices, 0)
+    return {
+      total: meshNodes.length,
+      online,
+      totalDevices,
+    }
+  }, [nodes])
+
+  if (loading) {
+    return (
+      <PageTransition>
+        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+            <p className="text-sm text-slate-400">Loading mesh topology…</p>
+          </div>
+        </div>
+      </PageTransition>
+    )
+  }
+
+  if (error) {
+    return (
+      <PageTransition>
+        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-rose-400">{error}</p>
+            <button
+              onClick={() => {
+                setLoading(true)
+                buildGraph(true)
+              }}
+              className="mt-3 text-xs text-blue-400 hover:underline"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </PageTransition>
+    )
+  }
+
+  return (
+    <PageTransition>
+      <div className="-m-6 h-[calc(100vh-56px)]">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.3 }}
+          minZoom={0.3}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+          className="bg-slate-950"
+        >
+          <Controls
+            className="!border-slate-700 !bg-slate-900 [&>button]:!border-slate-700 [&>button]:!bg-slate-900 [&>button]:!text-slate-300 [&>button:hover]:!bg-slate-800"
+            showInteractive={false}
+          />
+          <MiniMap
+            nodeColor={(n) => {
+              const data = n.data as MeshNodeData
+              if (data.node?.is_main) return '#f59e0b'
+              return data.node?.is_online ? '#34d399' : '#475569'
+            }}
+            className="!border-slate-700 !bg-slate-900/90"
+            maskColor="rgba(15, 23, 42, 0.7)"
+          />
+          <Background
+            variant={BackgroundVariant.Dots}
+            color="#334155"
+            gap={24}
+            size={1}
+          />
+
+          {/* Floating toolbar */}
+          <div className="absolute right-4 top-4 z-10 flex items-center gap-3 rounded-lg border border-slate-700/50 bg-slate-900/80 px-4 py-2 backdrop-blur-sm">
+            <span className="text-[11px] text-slate-400">
+              {stats.total} node{stats.total !== 1 ? 's' : ''} · {stats.online} online · {stats.totalDevices} device{stats.totalDevices !== 1 ? 's' : ''}
+            </span>
+            <div className="h-3 w-px bg-slate-700" />
+            <button
+              onClick={() => buildGraph(false)}
+              className="text-slate-400 transition-colors hover:text-white"
+              title="Refresh now"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+            {lastRefresh && (
+              <span className="text-[10px] text-slate-500">
+                {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+        </ReactFlow>
+      </div>
+
+      {/* Node detail slide-in panel */}
+      <Sheet
+        open={selectedNode !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedNode(null)
+        }}
+      >
+        <SheetContent
+          side="right"
+          className="w-full overflow-y-auto border-slate-800 bg-slate-950 sm:max-w-md"
+        >
+          {selectedNode && <MeshNodeDetailPanel node={selectedNode} />}
+        </SheetContent>
+      </Sheet>
+    </PageTransition>
+  )
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Search,
   Server,
   Settings,
+  Share2,
   Shield,
   Workflow,
 } from "lucide-react";
@@ -42,6 +43,7 @@ const navItems = [
   { href: "/npm", label: "NPM", icon: Globe },
   { href: "/services", label: "Services", icon: Workflow },
   { href: "/topology", label: "Topology", icon: Network },
+  { href: "/mesh", label: "Mesh", icon: Share2 },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/vpn-status", label: "VPN Status", icon: Shield },
   { href: "/nat", label: "NAT", icon: ArrowRightLeft },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1935,3 +1935,13 @@ export function deleteMikrotikNatRule(id: string): Promise<void> {
     `/api/v1/nat/mikrotik/rules/${encodeURIComponent(id)}`
   );
 }
+
+// ─── Mesh Topology (Xiaomi) ─────────────────────────────────
+
+export function fetchMeshTopology(): Promise<
+  import("./types").MeshTopologyResponse
+> {
+  return apiGet<import("./types").MeshTopologyResponse>(
+    "/api/v1/mesh/topology"
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1804,3 +1804,25 @@ export interface CreateMikrotikNatRuleRequest {
   comment?: string;
   disabled?: boolean;
 }
+
+// ─── Mesh Topology (Xiaomi) ─────────────────────────────────
+
+export interface MeshNode {
+  ip: string;
+  mac: string;
+  name: string;
+  model: string;
+  hardware: string;
+  is_main: boolean;
+  online_devices: number;
+  backhaul_type: string;
+  parent_mac: string;
+  signal: number;
+  is_online: boolean;
+}
+
+export interface MeshTopologyResponse {
+  nodes: MeshNode[];
+  main_ip: string;
+  total_devices: number;
+}


### PR DESCRIPTION
Closes #294

## Summary

- **Backend**: Added `server/src/api/mesh.rs` — proxy endpoint (`GET /api/v1/mesh/topology`) that fetches the Xiaomi router's `api/misystem/topo_graph` (no auth required). Router IP read from `xiaomi_mesh_ip` setting (defaults to `10.10.0.199`).
- **Frontend**: New `/mesh` page using XYFlow (same library as existing topology page) with:
  - Radial layout: main node (CAP) centered, satellites arranged around it
  - Custom mesh node cards showing name, IP, status, device count, backhaul type, and model
  - Color coding: amber for main/CAP, blue for online satellites, grey for offline
  - Edge styling: solid blue for wired backhaul, dashed purple for wireless
  - Click node → slide-out panel with full details (IP, MAC, model, hardware, role, backhaul, device count)
  - 20s polling interval for near-real-time health monitoring
  - Refresh button in floating toolbar
- **Navigation**: Added "Mesh" item to sidebar (Share2 icon, placed after Topology)
- **Types**: `MeshNode` and `MeshTopologyResponse` TypeScript interfaces + `fetchMeshTopology()` API client

## Dependencies

Depends on #292 (Xiaomi MiWiFi API client) for the full authenticated API. This PR only uses the no-auth `topo_graph` endpoint, so it works standalone.

## Test plan

- [ ] Verify mesh page loads and shows topology when Xiaomi router at 10.10.0.199 is reachable
- [ ] Verify nodes display correct name, IP, status, device count
- [ ] Verify click on node opens detail panel
- [ ] Verify 20s polling updates node data
- [ ] Verify graceful error when router is unreachable (502 → error state with retry)
- [ ] Verify sidebar shows "Mesh" nav item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Xiaomi mesh topology visualization with backend proxy endpoint and React-based visual map using XYFlow. Backend fetches router topology via unauthenticated endpoint, frontend displays nodes in radial layout with color-coded status, 20s polling, and interactive detail panels.

**Key Changes:**
- Backend proxy endpoint `/api/v1/mesh/topology` fetches from Xiaomi router (configurable IP via settings)
- React page at `/mesh` with radial node layout, custom node cards, edge styling, and slide-out detail panels
- 20-second polling for near-real-time updates
- Color coding: amber for main node, blue for online satellites, grey for offline
- Edge styling: solid blue for wired backhaul, dashed purple for wireless

**Issues Found:**
- SSRF vulnerability: `xiaomi_mesh_ip` setting value is not validated before use in HTTP request

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the SSRF vulnerability in the backend IP validation
- The frontend implementation is solid with proper error handling and well-structured React code. However, the backend has a security issue where the router IP from settings is used directly in HTTP requests without validation, creating an SSRF attack vector. Once the IP validation is added, this would be a 5/5.
- Pay close attention to `server/src/api/mesh.rs` - IP validation must be added before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mesh.rs | New Xiaomi mesh topology proxy endpoint - lacks IP validation which could allow SSRF via settings table |
| server/src/api/mod.rs | Added mesh module and route registration - standard pattern, no issues |
| web/src/app/(app)/mesh/page.tsx | New React mesh topology visualization page with XYFlow - well-structured, polling every 20s, proper error handling |
| web/src/components/layout/Sidebar.tsx | Added Mesh navigation item with Share2 icon - simple addition, no issues |
| web/src/lib/api.ts | Added fetchMeshTopology API client function - follows established patterns |
| web/src/lib/types.ts | Added MeshNode and MeshTopologyResponse TypeScript interfaces - properly typed |

</details>



<sub>Last reviewed commit: 8052ba7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->