### PR TITLE
feat: Settings — Xiaomi Mesh integration config (#296)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -49,6 +49,7 @@ pub mod unbound;
 pub mod vpn_status;
 pub mod vyos;
 pub mod xiaomi;
+pub mod xiaomi_mesh;
 
 pub use error::AppError;
 
@@ -74,6 +75,8 @@ pub struct AppState {
     pub caddy_http: reqwest::Client,
     /// Shared reqwest::Client for Xiaomi MiWiFi API.
     pub xiaomi_http: reqwest::Client,
+    /// Shared reqwest::Client for Xiaomi Mesh test-connection.
+    pub xiaomi_mesh_http: reqwest::Client,
 }
 
 impl AppState {
@@ -95,6 +98,10 @@ impl AppState {
                 .build()
                 .expect("caddy HTTP client"),
             xiaomi_http: crate::xiaomi::client::shared_http_client(),
+            xiaomi_mesh_http: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("xiaomi mesh HTTP client"),
         }
     }
 }
@@ -435,6 +442,11 @@ pub fn router(state: AppState) -> Router {
         .route("/unbound/dns-records/:id", delete(unbound::delete))
         .route("/unbound/dns-records/:id/toggle", post(unbound::toggle))
         .route("/unbound/test-connection", post(unbound::test_connection))
+        // Xiaomi Mesh
+        .route(
+            "/xiaomi-mesh/test-connection",
+            post(xiaomi_mesh::test_connection),
+        )
         // Unified Services wizard
         .route("/services/add", post(services::add_service))
         .route("/services/remove", post(services::remove_service))

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -38,6 +38,12 @@ pub struct SettingsResponse {
     pub unbound_control_path: Option<String>,
     // --- Caddy Reverse Proxy ---
     pub caddy_admin_url: Option<String>,
+    // --- Xiaomi Mesh ---
+    pub xiaomi_mesh_enabled: bool,
+    pub xiaomi_mesh_ip: Option<String>,
+    /// Never return the password to the frontend — just whether one is set.
+    pub xiaomi_mesh_password_set: bool,
+    pub xiaomi_mesh_poll_interval: Option<u64>,
 }
 
 /// Request body for updating settings.
@@ -70,6 +76,11 @@ pub struct UpdateSettingsRequest {
     pub unbound_control_path: Option<String>,
     // --- Caddy Reverse Proxy ---
     pub caddy_admin_url: Option<String>,
+    // --- Xiaomi Mesh ---
+    pub xiaomi_mesh_enabled: Option<bool>,
+    pub xiaomi_mesh_ip: Option<String>,
+    pub xiaomi_mesh_password: Option<String>,
+    pub xiaomi_mesh_poll_interval: Option<u64>,
 }
 
 /// Helper: read a string setting from the settings table.
@@ -155,6 +166,18 @@ pub async fn get_settings(
     // Caddy settings.
     let caddy_admin_url = get_setting(&state, "caddy_admin_url").await;
 
+    // Xiaomi Mesh settings.
+    let xiaomi_mesh_enabled = get_setting(&state, "xiaomi_mesh_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    let xiaomi_mesh_ip = get_setting(&state, "xiaomi_mesh_ip").await;
+    let xiaomi_mesh_password_set = get_setting(&state, "xiaomi_mesh_password").await.is_some();
+    let xiaomi_mesh_poll_interval = get_setting(&state, "xiaomi_mesh_poll_interval")
+        .await
+        .and_then(|v| v.parse().ok())
+        .or(Some(30));
+
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
@@ -176,6 +199,10 @@ pub async fn get_settings(
         mikrotik_enabled,
         unbound_control_path,
         caddy_admin_url,
+        xiaomi_mesh_enabled,
+        xiaomi_mesh_ip,
+        xiaomi_mesh_password_set,
+        xiaomi_mesh_poll_interval,
     }))
 }
 
@@ -308,6 +335,38 @@ pub async fn update_settings(
     if let Some(ref url) = body.caddy_admin_url {
         upsert_setting(&state, "caddy_admin_url", url).await?;
         info!(caddy_admin_url = %url, "Caddy admin URL updated");
+    }
+
+    // --- Xiaomi Mesh settings ---
+    if let Some(enabled) = body.xiaomi_mesh_enabled {
+        upsert_setting(
+            &state,
+            "xiaomi_mesh_enabled",
+            if enabled { "1" } else { "0" },
+        )
+        .await?;
+        info!(
+            xiaomi_mesh_enabled = enabled,
+            "Xiaomi Mesh enabled toggle updated"
+        );
+    }
+
+    if let Some(ref ip) = body.xiaomi_mesh_ip {
+        upsert_setting(&state, "xiaomi_mesh_ip", ip).await?;
+        info!(xiaomi_mesh_ip = %ip, "Xiaomi Mesh IP updated");
+    }
+
+    if let Some(ref password) = body.xiaomi_mesh_password {
+        upsert_setting(&state, "xiaomi_mesh_password", password).await?;
+        info!("Xiaomi Mesh password updated");
+    }
+
+    if let Some(interval) = body.xiaomi_mesh_poll_interval {
+        upsert_setting(&state, "xiaomi_mesh_poll_interval", &interval.to_string()).await?;
+        info!(
+            xiaomi_mesh_poll_interval = interval,
+            "Xiaomi Mesh poll interval updated"
+        );
     }
 
     // Return current state.

--- a/server/src/api/xiaomi_mesh.rs
+++ b/server/src/api/xiaomi_mesh.rs
@@ -1,0 +1,132 @@
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use super::AppState;
+
+/// Response for the Xiaomi Mesh test-connection endpoint.
+#[derive(Debug, Serialize)]
+pub struct XiaomiMeshTestConnectionResponse {
+    pub success: bool,
+    pub message: String,
+    pub router_model: Option<String>,
+    pub hardware: Option<String>,
+    pub firmware: Option<String>,
+    pub router_name: Option<String>,
+}
+
+/// Body for test-connection — allows testing before saving settings.
+#[derive(Debug, Deserialize)]
+pub struct TestConnectionRequest {
+    pub ip: Option<String>,
+}
+
+/// Helper: read a setting from the DB.
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+/// POST /api/v1/xiaomi-mesh/test-connection
+///
+/// Calls the Xiaomi router's `api/xqsystem/init_info` endpoint (no auth required)
+/// to verify connectivity and retrieve basic router info.
+pub async fn test_connection(
+    State(state): State<AppState>,
+    Json(body): Json<TestConnectionRequest>,
+) -> Json<XiaomiMeshTestConnectionResponse> {
+    // Use the IP from the request body if provided, otherwise fall back to saved setting.
+    let ip = match body.ip.filter(|s| !s.is_empty()) {
+        Some(ip) => ip,
+        None => match get_setting(&state, "xiaomi_mesh_ip").await {
+            Some(ip) => ip,
+            None => {
+                return Json(XiaomiMeshTestConnectionResponse {
+                    success: false,
+                    message: "No router IP configured. Enter an IP and save first.".to_string(),
+                    router_model: None,
+                    hardware: None,
+                    firmware: None,
+                    router_name: None,
+                });
+            }
+        },
+    };
+
+    let url = format!("http://{ip}/cgi-bin/luci/api/xqsystem/init_info");
+
+    match state.xiaomi_mesh_http.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body_text = resp.text().await.unwrap_or_default();
+            // Parse the JSON response to extract router info.
+            match serde_json::from_str::<serde_json::Value>(&body_text) {
+                Ok(json) => {
+                    let router_model = json
+                        .get("routerId")
+                        .or_else(|| json.get("routername"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let hardware = json
+                        .get("hardware")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let firmware = json
+                        .get("romversion")
+                        .or_else(|| json.get("rom"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let router_name = json
+                        .get("displayName")
+                        .or_else(|| json.get("routername"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+
+                    Json(XiaomiMeshTestConnectionResponse {
+                        success: true,
+                        message: format!("Connected to Xiaomi router at {ip}"),
+                        router_model,
+                        hardware,
+                        firmware,
+                        router_name,
+                    })
+                }
+                Err(_) => Json(XiaomiMeshTestConnectionResponse {
+                    success: true,
+                    message: format!("Connected to {ip} but could not parse router info response."),
+                    router_model: None,
+                    hardware: None,
+                    firmware: None,
+                    router_name: None,
+                }),
+            }
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            Json(XiaomiMeshTestConnectionResponse {
+                success: false,
+                message: format!("Router at {ip} responded with HTTP {status}: {body_text}"),
+                router_model: None,
+                hardware: None,
+                firmware: None,
+                router_name: None,
+            })
+        }
+        Err(e) => {
+            error!("Xiaomi Mesh test connection failed for {ip}: {e}");
+            Json(XiaomiMeshTestConnectionResponse {
+                success: false,
+                message: format!("Failed to reach Xiaomi router at {ip}: {e}"),
+                router_model: None,
+                hardware: None,
+                firmware: None,
+                router_name: None,
+            })
+        }
+    }
+}

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   ShieldAlert,
   Server,
+  Wifi,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageTransition } from "@/components/PageTransition";
@@ -56,6 +57,13 @@ const settingsGroups: SettingsGroup[] = [
         iconBg: "bg-teal-500/10",
         title: "Unbound DNS",
         description: "Manage local DNS A records via Unbound.",
+      },
+      {
+        href: "/settings/xiaomi-mesh",
+        icon: <Wifi className="h-4 w-4 text-orange-400" />,
+        iconBg: "bg-orange-500/10",
+        title: "Xiaomi Mesh",
+        description: "Configure Xiaomi mesh router integration.",
       },
       {
         href: "/settings/webhook",

--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Wifi,
+  Plug,
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  ArrowLeft,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { testXiaomiMeshConnection } from "@/lib/api";
+import { PageTransition } from "@/components/PageTransition";
+import Link from "next/link";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+export default function XiaomiMeshSettingsPage() {
+  const [enabled, setEnabled] = useState(false);
+  const [savedEnabled, setSavedEnabled] = useState(false);
+  const [ip, setIp] = useState("10.10.0.199");
+  const [savedIp, setSavedIp] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [passwordSet, setPasswordSet] = useState(false);
+  const [pollInterval, setPollInterval] = useState("30");
+  const [savedPollInterval, setSavedPollInterval] = useState<string | null>(
+    null
+  );
+
+  const [saveStatus, setSaveStatus] = useState<Status>("idle");
+  const [saveMsg, setSaveMsg] = useState("");
+  const [testStatus, setTestStatus] = useState<Status>("idle");
+  const [testMsg, setTestMsg] = useState("");
+  const [testDetails, setTestDetails] = useState<{
+    router_model?: string | null;
+    hardware?: string | null;
+    firmware?: string | null;
+    router_name?: string | null;
+  } | null>(null);
+
+  const loadTokenRef = useRef(0);
+
+  useEffect(() => {
+    const loadToken = ++loadTokenRef.current;
+    fetch("/api/v1/settings", { credentials: "include" })
+      .then((res) => res.json())
+      .then(
+        (data: {
+          xiaomi_mesh_enabled: boolean;
+          xiaomi_mesh_ip: string | null;
+          xiaomi_mesh_password_set: boolean;
+          xiaomi_mesh_poll_interval: number | null;
+        }) => {
+          if (loadToken !== loadTokenRef.current) return;
+          setEnabled(data.xiaomi_mesh_enabled);
+          setSavedEnabled(data.xiaomi_mesh_enabled);
+          if (data.xiaomi_mesh_ip) {
+            setIp(data.xiaomi_mesh_ip);
+            setSavedIp(data.xiaomi_mesh_ip);
+          }
+          setPasswordSet(data.xiaomi_mesh_password_set);
+          if (data.xiaomi_mesh_poll_interval !== null) {
+            setPollInterval(String(data.xiaomi_mesh_poll_interval));
+            setSavedPollInterval(String(data.xiaomi_mesh_poll_interval));
+          }
+        }
+      )
+      .catch(() => {});
+  }, []);
+
+  const dirty =
+    enabled !== savedEnabled ||
+    ip !== (savedIp ?? "10.10.0.199") ||
+    password.length > 0 ||
+    pollInterval !== (savedPollInterval ?? "30");
+
+  // Validate IPv4
+  function isValidIpv4(value: string): boolean {
+    const parts = value.split(".");
+    if (parts.length !== 4) return false;
+    return parts.every((p) => {
+      const n = Number(p);
+      return /^\d{1,3}$/.test(p) && n >= 0 && n <= 255;
+    });
+  }
+
+  async function handleSave() {
+    // Validate
+    if (!isValidIpv4(ip)) {
+      setSaveStatus("error");
+      setSaveMsg("Invalid IPv4 address.");
+      return;
+    }
+    if (enabled && !passwordSet && password.length === 0) {
+      setSaveStatus("error");
+      setSaveMsg("Password is required when integration is enabled.");
+      return;
+    }
+    const interval = Number(pollInterval);
+    if (isNaN(interval) || interval < 10 || interval > 300) {
+      setSaveStatus("error");
+      setSaveMsg("Poll interval must be between 10 and 300 seconds.");
+      return;
+    }
+
+    loadTokenRef.current++;
+    setSaveStatus("loading");
+    setSaveMsg("");
+    try {
+      const body: Record<string, string | boolean | number> = {};
+      if (enabled !== savedEnabled) body.xiaomi_mesh_enabled = enabled;
+      if (ip !== (savedIp ?? "10.10.0.199")) body.xiaomi_mesh_ip = ip;
+      if (password.length > 0) body.xiaomi_mesh_password = password;
+      if (pollInterval !== (savedPollInterval ?? "30"))
+        body.xiaomi_mesh_poll_interval = interval;
+
+      // Always send all changed fields
+      if (Object.keys(body).length === 0 && dirty) {
+        // If dirty flag is set but body is empty, send all fields
+        body.xiaomi_mesh_enabled = enabled;
+        body.xiaomi_mesh_ip = ip;
+        body.xiaomi_mesh_poll_interval = interval;
+      }
+
+      const res = await fetch("/api/v1/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSavedEnabled(data.xiaomi_mesh_enabled);
+        setEnabled(data.xiaomi_mesh_enabled);
+        if (data.xiaomi_mesh_ip) {
+          setSavedIp(data.xiaomi_mesh_ip);
+          setIp(data.xiaomi_mesh_ip);
+        }
+        setPasswordSet(data.xiaomi_mesh_password_set);
+        setPassword("");
+        if (data.xiaomi_mesh_poll_interval !== null) {
+          setSavedPollInterval(String(data.xiaomi_mesh_poll_interval));
+          setPollInterval(String(data.xiaomi_mesh_poll_interval));
+        }
+        setSaveStatus("success");
+        setSaveMsg("Xiaomi Mesh settings saved.");
+        setTimeout(() => setSaveStatus("idle"), 3000);
+      } else {
+        setSaveStatus("error");
+        setSaveMsg(`Failed to save (${res.status}).`);
+      }
+    } catch {
+      setSaveStatus("error");
+      setSaveMsg("Network error.");
+    }
+  }
+
+  async function handleTest() {
+    setTestStatus("loading");
+    setTestMsg("");
+    setTestDetails(null);
+    try {
+      const data = await testXiaomiMeshConnection(ip);
+      if (data.success) {
+        setTestStatus("success");
+        setTestMsg(data.message);
+        setTestDetails({
+          router_model: data.router_model,
+          hardware: data.hardware,
+          firmware: data.firmware,
+          router_name: data.router_name,
+        });
+        setTimeout(() => setTestStatus("idle"), 10000);
+      } else {
+        setTestStatus("error");
+        setTestMsg(data.message);
+      }
+    } catch {
+      setTestStatus("error");
+      setTestMsg("Failed to test connection.");
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-lg space-y-6 py-8">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/settings"
+            className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-800 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <h1 className="text-2xl font-semibold text-white">Xiaomi Mesh</h1>
+        </div>
+
+        <Card className="border-slate-800 bg-slate-900">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-orange-500/10">
+                <Wifi className="h-4 w-4 text-orange-400" />
+              </div>
+              <div>
+                <CardTitle className="text-base text-white">
+                  Xiaomi Mesh Connection
+                </CardTitle>
+                <CardDescription className="text-xs text-slate-500">
+                  Connect to your Xiaomi mesh router to fetch WiFi clients, mesh
+                  topology, and device info.
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Enable toggle */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="xiaomi-enabled" className="text-xs text-slate-400">
+                Enable Integration
+              </Label>
+              <Switch
+                id="xiaomi-enabled"
+                checked={enabled}
+                onCheckedChange={setEnabled}
+              />
+            </div>
+
+            {/* Router IP */}
+            <div className="space-y-1.5">
+              <Label htmlFor="xiaomi-ip" className="text-xs text-slate-400">
+                Router IP
+              </Label>
+              <Input
+                id="xiaomi-ip"
+                type="text"
+                value={ip}
+                onChange={(e) => setIp(e.target.value)}
+                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+                placeholder="10.10.0.199"
+              />
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1.5">
+              <Label
+                htmlFor="xiaomi-password"
+                className="text-xs text-slate-400"
+              >
+                Password{" "}
+                {passwordSet && (
+                  <span className="text-emerald-500">(saved)</span>
+                )}
+              </Label>
+              <Input
+                id="xiaomi-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+                placeholder={
+                  passwordSet
+                    ? "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022  (leave blank to keep current)"
+                    : "Enter router password"
+                }
+              />
+            </div>
+
+            {/* Poll interval */}
+            <div className="space-y-1.5">
+              <Label
+                htmlFor="xiaomi-poll-interval"
+                className="text-xs text-slate-400"
+              >
+                Poll Interval (seconds)
+              </Label>
+              <Input
+                id="xiaomi-poll-interval"
+                type="number"
+                min={10}
+                max={300}
+                value={pollInterval}
+                onChange={(e) => setPollInterval(e.target.value)}
+                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+                placeholder="30"
+              />
+              <p className="text-xs text-slate-600">Min 10s, max 300s</p>
+            </div>
+
+            {/* Save status messages */}
+            {saveStatus === "success" && saveMsg && (
+              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+                <p className="text-xs text-emerald-400">{saveMsg}</p>
+              </div>
+            )}
+            {saveStatus === "error" && saveMsg && (
+              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+                <p className="text-xs text-rose-400">{saveMsg}</p>
+              </div>
+            )}
+
+            {/* Test connection status */}
+            {testStatus === "success" && testMsg && (
+              <div className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+                  <p className="text-xs text-emerald-400">{testMsg}</p>
+                </div>
+                {testDetails && (
+                  <div className="space-y-0.5 pl-6 text-xs text-emerald-400/80">
+                    {testDetails.router_model && (
+                      <p>Model: {testDetails.router_model}</p>
+                    )}
+                    {testDetails.hardware && (
+                      <p>Hardware: {testDetails.hardware}</p>
+                    )}
+                    {testDetails.firmware && (
+                      <p>Firmware: {testDetails.firmware}</p>
+                    )}
+                    {testDetails.router_name && (
+                      <p>Name: {testDetails.router_name}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+            {testStatus === "error" && testMsg && (
+              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+                <p className="text-xs text-rose-400">{testMsg}</p>
+              </div>
+            )}
+
+            {/* Buttons */}
+            <div className="flex gap-2">
+              <Button
+                onClick={handleSave}
+                disabled={!dirty || saveStatus === "loading"}
+                className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
+              >
+                {saveStatus === "loading" ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                Save
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleTest}
+                disabled={!ip || testStatus === "loading"}
+                className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+              >
+                {testStatus === "loading" ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Plug className="mr-1.5 h-3.5 w-3.5" />
+                )}
+                Test Connection
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -857,6 +857,10 @@ export function updateSettings(body: {
   mikrotik_enabled?: boolean;
   unbound_control_path?: string;
   caddy_admin_url?: string;
+  xiaomi_mesh_enabled?: boolean;
+  xiaomi_mesh_ip?: string;
+  xiaomi_mesh_password?: string;
+  xiaomi_mesh_poll_interval?: number;
 }): Promise<SettingsData> {
   return apiPatch<SettingsData>("/api/v1/settings", body);
 }
@@ -1990,4 +1994,15 @@ export function fetchXiaomiLanInfo(): Promise<
   import("./types").XiaomiLanInfo
 > {
   return apiGet<import("./types").XiaomiLanInfo>("/api/v1/xiaomi/lan-info");
+}
+
+// ─── Xiaomi Mesh Settings ────────────────────────────────
+
+export function testXiaomiMeshConnection(
+  ip?: string
+): Promise<import("./types").XiaomiMeshTestConnectionResponse> {
+  return apiPost<import("./types").XiaomiMeshTestConnectionResponse>(
+    "/api/v1/xiaomi-mesh/test-connection",
+    { ip }
+  );
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -529,6 +529,11 @@ export interface SettingsData {
   unbound_control_path: string | null;
   // Caddy Reverse Proxy
   caddy_admin_url: string | null;
+  // Xiaomi Mesh
+  xiaomi_mesh_enabled: boolean;
+  xiaomi_mesh_ip: string | null;
+  xiaomi_mesh_password_set: boolean;
+  xiaomi_mesh_poll_interval: number | null;
 }
 
 // ─── Nginx Proxy Manager ─────────────────────────────────
@@ -1914,4 +1919,15 @@ export interface XiaomiNewStatus {
   sn: string | null;
   devices_online: number | null;
   devices_total: number | null;
+}
+
+// ─── Xiaomi Mesh Settings ────────────────────────────────
+
+export interface XiaomiMeshTestConnectionResponse {
+  success: boolean;
+  message: string;
+  router_model: string | null;
+  hardware: string | null;
+  firmware: string | null;
+  router_name: string | null;
 }


### PR DESCRIPTION
Closes #296

## Summary
- Add Xiaomi Mesh integration card to **Settings > Integrations** with enable toggle, router IP, password, and poll interval fields
- Backend: new settings fields in `SettingsResponse`/`UpdateSettingsRequest`, stored in the `settings` key-value table (same pattern as MikroTik/VyOS)
- Backend: `POST /api/v1/xiaomi-mesh/test-connection` endpoint that calls `api/xqsystem/init_info` (no auth) and returns router model, hardware, firmware, and name
- Frontend: new `/settings/xiaomi-mesh` page with save + test connection, IPv4 validation, poll interval range (10-300s), password-required-when-enabled check

## Test plan
- [ ] Navigate to Settings > Integrations — verify "Xiaomi Mesh" card appears with Wifi icon
- [ ] Click into Xiaomi Mesh settings — verify form loads with defaults (IP: 10.10.0.199, Poll: 30s)
- [ ] Toggle enable on without password — verify save shows validation error
- [ ] Enter invalid IP (e.g. "abc") — verify validation error
- [ ] Enter valid settings and save — verify success message and fields persist on reload
- [ ] Click "Test Connection" with a reachable Xiaomi router — verify success with router details
- [ ] Click "Test Connection" with unreachable IP — verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Xiaomi Mesh router integration settings to the Settings UI, following the existing pattern established for MikroTik and VyOS integrations. The implementation includes backend settings storage, a test-connection endpoint, and a complete frontend settings page.

**Key changes:**
- Backend settings API extended with `xiaomi_mesh_enabled`, `xiaomi_mesh_ip`, `xiaomi_mesh_password`, and `xiaomi_mesh_poll_interval` (10-300s range)
- New `/api/v1/xiaomi-mesh/test-connection` endpoint validates router connectivity via unauthenticated `api/xqsystem/init_info` call
- Frontend settings page includes enable toggle, IPv4 validation, password field with saved state indicator, and test connection button
- Password storage follows existing plaintext pattern (documented limitation for single-user deployments)

**Implementation quality:**
- Clean separation of concerns with dedicated module for Xiaomi Mesh test connection
- Proper error handling and user-friendly messages
- Consistent with existing integration patterns (MikroTik, VyOS, NPM)
- Frontend validation covers all required fields and ranges

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, includes proper validation (IPv4, poll interval range, password-when-enabled), and has clean error handling. The code is straightforward settings CRUD with no complex logic or security concerns beyond the documented plaintext password storage (consistent with other integrations).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi_mesh.rs | New test-connection endpoint for Xiaomi Mesh — validates router connectivity and retrieves basic info (model, hardware, firmware). Clean implementation with proper error handling. |
| server/src/api/settings.rs | Added Xiaomi Mesh settings fields (enabled, IP, password, poll interval) following existing pattern for MikroTik/NPM. Password stored in plaintext like other integrations. |
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | New settings page with enable toggle, IP validation, password field, and poll interval (10-300s). Includes test connection functionality. Minor edge case in dirty flag logic. |

</details>



<sub>Last reviewed commit: 4695ade</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->