### PR TITLE
feat: DNS test setup — configure Unbound on LXC 115 as network DNS server (#298)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,10 @@ services:
     restart: unless-stopped
     networks:
       - panoptikon-net
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
     expose:
-      - "53/tcp"
-      - "53/udp"
       - "5335/tcp"
       - "5335/udp"
     volumes:

--- a/docker/unbound/unbound.conf
+++ b/docker/unbound/unbound.conf
@@ -50,3 +50,7 @@ server:
     do-ip6: no
     do-udp: yes
     do-tcp: yes
+
+    # Local test zone — used by test clients to verify DNS resolution
+    local-zone: "ok.labs." static
+    local-data: "local.ok.labs. IN A 10.10.0.22"

--- a/docs/test-environment.md
+++ b/docs/test-environment.md
@@ -20,11 +20,15 @@ Setup guide for the Panoptikon MikroTik integration test environment. Uses 2-3 l
 │  │ .200         │  │ .201         │  │ .202         │         │
 │  │ 256MB / 1CPU │  │ 256MB / 1CPU │  │ 128MB / 1CPU │         │
 │  └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                 │
-│  ┌──────────────────┐                                           │
-│  │ Panoptikon       │                                           │
-│  │ 10.10.0.14:8080  │  (monitoring all of the above)           │
-│  └──────────────────┘                                           │
+│          │                │                │                    │
+│          └────────────────┼────────────────┘                    │
+│                      DNS queries                                │
+│                           ▼                                     │
+│  ┌──────────────────────────────────┐                           │
+│  │ Panoptikon          CT 115      │                           │
+│  │ 10.10.0.22:8080  (dashboard)    │                           │
+│  │ 10.10.0.22:53   (Unbound DNS)  │                           │
+│  └──────────────────────────────────┘                           │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -78,7 +82,7 @@ If the MikroTik CHR VM is not yet configured, follow these steps from the Router
 # 4. Configure DHCP server for the test subnet
 /ip pool add name=test-pool ranges=10.10.0.200-10.10.0.254
 /ip dhcp-server add name=test-dhcp interface=bridge-test address-pool=test-pool
-/ip dhcp-server network add address=10.10.0.0/24 gateway=10.10.0.125 dns-server=1.1.1.1
+/ip dhcp-server network add address=10.10.0.0/24 gateway=10.10.0.125 dns-server=10.10.0.22
 
 # 5. Enable masquerade for internet access (if the CHR has WAN)
 /ip firewall nat add chain=srcnat out-interface=ether1 action=masquerade
@@ -92,6 +96,55 @@ If the MikroTik CHR VM is not yet configured, follow these steps from the Router
 
 ```routeros
 /user add name=panoptikon password=panoptikon-test group=read
+```
+
+## DNS Setup (Unbound on LXC 115)
+
+Panoptikon runs Unbound as a network-wide DNS resolver on LXC 115 (`10.10.0.22`). The setup script configures test containers to use it automatically.
+
+### What the setup script does
+
+1. **Opens port 53** on the Proxmox firewall for CT 115 (UDP + TCP, source `10.10.0.0/24`)
+2. **Sets `10.10.0.22`** as the nameserver for all test containers
+3. **Installs `dnsutils`** in test containers so `dig` is available for verification
+
+### MikroTik DHCP — hand out Unbound as DNS
+
+If test containers use DHCP (instead of static IPs), update the MikroTik DHCP network to hand out Panoptikon's Unbound:
+
+```routeros
+# Update existing DHCP network to use Panoptikon DNS
+/ip dhcp-server network set [find address="10.10.0.0/24"] dns-server=10.10.0.22
+```
+
+### Verify DNS from a test client
+
+```bash
+# External DNS forwarding (should resolve via Unbound → root hints)
+pct exec 200 -- dig @10.10.0.22 google.com +short
+
+# Local record resolution (ok.labs test zone configured in unbound.conf)
+pct exec 200 -- dig @10.10.0.22 local.ok.labs +short
+# Expected: 10.10.0.22
+
+# Verify the container's default resolver is Unbound
+pct exec 200 -- dig google.com +short
+```
+
+### Manual firewall setup (if not using the setup script)
+
+If CT 115 already exists and you need to open port 53 manually:
+
+```bash
+# Add rules to /etc/pve/firewall/115.fw
+cat >> /etc/pve/firewall/115.fw <<'EOF'
+[OPTIONS]
+enable: 1
+
+[RULES]
+IN ACCEPT -p udp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-udp
+IN ACCEPT -p tcp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-tcp
+EOF
 ```
 
 ## Validation Scenarios
@@ -205,6 +258,9 @@ pct exec 201 -- bash -c "while true; do curl -s -o /dev/null https://speed.cloud
 | Panoptikon doesn't see containers | Verify ARP scanner subnet includes `10.10.0.0/24` in `panoptikon.toml` |
 | REST API connection refused | Check MikroTik: `/ip service print` — api-ssl should be enabled |
 | Containers have no internet | Check NAT masquerade: `/ip firewall nat print` |
+| DNS queries to 10.10.0.22 fail | Verify Unbound container is running: `docker compose ps unbound` |
+| DNS queries timeout | Check CT 115 firewall allows port 53: `cat /etc/pve/firewall/115.fw` |
+| `local.ok.labs` not resolving | Verify unbound.conf has `local-data` entry and restart: `docker compose restart unbound` |
 
 ## Cleanup
 

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -27,7 +27,7 @@ MIKROTIK_GW="10.10.0.125"
 BRIDGE="vmbr0"
 TEMPLATE="local:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst"
 STORAGE="local-lvm"
-NAMESERVER="1.1.1.1"
+NAMESERVER="10.10.0.22"           # Panoptikon Unbound on LXC 115
 
 # Container definitions: CTID  NAME              IP               RAM(MB)  DISK(GB)  DESCRIPTION
 CONTAINERS=(
@@ -55,10 +55,56 @@ check_prerequisites() {
 }
 
 # ---------------------------------------------------------------------------
+# Panoptikon LXC 115 — open port 53 for DNS
+# ---------------------------------------------------------------------------
+PANOPTIKON_CTID="115"
+
+open_dns_port() {
+  local fw_dir="/etc/pve/firewall"
+  local fw_file="${fw_dir}/${PANOPTIKON_CTID}.fw"
+
+  if [[ ! -d "$fw_dir" ]]; then
+    log "Proxmox firewall directory not found — skipping DNS port config"
+    return 0
+  fi
+
+  # Create or append firewall rules for LXC 115
+  if [[ -f "$fw_file" ]] && grep -q "comment=allow-dns" "$fw_file"; then
+    log "DNS firewall rules already present for CT $PANOPTIKON_CTID"
+    return 0
+  fi
+
+  log "Opening port 53 (TCP+UDP) on CT $PANOPTIKON_CTID firewall..."
+
+  # Ensure [OPTIONS] section exists with firewall enabled
+  if [[ ! -f "$fw_file" ]] || ! grep -q '^\[OPTIONS\]' "$fw_file"; then
+    cat >> "$fw_file" <<'FWEOF'
+[OPTIONS]
+enable: 1
+
+FWEOF
+  fi
+
+  # Ensure [RULES] section exists
+  if ! grep -q '^\[RULES\]' "$fw_file"; then
+    echo "[RULES]" >> "$fw_file"
+  fi
+
+  # Add DNS allow rules
+  cat >> "$fw_file" <<FWEOF
+IN ACCEPT -p udp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-udp
+IN ACCEPT -p tcp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-tcp
+FWEOF
+
+  log "Firewall rules added for CT $PANOPTIKON_CTID"
+}
+
+# ---------------------------------------------------------------------------
 # Create containers
 # ---------------------------------------------------------------------------
 create_containers() {
   check_prerequisites
+  open_dns_port
 
   for entry in "${CONTAINERS[@]}"; do
     read -r ctid name ip ram disk desc <<< "$entry"
@@ -91,7 +137,7 @@ create_containers() {
     log "Installing basic tools in $ctid..."
     pct exec "$ctid" -- bash -c "
       apt-get update -qq &&
-      apt-get install -y -qq curl iputils-ping net-tools > /dev/null 2>&1
+      apt-get install -y -qq curl iputils-ping net-tools dnsutils > /dev/null 2>&1
     " || log "Warning: package install in $ctid may have failed (non-fatal)"
 
     log "Container $ctid ($name) ready at ${ip%%/*}"


### PR DESCRIPTION
Closes #298

## Summary

- **Publish Unbound port 53** to the Docker host in `docker-compose.yml` — was previously `expose`-only (internal to Docker network), now mapped as `ports: 53:53` so test clients on the LAN can reach it at `10.10.0.22:53`
- **Add `local.ok.labs` test zone** to `unbound.conf` — static local-data record resolving to `10.10.0.22` for DNS verification
- **Update `setup-test-env.sh`** to use Panoptikon Unbound (`10.10.0.22`) as the nameserver for all test containers, open port 53 on CT 115's Proxmox firewall, and install `dnsutils` for `dig`
- **Update `docs/test-environment.md`** with DNS setup section, updated network topology diagram showing Unbound, MikroTik DHCP DNS config (`dns-server=10.10.0.22`), verification commands, and troubleshooting entries

## Test plan

- [ ] `dig @10.10.0.22 google.com` — external DNS forwarding works via Unbound
- [ ] `dig @10.10.0.22 local.ok.labs` — local test zone resolves to `10.10.0.22`
- [ ] Test containers created by `setup-test-env.sh` use `10.10.0.22` as default resolver
- [ ] CT 115 firewall allows port 53 from `10.10.0.0/24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Configures Unbound on LXC 115 as the network DNS server for test clients by publishing port 53 to the Docker host (10.10.0.22), adding a `local.ok.labs` test zone for verification, updating the setup script to configure CT 115 firewall rules and set Unbound as the default nameserver, and documenting the DNS setup with verification commands.

- Published Unbound port 53 (TCP+UDP) from Docker-internal to host-accessible at `10.10.0.22:53`
- Added `local.ok.labs` static DNS zone resolving to `10.10.0.22` for testing
- Automated CT 115 firewall configuration in `setup-test-env.sh` (allows port 53 from `10.10.0.0/24`)
- Changed test container nameserver from `1.1.1.1` to `10.10.0.22` (Panoptikon Unbound)
- Installed `dnsutils` in test containers for `dig` verification
- Updated docs with DNS setup section, MikroTik DHCP DNS config, verification commands, and troubleshooting
- Corrected network topology diagram IP address from `10.10.0.14` to `10.10.0.22` to match actual deployment

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns
- All changes are well-structured, properly documented, and consistent across configuration files. The firewall rule implementation is defensive (checks for existing rules before adding), and the DNS configuration follows standard best practices. Documentation is thorough with verification steps and troubleshooting guidance.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker-compose.yml | Published Unbound port 53 (TCP+UDP) to Docker host, making it accessible to LAN clients at 10.10.0.22:53 |
| docker/unbound/unbound.conf | Added `local.ok.labs` test zone with static A record pointing to 10.10.0.22 for DNS verification |
| scripts/setup-test-env.sh | Updated nameserver to 10.10.0.22, added `open_dns_port()` to configure CT 115 firewall, installed `dnsutils` in test containers |
| docs/test-environment.md | Updated network topology diagram (10.10.0.14→10.10.0.22), added DNS setup section with verification commands, troubleshooting entries, and MikroTik DHCP DNS configuration |

</details>



<sub>Last reviewed commit: c1bb8f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->