### PR TITLE
feat: Xiaomi router tab — WAN, system status, WiFi overview (#295)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -506,6 +506,9 @@ pub fn router(state: AppState) -> Router {
         .route("/xiaomi/wifi-devices", get(xiaomi::wifi_devices))
         .route("/xiaomi/wan-info", get(xiaomi::wan_info))
         .route("/xiaomi/lan-info", get(xiaomi::lan_info))
+        .route("/xiaomi/wifi-detail-all", get(xiaomi::wifi_detail_all))
+        .route("/xiaomi/init-info", get(xiaomi::init_info))
+        .route("/xiaomi/rom-update", get(xiaomi::rom_update))
         // QoS / Traffic Shaping
         .route("/qos/summary", get(qos::qos_summary))
         .route("/qos/vyos/policies", get(qos::vyos_traffic_policies))

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -38,6 +38,8 @@ pub struct SettingsResponse {
     pub unbound_control_path: Option<String>,
     // --- Caddy Reverse Proxy ---
     pub caddy_admin_url: Option<String>,
+    // --- Xiaomi MiWiFi ---
+    pub xiaomi_enabled: bool,
 }
 
 /// Request body for updating settings.
@@ -155,6 +157,12 @@ pub async fn get_settings(
     // Caddy settings.
     let caddy_admin_url = get_setting(&state, "caddy_admin_url").await;
 
+    // Xiaomi MiWiFi settings.
+    let xiaomi_enabled = get_setting(&state, "xiaomi_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
@@ -176,6 +184,7 @@ pub async fn get_settings(
         mikrotik_enabled,
         unbound_control_path,
         caddy_admin_url,
+        xiaomi_enabled,
     }))
 }
 

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -113,6 +113,7 @@ pub struct XiaomiWanInfoResponse {
     pub dns: Option<String>,
     pub wan_type: Option<String>,
     pub mask: Option<String>,
+    pub ipv6: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -137,6 +138,32 @@ pub struct XiaomiNewStatusResponse {
     pub sn: Option<String>,
     pub devices_online: Option<i32>,
     pub devices_total: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWifiBandResponse {
+    pub ssid: Option<String>,
+    pub channel: Option<String>,
+    pub bandwidth: Option<String>,
+    pub signal: Option<i32>,
+    pub status: Option<String>,
+    pub ifname: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiInitInfoResponse {
+    pub router_name: Option<String>,
+    pub hardware: Option<String>,
+    pub rom_version: Option<String>,
+    pub language: Option<String>,
+    pub countrycode: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiRomUpdateResponse {
+    pub update_available: bool,
+    pub latest_version: Option<String>,
+    pub changelog_url: Option<String>,
 }
 
 // ── Handlers ───────────────────────────────────────────────
@@ -357,6 +384,7 @@ pub async fn wan_info(
             dns: info.dns,
             wan_type: info.wan_type,
             mask: info.mask,
+            ipv6: info.ipv6,
         })),
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi WAN info request failed");
@@ -390,6 +418,82 @@ pub async fn lan_info(
         })),
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi LAN info request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/wifi-detail-all — per-band WiFi details.
+pub async fn wifi_detail_all(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<XiaomiWifiBandResponse>>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.wifi_detail_all().await {
+        Ok(bands) => Ok(Json(
+            bands
+                .into_iter()
+                .map(|b| XiaomiWifiBandResponse {
+                    ssid: b.ssid,
+                    channel: b.channel,
+                    bandwidth: b.bandwidth,
+                    signal: b.signal,
+                    status: b.status,
+                    ifname: b.ifname,
+                })
+                .collect(),
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi wifi_detail_all request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/init-info — router identity, firmware version, locale.
+pub async fn init_info(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiInitInfoResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.init_info().await {
+        Ok(info) => Ok(Json(XiaomiInitInfoResponse {
+            router_name: info.router_name,
+            hardware: info.hardware,
+            rom_version: info.rom_version,
+            language: info.language,
+            countrycode: info.countrycode,
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi init_info request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/rom-update — check for firmware update.
+pub async fn rom_update(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiRomUpdateResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.check_rom_update().await {
+        Ok(update) => Ok(Json(XiaomiRomUpdateResponse {
+            update_available: update.need_update.unwrap_or(0) == 1,
+            latest_version: update.version,
+            changelog_url: update.changelog_url,
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi check_rom_update request failed");
             Err(StatusCode::BAD_GATEWAY)
         }
     }

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -358,6 +358,30 @@ impl XiaomiClient {
             serde_json::from_value(val).context("failed to parse LAN info")?;
         res.info.context("LAN info field missing from response")
     }
+
+    /// Fetch per-band WiFi details (SSID, channel, bandwidth per radio).
+    pub async fn wifi_detail_all(&self) -> Result<Vec<WifiBandDetail>> {
+        let val = self.get_authed("xqnetwork/wifi_detail_all").await?;
+        let res: WifiDetailAllResponse =
+            serde_json::from_value(val).context("failed to parse wifi_detail_all")?;
+        Ok(res.info)
+    }
+
+    /// Fetch init info (router name, hardware, firmware version, locale).
+    pub async fn init_info(&self) -> Result<InitInfo> {
+        let val = self.get_authed("xqsystem/init_info").await?;
+        let res: InitInfoResponse =
+            serde_json::from_value(val).context("failed to parse init_info")?;
+        Ok(res.info)
+    }
+
+    /// Check for ROM (firmware) update availability.
+    pub async fn check_rom_update(&self) -> Result<RomUpdateCheck> {
+        let val = self.get_authed("xqsystem/check_rom_update").await?;
+        let res: RomUpdateCheck =
+            serde_json::from_value(val).context("failed to parse check_rom_update")?;
+        Ok(res)
+    }
 }
 
 /// Extract a JavaScript variable value from HTML source.

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -258,3 +258,61 @@ pub struct LanInfoResponse {
     #[serde(default)]
     pub info: Option<LanInfo>,
 }
+
+// ── WiFi detail (all bands) ────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WifiBandDetail {
+    #[serde(default)]
+    pub ssid: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub bandwidth: Option<String>,
+    #[serde(default)]
+    pub signal: Option<i32>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default, rename = "ifname")]
+    pub ifname: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WifiDetailAllResponse {
+    #[serde(default)]
+    pub info: Vec<WifiBandDetail>,
+}
+
+// ── Init info (firmware / hardware identity) ───────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitInfo {
+    #[serde(default, rename = "routername")]
+    pub router_name: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    #[serde(default, rename = "romversion")]
+    pub rom_version: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub countrycode: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InitInfoResponse {
+    #[serde(flatten)]
+    pub info: InitInfo,
+}
+
+// ── ROM update check ───────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RomUpdateCheck {
+    #[serde(default, rename = "needUpdate")]
+    pub need_update: Option<i32>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default, rename = "changelogUrl")]
+    pub changelog_url: Option<String>,
+}

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -135,6 +135,7 @@ import {
 } from "@/lib/api";
 import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
 import MikrotikRouter from "@/components/MikrotikRouter";
+import XiaomiRouter from "@/components/XiaomiRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -5890,27 +5891,33 @@ export default function RouterPage() {
   const [summary, setSummary] = useState<RouterSummary | null>(null);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("mikrotik");
+  const [routerType, setRouterType] = useState<"vyos" | "mikrotik" | "xiaomi">("mikrotik");
 
   // Load settings to determine which routers are configured
   useEffect(() => {
     const loadSettings = async () => {
       let mtEnabled = false;
+      let xmEnabled = false;
       let vyosConf = false;
       try {
         const settings = await fetchSettings();
         mtEnabled = settings.mikrotik_enabled;
+        xmEnabled = settings.xiaomi_enabled;
         vyosConf = !!settings.vyos_url && settings.vyos_api_key_set;
       } catch {
         // ignore
       }
       setMikrotikEnabled(mtEnabled);
+      setXiaomiEnabled(xmEnabled);
       setVyosConfigured(vyosConf);
 
-      // Default to mikrotik if enabled, fallback to vyos only if mikrotik not available
+      // Default to mikrotik if enabled, then xiaomi, fallback to vyos
       if (mtEnabled) {
         setRouterType("mikrotik");
+      } else if (xmEnabled) {
+        setRouterType("xiaomi");
       } else if (vyosConf) {
         setRouterType("vyos");
       }
@@ -5948,29 +5955,47 @@ export default function RouterPage() {
     loadVyosSummary();
   }, [routerType, summary]);
 
-  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled;
+  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled && !xiaomiEnabled;
+  const hasMultipleRouters = [mikrotikEnabled, xiaomiEnabled, vyosConfigured].filter(Boolean).length > 1 || mikrotikEnabled;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, tabs when MikroTik is enabled */}
+        {/* Router type selector — skeleton while settings load, tabs when multiple routers available */}
         {!settingsLoaded ? (
           <Skeleton className="h-9 w-48" />
-        ) : mikrotikEnabled ? (
+        ) : hasMultipleRouters ? (
           <div className="flex gap-2">
-            <Button
-              variant={routerType === "mikrotik" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("mikrotik")}
-              className={
-                routerType === "mikrotik"
-                  ? "bg-pink-600 text-white hover:bg-pink-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              MikroTik
-            </Button>
+            {mikrotikEnabled && (
+              <Button
+                variant={routerType === "mikrotik" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("mikrotik")}
+                className={
+                  routerType === "mikrotik"
+                    ? "bg-pink-600 text-white hover:bg-pink-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                MikroTik
+              </Button>
+            )}
+            {xiaomiEnabled && (
+              <Button
+                variant={routerType === "xiaomi" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("xiaomi")}
+                className={
+                  routerType === "xiaomi"
+                    ? "bg-orange-600 text-white hover:bg-orange-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                Xiaomi
+              </Button>
+            )}
             <Button
               variant={routerType === "vyos" ? "default" : "outline"}
               size="sm"
@@ -5982,7 +6007,7 @@ export default function RouterPage() {
               }
             >
               <Router className="mr-1.5 h-3.5 w-3.5" />
-              VyOS (Optional)
+              VyOS{!vyosConfigured ? " (Optional)" : ""}
             </Button>
           </div>
         ) : null}
@@ -5997,6 +6022,8 @@ export default function RouterPage() {
           <NotConfigured />
         ) : routerType === "mikrotik" && mikrotikEnabled ? (
           <MikrotikRouter />
+        ) : routerType === "xiaomi" && xiaomiEnabled ? (
+          <XiaomiRouter />
         ) : routerType === "vyos" && !vyosConfigured ? (
           <VyosNotConfigured />
         ) : routerType === "vyos" && !summary ? (

--- a/web/src/components/XiaomiRouter.tsx
+++ b/web/src/components/XiaomiRouter.tsx
@@ -1,0 +1,737 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Router,
+  Globe,
+  Cpu,
+  MemoryStick,
+  Wifi,
+  Server,
+  AlertCircle,
+  Thermometer,
+  Clock,
+  Download,
+  Upload,
+  RefreshCw,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import {
+  fetchXiaomiStatus,
+  fetchXiaomiWanInfo,
+  fetchXiaomiNewStatus,
+  fetchXiaomiWifiDevices,
+  fetchXiaomiWifiDetailAll,
+  fetchXiaomiInitInfo,
+  fetchXiaomiRomUpdate,
+} from "@/lib/api";
+import type {
+  XiaomiStatus,
+  XiaomiWanInfo,
+  XiaomiNewStatus,
+  XiaomiWifiDevice,
+  XiaomiWifiBand,
+  XiaomiInitInfo,
+  XiaomiRomUpdate,
+} from "@/lib/types";
+
+// ── Generic data loader hook ──────────────────────────────
+
+function useData<T>(fetcher: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetcher();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}
+
+// ── Helpers ───────────────────────────────────────────────
+
+function cpuColor(load: number): string {
+  if (load >= 80) return "text-red-400";
+  if (load >= 50) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function memColor(usage: number): string {
+  if (usage >= 80) return "text-red-400";
+  if (usage >= 60) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function tempColor(temp: number): string {
+  if (temp >= 80) return "text-red-400";
+  if (temp >= 60) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+function progressColor(pct: number): string {
+  if (pct >= 80) return "bg-red-500";
+  if (pct >= 50) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+// ── Section: WAN Info ─────────────────────────────────────
+
+function WanInfoSection({
+  wanInfo,
+  loading,
+}: {
+  wanInfo: XiaomiWanInfo | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Globe className="h-4 w-4 text-blue-400" />
+            WAN Info
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!wanInfo) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Globe className="h-4 w-4 text-blue-400" />
+            WAN Info
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-slate-500">Unable to load WAN info</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const ipv6Status =
+    wanInfo.ipv6 && typeof wanInfo.ipv6 === "object"
+      ? "Enabled"
+      : wanInfo.ipv6
+        ? String(wanInfo.ipv6)
+        : "Disabled";
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Globe className="h-4 w-4 text-blue-400" />
+          WAN Info
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-slate-500">WAN IP</dt>
+          <dd className="font-mono text-white">{wanInfo.ip ?? "\u2014"}</dd>
+
+          <dt className="text-slate-500">Gateway</dt>
+          <dd className="font-mono text-white">{wanInfo.gateway ?? "\u2014"}</dd>
+
+          <dt className="text-slate-500">DNS</dt>
+          <dd className="font-mono text-white">{wanInfo.dns ?? "\u2014"}</dd>
+
+          <dt className="text-slate-500">WAN Type</dt>
+          <dd className="text-white">
+            <Badge
+              variant="outline"
+              className="border-slate-700 text-slate-300"
+            >
+              {wanInfo.wan_type ?? "Unknown"}
+            </Badge>
+          </dd>
+
+          <dt className="text-slate-500">Subnet Mask</dt>
+          <dd className="font-mono text-white">{wanInfo.mask ?? "\u2014"}</dd>
+
+          <dt className="text-slate-500">IPv6</dt>
+          <dd className="text-white">
+            <Badge
+              variant="outline"
+              className={
+                ipv6Status === "Enabled" || ipv6Status !== "Disabled"
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                  : "border-slate-700 text-slate-400"
+              }
+            >
+              {ipv6Status}
+            </Badge>
+          </dd>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Section: System Stats ─────────────────────────────────
+
+function SystemStatsSection({
+  status,
+  loading,
+}: {
+  status: XiaomiStatus | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Server className="h-4 w-4 text-violet-400" />
+            System Stats
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status || !status.reachable) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Server className="h-4 w-4 text-violet-400" />
+            System Stats
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-slate-500">
+            {!status?.configured
+              ? "Xiaomi router not configured"
+              : "Unable to reach router"}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const cpuLoad = status.cpu_load ?? 0;
+  const cpuPct = Math.round(cpuLoad * 100);
+  const memUsage = status.mem_usage ?? 0;
+  const memPct = Math.round(memUsage * 100);
+  const temp = status.temperature ?? 0;
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Server className="h-4 w-4 text-violet-400" />
+          System Stats
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* CPU */}
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Cpu className="h-4 w-4 text-blue-400" />
+              <span className="text-sm font-medium text-slate-300">CPU</span>
+            </div>
+            <span className={`text-lg font-bold ${cpuColor(cpuPct)}`}>
+              {cpuPct}%
+            </span>
+          </div>
+          <div className="relative h-2 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`absolute left-0 top-0 h-full rounded-full transition-all ${progressColor(cpuPct)}`}
+              style={{ width: `${cpuPct}%` }}
+            />
+          </div>
+          <p className="mt-1.5 text-xs text-slate-500">
+            {status.cpu_cores ?? "?"}-core @ {status.cpu_freq ?? "?"}
+          </p>
+        </div>
+
+        {/* Memory */}
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <MemoryStick className="h-4 w-4 text-purple-400" />
+              <span className="text-sm font-medium text-slate-300">Memory</span>
+            </div>
+            <span className={`text-lg font-bold ${memColor(memPct)}`}>
+              {memPct}%
+            </span>
+          </div>
+          <div className="relative h-2 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`absolute left-0 top-0 h-full rounded-full transition-all ${progressColor(memPct)}`}
+              style={{ width: `${memPct}%` }}
+            />
+          </div>
+          <p className="mt-1.5 text-xs text-slate-500">
+            {status.mem_total ?? "?"} {status.mem_type ?? ""}
+          </p>
+        </div>
+
+        {/* Temperature */}
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Thermometer className="h-4 w-4 text-orange-400" />
+              <span className="text-sm font-medium text-slate-300">Temperature</span>
+            </div>
+            <span className={`text-lg font-bold ${tempColor(temp)}`}>
+              {temp > 0 ? `${temp}\u00b0C` : "\u2014"}
+            </span>
+          </div>
+        </div>
+
+        {/* WAN Throughput */}
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Globe className="h-4 w-4 text-cyan-400" />
+            <span className="text-sm font-medium text-slate-300">WAN Throughput</span>
+          </div>
+          <div className="flex items-center gap-4 text-sm">
+            <div className="flex items-center gap-1.5">
+              <Download className="h-3.5 w-3.5 text-emerald-400" />
+              <span className="text-white">
+                {status.wan_download
+                  ? `${(parseInt(status.wan_download, 10) / 1024).toFixed(1)} KB/s`
+                  : "\u2014"}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Upload className="h-3.5 w-3.5 text-blue-400" />
+              <span className="text-white">
+                {status.wan_upload
+                  ? `${(parseInt(status.wan_upload, 10) / 1024).toFixed(1)} KB/s`
+                  : "\u2014"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Section: WiFi Bands Summary ───────────────────────────
+
+function WifiBandsSection({
+  bands,
+  wifiDevices,
+  loading,
+}: {
+  bands: XiaomiWifiBand[] | null;
+  wifiDevices: XiaomiWifiDevice[] | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Wifi className="h-4 w-4 text-green-400" />
+            WiFi Bands
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Skeleton key={i} className="h-32 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!bands || bands.length === 0) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Wifi className="h-4 w-4 text-green-400" />
+            WiFi Bands
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-slate-500">No WiFi band data available</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Count clients per band from wifiDevices
+  const clientsByBand = new Map<string, number>();
+  if (wifiDevices) {
+    for (const device of wifiDevices) {
+      const band = device.band ?? "unknown";
+      clientsByBand.set(band, (clientsByBand.get(band) ?? 0) + 1);
+    }
+  }
+
+  // Classify band from ifname: wl0 = 2.4GHz, wl1 = 5GHz (typical Xiaomi convention)
+  function guessBandLabel(band: XiaomiWifiBand): string {
+    const ifname = band.ifname ?? "";
+    const ch = parseInt(band.channel ?? "0", 10);
+    if (ifname.includes("wl0") || ifname.includes("2g") || (ch >= 1 && ch <= 14))
+      return "2.4 GHz";
+    if (ifname.includes("wl1") || ifname.includes("5g") || ch >= 36)
+      return "5 GHz";
+    if (ifname.includes("wl2") || ifname.includes("6g") || ch >= 1)
+      return "6 GHz";
+    return ifname || "Unknown";
+  }
+
+  function clientsForBand(band: XiaomiWifiBand): number {
+    const label = guessBandLabel(band);
+    // Match on common patterns from wifiDevices band field
+    let count = 0;
+    if (wifiDevices) {
+      for (const d of wifiDevices) {
+        const dBand = d.band ?? "";
+        if (
+          (label === "2.4 GHz" && dBand.includes("2.4")) ||
+          (label === "5 GHz" && dBand.includes("5")) ||
+          (label === "6 GHz" && dBand.includes("6"))
+        ) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Wifi className="h-4 w-4 text-green-400" />
+          WiFi Bands
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {bands.map((band, idx) => {
+          const bandLabel = guessBandLabel(band);
+          const clients = clientsForBand(band);
+          const isEnabled = band.status === "1" || band.status === "on";
+
+          return (
+            <div
+              key={idx}
+              className="rounded-lg border border-slate-800 bg-slate-950 p-4"
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-sm font-medium text-white">
+                  {bandLabel}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={
+                    isEnabled
+                      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                      : "border-slate-700 text-slate-500"
+                  }
+                >
+                  {isEnabled ? "Active" : "Disabled"}
+                </Badge>
+              </div>
+              <dl className="space-y-1.5 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-slate-500">SSID</dt>
+                  <dd className="font-mono text-white">{band.ssid ?? "\u2014"}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-slate-500">Channel</dt>
+                  <dd className="text-white">{band.channel ?? "\u2014"}</dd>
+                </div>
+                {band.bandwidth && (
+                  <div className="flex justify-between">
+                    <dt className="text-slate-500">Bandwidth</dt>
+                    <dd className="text-white">{band.bandwidth}</dd>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <dt className="text-slate-500">Clients</dt>
+                  <dd className="text-white">{clients}</dd>
+                </div>
+              </dl>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Section: Firmware & Updates ───────────────────────────
+
+function FirmwareSection({
+  initInfo,
+  newStatus,
+  romUpdate,
+  loading,
+}: {
+  initInfo: XiaomiInitInfo | null;
+  newStatus: XiaomiNewStatus | null;
+  romUpdate: XiaomiRomUpdate | null;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <Card className="border-slate-800 bg-slate-900">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <Server className="h-4 w-4 text-amber-400" />
+            Firmware & Updates
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const version =
+    initInfo?.rom_version ?? newStatus?.version ?? "\u2014";
+  const hardware = initInfo?.hardware ?? newStatus?.platform ?? "\u2014";
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Server className="h-4 w-4 text-amber-400" />
+          Firmware & Updates
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-slate-500">Firmware</dt>
+          <dd className="font-mono text-white">{version}</dd>
+
+          <dt className="text-slate-500">Hardware</dt>
+          <dd className="text-white">{hardware}</dd>
+
+          {initInfo?.router_name && (
+            <>
+              <dt className="text-slate-500">Router Name</dt>
+              <dd className="text-white">{initInfo.router_name}</dd>
+            </>
+          )}
+
+          {initInfo?.language && (
+            <>
+              <dt className="text-slate-500">Locale</dt>
+              <dd className="text-white">
+                {initInfo.language}
+                {initInfo.countrycode ? ` (${initInfo.countrycode})` : ""}
+              </dd>
+            </>
+          )}
+
+          <dt className="text-slate-500">Update</dt>
+          <dd>
+            {romUpdate ? (
+              romUpdate.update_available ? (
+                <Badge
+                  variant="outline"
+                  className="border-amber-500/30 bg-amber-500/10 text-amber-400"
+                >
+                  Update available
+                  {romUpdate.latest_version
+                    ? `: ${romUpdate.latest_version}`
+                    : ""}
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                >
+                  Up to date
+                </Badge>
+              )
+            ) : (
+              <span className="text-slate-500">Unable to check</span>
+            )}
+          </dd>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────
+
+export default function XiaomiRouter() {
+  const statusResult = useData(fetchXiaomiStatus);
+  const wanResult = useData(fetchXiaomiWanInfo);
+  const newStatusResult = useData(fetchXiaomiNewStatus);
+  const wifiDevicesResult = useData(fetchXiaomiWifiDevices);
+  const wifiBandsResult = useData(fetchXiaomiWifiDetailAll);
+  const initInfoResult = useData(fetchXiaomiInitInfo);
+  const romUpdateResult = useData(fetchXiaomiRomUpdate);
+
+  const allLoading =
+    statusResult.loading &&
+    wanResult.loading &&
+    wifiBandsResult.loading &&
+    initInfoResult.loading;
+
+  const handleRefresh = () => {
+    statusResult.reload();
+    wanResult.reload();
+    newStatusResult.reload();
+    wifiDevicesResult.reload();
+    wifiBandsResult.reload();
+    initInfoResult.reload();
+    romUpdateResult.reload();
+    toast.success("Refreshing Xiaomi router data...");
+  };
+
+  const status = statusResult.data;
+
+  // If not configured at all, show a placeholder
+  if (!statusResult.loading && status && !status.configured) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-slate-800">
+              <Router className="h-8 w-8 text-slate-500" />
+            </div>
+            <h1 className="text-xl font-semibold text-white">
+              Xiaomi Router Not Configured
+            </h1>
+            <p className="text-center text-sm text-slate-500">
+              Enable Xiaomi MiWiFi integration in Settings to connect your
+              router.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
+            <Router className="h-5 w-5 text-orange-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Xiaomi Router</h1>
+            <p className="text-xs text-slate-500">
+              {initInfoResult.data?.hardware ?? newStatusResult.data?.platform ?? "MiWiFi"}{" "}
+              {(initInfoResult.data?.rom_version ?? newStatusResult.data?.version) && (
+                <span className="text-slate-600">
+                  &middot; v{initInfoResult.data?.rom_version ?? newStatusResult.data?.version}
+                </span>
+              )}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {!statusResult.loading && status && (
+            <>
+              {status.reachable ? (
+                <Badge
+                  variant="outline"
+                  className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                >
+                  &#9679; Connected
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-red-500/30 bg-red-500/10 text-red-400"
+                >
+                  &#9679; Unreachable
+                </Badge>
+              )}
+              {status.devices_online != null && (
+                <Badge
+                  variant="outline"
+                  className="border-slate-700 text-slate-300"
+                >
+                  {status.devices_online} device{status.devices_online !== 1 ? "s" : ""} online
+                </Badge>
+              )}
+            </>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            className="border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {/* Sections */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <WanInfoSection wanInfo={wanResult.data} loading={wanResult.loading} />
+        <SystemStatsSection
+          status={statusResult.data}
+          loading={statusResult.loading}
+        />
+      </div>
+
+      <WifiBandsSection
+        bands={wifiBandsResult.data}
+        wifiDevices={wifiDevicesResult.data}
+        loading={wifiBandsResult.loading || wifiDevicesResult.loading}
+      />
+
+      <FirmwareSection
+        initInfo={initInfoResult.data}
+        newStatus={newStatusResult.data}
+        romUpdate={romUpdateResult.data}
+        loading={initInfoResult.loading || romUpdateResult.loading}
+      />
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1991,3 +1991,23 @@ export function fetchXiaomiLanInfo(): Promise<
 > {
   return apiGet<import("./types").XiaomiLanInfo>("/api/v1/xiaomi/lan-info");
 }
+
+export function fetchXiaomiWifiDetailAll(): Promise<
+  import("./types").XiaomiWifiBand[]
+> {
+  return apiGet<import("./types").XiaomiWifiBand[]>(
+    "/api/v1/xiaomi/wifi-detail-all"
+  );
+}
+
+export function fetchXiaomiInitInfo(): Promise<
+  import("./types").XiaomiInitInfo
+> {
+  return apiGet<import("./types").XiaomiInitInfo>("/api/v1/xiaomi/init-info");
+}
+
+export function fetchXiaomiRomUpdate(): Promise<
+  import("./types").XiaomiRomUpdate
+> {
+  return apiGet<import("./types").XiaomiRomUpdate>("/api/v1/xiaomi/rom-update");
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -529,6 +529,8 @@ export interface SettingsData {
   unbound_control_path: string | null;
   // Caddy Reverse Proxy
   caddy_admin_url: string | null;
+  // Xiaomi MiWiFi
+  xiaomi_enabled: boolean;
 }
 
 // ─── Nginx Proxy Manager ─────────────────────────────────
@@ -1893,6 +1895,7 @@ export interface XiaomiWanInfo {
   dns: string | null;
   wan_type: string | null;
   mask: string | null;
+  ipv6: unknown | null;
 }
 
 export interface XiaomiLanPort {
@@ -1914,4 +1917,27 @@ export interface XiaomiNewStatus {
   sn: string | null;
   devices_online: number | null;
   devices_total: number | null;
+}
+
+export interface XiaomiWifiBand {
+  ssid: string | null;
+  channel: string | null;
+  bandwidth: string | null;
+  signal: number | null;
+  status: string | null;
+  ifname: string | null;
+}
+
+export interface XiaomiInitInfo {
+  router_name: string | null;
+  hardware: string | null;
+  rom_version: string | null;
+  language: string | null;
+  countrycode: string | null;
+}
+
+export interface XiaomiRomUpdate {
+  update_available: boolean;
+  latest_version: string | null;
+  changelog_url: string | null;
 }


### PR DESCRIPTION
Closes #295

## Summary
- Add "Xiaomi" tab to the Router page alongside existing VyOS/MikroTik tabs
- New `XiaomiRouter` component with 4 sections: WAN Info, System Stats (CPU/RAM gauges, temperature), WiFi Bands summary, and Firmware & Updates
- Backend: 3 new proxy endpoints (`wifi_detail_all`, `init_info`, `rom_update`) + `xiaomi_enabled` in settings response
- Frontend: TypeScript types, API client functions, and router page integration with dynamic tab selector

## Depends On
- #292 (Xiaomi MiWiFi API client) — merged

## Test plan
- [ ] Enable Xiaomi integration in settings (`xiaomi_enabled`, `xiaomi_ip`, `xiaomi_password`)
- [ ] Navigate to Router page — Xiaomi tab should appear in selector
- [ ] Verify WAN Info section shows IP, gateway, DNS, type, IPv6 status
- [ ] Verify System Stats shows CPU/RAM gauges with color thresholds, temperature, WAN throughput
- [ ] Verify WiFi Bands shows per-band SSID, channel, client count
- [ ] Verify Firmware section shows version, hardware, update availability
- [ ] Verify MikroTik and VyOS tabs still work correctly
- [ ] Verify "Not Configured" state when Xiaomi is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Xiaomi MiWiFi router tab to the Router page, building on the previously merged API client (#292). The backend adds 3 new proxy endpoints (`wifi_detail_all`, `init_info`, `rom_update`) and exposes `xiaomi_enabled` in settings. The frontend introduces a 737-line `XiaomiRouter` component with WAN info, system stats (CPU/RAM gauges, temperature), WiFi bands summary, and firmware/update sections, plus dynamic tab selection alongside MikroTik and VyOS.

- **Bug in WiFi band detection**: `guessBandLabel` uses `ch >= 1` as a catch-all for 6 GHz, which will mislabel 5 GHz channels 15–35 as "6 GHz". The 6 GHz branch should rely on `ifname` only since channel numbers overlap with 2.4 GHz.
- **Tab selector asymmetry**: The `hasMultipleRouters` condition gives MikroTik special treatment (`|| mikrotikEnabled`) but not Xiaomi, so a Xiaomi-only setup hides the tab selector while MikroTik-only shows it.
- **Unused imports**: `AlertCircle`, `Clock`, and `Progress` are imported but unused in the new component.

<h3>Confidence Score: 3/5</h3>

- Functional but has a WiFi band classification bug that will produce incorrect labels for some channel configurations
- The backend changes are clean and follow established patterns. The frontend has a logic bug in guessBandLabel where the 6 GHz fallback condition (ch >= 1) catches channels that should be classified as 5 GHz (channels 15-35). There are also minor UX inconsistencies in tab selector visibility and unused imports.
- web/src/components/XiaomiRouter.tsx — guessBandLabel function has incorrect channel-to-band mapping logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Registers 3 new Xiaomi routes (`wifi-detail-all`, `init-info`, `rom-update`). Straightforward additions following existing patterns. |
| server/src/api/settings.rs | Adds `xiaomi_enabled` boolean to settings response, parsed from DB with `"1"` / `"true"` matching. Clean addition. |
| server/src/api/xiaomi.rs | Adds 3 new proxy handlers (`wifi_detail_all`, `init_info`, `rom_update`) with response types. Follows established patterns from existing handlers; `ipv6` field added to WAN info. |
| server/src/xiaomi/client.rs | Adds 3 new client methods (`wifi_detail_all`, `init_info`, `check_rom_update`) using the existing authenticated GET helper. Consistent with other methods. |
| server/src/xiaomi/types.rs | Adds deserialization types for WiFi band details, init info, and ROM update check. Proper use of `serde(default)`, `rename`, and `flatten` annotations. |
| web/src/app/(app)/router/page.tsx | Integrates Xiaomi tab into router page with dynamic tab selector. Minor UX inconsistency: tab selector is hidden when only Xiaomi is enabled (unlike MikroTik-only). |
| web/src/components/XiaomiRouter.tsx | New 737-line component with WAN, system stats, WiFi bands, and firmware sections. Has a logic bug in `guessBandLabel` where `ch >= 1` fallback mislabels 5 GHz channels as 6 GHz. Unused imports present. |
| web/src/lib/api.ts | Adds 3 new API client functions for Xiaomi endpoints. Clean and consistent with existing pattern using `apiGet`. |
| web/src/lib/types.ts | Adds TypeScript interfaces for WiFi bands, init info, ROM update, `xiaomi_enabled` setting, and `ipv6` field on WAN info. Types align correctly with backend response structs. |

</details>



<sub>Last reviewed commit: 574cb86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->