### PR TITLE
feat: move NPM integration to Optional/Legacy section — Caddy is now primary (#302)

### DIFF
--- a/web/src/app/(app)/settings/npm/page.tsx
+++ b/web/src/app/(app)/settings/npm/page.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   CheckCircle,
   AlertCircle,
+  AlertTriangle,
   ArrowLeft,
 } from "lucide-react";
 import {
@@ -137,6 +138,20 @@ export default function NpmSettingsPage() {
             <ArrowLeft className="h-4 w-4" />
           </Link>
           <h1 className="text-2xl font-semibold text-white">Nginx Proxy Manager</h1>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+          <p className="text-xs text-amber-400">
+            Legacy — consider migrating to{" "}
+            <Link
+              href="/settings/caddy"
+              className="font-medium underline hover:text-amber-300"
+            >
+              Caddy
+            </Link>
+            , the primary reverse proxy.
+          </p>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -28,6 +28,7 @@ interface SettingsItem {
 
 interface SettingsGroup {
   label: string;
+  subtitle?: string;
   items: SettingsItem[];
 }
 
@@ -43,18 +44,11 @@ const settingsGroups: SettingsGroup[] = [
         description: "Configure MikroTik or VyOS router integration.",
       },
       {
-        href: "/settings/npm",
-        icon: <Globe className="h-4 w-4 text-orange-400" />,
-        iconBg: "bg-orange-500/10",
-        title: "Nginx Proxy Manager",
-        description: "Manage reverse proxy hosts via NPM.",
-      },
-      {
         href: "/settings/caddy",
         icon: <Shield className="h-4 w-4 text-emerald-400" />,
         iconBg: "bg-emerald-500/10",
         title: "Caddy Reverse Proxy",
-        description: "Manage reverse proxy hosts via Caddy.",
+        description: "Primary reverse proxy — manage hosts via Caddy.",
       },
       {
         href: "/settings/dns",
@@ -138,6 +132,19 @@ const settingsGroups: SettingsGroup[] = [
       },
     ],
   },
+  {
+    label: "Legacy / Optional",
+    subtitle: "Use Caddy for new deployments.",
+    items: [
+      {
+        href: "/settings/npm",
+        icon: <Globe className="h-4 w-4 text-orange-400" />,
+        iconBg: "bg-orange-500/10",
+        title: "Nginx Proxy Manager",
+        description: "Legacy reverse proxy — consider migrating to Caddy.",
+      },
+    ],
+  },
 ];
 
 export default function SettingsPage() {
@@ -148,9 +155,16 @@ export default function SettingsPage() {
 
         {settingsGroups.map((group) => (
           <section key={group.label} className="space-y-3">
-            <h2 className="text-xs font-medium uppercase tracking-wider text-slate-500">
-              {group.label}
-            </h2>
+            <div>
+              <h2 className="text-xs font-medium uppercase tracking-wider text-slate-500">
+                {group.label}
+              </h2>
+              {group.subtitle && (
+                <p className="mt-1 text-xs text-slate-600">
+                  {group.subtitle}
+                </p>
+              )}
+            </div>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {group.items.map((item) => (
                 <Link key={item.href} href={item.href} className="group">


### PR DESCRIPTION
## Summary

- Moved Nginx Proxy Manager card from the main **Integrations** section to a new **Legacy / Optional** section at the bottom of Settings, with subtitle "Use Caddy for new deployments."
- Updated Caddy card description to **"Primary reverse proxy — manage hosts via Caddy."** making it prominently featured as the primary proxy option.
- Added a **legacy migration banner** on the NPM settings page with amber styling: "Legacy — consider migrating to Caddy, the primary reverse proxy." with a link to the Caddy settings.
- All NPM pages and functionality remain fully intact — no code was removed.

Closes #302

## Test plan

- [ ] Navigate to Settings page and verify NPM card appears under "Legacy / Optional" section (not under Integrations)
- [ ] Verify "Use Caddy for new deployments." subtitle appears under the Legacy / Optional heading
- [ ] Verify Caddy card shows updated description "Primary reverse proxy — manage hosts via Caddy."
- [ ] Navigate to Settings > NPM and verify legacy amber banner appears below the header
- [ ] Verify the Caddy link in the NPM banner navigates to `/settings/caddy`
- [ ] Verify NPM settings page functionality (save/test connection) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully repositions Nginx Proxy Manager as a legacy option while promoting Caddy as the primary reverse proxy solution. The changes are entirely UI/UX focused with no functional code modifications.

- Moved NPM card from main Integrations section to new Legacy/Optional section at bottom of Settings page
- Updated Caddy description to explicitly state "Primary reverse proxy"
- Added amber-styled legacy migration banner on NPM settings page with link to Caddy
- Added optional `subtitle` field to settings group interface for contextual messaging
- All NPM functionality remains fully intact and operational

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Changes are purely presentational UI updates with no logic modifications. The refactoring moves UI elements, updates text labels, and adds visual indicators. All existing NPM functionality is preserved, link targets are verified to exist, and the implementation follows established patterns used elsewhere in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/npm/page.tsx | Added legacy migration banner with link to Caddy settings. Clean implementation with proper styling and icon usage. |
| web/src/app/(app)/settings/page.tsx | Moved NPM to new Legacy/Optional section, promoted Caddy as primary proxy. Properly extended interface with optional subtitle field. |

</details>



<sub>Last reviewed commit: ee082da</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->