### PR TITLE
feat: Xiaomi router tab — WAN, system status, WiFi overview (#295)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -47,6 +47,7 @@ pub mod traffic;
 pub mod unbound;
 pub mod vpn_status;
 pub mod vyos;
+pub mod xiaomi;
 
 pub use error::AppError;
 
@@ -70,6 +71,10 @@ pub struct AppState {
     pub mikrotik_cache: Arc<crate::mikrotik::client::MikrotikCache>,
     /// Shared reqwest::Client for Caddy Admin API.
     pub caddy_http: reqwest::Client,
+    /// Shared reqwest::Client for Xiaomi MiWiFi API.
+    pub xiaomi_http: reqwest::Client,
+    /// TTL cache for Xiaomi read operations.
+    pub xiaomi_cache: Arc<crate::xiaomi::client::XiaomiCache>,
 }
 
 impl AppState {
@@ -90,6 +95,8 @@ impl AppState {
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .expect("caddy HTTP client"),
+            xiaomi_http: crate::xiaomi::client::shared_http_client(),
+            xiaomi_cache: Arc::new(crate::xiaomi::client::XiaomiCache::new()),
         }
     }
 }
@@ -491,6 +498,11 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/mikrotik/dns", get(mikrotik::dns))
         .route("/mikrotik/wireguard", get(mikrotik::wireguard))
+        // Xiaomi MiWiFi router proxy
+        .route("/xiaomi/status", get(xiaomi::status))
+        .route("/xiaomi/wan", get(xiaomi::wan_info))
+        .route("/xiaomi/wifi", get(xiaomi::wifi))
+        .route("/xiaomi/firmware", get(xiaomi::firmware))
         // QoS / Traffic Shaping
         .route("/qos/summary", get(qos::qos_summary))
         .route("/qos/vyos/policies", get(qos::vyos_traffic_policies))
@@ -631,6 +643,9 @@ async fn vyos_cache_invalidation(
         }
         if path.contains("/mikrotik/") {
             state.mikrotik_cache.clear();
+        }
+        if path.contains("/xiaomi/") {
+            state.xiaomi_cache.clear();
         }
     }
     response

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -34,6 +34,11 @@ pub struct SettingsResponse {
     /// Never return the password to the frontend — just whether one is set.
     pub mikrotik_password_set: bool,
     pub mikrotik_enabled: bool,
+    // --- Xiaomi MiWiFi ---
+    pub xiaomi_url: Option<String>,
+    /// Never return the password to the frontend — just whether one is set.
+    pub xiaomi_password_set: bool,
+    pub xiaomi_enabled: bool,
     // --- Unbound DNS ---
     pub unbound_control_path: Option<String>,
     // --- Caddy Reverse Proxy ---
@@ -66,6 +71,10 @@ pub struct UpdateSettingsRequest {
     pub mikrotik_user: Option<String>,
     pub mikrotik_password: Option<String>,
     pub mikrotik_enabled: Option<bool>,
+    // --- Xiaomi MiWiFi ---
+    pub xiaomi_url: Option<String>,
+    pub xiaomi_password: Option<String>,
+    pub xiaomi_enabled: Option<bool>,
     // --- Unbound DNS ---
     pub unbound_control_path: Option<String>,
     // --- Caddy Reverse Proxy ---
@@ -149,6 +158,14 @@ pub async fn get_settings(
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
 
+    // Xiaomi MiWiFi settings.
+    let xiaomi_url = get_setting(&state, "xiaomi_url").await;
+    let xiaomi_password_set = get_setting(&state, "xiaomi_password").await.is_some();
+    let xiaomi_enabled = get_setting(&state, "xiaomi_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
     // Unbound DNS settings.
     let unbound_control_path = get_setting(&state, "unbound_control_path").await;
 
@@ -174,6 +191,9 @@ pub async fn get_settings(
         mikrotik_user,
         mikrotik_password_set,
         mikrotik_enabled,
+        xiaomi_url,
+        xiaomi_password_set,
+        xiaomi_enabled,
         unbound_control_path,
         caddy_admin_url,
     }))
@@ -296,6 +316,22 @@ pub async fn update_settings(
             mikrotik_enabled = enabled,
             "MikroTik enabled toggle updated"
         );
+    }
+
+    // --- Xiaomi MiWiFi settings ---
+    if let Some(ref url) = body.xiaomi_url {
+        upsert_setting(&state, "xiaomi_url", url).await?;
+        info!(xiaomi_url = %url, "Xiaomi URL updated");
+    }
+
+    if let Some(ref password) = body.xiaomi_password {
+        upsert_setting(&state, "xiaomi_password", password).await?;
+        info!("Xiaomi password updated");
+    }
+
+    if let Some(enabled) = body.xiaomi_enabled {
+        upsert_setting(&state, "xiaomi_enabled", if enabled { "1" } else { "0" }).await?;
+        info!(xiaomi_enabled = enabled, "Xiaomi enabled toggle updated");
     }
 
     // --- Unbound DNS settings ---

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -1,0 +1,285 @@
+//! Xiaomi MiWiFi API handler endpoints.
+//!
+//! These endpoints proxy requests to a Xiaomi router via its MiWiFi HTTP API,
+//! using cached responses to avoid redundant network calls.
+
+use axum::{extract::State, http::StatusCode, Json};
+
+use super::AppState;
+use crate::xiaomi::client::XiaomiClient;
+use crate::xiaomi::types::*;
+
+// ── Helper: build a Xiaomi client from DB settings ──────
+
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+/// Try to construct a Xiaomi client from saved settings.
+/// Returns `None` if Xiaomi is not configured or not enabled.
+async fn xiaomi_client(state: &AppState) -> Option<XiaomiClient> {
+    let enabled = get_setting(state, "xiaomi_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let url = get_setting(state, "xiaomi_url").await?;
+    let password = get_setting(state, "xiaomi_password")
+        .await
+        .unwrap_or_default();
+
+    Some(XiaomiClient::with_http(
+        &url,
+        &password,
+        state.xiaomi_http.clone(),
+    ))
+}
+
+// ── Endpoints ──────────────────────────────────────────────
+
+/// GET /api/v1/xiaomi/status
+pub async fn status(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiStatusResponse>, StatusCode> {
+    let Some(client) = xiaomi_client(&state).await else {
+        return Ok(Json(XiaomiStatusResponse {
+            configured: false,
+            reachable: false,
+            cpu: None,
+            mem: None,
+            temperature: None,
+            uptime: None,
+            wan_traffic: None,
+            device_count: None,
+        }));
+    };
+
+    if let Some(cached) = state.xiaomi_cache.get("status") {
+        if let Ok(resp) = serde_json::from_value::<XiaomiStatusResponse>(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    match client.system_status().await {
+        Ok(data) => {
+            let resp = XiaomiStatusResponse {
+                configured: true,
+                reachable: true,
+                cpu: data.cpu.map(|c| XiaomiCpu {
+                    cores: c.core,
+                    frequency: c.hz,
+                    load: c.load,
+                }),
+                mem: data.mem.map(|m| XiaomiMem {
+                    usage: m.usage,
+                    total: m.total,
+                    frequency: m.hz,
+                    mem_type: m.mem_type,
+                }),
+                temperature: data.temperature,
+                uptime: data.uptime,
+                wan_traffic: data.wan.map(|w| XiaomiWanTraffic {
+                    download_speed: w.downspeed,
+                    upload_speed: w.upspeed,
+                    max_download_speed: w.maxdownloadspeed,
+                    max_upload_speed: w.maxuploadspeed,
+                }),
+                device_count: data.count.map(|c| XiaomiDeviceCount {
+                    online: c.online,
+                    total: c.all,
+                    online_without_mesh: c.online_without_mesh,
+                    total_without_mesh: c.all_without_mesh,
+                }),
+            };
+            if let Ok(val) = serde_json::to_value(&resp) {
+                state.xiaomi_cache.set("status".into(), val);
+            }
+            Ok(Json(resp))
+        }
+        Err(e) => {
+            tracing::warn!("Xiaomi status check failed: {e}");
+            Ok(Json(XiaomiStatusResponse {
+                configured: true,
+                reachable: false,
+                cpu: None,
+                mem: None,
+                temperature: None,
+                uptime: None,
+                wan_traffic: None,
+                device_count: None,
+            }))
+        }
+    }
+}
+
+/// GET /api/v1/xiaomi/wan
+pub async fn wan_info(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiWanInfoResponse>, StatusCode> {
+    let client = xiaomi_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    if let Some(cached) = state.xiaomi_cache.get("wan") {
+        if let Ok(resp) = serde_json::from_value(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    let data = client.wan_info().await.map_err(|e| {
+        tracing::error!("Xiaomi WAN info error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let detail = data.info.unwrap_or(WanDetail {
+        wan_type: None,
+        ipv4: None,
+        ipv6: None,
+        details: None,
+    });
+
+    let mut dns_servers = Vec::new();
+    if let Some(ref v4) = detail.ipv4 {
+        if let Some(ref d) = v4.dns1 {
+            if !d.is_empty() {
+                dns_servers.push(d.clone());
+            }
+        }
+        if let Some(ref d) = v4.dns2 {
+            if !d.is_empty() {
+                dns_servers.push(d.clone());
+            }
+        }
+    }
+
+    let mut ipv6_dns = Vec::new();
+    if let Some(ref v6) = detail.ipv6 {
+        if let Some(ref d) = v6.dns1 {
+            if !d.is_empty() {
+                ipv6_dns.push(d.clone());
+            }
+        }
+        if let Some(ref d) = v6.dns2 {
+            if !d.is_empty() {
+                ipv6_dns.push(d.clone());
+            }
+        }
+    }
+
+    let wan_type = detail
+        .details
+        .as_ref()
+        .and_then(|d| d.wan_type.clone())
+        .or(detail.wan_type);
+
+    let resp = XiaomiWanInfoResponse {
+        wan_type,
+        ip: detail.ipv4.as_ref().and_then(|v| v.ip.clone()),
+        mask: detail.ipv4.as_ref().and_then(|v| v.mask.clone()),
+        gateway: detail.ipv4.as_ref().and_then(|v| v.gateway.clone()),
+        dns_servers,
+        ipv6_ip: detail.ipv6.as_ref().and_then(|v| v.ip.clone()),
+        ipv6_gateway: detail.ipv6.as_ref().and_then(|v| v.gateway.clone()),
+        ipv6_dns,
+        ipv6_prefix: detail.ipv6.as_ref().and_then(|v| v.prefix.clone()),
+    };
+
+    if let Ok(val) = serde_json::to_value(&resp) {
+        state.xiaomi_cache.set("wan".into(), val);
+    }
+    Ok(Json(resp))
+}
+
+/// GET /api/v1/xiaomi/wifi
+pub async fn wifi(State(state): State<AppState>) -> Result<Json<XiaomiWifiResponse>, StatusCode> {
+    let client = xiaomi_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    if let Some(cached) = state.xiaomi_cache.get("wifi") {
+        if let Ok(resp) = serde_json::from_value(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    let wifi_detail = client
+        .wifi_detail_all()
+        .await
+        .unwrap_or(WifiDetailAllData { info: None });
+
+    let bands: Vec<XiaomiWifiBand> = wifi_detail
+        .info
+        .unwrap_or_default()
+        .into_iter()
+        .map(|b| {
+            let channel_str = b.channel.map(|c| match c {
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
+            });
+            let name = b.if_name.clone().unwrap_or_else(|| "unknown".to_string());
+            XiaomiWifiBand {
+                name,
+                ssid: b.ssid,
+                channel: channel_str,
+                bandwidth: b.bandwidth,
+                encryption: b.encryption,
+                band_steering: b.band_steering,
+                status: b.status,
+            }
+        })
+        .collect();
+
+    let resp = XiaomiWifiResponse { bands };
+
+    if let Ok(val) = serde_json::to_value(&resp) {
+        state.xiaomi_cache.set("wifi".into(), val);
+    }
+    Ok(Json(resp))
+}
+
+/// GET /api/v1/xiaomi/firmware
+pub async fn firmware(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiFirmwareResponse>, StatusCode> {
+    let client = xiaomi_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    if let Some(cached) = state.xiaomi_cache.get("firmware") {
+        if let Ok(resp) = serde_json::from_value(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    let init = client.init_info().await.map_err(|e| {
+        tracing::error!("Xiaomi init info error: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    let update = client.check_rom_update().await.unwrap_or(RomUpdateData {
+        need_update: Some(0),
+    });
+
+    let resp = XiaomiFirmwareResponse {
+        router_name: init.router_name,
+        rom_version: init.rom_version,
+        hardware: init.hardware,
+        language: init.language,
+        update_available: update.need_update.unwrap_or(0) == 1,
+    };
+
+    if let Ok(val) = serde_json::to_value(&resp) {
+        state.xiaomi_cache.set("firmware".into(), val);
+    }
+    Ok(Json(resp))
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,3 +18,4 @@ pub mod static_files;
 pub mod vyos;
 pub mod webhook;
 pub mod ws;
+pub mod xiaomi;

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -1,0 +1,263 @@
+//! Xiaomi MiWiFi API client.
+//!
+//! Communicates with a Xiaomi router using its HTTP-based MiWiFi API.
+//! Auth is via a `stok` token obtained by logging in with password.
+
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+use super::types::*;
+
+/// Default TTL for cached responses (30 seconds, matching other router caches).
+const CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Build the shared `reqwest::Client` for Xiaomi MiWiFi API calls.
+///
+/// Xiaomi routers use plain HTTP by default, but we accept invalid certs
+/// in case HTTPS is enabled with a self-signed cert.
+pub fn shared_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(10))
+        .pool_max_idle_per_host(4)
+        .tcp_keepalive(Duration::from_secs(30))
+        .build()
+        .expect("failed to build shared reqwest client for Xiaomi")
+}
+
+/// A cache entry: the JSON value and the instant it was stored.
+struct CacheEntry {
+    value: Value,
+    inserted: Instant,
+}
+
+/// Thread-safe TTL cache for Xiaomi API responses.
+pub struct XiaomiCache {
+    map: DashMap<String, CacheEntry>,
+    ttl: Duration,
+}
+
+impl XiaomiCache {
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+            ttl: CACHE_TTL,
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Value> {
+        let entry = self.map.get(key)?;
+        if entry.inserted.elapsed() < self.ttl {
+            Some(entry.value.clone())
+        } else {
+            drop(entry);
+            self.map.remove(key);
+            None
+        }
+    }
+
+    pub fn set(&self, key: String, value: Value) {
+        self.map.insert(
+            key,
+            CacheEntry {
+                value,
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    pub fn clear(&self) {
+        self.map.clear();
+    }
+}
+
+impl Default for XiaomiCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A lightweight client for the Xiaomi MiWiFi HTTP API.
+#[derive(Debug, Clone)]
+pub struct XiaomiClient {
+    base_url: String,
+    password: String,
+    http: reqwest::Client,
+}
+
+impl XiaomiClient {
+    /// Create a Xiaomi client reusing an existing `reqwest::Client`.
+    pub fn with_http(base_url: &str, password: &str, http: reqwest::Client) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            password: password.to_string(),
+            http,
+        }
+    }
+
+    /// Login to obtain a `stok` token.
+    async fn login(&self) -> Result<String> {
+        let url = format!("{}/cgi-bin/luci/api/xqsystem/login", self.base_url);
+
+        let resp = self
+            .http
+            .post(&url)
+            .form(&[("username", "admin"), ("password", self.password.as_str())])
+            .send()
+            .await
+            .context("Xiaomi login request failed")?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .context("failed to read Xiaomi login response body")?;
+
+        if !status.is_success() {
+            anyhow::bail!("Xiaomi login returned HTTP {status}: {body}");
+        }
+
+        let login: LoginResponse =
+            serde_json::from_str(&body).context("failed to parse Xiaomi login response")?;
+
+        if login.code != 0 {
+            anyhow::bail!("Xiaomi login failed with code {}", login.code);
+        }
+
+        login
+            .token
+            .ok_or_else(|| anyhow::anyhow!("Xiaomi login returned no token"))
+    }
+
+    /// GET an authenticated MiWiFi API endpoint.
+    async fn get(&self, stok: &str, api_path: &str) -> Result<Value> {
+        let url = format!("{}/cgi-bin/luci/;stok={}/{}", self.base_url, stok, api_path);
+
+        let start = Instant::now();
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("Xiaomi API request failed")?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .context("failed to read Xiaomi API response body")?;
+
+        let elapsed = start.elapsed();
+        tracing::debug!(
+            api_path,
+            http_status = %status,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "Xiaomi API response"
+        );
+
+        if !status.is_success() {
+            anyhow::bail!("Xiaomi API returned HTTP {status}: {body}");
+        }
+
+        let parsed: Value =
+            serde_json::from_str(&body).context("failed to parse Xiaomi API response JSON")?;
+
+        // MiWiFi APIs return {"code": 0, ...} on success
+        if parsed.get("code").and_then(|c| c.as_i64()) != Some(0) {
+            anyhow::bail!(
+                "Xiaomi API error: code={}",
+                parsed.get("code").unwrap_or(&Value::Null)
+            );
+        }
+
+        Ok(parsed)
+    }
+
+    /// Login and fetch an API endpoint, returning the raw JSON.
+    async fn authenticated_get(&self, api_path: &str) -> Result<Value> {
+        let stok = self.login().await?;
+        self.get(&stok, api_path).await
+    }
+
+    /// Fetch system status (`api/misystem/status`).
+    pub async fn system_status(&self) -> Result<SystemStatusData> {
+        let val = self.authenticated_get("api/misystem/status").await?;
+        let data: SystemStatusData =
+            serde_json::from_value(val).context("failed to parse system status")?;
+        Ok(data)
+    }
+
+    /// Fetch WAN info (`api/xqnetwork/wan_info`).
+    pub async fn wan_info(&self) -> Result<WanInfoData> {
+        let val = self.authenticated_get("api/xqnetwork/wan_info").await?;
+        let data: WanInfoData = serde_json::from_value(val).context("failed to parse WAN info")?;
+        Ok(data)
+    }
+
+    /// Fetch init info (`api/xqsystem/init_info`).
+    pub async fn init_info(&self) -> Result<InitInfoData> {
+        let val = self.authenticated_get("api/xqsystem/init_info").await?;
+        let data: InitInfoData =
+            serde_json::from_value(val).context("failed to parse init info")?;
+        Ok(data)
+    }
+
+    /// Check ROM update (`api/xqsystem/check_rom_update`).
+    pub async fn check_rom_update(&self) -> Result<RomUpdateData> {
+        let val = self
+            .authenticated_get("api/xqsystem/check_rom_update")
+            .await?;
+        let data: RomUpdateData =
+            serde_json::from_value(val).context("failed to parse ROM update check")?;
+        Ok(data)
+    }
+
+    /// Fetch WiFi new status (`api/misystem/newstatus`).
+    pub async fn new_status(&self) -> Result<NewStatusData> {
+        let val = self.authenticated_get("api/misystem/newstatus").await?;
+        let data: NewStatusData =
+            serde_json::from_value(val).context("failed to parse new status")?;
+        Ok(data)
+    }
+
+    /// Fetch WiFi detail for all bands (`api/xqnetwork/wifi_detail_all`).
+    pub async fn wifi_detail_all(&self) -> Result<WifiDetailAllData> {
+        let val = self
+            .authenticated_get("api/xqnetwork/wifi_detail_all")
+            .await?;
+        let data: WifiDetailAllData =
+            serde_json::from_value(val).context("failed to parse WiFi detail")?;
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_get_returns_none_when_empty() {
+        let cache = XiaomiCache::new();
+        assert!(cache.get("status").is_none());
+    }
+
+    #[test]
+    fn cache_set_then_get_returns_value() {
+        let cache = XiaomiCache::new();
+        let val = serde_json::json!({"cpu": {"load": 10}});
+        cache.set("status".into(), val.clone());
+        assert_eq!(cache.get("status"), Some(val));
+    }
+
+    #[test]
+    fn cache_clear_removes_everything() {
+        let cache = XiaomiCache::new();
+        cache.set("a".into(), Value::Null);
+        cache.set("b".into(), Value::Null);
+        cache.clear();
+        assert!(cache.get("a").is_none());
+        assert!(cache.get("b").is_none());
+    }
+}

--- a/server/src/xiaomi/mod.rs
+++ b/server/src/xiaomi/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod types;

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -1,0 +1,239 @@
+//! Deserialization types for Xiaomi MiWiFi API responses.
+
+use serde::{Deserialize, Serialize};
+
+/// Generic MiWiFi API response wrapper.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MiWiFiResponse<T> {
+    pub code: i32,
+    #[serde(flatten)]
+    pub data: T,
+}
+
+/// `api/misystem/status` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SystemStatusData {
+    pub mem: Option<MemInfo>,
+    pub cpu: Option<CpuInfo>,
+    pub wan: Option<WanTraffic>,
+    pub count: Option<DeviceCount>,
+    pub temperature: Option<f64>,
+    pub uptime: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemInfo {
+    pub usage: Option<f64>,
+    pub total: Option<String>,
+    pub hz: Option<String>,
+    #[serde(rename = "type")]
+    pub mem_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CpuInfo {
+    pub core: Option<u32>,
+    pub hz: Option<String>,
+    pub load: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanTraffic {
+    pub downspeed: Option<String>,
+    pub upspeed: Option<String>,
+    pub maxdownloadspeed: Option<String>,
+    pub maxuploadspeed: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeviceCount {
+    pub online: Option<u32>,
+    pub all: Option<u32>,
+    #[serde(rename = "online_without_mash")]
+    pub online_without_mesh: Option<u32>,
+    #[serde(rename = "all_without_mash")]
+    pub all_without_mesh: Option<u32>,
+}
+
+/// `api/xqnetwork/wan_info` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanInfoData {
+    pub info: Option<WanDetail>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanDetail {
+    #[serde(rename = "wanType")]
+    pub wan_type: Option<String>,
+    pub ipv4: Option<WanIpv4>,
+    pub ipv6: Option<WanIpv6>,
+    pub details: Option<WanDetails>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanIpv4 {
+    pub ip: Option<String>,
+    pub mask: Option<String>,
+    pub gateway: Option<String>,
+    pub dns1: Option<String>,
+    pub dns2: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanIpv6 {
+    pub ip: Option<String>,
+    pub gateway: Option<String>,
+    pub dns1: Option<String>,
+    pub dns2: Option<String>,
+    pub prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanDetails {
+    #[serde(rename = "wanType")]
+    pub wan_type: Option<String>,
+    pub pppname: Option<String>,
+}
+
+/// `api/xqsystem/init_info` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InitInfoData {
+    #[serde(rename = "routername")]
+    pub router_name: Option<String>,
+    #[serde(rename = "romversion")]
+    pub rom_version: Option<String>,
+    pub hardware: Option<String>,
+    pub language: Option<String>,
+}
+
+/// `api/xqsystem/check_rom_update` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RomUpdateData {
+    #[serde(rename = "needUpdate")]
+    pub need_update: Option<i32>,
+}
+
+/// `api/misystem/newstatus` response — WiFi band info.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NewStatusData {
+    #[serde(rename = "2g")]
+    pub band_2g: Option<BandInfo>,
+    #[serde(rename = "5g")]
+    pub band_5g: Option<BandInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BandInfo {
+    pub ssid: Option<String>,
+    pub channel: Option<u32>,
+    pub bandwidth: Option<String>,
+}
+
+/// `api/xqnetwork/wifi_detail_all` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WifiDetailAllData {
+    pub info: Option<Vec<WifiBandDetail>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WifiBandDetail {
+    #[serde(rename = "ifname")]
+    pub if_name: Option<String>,
+    pub ssid: Option<String>,
+    pub status: Option<String>,
+    pub channel: Option<serde_json::Value>,
+    pub bandwidth: Option<String>,
+    pub encryption: Option<String>,
+    #[serde(rename = "bandsteering")]
+    pub band_steering: Option<String>,
+}
+
+/// Token response from `api/xqsystem/login`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoginResponse {
+    pub code: i32,
+    pub token: Option<String>,
+}
+
+// ── Serialized API response types (sent to frontend) ─────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiStatusResponse {
+    pub configured: bool,
+    pub reachable: bool,
+    pub cpu: Option<XiaomiCpu>,
+    pub mem: Option<XiaomiMem>,
+    pub temperature: Option<f64>,
+    pub uptime: Option<String>,
+    pub wan_traffic: Option<XiaomiWanTraffic>,
+    pub device_count: Option<XiaomiDeviceCount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiCpu {
+    pub cores: Option<u32>,
+    pub frequency: Option<String>,
+    pub load: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiMem {
+    pub usage: Option<f64>,
+    pub total: Option<String>,
+    pub frequency: Option<String>,
+    pub mem_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiWanTraffic {
+    pub download_speed: Option<String>,
+    pub upload_speed: Option<String>,
+    pub max_download_speed: Option<String>,
+    pub max_upload_speed: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiDeviceCount {
+    pub online: Option<u32>,
+    pub total: Option<u32>,
+    pub online_without_mesh: Option<u32>,
+    pub total_without_mesh: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiWanInfoResponse {
+    pub wan_type: Option<String>,
+    pub ip: Option<String>,
+    pub mask: Option<String>,
+    pub gateway: Option<String>,
+    pub dns_servers: Vec<String>,
+    pub ipv6_ip: Option<String>,
+    pub ipv6_gateway: Option<String>,
+    pub ipv6_dns: Vec<String>,
+    pub ipv6_prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiWifiBand {
+    pub name: String,
+    pub ssid: Option<String>,
+    pub channel: Option<String>,
+    pub bandwidth: Option<String>,
+    pub encryption: Option<String>,
+    pub band_steering: Option<String>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiWifiResponse {
+    pub bands: Vec<XiaomiWifiBand>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct XiaomiFirmwareResponse {
+    pub router_name: Option<String>,
+    pub rom_version: Option<String>,
+    pub hardware: Option<String>,
+    pub language: Option<String>,
+    pub update_available: bool,
+}

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -135,6 +135,7 @@ import {
 } from "@/lib/api";
 import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
 import MikrotikRouter from "@/components/MikrotikRouter";
+import XiaomiRouter from "@/components/XiaomiRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -5891,26 +5892,32 @@ export default function RouterPage() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("mikrotik");
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
+  const [routerType, setRouterType] = useState<"vyos" | "mikrotik" | "xiaomi">("mikrotik");
 
   // Load settings to determine which routers are configured
   useEffect(() => {
     const loadSettings = async () => {
       let mtEnabled = false;
       let vyosConf = false;
+      let xiEnabled = false;
       try {
         const settings = await fetchSettings();
         mtEnabled = settings.mikrotik_enabled;
         vyosConf = !!settings.vyos_url && settings.vyos_api_key_set;
+        xiEnabled = settings.xiaomi_enabled;
       } catch {
         // ignore
       }
       setMikrotikEnabled(mtEnabled);
       setVyosConfigured(vyosConf);
+      setXiaomiEnabled(xiEnabled);
 
-      // Default to mikrotik if enabled, fallback to vyos only if mikrotik not available
+      // Default to mikrotik if enabled, fallback to xiaomi, then vyos
       if (mtEnabled) {
         setRouterType("mikrotik");
+      } else if (xiEnabled) {
+        setRouterType("xiaomi");
       } else if (vyosConf) {
         setRouterType("vyos");
       }
@@ -5948,29 +5955,46 @@ export default function RouterPage() {
     loadVyosSummary();
   }, [routerType, summary]);
 
-  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled;
+  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled && !xiaomiEnabled;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, tabs when MikroTik is enabled */}
+        {/* Router type selector — skeleton while settings load, tabs when multiple routers available */}
         {!settingsLoaded ? (
           <Skeleton className="h-9 w-48" />
-        ) : mikrotikEnabled ? (
+        ) : (mikrotikEnabled || xiaomiEnabled) ? (
           <div className="flex gap-2">
-            <Button
-              variant={routerType === "mikrotik" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("mikrotik")}
-              className={
-                routerType === "mikrotik"
-                  ? "bg-pink-600 text-white hover:bg-pink-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              MikroTik
-            </Button>
+            {mikrotikEnabled && (
+              <Button
+                variant={routerType === "mikrotik" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("mikrotik")}
+                className={
+                  routerType === "mikrotik"
+                    ? "bg-pink-600 text-white hover:bg-pink-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                MikroTik
+              </Button>
+            )}
+            {xiaomiEnabled && (
+              <Button
+                variant={routerType === "xiaomi" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("xiaomi")}
+                className={
+                  routerType === "xiaomi"
+                    ? "bg-orange-600 text-white hover:bg-orange-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                Xiaomi
+              </Button>
+            )}
             <Button
               variant={routerType === "vyos" ? "default" : "outline"}
               size="sm"
@@ -5997,6 +6021,8 @@ export default function RouterPage() {
           <NotConfigured />
         ) : routerType === "mikrotik" && mikrotikEnabled ? (
           <MikrotikRouter />
+        ) : routerType === "xiaomi" && xiaomiEnabled ? (
+          <XiaomiRouter />
         ) : routerType === "vyos" && !vyosConfigured ? (
           <VyosNotConfigured />
         ) : routerType === "vyos" && !summary ? (

--- a/web/src/components/XiaomiRouter.tsx
+++ b/web/src/components/XiaomiRouter.tsx
@@ -1,0 +1,630 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Router,
+  Globe,
+  AlertCircle,
+  Cpu,
+  Clock,
+  MemoryStick,
+  Wifi,
+  Thermometer,
+  Download,
+  Upload,
+  Users,
+  RefreshCw,
+  Info,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import {
+  fetchXiaomiStatus,
+  fetchXiaomiWanInfo,
+  fetchXiaomiWifi,
+  fetchXiaomiFirmware,
+} from "@/lib/api";
+import type {
+  XiaomiStatus,
+  XiaomiWanInfo,
+  XiaomiWifiInfo,
+  XiaomiFirmware,
+} from "@/lib/types";
+
+// ── Generic data loader hook ────────────────────────────
+
+function useData<T>(fetcher: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetcher();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}
+
+// ── Helpers ─────────────────────────────────────────────
+
+function formatUptime(seconds: string | null): string {
+  if (!seconds) return "Unknown";
+  const s = parseInt(seconds, 10);
+  if (isNaN(s)) return seconds;
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function formatSpeed(bytesPerSec: string | null | undefined): string {
+  if (!bytesPerSec) return "0 B/s";
+  const n = parseInt(bytesPerSec, 10);
+  if (isNaN(n)) return bytesPerSec;
+  if (n > 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)} GB/s`;
+  if (n > 1_000_000) return `${(n / 1_000_000).toFixed(1)} MB/s`;
+  if (n > 1_000) return `${(n / 1_000).toFixed(1)} KB/s`;
+  return `${n} B/s`;
+}
+
+function cpuColor(load: number): string {
+  if (load > 80) return "text-rose-400";
+  if (load > 50) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function memColor(usage: number): string {
+  if (usage > 0.85) return "text-rose-400";
+  if (usage > 0.6) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function tempColor(temp: number): string {
+  if (temp > 80) return "text-rose-400";
+  if (temp > 60) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function progressColor(value: number): string {
+  if (value > 80) return "[&>div]:bg-rose-500";
+  if (value > 50) return "[&>div]:bg-amber-500";
+  return "[&>div]:bg-emerald-500";
+}
+
+// ── Status Header ───────────────────────────────────────
+
+function XiaomiStatusHeader({ status, firmware }: { status: XiaomiStatus; firmware: XiaomiFirmware | null }) {
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
+          <Router className="h-5 w-5 text-orange-400" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-white">
+            {firmware?.router_name || "Xiaomi Router"}
+          </h1>
+          <p className="text-xs text-slate-500">
+            {firmware?.hardware ?? "Xiaomi MiWiFi"}{" "}
+            {firmware?.rom_version && (
+              <span className="text-slate-600">· v{firmware.rom_version}</span>
+            )}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {status.reachable ? (
+          <Badge
+            variant="outline"
+            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+          >
+            ● Connected
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+          >
+            ● Unreachable
+          </Badge>
+        )}
+        {status.uptime && (
+          <Badge variant="outline" className="border-slate-800 text-slate-400">
+            Uptime: {formatUptime(status.uptime)}
+          </Badge>
+        )}
+        {status.device_count?.online != null && (
+          <Badge variant="outline" className="border-cyan-500/30 bg-cyan-500/10 text-cyan-400">
+            <Users className="mr-1 h-3 w-3" />
+            {status.device_count.online} devices online
+          </Badge>
+        )}
+        {firmware?.update_available && (
+          <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-400">
+            Update available
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── System Stats Panel ──────────────────────────────────
+
+function SystemStatsPanel({ status }: { status: XiaomiStatus }) {
+  const cpuLoad = status.cpu?.load ?? 0;
+  const memUsage = status.mem?.usage ?? 0;
+  const memPercent = Math.round(memUsage * 100);
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {/* CPU */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-2 text-sm text-slate-400">
+            <Cpu className="h-4 w-4" />
+            CPU
+          </div>
+          <div className="mt-2">
+            <span className={`text-2xl font-bold ${cpuColor(cpuLoad)}`}>
+              {cpuLoad}%
+            </span>
+            <span className="ml-2 text-xs text-slate-500">
+              {status.cpu?.cores ?? "?"} cores @ {status.cpu?.frequency ?? "?"}
+            </span>
+          </div>
+          <Progress
+            value={cpuLoad}
+            max={100}
+            className={`mt-2 h-2 bg-slate-800 ${progressColor(cpuLoad)}`}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Memory */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-2 text-sm text-slate-400">
+            <MemoryStick className="h-4 w-4" />
+            Memory
+          </div>
+          <div className="mt-2">
+            <span className={`text-2xl font-bold ${memColor(memUsage)}`}>
+              {memPercent}%
+            </span>
+            <span className="ml-2 text-xs text-slate-500">
+              of {status.mem?.total ?? "?"} {status.mem?.mem_type ?? ""} @ {status.mem?.frequency ?? "?"}
+            </span>
+          </div>
+          <Progress
+            value={memPercent}
+            max={100}
+            className={`mt-2 h-2 bg-slate-800 ${progressColor(memPercent)}`}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Temperature */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-2 text-sm text-slate-400">
+            <Thermometer className="h-4 w-4" />
+            Temperature
+          </div>
+          <div className="mt-2">
+            {status.temperature != null ? (
+              <>
+                <span className={`text-2xl font-bold ${tempColor(status.temperature)}`}>
+                  {status.temperature}°C
+                </span>
+              </>
+            ) : (
+              <span className="text-2xl font-bold text-slate-500">N/A</span>
+            )}
+          </div>
+          {status.temperature != null && (
+            <Progress
+              value={status.temperature}
+              max={100}
+              className={`mt-2 h-2 bg-slate-800 ${progressColor(status.temperature)}`}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Uptime */}
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="pt-6">
+          <div className="flex items-center gap-2 text-sm text-slate-400">
+            <Clock className="h-4 w-4" />
+            Uptime
+          </div>
+          <div className="mt-2">
+            <span className="text-2xl font-bold text-blue-400">
+              {formatUptime(status.uptime)}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ── WAN Info Panel ──────────────────────────────────────
+
+function WanInfoPanel({ wan }: { wan: XiaomiWanInfo }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Globe className="h-4 w-4 text-blue-400" />
+          WAN Information
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {/* IPv4 */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium text-white">IPv4</h3>
+            <div className="space-y-2">
+              <InfoRow label="WAN Type" value={wan.wan_type ?? "Unknown"} />
+              <InfoRow label="IP Address" value={wan.ip ?? "—"} />
+              <InfoRow label="Subnet Mask" value={wan.mask ?? "—"} />
+              <InfoRow label="Gateway" value={wan.gateway ?? "—"} />
+              <InfoRow
+                label="DNS Servers"
+                value={wan.dns_servers.length > 0 ? wan.dns_servers.join(", ") : "—"}
+              />
+            </div>
+          </div>
+
+          {/* IPv6 */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium text-white">IPv6</h3>
+            <div className="space-y-2">
+              <InfoRow
+                label="Status"
+                value={wan.ipv6_ip ? "Enabled" : "Disabled"}
+                valueClassName={wan.ipv6_ip ? "text-emerald-400" : "text-slate-500"}
+              />
+              {wan.ipv6_ip && (
+                <>
+                  <InfoRow label="IP Address" value={wan.ipv6_ip} />
+                  <InfoRow label="Gateway" value={wan.ipv6_gateway ?? "—"} />
+                  <InfoRow label="Prefix" value={wan.ipv6_prefix ?? "—"} />
+                  <InfoRow
+                    label="DNS Servers"
+                    value={wan.ipv6_dns.length > 0 ? wan.ipv6_dns.join(", ") : "—"}
+                  />
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="flex justify-between text-sm">
+      <span className="text-slate-400">{label}</span>
+      <span className={`font-mono ${valueClassName ?? "text-white"}`}>{value}</span>
+    </div>
+  );
+}
+
+// ── WiFi Bands Panel ────────────────────────────────────
+
+function WifiBandsPanel({ wifi }: { wifi: XiaomiWifiInfo }) {
+  if (wifi.bands.length === 0) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex items-center gap-2 py-8 text-sm text-slate-500">
+          <Wifi className="h-4 w-4" />
+          No WiFi bands detected
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Wifi className="h-4 w-4 text-purple-400" />
+          WiFi Bands
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {wifi.bands.map((band) => (
+            <div key={band.name} className="rounded-lg border border-slate-800 bg-slate-950 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-white">{band.name}</span>
+                {band.status === "1" ? (
+                  <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400">
+                    Active
+                  </Badge>
+                ) : (
+                  <Badge variant="outline" className="border-slate-700 text-slate-500">
+                    Inactive
+                  </Badge>
+                )}
+              </div>
+              <div className="mt-3 space-y-2">
+                <InfoRow label="SSID" value={band.ssid ?? "—"} />
+                <InfoRow label="Channel" value={band.channel ?? "Auto"} />
+                <InfoRow label="Bandwidth" value={band.bandwidth ?? "—"} />
+                <InfoRow label="Encryption" value={band.encryption ?? "—"} />
+                {band.band_steering != null && (
+                  <InfoRow
+                    label="Band Steering"
+                    value={band.band_steering === "1" ? "Enabled" : "Disabled"}
+                    valueClassName={band.band_steering === "1" ? "text-emerald-400" : "text-slate-500"}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Firmware Panel ──────────────────────────────────────
+
+function FirmwarePanel({ firmware }: { firmware: XiaomiFirmware }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Info className="h-4 w-4 text-cyan-400" />
+          Firmware & Hardware
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <InfoRow label="Router Name" value={firmware.router_name ?? "—"} />
+          <InfoRow label="Firmware Version" value={firmware.rom_version ?? "—"} />
+          <InfoRow label="Hardware" value={firmware.hardware ?? "—"} />
+          <InfoRow label="Language" value={firmware.language ?? "—"} />
+          <InfoRow
+            label="Update Available"
+            value={firmware.update_available ? "Yes" : "No"}
+            valueClassName={firmware.update_available ? "text-amber-400" : "text-emerald-400"}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── WAN Traffic Panel ───────────────────────────────────
+
+function WanTrafficPanel({ status }: { status: XiaomiStatus }) {
+  if (!status.wan_traffic) return null;
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Globe className="h-4 w-4 text-blue-400" />
+          WAN Traffic
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-lg border border-slate-800 bg-slate-950 p-4">
+            <Download className="h-5 w-5 text-emerald-400" />
+            <div>
+              <div className="text-xs text-slate-400">Download</div>
+              <div className="text-lg font-bold text-white">
+                {formatSpeed(status.wan_traffic.download_speed)}
+              </div>
+              <div className="text-xs text-slate-500">
+                Max: {formatSpeed(status.wan_traffic.max_download_speed)}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 rounded-lg border border-slate-800 bg-slate-950 p-4">
+            <Upload className="h-5 w-5 text-blue-400" />
+            <div>
+              <div className="text-xs text-slate-400">Upload</div>
+              <div className="text-lg font-bold text-white">
+                {formatSpeed(status.wan_traffic.upload_speed)}
+              </div>
+              <div className="text-xs text-slate-500">
+                Max: {formatSpeed(status.wan_traffic.max_upload_speed)}
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────
+
+export default function XiaomiRouter() {
+  const statusData = useData(useCallback(() => fetchXiaomiStatus(), []));
+  const [tab, setTab] = useState("system");
+
+  // Lazy-load tab data
+  const wanData = useData(useCallback(() => fetchXiaomiWanInfo(), []));
+  const wifiData = useData(useCallback(() => fetchXiaomiWifi(), []));
+  const firmwareData = useData(useCallback(() => fetchXiaomiFirmware(), []));
+
+  // Auto-refresh status every 30s
+  useEffect(() => {
+    const interval = setInterval(() => statusData.reload(), 30_000);
+    return () => clearInterval(interval);
+  }, [statusData.reload]);
+
+  if (statusData.loading && !statusData.data) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-64" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!statusData.data?.configured) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-400">
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        Xiaomi router is not configured. Enable it in Settings &gt; Integrations.
+      </div>
+    );
+  }
+
+  if (!statusData.data.reachable) {
+    return (
+      <div className="space-y-4">
+        <XiaomiStatusHeader status={statusData.data} firmware={firmwareData.data} />
+        <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          Cannot reach Xiaomi router. Check the URL and password in Settings.
+        </div>
+      </div>
+    );
+  }
+
+  const status = statusData.data;
+
+  return (
+    <div className="space-y-6">
+      <XiaomiStatusHeader status={status} firmware={firmwareData.data} />
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <div className="flex items-center justify-between">
+          <TabsList className="border-slate-800 bg-slate-950">
+            <TabsTrigger
+              value="system"
+              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+            >
+              <Cpu className="mr-1.5 h-3.5 w-3.5" />
+              System
+            </TabsTrigger>
+            <TabsTrigger
+              value="wan"
+              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+            >
+              <Globe className="mr-1.5 h-3.5 w-3.5" />
+              WAN
+            </TabsTrigger>
+            <TabsTrigger
+              value="wifi"
+              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+            >
+              <Wifi className="mr-1.5 h-3.5 w-3.5" />
+              WiFi
+            </TabsTrigger>
+            <TabsTrigger
+              value="firmware"
+              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+            >
+              <Info className="mr-1.5 h-3.5 w-3.5" />
+              Firmware
+            </TabsTrigger>
+          </TabsList>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-slate-400 hover:text-white"
+            onClick={() => {
+              statusData.reload();
+              wanData.reload();
+              wifiData.reload();
+              firmwareData.reload();
+            }}
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </div>
+
+        <TabsContent value="system" className="space-y-4">
+          <SystemStatsPanel status={status} />
+          <WanTrafficPanel status={status} />
+        </TabsContent>
+
+        <TabsContent value="wan">
+          {wanData.loading && !wanData.data ? (
+            <Skeleton className="h-64 w-full" />
+          ) : wanData.error && !wanData.data ? (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {wanData.error}
+            </div>
+          ) : wanData.data ? (
+            <WanInfoPanel wan={wanData.data} />
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="wifi">
+          {wifiData.loading && !wifiData.data ? (
+            <Skeleton className="h-64 w-full" />
+          ) : wifiData.error && !wifiData.data ? (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {wifiData.error}
+            </div>
+          ) : wifiData.data ? (
+            <WifiBandsPanel wifi={wifiData.data} />
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="firmware">
+          {firmwareData.loading && !firmwareData.data ? (
+            <Skeleton className="h-64 w-full" />
+          ) : firmwareData.error && !firmwareData.data ? (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-400">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {firmwareData.error}
+            </div>
+          ) : firmwareData.data ? (
+            <FirmwarePanel firmware={firmwareData.data} />
+          ) : null}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1935,3 +1935,31 @@ export function deleteMikrotikNatRule(id: string): Promise<void> {
     `/api/v1/nat/mikrotik/rules/${encodeURIComponent(id)}`
   );
 }
+
+// ── Xiaomi MiWiFi ────────────────────────────────────────
+
+export function fetchXiaomiStatus(): Promise<
+  import("./types").XiaomiStatus
+> {
+  return apiGet<import("./types").XiaomiStatus>("/api/v1/xiaomi/status");
+}
+
+export function fetchXiaomiWanInfo(): Promise<
+  import("./types").XiaomiWanInfo
+> {
+  return apiGet<import("./types").XiaomiWanInfo>("/api/v1/xiaomi/wan");
+}
+
+export function fetchXiaomiWifi(): Promise<
+  import("./types").XiaomiWifiInfo
+> {
+  return apiGet<import("./types").XiaomiWifiInfo>("/api/v1/xiaomi/wifi");
+}
+
+export function fetchXiaomiFirmware(): Promise<
+  import("./types").XiaomiFirmware
+> {
+  return apiGet<import("./types").XiaomiFirmware>(
+    "/api/v1/xiaomi/firmware"
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -525,6 +525,10 @@ export interface SettingsData {
   mikrotik_user: string | null;
   mikrotik_password_set: boolean;
   mikrotik_enabled: boolean;
+  // Xiaomi MiWiFi
+  xiaomi_url: string | null;
+  xiaomi_password_set: boolean;
+  xiaomi_enabled: boolean;
   // Unbound DNS
   unbound_control_path: string | null;
   // Caddy Reverse Proxy
@@ -1803,4 +1807,78 @@ export interface CreateMikrotikNatRuleRequest {
   to_ports?: string;
   comment?: string;
   disabled?: boolean;
+}
+
+// ─── Xiaomi MiWiFi ──────────────────────────────────────
+
+export interface XiaomiStatus {
+  configured: boolean;
+  reachable: boolean;
+  cpu: XiaomiCpu | null;
+  mem: XiaomiMem | null;
+  temperature: number | null;
+  uptime: string | null;
+  wan_traffic: XiaomiWanTraffic | null;
+  device_count: XiaomiDeviceCount | null;
+}
+
+export interface XiaomiCpu {
+  cores: number | null;
+  frequency: string | null;
+  load: number | null;
+}
+
+export interface XiaomiMem {
+  usage: number | null;
+  total: string | null;
+  frequency: string | null;
+  mem_type: string | null;
+}
+
+export interface XiaomiWanTraffic {
+  download_speed: string | null;
+  upload_speed: string | null;
+  max_download_speed: string | null;
+  max_upload_speed: string | null;
+}
+
+export interface XiaomiDeviceCount {
+  online: number | null;
+  total: number | null;
+  online_without_mesh: number | null;
+  total_without_mesh: number | null;
+}
+
+export interface XiaomiWanInfo {
+  wan_type: string | null;
+  ip: string | null;
+  mask: string | null;
+  gateway: string | null;
+  dns_servers: string[];
+  ipv6_ip: string | null;
+  ipv6_gateway: string | null;
+  ipv6_dns: string[];
+  ipv6_prefix: string | null;
+}
+
+export interface XiaomiWifiBand {
+  name: string;
+  ssid: string | null;
+  channel: string | null;
+  bandwidth: string | null;
+  encryption: string | null;
+  band_steering: string | null;
+  status: string | null;
+}
+
+export interface XiaomiWifiInfo {
+  bands: XiaomiWifiBand[];
+}
+
+export interface XiaomiFirmware {
+  router_name: string | null;
+  rom_version: string | null;
+  hardware: string | null;
+  language: string | null;
+  update_available: boolean;
 }


### PR DESCRIPTION
Closes #295

## Summary

- Add "Xiaomi" tab to the Router page alongside MikroTik and VyOS tabs
- Xiaomi MiWiFi API client with token-based authentication and 30s TTL cache
- 4 backend proxy endpoints: `/xiaomi/status`, `/xiaomi/wan`, `/xiaomi/wifi`, `/xiaomi/firmware`
- Settings integration (`xiaomi_url`, `xiaomi_password`, `xiaomi_enabled`) for configuration via Settings page
- XiaomiRouter component with System, WAN, WiFi, and Firmware tabs
- System stats displayed as gauges/progress bars with color thresholds (CPU, RAM, Temperature)
- WAN panel shows IPv4/IPv6 details, gateway, DNS servers, WAN type
- WiFi panel shows per-band SSID, channel, bandwidth, encryption, band steering status
- Firmware panel shows version, hardware model, locale, and update availability

## Design Decisions

- Since #292 (Xiaomi MiWiFi API client) is not yet merged, this PR includes the full client implementation (`server/src/xiaomi/`) following the exact same patterns as the MikroTik client module
- Xiaomi uses token-based auth (stok parameter) obtained via login, unlike MikroTik's HTTP Basic auth
- Orange accent color (`bg-orange-600`) for the Xiaomi tab to differentiate from MikroTik (pink) and VyOS (blue)
- Router type selector now shows all enabled routers dynamically, defaulting to MikroTik > Xiaomi > VyOS priority

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo check` passes (no compile errors)
- [x] `cargo test` passes (297 unit + 18 integration tests, including 3 new Xiaomi cache tests)
- [ ] Manual: Enable Xiaomi in Settings, verify System/WAN/WiFi/Firmware tabs render correctly
- [ ] Manual: Verify router tab selector shows Xiaomi button when enabled
- [ ] Manual: Verify auto-refresh works (30s interval on status data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive Xiaomi MiWiFi router integration to Panoptikon with dashboard UI, following the same architectural patterns as existing MikroTik support.

## Key Changes

- **Backend API client** (`server/src/xiaomi/`) implements token-based authentication via `stok` parameter, 30s TTL cache, and six endpoint methods for system status, WAN info, WiFi details, and firmware data
- **Four proxy endpoints** expose `/api/v1/xiaomi/{status,wan,wifi,firmware}` with graceful handling of unconfigured/unreachable states
- **Settings integration** adds `xiaomi_url`, `xiaomi_password`, `xiaomi_enabled` configuration options via Settings page
- **XiaomiRouter component** provides full-featured dashboard with System/WAN/WiFi/Firmware tabs, auto-refresh every 30s, color-coded system gauges (CPU, RAM, temperature), and comprehensive network details
- **Router selector UI** now dynamically shows enabled routers with orange accent for Xiaomi, maintaining MikroTik > Xiaomi > VyOS priority

## Implementation Quality

- Consistent with existing codebase patterns (mirrors MikroTik module structure)
- Proper error handling and fallback responses
- Cache integration with middleware invalidation
- 3 new unit tests for cache functionality
- All types use `Option<T>` for robustness against API variations
- Clean separation of concerns between client, API handlers, and UI components

## Notes

- The `stok` token appears in URLs (`/cgi-bin/luci/;stok={token}/api/...`) and debug logs at line server/src/xiaomi/client.rs:153-158, which could expose session tokens if debug logging is enabled in production

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for token security in logs
- Well-structured implementation following established patterns in the codebase. The Xiaomi integration mirrors the MikroTik client architecture, includes proper error handling, caching, and comprehensive tests. Minor concern: stok tokens logged in debug traces could expose session tokens in production logs, though this is low risk given the controlled environment.
- server/src/xiaomi/client.rs — verify debug logging doesn't expose stok tokens in production environments

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/client.rs | New Xiaomi MiWiFi API client with token auth, 30s cache, and comprehensive endpoint methods — follows MikroTik client patterns consistently |
| server/src/api/xiaomi.rs | Four proxy endpoints (status, wan, wifi, firmware) with cache integration — handles unconfigured/unreachable states gracefully with proper fallbacks |
| server/src/api/settings.rs | Added xiaomi_url, xiaomi_password, xiaomi_enabled settings — consistent with existing MikroTik/VyOS integration patterns |
| web/src/components/XiaomiRouter.tsx | Full-featured router dashboard with System/WAN/WiFi/Firmware tabs — 30s auto-refresh, lazy tab loading, comprehensive UI with gauges and color-coded thresholds |

</details>



<sub>Last reviewed commit: 0b76a0a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->