### PR TITLE
feat: Xiaomi MiWiFi API client — SHA256 auth + stok token management (#292)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "similar",
  "sqlx",
  "ssh2",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 mime_guess = "2"
 similar = "2"
 ssh2 = "0.9"
+sha2 = "0.10"
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"] }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -48,6 +48,7 @@ pub mod traffic;
 pub mod unbound;
 pub mod vpn_status;
 pub mod vyos;
+pub mod xiaomi;
 
 pub use error::AppError;
 
@@ -71,6 +72,8 @@ pub struct AppState {
     pub mikrotik_cache: Arc<crate::mikrotik::client::MikrotikCache>,
     /// Shared reqwest::Client for Caddy Admin API.
     pub caddy_http: reqwest::Client,
+    /// Shared reqwest::Client for Xiaomi MiWiFi API.
+    pub xiaomi_http: reqwest::Client,
 }
 
 impl AppState {
@@ -91,6 +94,7 @@ impl AppState {
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .expect("caddy HTTP client"),
+            xiaomi_http: crate::xiaomi::client::shared_http_client(),
         }
     }
 }
@@ -494,6 +498,14 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/mikrotik/dns", get(mikrotik::dns))
         .route("/mikrotik/wireguard", get(mikrotik::wireguard))
+        // Xiaomi MiWiFi
+        .route("/xiaomi/status", get(xiaomi::status))
+        .route("/xiaomi/topology", get(xiaomi::topology))
+        .route("/xiaomi/devices", get(xiaomi::devices))
+        .route("/xiaomi/new-status", get(xiaomi::new_status))
+        .route("/xiaomi/wifi-devices", get(xiaomi::wifi_devices))
+        .route("/xiaomi/wan-info", get(xiaomi::wan_info))
+        .route("/xiaomi/lan-info", get(xiaomi::lan_info))
         // QoS / Traffic Shaping
         .route("/qos/summary", get(qos::qos_summary))
         .route("/qos/vyos/policies", get(qos::vyos_traffic_policies))

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -1,0 +1,396 @@
+//! Xiaomi MiWiFi API handler endpoints.
+//!
+//! These endpoints proxy requests to a Xiaomi router via its MiWiFi API,
+//! handling SHA256 auth + stok token management transparently.
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+
+use super::AppState;
+use crate::xiaomi::client::XiaomiClient;
+
+// ── Helper: build a Xiaomi client from DB settings ─────────
+
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+/// Try to construct a Xiaomi client from saved settings.
+/// Returns `None` if Xiaomi integration is not configured or not enabled.
+async fn xiaomi_client(state: &AppState) -> Option<XiaomiClient> {
+    let enabled = get_setting(state, "xiaomi_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let ip = get_setting(state, "xiaomi_ip")
+        .await
+        .unwrap_or_else(|| "10.10.0.199".to_string());
+    let password = get_setting(state, "xiaomi_password").await?;
+
+    Some(XiaomiClient::new(&ip, &password, state.xiaomi_http.clone()))
+}
+
+// ── Response types ─────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiStatusResponse {
+    pub configured: bool,
+    pub reachable: bool,
+    pub cpu_cores: Option<i32>,
+    pub cpu_freq: Option<String>,
+    pub cpu_load: Option<f64>,
+    pub mem_usage: Option<f64>,
+    pub mem_total: Option<String>,
+    pub mem_type: Option<String>,
+    pub temperature: Option<i32>,
+    pub wan_download: Option<String>,
+    pub wan_upload: Option<String>,
+    pub devices_online: Option<i32>,
+    pub devices_total: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiTopoNodeResponse {
+    pub mac: Option<String>,
+    pub name: Option<String>,
+    pub locale: Option<String>,
+    pub ip: Option<String>,
+    pub online: Option<i32>,
+    pub hardware: Option<String>,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiTopoLeafResponse {
+    pub mac: Option<String>,
+    pub ip: Option<String>,
+    pub name: Option<String>,
+    pub online: Option<i32>,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiTopoResponse {
+    pub nodes: Vec<XiaomiTopoNodeResponse>,
+    pub leafs: Vec<XiaomiTopoLeafResponse>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiDeviceResponse {
+    pub mac: Option<String>,
+    pub name: Option<String>,
+    pub ip: Option<String>,
+    pub download_speed: Option<String>,
+    pub upload_speed: Option<String>,
+    pub online: bool,
+    pub device_type: Option<i32>,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWifiDeviceResponse {
+    pub mac: Option<String>,
+    pub ip: Option<String>,
+    pub name: Option<String>,
+    pub signal: Option<i32>,
+    pub band: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWanInfoResponse {
+    pub ip: Option<String>,
+    pub gateway: Option<String>,
+    pub dns: Option<String>,
+    pub wan_type: Option<String>,
+    pub mask: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiLanPortResponse {
+    pub port: Option<i32>,
+    pub link_status: Option<String>,
+    pub speed: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiLanInfoResponse {
+    pub ip: Option<String>,
+    pub mask: Option<String>,
+    pub ports: Vec<XiaomiLanPortResponse>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiNewStatusResponse {
+    pub mac: Option<String>,
+    pub platform: Option<String>,
+    pub version: Option<String>,
+    pub sn: Option<String>,
+    pub devices_online: Option<i32>,
+    pub devices_total: Option<i32>,
+}
+
+// ── Handlers ───────────────────────────────────────────────
+
+/// GET /xiaomi/status — system status (CPU, memory, temp, speeds).
+pub async fn status(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiStatusResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => {
+            return Ok(Json(XiaomiStatusResponse {
+                configured: false,
+                reachable: false,
+                cpu_cores: None,
+                cpu_freq: None,
+                cpu_load: None,
+                mem_usage: None,
+                mem_total: None,
+                mem_type: None,
+                temperature: None,
+                wan_download: None,
+                wan_upload: None,
+                devices_online: None,
+                devices_total: None,
+            }));
+        }
+    };
+
+    match client.system_status().await {
+        Ok(s) => Ok(Json(XiaomiStatusResponse {
+            configured: true,
+            reachable: true,
+            cpu_cores: s.cpu.as_ref().and_then(|c| c.core),
+            cpu_freq: s.cpu.as_ref().and_then(|c| c.hz.clone()),
+            cpu_load: s.cpu.as_ref().and_then(|c| c.load),
+            mem_usage: s.mem.as_ref().and_then(|m| m.usage),
+            mem_total: s.mem.as_ref().and_then(|m| m.total.clone()),
+            mem_type: s.mem.as_ref().and_then(|m| m.mem_type.clone()),
+            temperature: s.temperature,
+            wan_download: s.wan.as_ref().and_then(|w| w.downspeed.clone()),
+            wan_upload: s.wan.as_ref().and_then(|w| w.upspeed.clone()),
+            devices_online: s.count.as_ref().and_then(|c| c.online),
+            devices_total: s.count.as_ref().and_then(|c| c.all),
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi status request failed");
+            Ok(Json(XiaomiStatusResponse {
+                configured: true,
+                reachable: false,
+                cpu_cores: None,
+                cpu_freq: None,
+                cpu_load: None,
+                mem_usage: None,
+                mem_total: None,
+                mem_type: None,
+                temperature: None,
+                wan_download: None,
+                wan_upload: None,
+                devices_online: None,
+                devices_total: None,
+            }))
+        }
+    }
+}
+
+/// GET /xiaomi/topology — mesh topology graph (no auth required).
+pub async fn topology(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiTopoResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.topo_graph().await {
+        Ok(topo) => {
+            let graph = topo
+                .graph
+                .unwrap_or_else(|| crate::xiaomi::types::TopoGraphInner {
+                    nodes: vec![],
+                    leafs: vec![],
+                });
+            Ok(Json(XiaomiTopoResponse {
+                nodes: graph
+                    .nodes
+                    .into_iter()
+                    .map(|n| XiaomiTopoNodeResponse {
+                        mac: n.mac,
+                        name: n.name,
+                        locale: n.locale,
+                        ip: n.ip,
+                        online: n.online,
+                        hardware: n.hardware,
+                        model: n.model,
+                    })
+                    .collect(),
+                leafs: graph
+                    .leafs
+                    .into_iter()
+                    .map(|l| XiaomiTopoLeafResponse {
+                        mac: l.mac,
+                        ip: l.ip,
+                        name: l.name,
+                        online: l.online,
+                        parent_id: l.parent_id,
+                    })
+                    .collect(),
+            }))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi topology request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/devices — all connected devices.
+pub async fn devices(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<XiaomiDeviceResponse>>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.device_list().await {
+        Ok(list) => Ok(Json(
+            list.into_iter()
+                .map(|d| {
+                    let first_ip = d.ip.first();
+                    XiaomiDeviceResponse {
+                        mac: d.mac,
+                        name: d.name,
+                        ip: first_ip.and_then(|i| i.ip.clone()),
+                        download_speed: first_ip.and_then(|i| i.downspeed.clone()),
+                        upload_speed: first_ip.and_then(|i| i.upspeed.clone()),
+                        online: d.online.as_deref() == Some("1"),
+                        device_type: d.device_type,
+                        parent_id: d.parent_id,
+                    }
+                })
+                .collect(),
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi device list request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/new-status — hardware info + connected count.
+pub async fn new_status(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiNewStatusResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.new_status().await {
+        Ok(ns) => Ok(Json(XiaomiNewStatusResponse {
+            mac: ns.hardware.as_ref().and_then(|h| h.mac.clone()),
+            platform: ns.hardware.as_ref().and_then(|h| h.platform.clone()),
+            version: ns.hardware.as_ref().and_then(|h| h.version.clone()),
+            sn: ns.hardware.as_ref().and_then(|h| h.sn.clone()),
+            devices_online: ns.count.as_ref().and_then(|c| c.online),
+            devices_total: ns.count.as_ref().and_then(|c| c.all),
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi new status request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/wifi-devices — WiFi clients with signal + band.
+pub async fn wifi_devices(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<XiaomiWifiDeviceResponse>>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.wifi_devices().await {
+        Ok(list) => Ok(Json(
+            list.into_iter()
+                .map(|d| XiaomiWifiDeviceResponse {
+                    mac: d.mac,
+                    ip: d.ip,
+                    name: d.name,
+                    signal: d.signal,
+                    band: d.band,
+                })
+                .collect(),
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi wifi devices request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/wan-info — WAN connection details.
+pub async fn wan_info(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiWanInfoResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.wan_info().await {
+        Ok(info) => Ok(Json(XiaomiWanInfoResponse {
+            ip: info.ip,
+            gateway: info.gateway,
+            dns: info.dns,
+            wan_type: info.wan_type,
+            mask: info.mask,
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi WAN info request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/lan-info — LAN IP, subnet, port status.
+pub async fn lan_info(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiLanInfoResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.lan_info().await {
+        Ok(info) => Ok(Json(XiaomiLanInfoResponse {
+            ip: info.ip,
+            mask: info.mask,
+            ports: info
+                .ports
+                .into_iter()
+                .map(|p| XiaomiLanPortResponse {
+                    port: p.port,
+                    link_status: p.linkstatus,
+                    speed: p.speed,
+                })
+                .collect(),
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi LAN info request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,3 +18,4 @@ pub mod static_files;
 pub mod vyos;
 pub mod webhook;
 pub mod ws;
+pub mod xiaomi;

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -1,0 +1,436 @@
+//! Xiaomi MiWiFi HTTP API client.
+//!
+//! Implements the SHA256 auth protocol (newEncryptMode=1) used by modern
+//! Xiaomi routers (e.g. BE3600 2.5G mesh).
+//!
+//! Auth flow:
+//! 1. GET /cgi-bin/luci/web/home → extract `key` and `deviceId` from HTML
+//! 2. Build nonce: `{type}_{deviceId}_{timestamp}_{random}`
+//! 3. Hash password: SHA256(nonce + SHA256(password + key))
+//! 4. POST /cgi-bin/luci/api/xqsystem/login → returns stok token
+//!
+//! All authenticated endpoints use URL-path token:
+//!   http://<ip>/cgi-bin/luci/;stok=<TOKEN>/api/<endpoint>
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
+
+use super::types::*;
+
+/// Build the shared `reqwest::Client` for Xiaomi MiWiFi API calls.
+///
+/// Xiaomi routers use plain HTTP by default on the LAN.
+pub fn shared_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .pool_max_idle_per_host(4)
+        .tcp_keepalive(Duration::from_secs(30))
+        .build()
+        .expect("failed to build shared reqwest client for Xiaomi MiWiFi")
+}
+
+/// In-memory stok token with expiry tracking.
+#[derive(Debug, Clone)]
+struct StokToken {
+    token: String,
+    obtained_at: Instant,
+}
+
+impl StokToken {
+    /// Tokens are considered fresh for 30 minutes.
+    fn is_valid(&self) -> bool {
+        self.obtained_at.elapsed() < Duration::from_secs(30 * 60)
+    }
+}
+
+/// Thread-safe Xiaomi MiWiFi API client with automatic token management.
+#[derive(Clone)]
+pub struct XiaomiClient {
+    base_url: String,
+    password: String,
+    http: reqwest::Client,
+    stok: Arc<RwLock<Option<StokToken>>>,
+}
+
+impl XiaomiClient {
+    /// Create a new Xiaomi client reusing an existing `reqwest::Client`.
+    pub fn new(router_ip: &str, password: &str, http: reqwest::Client) -> Self {
+        let base_url = format!("http://{}", router_ip.trim_end_matches('/'));
+        Self {
+            base_url,
+            password: password.to_string(),
+            http,
+            stok: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    // ── Auth helpers ────────────────────────────────────────
+
+    /// Extract `key` and `deviceId` from the router's home page.
+    async fn extract_credentials(&self) -> Result<(String, String)> {
+        let url = format!("{}/cgi-bin/luci/web/home", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("failed to fetch MiWiFi home page")?;
+
+        let body = resp
+            .text()
+            .await
+            .context("failed to read MiWiFi home page body")?;
+
+        // Extract key: look for `key = "..."` or `var key = "..."` in the HTML/JS
+        let key = extract_js_var(&body, "key")
+            .context("failed to extract 'key' from MiWiFi home page")?;
+        let device_id = extract_js_var(&body, "deviceId")
+            .context("failed to extract 'deviceId' from MiWiFi home page")?;
+
+        Ok((key, device_id))
+    }
+
+    /// Generate a nonce string for the login request.
+    fn generate_nonce(device_id: &str) -> String {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let random: u32 = (timestamp as u32) ^ 0x1234_5678; // simple deterministic random
+        format!("0_{device_id}_{timestamp}_{random}")
+    }
+
+    /// Compute the password hash: SHA256(nonce + SHA256(password + key))
+    fn hash_password(password: &str, key: &str, nonce: &str) -> String {
+        // Step 1: SHA256(password + key)
+        let mut hasher = Sha256::new();
+        hasher.update(password.as_bytes());
+        hasher.update(key.as_bytes());
+        let inner_hash = format!("{:x}", hasher.finalize());
+
+        // Step 2: SHA256(nonce + inner_hash)
+        let mut hasher = Sha256::new();
+        hasher.update(nonce.as_bytes());
+        hasher.update(inner_hash.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    /// Perform the login flow and obtain a stok token.
+    async fn login(&self) -> Result<String> {
+        let (key, device_id) = self.extract_credentials().await?;
+        let nonce = Self::generate_nonce(&device_id);
+        let password_hash = Self::hash_password(&self.password, &key, &nonce);
+
+        let login_url = format!("{}/cgi-bin/luci/api/xqsystem/login", self.base_url);
+
+        let resp = self
+            .http
+            .post(&login_url)
+            .form(&[
+                ("username", "admin"),
+                ("password", password_hash.as_str()),
+                ("logtype", "2"),
+                ("nonce", nonce.as_str()),
+            ])
+            .send()
+            .await
+            .context("MiWiFi login request failed")?;
+
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .context("failed to parse MiWiFi login response")?;
+
+        tracing::debug!(
+            http_status = %status,
+            code = body.get("code").and_then(|v| v.as_i64()).unwrap_or(-1),
+            "MiWiFi login response"
+        );
+
+        let code = body.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);
+
+        if code != 0 {
+            let msg = body
+                .get("msg")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            anyhow::bail!("MiWiFi login failed (code {code}): {msg}");
+        }
+
+        let token = body
+            .get("token")
+            .and_then(|v| v.as_str())
+            .context("MiWiFi login response missing 'token' field")?
+            .to_string();
+
+        Ok(token)
+    }
+
+    /// Get a valid stok token, logging in if necessary.
+    async fn get_stok(&self) -> Result<String> {
+        // Try the cached token first.
+        {
+            let cached = self.stok.read().await;
+            if let Some(ref tok) = *cached {
+                if tok.is_valid() {
+                    return Ok(tok.token.clone());
+                }
+            }
+        }
+
+        // Need to refresh.
+        let token = self.login().await?;
+        let mut cached = self.stok.write().await;
+        *cached = Some(StokToken {
+            token: token.clone(),
+            obtained_at: Instant::now(),
+        });
+        Ok(token)
+    }
+
+    /// Invalidate the cached token (e.g., after a 401 or error response).
+    async fn invalidate_stok(&self) {
+        let mut cached = self.stok.write().await;
+        *cached = None;
+    }
+
+    // ── HTTP helpers ────────────────────────────────────────
+
+    /// GET an unauthenticated endpoint.
+    async fn get_no_auth(&self, api_path: &str) -> Result<Value> {
+        let url = format!("{}/cgi-bin/luci/api/{}", self.base_url, api_path);
+
+        let start = Instant::now();
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("MiWiFi API request failed")?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .context("failed to read MiWiFi API response body")?;
+        let elapsed = start.elapsed();
+
+        tracing::info!(
+            path = api_path,
+            http_status = %status,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "MiWiFi API response (no auth)"
+        );
+
+        if !status.is_success() {
+            anyhow::bail!("MiWiFi API returned HTTP {status}: {body}");
+        }
+
+        let parsed: Value =
+            serde_json::from_str(&body).context("failed to parse MiWiFi API response JSON")?;
+
+        Ok(parsed)
+    }
+
+    /// GET an authenticated endpoint (uses stok token in URL path).
+    /// Retries once on auth failure by refreshing the token.
+    async fn get_authed(&self, api_path: &str) -> Result<Value> {
+        for attempt in 0..2 {
+            let stok = self.get_stok().await?;
+            let url = format!(
+                "{}/cgi-bin/luci/;stok={}/api/{}",
+                self.base_url, stok, api_path
+            );
+
+            let start = Instant::now();
+            let resp = self
+                .http
+                .get(&url)
+                .send()
+                .await
+                .context("MiWiFi API request failed")?;
+
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .context("failed to read MiWiFi API response body")?;
+            let elapsed = start.elapsed();
+
+            tracing::info!(
+                path = api_path,
+                http_status = %status,
+                elapsed_ms = elapsed.as_millis() as u64,
+                attempt,
+                "MiWiFi API response (authed)"
+            );
+
+            if status == reqwest::StatusCode::UNAUTHORIZED
+                || status == reqwest::StatusCode::FORBIDDEN
+            {
+                if attempt == 0 {
+                    tracing::warn!("MiWiFi auth failed, refreshing token");
+                    self.invalidate_stok().await;
+                    continue;
+                }
+                anyhow::bail!("MiWiFi API returned HTTP {status} after token refresh");
+            }
+
+            if !status.is_success() {
+                anyhow::bail!("MiWiFi API returned HTTP {status}: {body}");
+            }
+
+            let parsed: Value =
+                serde_json::from_str(&body).context("failed to parse MiWiFi API response JSON")?;
+
+            // Check for error code in response body.
+            let code = parsed.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
+            if code != 0 && attempt == 0 {
+                tracing::warn!(code, "MiWiFi API error code, refreshing token");
+                self.invalidate_stok().await;
+                continue;
+            }
+
+            return Ok(parsed);
+        }
+
+        anyhow::bail!("MiWiFi API request failed after retries")
+    }
+
+    // ── Public API methods ──────────────────────────────────
+
+    /// Fetch mesh topology graph (no auth required).
+    pub async fn topo_graph(&self) -> Result<TopoGraph> {
+        let val = self.get_no_auth("misystem/topo_graph").await?;
+        let res: MiWiFiResponse<TopoGraph> =
+            serde_json::from_value(val).context("failed to parse topo_graph")?;
+        Ok(res.data)
+    }
+
+    /// Fetch system status (CPU, memory, temp, WAN speeds, device counts).
+    pub async fn system_status(&self) -> Result<SystemStatus> {
+        let val = self.get_authed("misystem/status").await?;
+        let res: SystemStatus =
+            serde_json::from_value(val).context("failed to parse system status")?;
+        Ok(res)
+    }
+
+    /// Fetch all connected devices.
+    pub async fn device_list(&self) -> Result<Vec<MiWiFiDevice>> {
+        let val = self.get_authed("misystem/devicelist").await?;
+        let res: DeviceListResponse =
+            serde_json::from_value(val).context("failed to parse device list")?;
+        Ok(res.list)
+    }
+
+    /// Fetch new status (hardware info, connected count, WiFi SSIDs).
+    pub async fn new_status(&self) -> Result<NewStatus> {
+        let val = self.get_authed("misystem/newstatus").await?;
+        let res: NewStatus = serde_json::from_value(val).context("failed to parse new status")?;
+        Ok(res)
+    }
+
+    /// Fetch WiFi connected devices with signal strength and band.
+    pub async fn wifi_devices(&self) -> Result<Vec<WifiDevice>> {
+        let val = self.get_authed("xqnetwork/wifi_connect_devices").await?;
+        let res: WifiDevicesResponse =
+            serde_json::from_value(val).context("failed to parse wifi devices")?;
+        Ok(res.list)
+    }
+
+    /// Fetch WAN info (type, gateway, DNS, IPv6).
+    pub async fn wan_info(&self) -> Result<WanInfo> {
+        let val = self.get_authed("xqnetwork/wan_info").await?;
+        let res: WanInfoResponse =
+            serde_json::from_value(val).context("failed to parse WAN info")?;
+        res.info.context("WAN info field missing from response")
+    }
+
+    /// Fetch LAN info (IP, subnet, link status per port).
+    pub async fn lan_info(&self) -> Result<LanInfo> {
+        let val = self.get_authed("xqnetwork/lan_info").await?;
+        let res: LanInfoResponse =
+            serde_json::from_value(val).context("failed to parse LAN info")?;
+        res.info.context("LAN info field missing from response")
+    }
+}
+
+/// Extract a JavaScript variable value from HTML source.
+/// Matches patterns like `var key = "abc123"`, `key = "abc123"`, `key: "abc123"`.
+fn extract_js_var(html: &str, var_name: &str) -> Option<String> {
+    // Build patterns to try, including variants with spaces
+    let patterns = [
+        format!("{var_name} = \""),
+        format!("{var_name} = '"),
+        format!("{var_name}= \""),
+        format!("{var_name}= '"),
+        format!("{var_name}=\""),
+        format!("{var_name}='"),
+        format!("{var_name}: \""),
+        format!("{var_name}: '"),
+        format!("{var_name}:\""),
+        format!("{var_name}:'"),
+    ];
+
+    for pattern in &patterns {
+        if let Some(start) = html.find(pattern.as_str()) {
+            let value_start = start + pattern.len();
+            let quote_char = if pattern.ends_with('"') { '"' } else { '\'' };
+            if let Some(end) = html[value_start..].find(quote_char) {
+                let value = &html[value_start..value_start + end];
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_key_from_html() {
+        let html = r#"var key = "a2ffa5c9be07488bbb04a3a47d3c5f6a";"#;
+        assert_eq!(
+            extract_js_var(html, "key"),
+            Some("a2ffa5c9be07488bbb04a3a47d3c5f6a".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_device_id_from_html() {
+        let html = r#"var deviceId = "AA:BB:CC:DD:EE:FF";"#;
+        assert_eq!(
+            extract_js_var(html, "deviceId"),
+            Some("AA:BB:CC:DD:EE:FF".to_string())
+        );
+    }
+
+    #[test]
+    fn hash_password_produces_correct_sha256() {
+        let password = "admin";
+        let key = "a2ffa5c9be07488bbb04a3a47d3c5f6a";
+        let nonce = "0_AA:BB:CC:DD:EE:FF_1700000000_305419896";
+
+        let hash = XiaomiClient::hash_password(password, key, nonce);
+        // Should be a 64-char hex string
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn nonce_format() {
+        let nonce = XiaomiClient::generate_nonce("AA:BB:CC:DD:EE:FF");
+        assert!(nonce.starts_with("0_AA:BB:CC:DD:EE:FF_"));
+        let parts: Vec<&str> = nonce.split('_').collect();
+        assert_eq!(parts.len(), 4);
+    }
+}

--- a/server/src/xiaomi/mod.rs
+++ b/server/src/xiaomi/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod types;

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -1,0 +1,260 @@
+//! Deserialization types for Xiaomi MiWiFi API responses.
+
+use serde::{Deserialize, Serialize};
+
+// ── Wrapper: every MiWiFi response has `{ "code": 0, ... }` ──
+
+/// Generic MiWiFi API response wrapper.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MiWiFiResponse<T> {
+    pub code: i32,
+    #[serde(flatten)]
+    pub data: T,
+}
+
+// ── Login ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoginResponse {
+    pub token: Option<String>,
+}
+
+// ── Topology (topo_graph) ───────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopoNode {
+    #[serde(default)]
+    pub mac: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub online: Option<i32>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopoLeaf {
+    #[serde(default)]
+    pub mac: Option<String>,
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub online: Option<i32>,
+    #[serde(default, rename = "parentId")]
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TopoGraph {
+    #[serde(default)]
+    pub graph: Option<TopoGraphInner>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TopoGraphInner {
+    #[serde(default)]
+    pub nodes: Vec<TopoNode>,
+    #[serde(default)]
+    pub leafs: Vec<TopoLeaf>,
+}
+
+// ── System status ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemInfo {
+    #[serde(default)]
+    pub usage: Option<f64>,
+    #[serde(default)]
+    pub total: Option<String>,
+    #[serde(default)]
+    pub hz: Option<String>,
+    #[serde(default, rename = "type")]
+    pub mem_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuInfo {
+    #[serde(default)]
+    pub core: Option<i32>,
+    #[serde(default)]
+    pub hz: Option<String>,
+    #[serde(default)]
+    pub load: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WanSpeed {
+    #[serde(default)]
+    pub downspeed: Option<String>,
+    #[serde(default)]
+    pub upspeed: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceCount {
+    #[serde(default)]
+    pub online: Option<i32>,
+    #[serde(default)]
+    pub all: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SystemStatus {
+    #[serde(default)]
+    pub mem: Option<MemInfo>,
+    #[serde(default)]
+    pub cpu: Option<CpuInfo>,
+    #[serde(default)]
+    pub wan: Option<WanSpeed>,
+    #[serde(default)]
+    pub count: Option<DeviceCount>,
+    #[serde(default)]
+    pub temperature: Option<i32>,
+}
+
+// ── Device list ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiWiFiDevice {
+    #[serde(default)]
+    pub mac: Option<String>,
+    #[serde(default)]
+    pub ip: Vec<MiWiFiDeviceIp>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default, rename = "type")]
+    pub device_type: Option<i32>,
+    #[serde(default)]
+    pub online: Option<String>,
+    #[serde(default)]
+    pub authority: Option<serde_json::Value>,
+    #[serde(default, rename = "parentId")]
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MiWiFiDeviceIp {
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub downspeed: Option<String>,
+    #[serde(default)]
+    pub upspeed: Option<String>,
+    #[serde(default)]
+    pub online: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeviceListResponse {
+    #[serde(default)]
+    pub list: Vec<MiWiFiDevice>,
+}
+
+// ── New status ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HardwareInfo {
+    #[serde(default)]
+    pub mac: Option<String>,
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub sn: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NewStatus {
+    #[serde(default)]
+    pub hardware: Option<HardwareInfo>,
+    #[serde(default)]
+    pub wan: Option<serde_json::Value>,
+    #[serde(default)]
+    pub count: Option<DeviceCount>,
+}
+
+// ── WiFi connected devices ──────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WifiDevice {
+    #[serde(default)]
+    pub mac: Option<String>,
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub signal: Option<i32>,
+    #[serde(default)]
+    pub band: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WifiDevicesResponse {
+    #[serde(default)]
+    pub list: Vec<WifiDevice>,
+}
+
+// ── WAN info ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WanInfo {
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub gateway: Option<String>,
+    #[serde(default)]
+    pub dns: Option<String>,
+    #[serde(default, rename = "wanType")]
+    pub wan_type: Option<String>,
+    #[serde(default)]
+    pub mask: Option<String>,
+    #[serde(default, rename = "ipv6")]
+    pub ipv6: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WanInfoResponse {
+    #[serde(default)]
+    pub info: Option<WanInfo>,
+}
+
+// ── LAN info ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanPort {
+    #[serde(default)]
+    pub port: Option<i32>,
+    #[serde(default)]
+    pub linkstatus: Option<String>,
+    #[serde(default)]
+    pub speed: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LanInfo {
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub mask: Option<String>,
+    #[serde(default)]
+    pub ports: Vec<LanPort>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LanInfoResponse {
+    #[serde(default)]
+    pub info: Option<LanInfo>,
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1945,3 +1945,49 @@ export function fetchMeshTopology(): Promise<
     "/api/v1/mesh/topology"
   );
 }
+
+// ─── Xiaomi MiWiFi ───────────────────────────────────────
+
+export function fetchXiaomiStatus(): Promise<
+  import("./types").XiaomiStatus
+> {
+  return apiGet<import("./types").XiaomiStatus>("/api/v1/xiaomi/status");
+}
+
+export function fetchXiaomiTopology(): Promise<
+  import("./types").XiaomiTopology
+> {
+  return apiGet<import("./types").XiaomiTopology>("/api/v1/xiaomi/topology");
+}
+
+export function fetchXiaomiDevices(): Promise<
+  import("./types").XiaomiDevice[]
+> {
+  return apiGet<import("./types").XiaomiDevice[]>("/api/v1/xiaomi/devices");
+}
+
+export function fetchXiaomiNewStatus(): Promise<
+  import("./types").XiaomiNewStatus
+> {
+  return apiGet<import("./types").XiaomiNewStatus>("/api/v1/xiaomi/new-status");
+}
+
+export function fetchXiaomiWifiDevices(): Promise<
+  import("./types").XiaomiWifiDevice[]
+> {
+  return apiGet<import("./types").XiaomiWifiDevice[]>(
+    "/api/v1/xiaomi/wifi-devices"
+  );
+}
+
+export function fetchXiaomiWanInfo(): Promise<
+  import("./types").XiaomiWanInfo
+> {
+  return apiGet<import("./types").XiaomiWanInfo>("/api/v1/xiaomi/wan-info");
+}
+
+export function fetchXiaomiLanInfo(): Promise<
+  import("./types").XiaomiLanInfo
+> {
+  return apiGet<import("./types").XiaomiLanInfo>("/api/v1/xiaomi/lan-info");
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1826,3 +1826,92 @@ export interface MeshTopologyResponse {
   main_ip: string;
   total_devices: number;
 }
+
+// ─── Xiaomi MiWiFi ──────────────────────────────────────
+
+export interface XiaomiStatus {
+  configured: boolean;
+  reachable: boolean;
+  cpu_cores: number | null;
+  cpu_freq: string | null;
+  cpu_load: number | null;
+  mem_usage: number | null;
+  mem_total: string | null;
+  mem_type: string | null;
+  temperature: number | null;
+  wan_download: string | null;
+  wan_upload: string | null;
+  devices_online: number | null;
+  devices_total: number | null;
+}
+
+export interface XiaomiTopoNode {
+  mac: string | null;
+  name: string | null;
+  locale: string | null;
+  ip: string | null;
+  online: number | null;
+  hardware: string | null;
+  model: string | null;
+}
+
+export interface XiaomiTopoLeaf {
+  mac: string | null;
+  ip: string | null;
+  name: string | null;
+  online: number | null;
+  parent_id: string | null;
+}
+
+export interface XiaomiTopology {
+  nodes: XiaomiTopoNode[];
+  leafs: XiaomiTopoLeaf[];
+}
+
+export interface XiaomiDevice {
+  mac: string | null;
+  name: string | null;
+  ip: string | null;
+  download_speed: string | null;
+  upload_speed: string | null;
+  online: boolean;
+  device_type: number | null;
+  parent_id: string | null;
+}
+
+export interface XiaomiWifiDevice {
+  mac: string | null;
+  ip: string | null;
+  name: string | null;
+  signal: number | null;
+  band: string | null;
+}
+
+export interface XiaomiWanInfo {
+  ip: string | null;
+  gateway: string | null;
+  dns: string | null;
+  wan_type: string | null;
+  mask: string | null;
+}
+
+export interface XiaomiLanPort {
+  port: number | null;
+  link_status: string | null;
+  speed: string | null;
+}
+
+export interface XiaomiLanInfo {
+  ip: string | null;
+  mask: string | null;
+  ports: XiaomiLanPort[];
+}
+
+export interface XiaomiNewStatus {
+  mac: string | null;
+  platform: string | null;
+  version: string | null;
+  sn: string | null;
+  devices_online: number | null;
+  devices_total: number | null;
+}


### PR DESCRIPTION
Closes #292

## Summary

- Implement Rust HTTP client for Xiaomi MiWiFi routers (BE3600 2.5G mesh) with SHA256 auth protocol (`newEncryptMode=1`)
- Automatic stok token management: extracts `key`/`deviceId` from router home page, generates nonce, hashes password with SHA256, and caches stok token in memory with automatic refresh on auth failure
- Rate-limit aware: retries once on 401/403 or non-zero error codes before failing

## Endpoints

| Route | Description |
|-------|-------------|
| `GET /api/v1/xiaomi/status` | CPU, memory, temp, WAN speeds, device counts |
| `GET /api/v1/xiaomi/topology` | Mesh topology graph (no auth required) |
| `GET /api/v1/xiaomi/devices` | All devices: MAC, IP, speed, parent mesh node |
| `GET /api/v1/xiaomi/new-status` | Hardware info, firmware version, connected count |
| `GET /api/v1/xiaomi/wifi-devices` | WiFi clients with signal strength + band |
| `GET /api/v1/xiaomi/wan-info` | WAN type, gateway, DNS |
| `GET /api/v1/xiaomi/lan-info` | LAN IP, subnet, link status per port |

## Files

- `server/src/xiaomi/client.rs` — HTTP client with SHA256 auth + stok token management
- `server/src/xiaomi/types.rs` — Serde deserialization types for all MiWiFi API responses
- `server/src/api/xiaomi.rs` — Axum handlers for 7 endpoints
- TypeScript types and API client functions in `web/src/lib/`

## Configuration

Settings keys: `xiaomi_enabled`, `xiaomi_ip` (default: `10.10.0.199`), `xiaomi_password`

## Test plan

- [x] Unit tests pass for JS var extraction, nonce format, SHA256 password hashing
- [x] `cargo check` passes
- [x] `cargo fmt` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements comprehensive Xiaomi MiWiFi router integration with SHA256 authentication protocol and automatic stok token management. The implementation adds 7 new API endpoints exposing router status, mesh topology, device lists, and network configuration.

**Key Changes:**
- Adds HTTP client with SHA256 auth flow (`client.rs:74-172`) — extracts credentials from router homepage, generates nonce, hashes password, and caches token with 30-minute expiry
- Token auto-refresh on 401/403 or error codes with single retry (`client.rs:242-303`)
- 7 Axum handlers with graceful degradation when unconfigured (`api/xiaomi.rs`)
- Comprehensive serde types for all API responses (`types.rs`)
- TypeScript types and API client functions match backend schemas

**Minor Issue:**
- Nonce generation uses weak deterministic randomness (`timestamp XOR 0x12345678`) instead of cryptographic random — acceptable for this auth protocol but could be improved

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor style suggestion about nonce randomness
- Well-structured implementation with proper error handling, token caching, and comprehensive type coverage. Only minor improvement needed is using cryptographic random for nonce generation instead of deterministic XOR.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/client.rs | Implements SHA256 auth flow for Xiaomi routers with token caching. Minor issue: weak nonce randomness uses deterministic XOR instead of cryptographic random. |
| server/src/xiaomi/types.rs | Comprehensive serde types for Xiaomi API responses with proper optional field handling and default annotations. |
| server/src/api/xiaomi.rs | Clean Axum handlers for 7 Xiaomi endpoints with proper error handling and graceful degradation when unconfigured. |
| server/src/api/mod.rs | Adds Xiaomi router integration with shared HTTP client and 7 new API routes. |
| web/src/lib/api.ts | Adds 7 new API client functions for Xiaomi endpoints with proper TypeScript typing. |
| web/src/lib/types.ts | Adds comprehensive TypeScript types for Xiaomi API responses matching backend Rust types. |

</details>



<sub>Last reviewed commit: 2b7bbb7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->