### PR TITLE
feat: Xiaomi router tab — WAN, system status, WiFi overview

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -75,6 +75,8 @@ pub struct AppState {
     pub caddy_http: reqwest::Client,
     /// Shared reqwest::Client for Xiaomi MiWiFi API.
     pub xiaomi_http: reqwest::Client,
+    /// TTL cache for Xiaomi read operations.
+    pub xiaomi_cache: Arc<crate::xiaomi::client::XiaomiCache>,
     /// Shared reqwest::Client for Xiaomi Mesh test-connection.
     pub xiaomi_mesh_http: reqwest::Client,
 }
@@ -98,6 +100,7 @@ impl AppState {
                 .build()
                 .expect("caddy HTTP client"),
             xiaomi_http: crate::xiaomi::client::shared_http_client(),
+            xiaomi_cache: Arc::new(crate::xiaomi::client::XiaomiCache::new()),
             xiaomi_mesh_http: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
@@ -518,6 +521,8 @@ pub fn router(state: AppState) -> Router {
         .route("/xiaomi/wifi-devices", get(xiaomi::wifi_devices))
         .route("/xiaomi/wan-info", get(xiaomi::wan_info))
         .route("/xiaomi/lan-info", get(xiaomi::lan_info))
+        .route("/xiaomi/firmware", get(xiaomi::firmware))
+        .route("/xiaomi/wifi", get(xiaomi::wifi))
         // QoS / Traffic Shaping
         .route("/qos/summary", get(qos::qos_summary))
         .route("/qos/vyos/policies", get(qos::vyos_traffic_policies))
@@ -658,6 +663,9 @@ async fn vyos_cache_invalidation(
         }
         if path.contains("/mikrotik/") {
             state.mikrotik_cache.clear();
+        }
+        if path.contains("/xiaomi/") {
+            state.xiaomi_cache.clear();
         }
     }
     response

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -44,6 +44,10 @@ pub struct SettingsResponse {
     /// Never return the password to the frontend — just whether one is set.
     pub xiaomi_mesh_password_set: bool,
     pub xiaomi_mesh_poll_interval: Option<u64>,
+    // --- Xiaomi MiWiFi ---
+    pub xiaomi_ip: Option<String>,
+    pub xiaomi_password_set: bool,
+    pub xiaomi_enabled: bool,
 }
 
 /// Request body for updating settings.
@@ -81,6 +85,10 @@ pub struct UpdateSettingsRequest {
     pub xiaomi_mesh_ip: Option<String>,
     pub xiaomi_mesh_password: Option<String>,
     pub xiaomi_mesh_poll_interval: Option<u64>,
+    // --- Xiaomi MiWiFi ---
+    pub xiaomi_ip: Option<String>,
+    pub xiaomi_password: Option<String>,
+    pub xiaomi_enabled: Option<bool>,
 }
 
 /// Helper: read a string setting from the settings table.
@@ -178,6 +186,14 @@ pub async fn get_settings(
         .and_then(|v| v.parse().ok())
         .or(Some(30));
 
+    // Xiaomi MiWiFi settings.
+    let xiaomi_ip = get_setting(&state, "xiaomi_ip").await;
+    let xiaomi_password_set = get_setting(&state, "xiaomi_password").await.is_some();
+    let xiaomi_enabled = get_setting(&state, "xiaomi_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
@@ -203,6 +219,9 @@ pub async fn get_settings(
         xiaomi_mesh_ip,
         xiaomi_mesh_password_set,
         xiaomi_mesh_poll_interval,
+        xiaomi_ip,
+        xiaomi_password_set,
+        xiaomi_enabled,
     }))
 }
 
@@ -367,6 +386,22 @@ pub async fn update_settings(
             xiaomi_mesh_poll_interval = interval,
             "Xiaomi Mesh poll interval updated"
         );
+    }
+
+    // --- Xiaomi MiWiFi settings ---
+    if let Some(ref ip) = body.xiaomi_ip {
+        upsert_setting(&state, "xiaomi_ip", ip).await?;
+        info!(xiaomi_ip = %ip, "Xiaomi IP updated");
+    }
+
+    if let Some(ref password) = body.xiaomi_password {
+        upsert_setting(&state, "xiaomi_password", password).await?;
+        info!("Xiaomi password updated");
+    }
+
+    if let Some(enabled) = body.xiaomi_enabled {
+        upsert_setting(&state, "xiaomi_enabled", if enabled { "1" } else { "0" }).await?;
+        info!(xiaomi_enabled = enabled, "Xiaomi enabled toggle updated");
     }
 
     // Return current state.

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -52,9 +52,13 @@ pub struct XiaomiStatusResponse {
     pub mem_usage: Option<f64>,
     pub mem_total: Option<String>,
     pub mem_type: Option<String>,
-    pub temperature: Option<i32>,
+    pub mem_hz: Option<String>,
+    pub temperature: Option<f64>,
+    pub uptime: Option<String>,
     pub wan_download: Option<String>,
     pub wan_upload: Option<String>,
+    pub wan_max_download: Option<String>,
+    pub wan_max_upload: Option<String>,
     pub devices_online: Option<i32>,
     pub devices_total: Option<i32>,
 }
@@ -108,11 +112,19 @@ pub struct XiaomiWifiDeviceResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct XiaomiWanInfoResponse {
-    pub ip: Option<String>,
+    pub configured: bool,
+    pub reachable: bool,
+    pub wan_ip: Option<String>,
     pub gateway: Option<String>,
-    pub dns: Option<String>,
+    pub dns1: Option<String>,
+    pub dns2: Option<String>,
+    pub subnet_mask: Option<String>,
     pub wan_type: Option<String>,
-    pub mask: Option<String>,
+    pub ipv6_ip: Option<String>,
+    pub ipv6_gateway: Option<String>,
+    pub ipv6_prefix: Option<String>,
+    pub ipv6_dns1: Option<String>,
+    pub ipv6_dns2: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -139,6 +151,34 @@ pub struct XiaomiNewStatusResponse {
     pub devices_total: Option<i32>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiFirmwareResponse {
+    pub configured: bool,
+    pub reachable: bool,
+    pub router_name: Option<String>,
+    pub hardware: Option<String>,
+    pub rom_version: Option<String>,
+    pub locale: Option<String>,
+    pub update_available: Option<bool>,
+    pub latest_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWifiBand {
+    pub ifname: Option<String>,
+    pub ssid: Option<String>,
+    pub channel: Option<String>,
+    pub bandwidth: Option<String>,
+    pub clients: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWifiResponse {
+    pub configured: bool,
+    pub reachable: bool,
+    pub bands: Vec<XiaomiWifiBand>,
+}
+
 // ── Handlers ───────────────────────────────────────────────
 
 /// GET /xiaomi/status — system status (CPU, memory, temp, speeds).
@@ -157,31 +197,51 @@ pub async fn status(
                 mem_usage: None,
                 mem_total: None,
                 mem_type: None,
+                mem_hz: None,
                 temperature: None,
+                uptime: None,
                 wan_download: None,
                 wan_upload: None,
+                wan_max_download: None,
+                wan_max_upload: None,
                 devices_online: None,
                 devices_total: None,
             }));
         }
     };
 
+    if let Some(cached) = state.xiaomi_cache.get("status") {
+        if let Ok(resp) = serde_json::from_value::<XiaomiStatusResponse>(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
     match client.system_status().await {
-        Ok(s) => Ok(Json(XiaomiStatusResponse {
-            configured: true,
-            reachable: true,
-            cpu_cores: s.cpu.as_ref().and_then(|c| c.core),
-            cpu_freq: s.cpu.as_ref().and_then(|c| c.hz.clone()),
-            cpu_load: s.cpu.as_ref().and_then(|c| c.load),
-            mem_usage: s.mem.as_ref().and_then(|m| m.usage),
-            mem_total: s.mem.as_ref().and_then(|m| m.total.clone()),
-            mem_type: s.mem.as_ref().and_then(|m| m.mem_type.clone()),
-            temperature: s.temperature,
-            wan_download: s.wan.as_ref().and_then(|w| w.downspeed.clone()),
-            wan_upload: s.wan.as_ref().and_then(|w| w.upspeed.clone()),
-            devices_online: s.count.as_ref().and_then(|c| c.online),
-            devices_total: s.count.as_ref().and_then(|c| c.all),
-        })),
+        Ok(s) => {
+            let resp = XiaomiStatusResponse {
+                configured: true,
+                reachable: true,
+                cpu_cores: s.cpu.as_ref().and_then(|c| c.core),
+                cpu_freq: s.cpu.as_ref().and_then(|c| c.hz.clone()),
+                cpu_load: s.cpu.as_ref().and_then(|c| c.load),
+                mem_usage: s.mem.as_ref().and_then(|m| m.usage),
+                mem_total: s.mem.as_ref().and_then(|m| m.total.clone()),
+                mem_type: s.mem.as_ref().and_then(|m| m.mem_type.clone()),
+                mem_hz: s.mem.as_ref().and_then(|m| m.hz.clone()),
+                temperature: s.temperature,
+                uptime: s.uptime,
+                wan_download: s.wan.as_ref().and_then(|w| w.downspeed.clone()),
+                wan_upload: s.wan.as_ref().and_then(|w| w.upspeed.clone()),
+                wan_max_download: s.wan.as_ref().and_then(|w| w.maxdownloadspeed.clone()),
+                wan_max_upload: s.wan.as_ref().and_then(|w| w.maxuploadspeed.clone()),
+                devices_online: s.count.as_ref().and_then(|c| c.online),
+                devices_total: s.count.as_ref().and_then(|c| c.all),
+            };
+            state
+                .xiaomi_cache
+                .set("status".to_string(), serde_json::to_value(&resp).unwrap());
+            Ok(Json(resp))
+        }
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi status request failed");
             Ok(Json(XiaomiStatusResponse {
@@ -193,9 +253,13 @@ pub async fn status(
                 mem_usage: None,
                 mem_total: None,
                 mem_type: None,
+                mem_hz: None,
                 temperature: None,
+                uptime: None,
                 wan_download: None,
                 wan_upload: None,
+                wan_max_download: None,
+                wan_max_upload: None,
                 devices_online: None,
                 devices_total: None,
             }))
@@ -203,7 +267,7 @@ pub async fn status(
     }
 }
 
-/// GET /xiaomi/topology — mesh topology graph (no auth required).
+/// GET /xiaomi/topology — mesh topology graph.
 pub async fn topology(
     State(state): State<AppState>,
 ) -> Result<Json<XiaomiTopoResponse>, StatusCode> {
@@ -341,26 +405,85 @@ pub async fn wifi_devices(
     }
 }
 
-/// GET /xiaomi/wan-info — WAN connection details.
+/// GET /xiaomi/wan-info — WAN connection details (IPv4 + IPv6).
 pub async fn wan_info(
     State(state): State<AppState>,
 ) -> Result<Json<XiaomiWanInfoResponse>, StatusCode> {
     let client = match xiaomi_client(&state).await {
         Some(c) => c,
-        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+        None => {
+            return Ok(Json(XiaomiWanInfoResponse {
+                configured: false,
+                reachable: false,
+                wan_ip: None,
+                gateway: None,
+                dns1: None,
+                dns2: None,
+                subnet_mask: None,
+                wan_type: None,
+                ipv6_ip: None,
+                ipv6_gateway: None,
+                ipv6_prefix: None,
+                ipv6_dns1: None,
+                ipv6_dns2: None,
+            }));
+        }
     };
 
+    if let Some(cached) = state.xiaomi_cache.get("wan_info") {
+        if let Ok(resp) = serde_json::from_value::<XiaomiWanInfoResponse>(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
     match client.wan_info().await {
-        Ok(info) => Ok(Json(XiaomiWanInfoResponse {
-            ip: info.ip,
-            gateway: info.gateway,
-            dns: info.dns,
-            wan_type: info.wan_type,
-            mask: info.mask,
-        })),
+        Ok(wan) => {
+            let info = wan.info.as_ref();
+            let ipv4 = info.and_then(|i| i.ipv4.as_ref());
+            let ipv6 = info.and_then(|i| i.ipv6.as_ref());
+            let resp = XiaomiWanInfoResponse {
+                configured: true,
+                reachable: true,
+                wan_ip: ipv4
+                    .and_then(|v| v.ip.clone())
+                    .or_else(|| info.and_then(|i| i.ip.clone())),
+                gateway: ipv4
+                    .and_then(|v| v.gateway.clone())
+                    .or_else(|| info.and_then(|i| i.gateway.clone())),
+                dns1: ipv4.and_then(|v| v.dns1.clone()),
+                dns2: ipv4.and_then(|v| v.dns2.clone()),
+                subnet_mask: ipv4
+                    .and_then(|v| v.mask.clone())
+                    .or_else(|| info.and_then(|i| i.mask.clone())),
+                wan_type: info.and_then(|i| i.wan_type.clone()),
+                ipv6_ip: ipv6.and_then(|v| v.ip.clone()),
+                ipv6_gateway: ipv6.and_then(|v| v.gateway.clone()),
+                ipv6_prefix: ipv6.and_then(|v| v.prefix.clone()),
+                ipv6_dns1: ipv6.and_then(|v| v.dns1.clone()),
+                ipv6_dns2: ipv6.and_then(|v| v.dns2.clone()),
+            };
+            state
+                .xiaomi_cache
+                .set("wan_info".to_string(), serde_json::to_value(&resp).unwrap());
+            Ok(Json(resp))
+        }
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi WAN info request failed");
-            Err(StatusCode::BAD_GATEWAY)
+            Ok(Json(XiaomiWanInfoResponse {
+                configured: true,
+                reachable: false,
+                wan_ip: None,
+                gateway: None,
+                dns1: None,
+                dns2: None,
+                subnet_mask: None,
+                wan_type: None,
+                ipv6_ip: None,
+                ipv6_gateway: None,
+                ipv6_prefix: None,
+                ipv6_dns1: None,
+                ipv6_dns2: None,
+            }))
         }
     }
 }
@@ -391,6 +514,148 @@ pub async fn lan_info(
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi LAN info request failed");
             Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/firmware — firmware version and update check.
+pub async fn firmware(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiFirmwareResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => {
+            return Ok(Json(XiaomiFirmwareResponse {
+                configured: false,
+                reachable: false,
+                router_name: None,
+                hardware: None,
+                rom_version: None,
+                locale: None,
+                update_available: None,
+                latest_version: None,
+            }));
+        }
+    };
+
+    if let Some(cached) = state.xiaomi_cache.get("firmware") {
+        if let Ok(resp) = serde_json::from_value::<XiaomiFirmwareResponse>(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    // Fetch both init_info and check_rom_update concurrently.
+    let (init_res, update_res) = tokio::join!(client.init_info(), client.check_rom_update());
+
+    match init_res {
+        Ok(init) => {
+            let update = update_res.ok();
+            let resp = XiaomiFirmwareResponse {
+                configured: true,
+                reachable: true,
+                router_name: init.router_name,
+                hardware: init.hardware,
+                rom_version: init.rom_version,
+                locale: init.locale,
+                update_available: update.as_ref().and_then(|u| u.need_update),
+                latest_version: update.as_ref().and_then(|u| u.latest.clone()),
+            };
+            state
+                .xiaomi_cache
+                .set("firmware".to_string(), serde_json::to_value(&resp).unwrap());
+            Ok(Json(resp))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi firmware info request failed");
+            Ok(Json(XiaomiFirmwareResponse {
+                configured: true,
+                reachable: false,
+                router_name: None,
+                hardware: None,
+                rom_version: None,
+                locale: None,
+                update_available: None,
+                latest_version: None,
+            }))
+        }
+    }
+}
+
+/// GET /xiaomi/wifi — WiFi bands summary.
+pub async fn wifi(State(state): State<AppState>) -> Result<Json<XiaomiWifiResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => {
+            return Ok(Json(XiaomiWifiResponse {
+                configured: false,
+                reachable: false,
+                bands: vec![],
+            }));
+        }
+    };
+
+    if let Some(cached) = state.xiaomi_cache.get("wifi") {
+        if let Ok(resp) = serde_json::from_value::<XiaomiWifiResponse>(cached) {
+            return Ok(Json(resp));
+        }
+    }
+
+    // Fetch wifi details and new status concurrently.
+    let (detail_res, newstatus_res) = tokio::join!(client.wifi_detail_all(), client.new_status());
+
+    match detail_res {
+        Ok(detail) => {
+            let newstatus = newstatus_res.ok();
+            let bands: Vec<XiaomiWifiBand> = detail
+                .info
+                .unwrap_or_default()
+                .into_iter()
+                .map(|band| {
+                    // Try to get client counts from newstatus per-band info.
+                    let clients = band
+                        .ifname
+                        .as_deref()
+                        .and_then(|ifname| {
+                            let ns = newstatus.as_ref()?;
+                            if ifname.contains("2g")
+                                || ifname.contains("2.4")
+                                || ifname.starts_with("wl0")
+                            {
+                                ns.band_2g.as_ref().and_then(|b| b.online)
+                            } else if ifname.contains("5g") || ifname.starts_with("wl1") {
+                                ns.band_5g.as_ref().and_then(|b| b.online)
+                            } else {
+                                None
+                            }
+                        })
+                        .or_else(|| band.status.as_deref().and_then(|s| s.parse().ok()));
+                    XiaomiWifiBand {
+                        ifname: band.ifname,
+                        ssid: band.ssid,
+                        channel: band.channel,
+                        bandwidth: band.bandwidth,
+                        clients,
+                    }
+                })
+                .collect();
+
+            let resp = XiaomiWifiResponse {
+                configured: true,
+                reachable: true,
+                bands,
+            };
+            state
+                .xiaomi_cache
+                .set("wifi".to_string(), serde_json::to_value(&resp).unwrap());
+            Ok(Json(resp))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi WiFi info request failed");
+            Ok(Json(XiaomiWifiResponse {
+                configured: true,
+                reachable: false,
+                bands: vec![],
+            }))
         }
     }
 }

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -13,6 +13,7 @@
 //!   http://<ip>/cgi-bin/luci/;stok=<TOKEN>/api/<endpoint>
 
 use anyhow::{Context, Result};
+use dashmap::DashMap;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -20,6 +21,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 use super::types::*;
+
+/// Default TTL for cached responses (30 seconds, matching MikroTik/VyOS cache).
+const CACHE_TTL: Duration = Duration::from_secs(30);
 
 /// Build the shared `reqwest::Client` for Xiaomi MiWiFi API calls.
 ///
@@ -32,6 +36,62 @@ pub fn shared_http_client() -> reqwest::Client {
         .build()
         .expect("failed to build shared reqwest client for Xiaomi MiWiFi")
 }
+
+// ── TTL Cache ──────────────────────────────────────────────
+
+/// A cache entry: the JSON value and the instant it was stored.
+struct CacheEntry {
+    value: Value,
+    inserted: Instant,
+}
+
+/// Thread-safe TTL cache for Xiaomi API responses.
+pub struct XiaomiCache {
+    map: DashMap<String, CacheEntry>,
+    ttl: Duration,
+}
+
+impl XiaomiCache {
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+            ttl: CACHE_TTL,
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Value> {
+        let entry = self.map.get(key)?;
+        if entry.inserted.elapsed() < self.ttl {
+            Some(entry.value.clone())
+        } else {
+            drop(entry);
+            self.map.remove(key);
+            None
+        }
+    }
+
+    pub fn set(&self, key: String, value: Value) {
+        self.map.insert(
+            key,
+            CacheEntry {
+                value,
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    pub fn clear(&self) {
+        self.map.clear();
+    }
+}
+
+impl Default for XiaomiCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Stok token management ──────────────────────────────────
 
 /// In-memory stok token with expiry tracking.
 #[derive(Debug, Clone)]
@@ -46,6 +106,8 @@ impl StokToken {
         self.obtained_at.elapsed() < Duration::from_secs(30 * 60)
     }
 }
+
+// ── Client ─────────────────────────────────────────────────
 
 /// Thread-safe Xiaomi MiWiFi API client with automatic token management.
 #[derive(Clone)]
@@ -85,7 +147,6 @@ impl XiaomiClient {
             .await
             .context("failed to read MiWiFi home page body")?;
 
-        // Extract key: look for `key = "..."` or `var key = "..."` in the HTML/JS
         let key = extract_js_var(&body, "key")
             .context("failed to extract 'key' from MiWiFi home page")?;
         let device_id = extract_js_var(&body, "deviceId")
@@ -100,19 +161,17 @@ impl XiaomiClient {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let random: u32 = (timestamp as u32) ^ 0x1234_5678; // simple deterministic random
+        let random: u32 = (timestamp as u32) ^ 0x1234_5678;
         format!("0_{device_id}_{timestamp}_{random}")
     }
 
     /// Compute the password hash: SHA256(nonce + SHA256(password + key))
     fn hash_password(password: &str, key: &str, nonce: &str) -> String {
-        // Step 1: SHA256(password + key)
         let mut hasher = Sha256::new();
         hasher.update(password.as_bytes());
         hasher.update(key.as_bytes());
         let inner_hash = format!("{:x}", hasher.finalize());
 
-        // Step 2: SHA256(nonce + inner_hash)
         let mut hasher = Sha256::new();
         hasher.update(nonce.as_bytes());
         hasher.update(inner_hash.as_bytes());
@@ -173,7 +232,6 @@ impl XiaomiClient {
 
     /// Get a valid stok token, logging in if necessary.
     async fn get_stok(&self) -> Result<String> {
-        // Try the cached token first.
         {
             let cached = self.stok.read().await;
             if let Some(ref tok) = *cached {
@@ -183,7 +241,6 @@ impl XiaomiClient {
             }
         }
 
-        // Need to refresh.
         let token = self.login().await?;
         let mut cached = self.stok.write().await;
         *cached = Some(StokToken {
@@ -328,7 +385,7 @@ impl XiaomiClient {
         Ok(res.list)
     }
 
-    /// Fetch new status (hardware info, connected count, WiFi SSIDs).
+    /// Fetch new status (hardware info, connected count, per-band WiFi counts).
     pub async fn new_status(&self) -> Result<NewStatus> {
         let val = self.get_authed("misystem/newstatus").await?;
         let res: NewStatus = serde_json::from_value(val).context("failed to parse new status")?;
@@ -343,12 +400,12 @@ impl XiaomiClient {
         Ok(res.list)
     }
 
-    /// Fetch WAN info (type, gateway, DNS, IPv6).
-    pub async fn wan_info(&self) -> Result<WanInfo> {
+    /// Fetch WAN info (type, gateway, DNS, IPv4/IPv6).
+    pub async fn wan_info(&self) -> Result<WanInfoResponse> {
         let val = self.get_authed("xqnetwork/wan_info").await?;
         let res: WanInfoResponse =
             serde_json::from_value(val).context("failed to parse WAN info")?;
-        res.info.context("WAN info field missing from response")
+        Ok(res)
     }
 
     /// Fetch LAN info (IP, subnet, link status per port).
@@ -358,12 +415,35 @@ impl XiaomiClient {
             serde_json::from_value(val).context("failed to parse LAN info")?;
         res.info.context("LAN info field missing from response")
     }
+
+    /// Fetch router init info (firmware version, hardware, router name).
+    pub async fn init_info(&self) -> Result<InitInfoResponse> {
+        let val = self.get_authed("xqsystem/init_info").await?;
+        let res: InitInfoResponse =
+            serde_json::from_value(val).context("failed to parse init_info")?;
+        Ok(res)
+    }
+
+    /// Check for firmware updates.
+    pub async fn check_rom_update(&self) -> Result<CheckRomUpdateResponse> {
+        let val = self.get_authed("xqsystem/check_rom_update").await?;
+        let res: CheckRomUpdateResponse =
+            serde_json::from_value(val).context("failed to parse check_rom_update")?;
+        Ok(res)
+    }
+
+    /// Fetch WiFi details for all bands.
+    pub async fn wifi_detail_all(&self) -> Result<WifiDetailAllResponse> {
+        let val = self.get_authed("xqnetwork/wifi_detail_all").await?;
+        let res: WifiDetailAllResponse =
+            serde_json::from_value(val).context("failed to parse wifi_detail_all")?;
+        Ok(res)
+    }
 }
 
 /// Extract a JavaScript variable value from HTML source.
 /// Matches patterns like `var key = "abc123"`, `key = "abc123"`, `key: "abc123"`.
 fn extract_js_var(html: &str, var_name: &str) -> Option<String> {
-    // Build patterns to try, including variants with spaces
     let patterns = [
         format!("{var_name} = \""),
         format!("{var_name} = '"),
@@ -421,7 +501,6 @@ mod tests {
         let nonce = "0_AA:BB:CC:DD:EE:FF_1700000000_305419896";
 
         let hash = XiaomiClient::hash_password(password, key, nonce);
-        // Should be a 64-char hex string
         assert_eq!(hash.len(), 64);
         assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
     }
@@ -432,5 +511,29 @@ mod tests {
         assert!(nonce.starts_with("0_AA:BB:CC:DD:EE:FF_"));
         let parts: Vec<&str> = nonce.split('_').collect();
         assert_eq!(parts.len(), 4);
+    }
+
+    #[test]
+    fn cache_get_returns_none_when_empty() {
+        let cache = XiaomiCache::new();
+        assert!(cache.get("status").is_none());
+    }
+
+    #[test]
+    fn cache_set_then_get_returns_value() {
+        let cache = XiaomiCache::new();
+        let val = serde_json::json!({"code": 0});
+        cache.set("status".into(), val.clone());
+        assert_eq!(cache.get("status"), Some(val));
+    }
+
+    #[test]
+    fn cache_clear_removes_everything() {
+        let cache = XiaomiCache::new();
+        cache.set("a".into(), Value::Null);
+        cache.set("b".into(), Value::Null);
+        cache.clear();
+        assert!(cache.get("a").is_none());
+        assert!(cache.get("b").is_none());
     }
 }

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -67,7 +67,7 @@ pub struct TopoGraphInner {
     pub leafs: Vec<TopoLeaf>,
 }
 
-// ── System status ───────────────────────────────────────────
+// ── System status (misystem/status) ─────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemInfo {
@@ -97,6 +97,10 @@ pub struct WanSpeed {
     pub downspeed: Option<String>,
     #[serde(default)]
     pub upspeed: Option<String>,
+    #[serde(default)]
+    pub maxdownloadspeed: Option<String>,
+    #[serde(default)]
+    pub maxuploadspeed: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,6 +109,10 @@ pub struct DeviceCount {
     pub online: Option<i32>,
     #[serde(default)]
     pub all: Option<i32>,
+    #[serde(default, rename = "online_without_mash")]
+    pub online_without_mesh: Option<i32>,
+    #[serde(default, rename = "all_without_mash")]
+    pub all_without_mesh: Option<i32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -118,7 +126,9 @@ pub struct SystemStatus {
     #[serde(default)]
     pub count: Option<DeviceCount>,
     #[serde(default)]
-    pub temperature: Option<i32>,
+    pub temperature: Option<f64>,
+    #[serde(default)]
+    pub uptime: Option<String>,
 }
 
 // ── Device list ─────────────────────────────────────────────
@@ -159,7 +169,7 @@ pub struct DeviceListResponse {
     pub list: Vec<MiWiFiDevice>,
 }
 
-// ── New status ──────────────────────────────────────────────
+// ── New status (misystem/newstatus) ─────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwareInfo {
@@ -175,6 +185,12 @@ pub struct HardwareInfo {
     pub sn: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BandStatus {
+    #[serde(default)]
+    pub online: Option<u32>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct NewStatus {
     #[serde(default)]
@@ -183,6 +199,10 @@ pub struct NewStatus {
     pub wan: Option<serde_json::Value>,
     #[serde(default)]
     pub count: Option<DeviceCount>,
+    #[serde(default, rename = "2g")]
+    pub band_2g: Option<BandStatus>,
+    #[serde(default, rename = "5g")]
+    pub band_5g: Option<BandStatus>,
 }
 
 // ── WiFi connected devices ──────────────────────────────────
@@ -207,22 +227,53 @@ pub struct WifiDevicesResponse {
     pub list: Vec<WifiDevice>,
 }
 
-// ── WAN info ────────────────────────────────────────────────
+// ── WAN info (xqnetwork/wan_info) ───────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WanIpv4 {
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub gateway: Option<String>,
+    #[serde(default, rename = "dns1")]
+    pub dns1: Option<String>,
+    #[serde(default, rename = "dns2")]
+    pub dns2: Option<String>,
+    #[serde(default)]
+    pub mask: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WanIpv6 {
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub gateway: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+    #[serde(default, rename = "dns1")]
+    pub dns1: Option<String>,
+    #[serde(default, rename = "dns2")]
+    pub dns2: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WanInfo {
+    #[serde(default)]
+    pub ipv4: Option<WanIpv4>,
+    #[serde(default)]
+    pub ipv6: Option<WanIpv6>,
+    #[serde(default, rename = "wanType")]
+    pub wan_type: Option<String>,
+    // Flat fields — some routers return these at the top level.
     #[serde(default)]
     pub ip: Option<String>,
     #[serde(default)]
     pub gateway: Option<String>,
     #[serde(default)]
     pub dns: Option<String>,
-    #[serde(default, rename = "wanType")]
-    pub wan_type: Option<String>,
     #[serde(default)]
     pub mask: Option<String>,
-    #[serde(default, rename = "ipv6")]
-    pub ipv6: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -257,4 +308,56 @@ pub struct LanInfo {
 pub struct LanInfoResponse {
     #[serde(default)]
     pub info: Option<LanInfo>,
+}
+
+// ── Init info (xqsystem/init_info) ─────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitInfoResponse {
+    #[serde(default)]
+    pub code: Option<i32>,
+    #[serde(default, rename = "routername")]
+    pub router_name: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    #[serde(default, rename = "romversion")]
+    pub rom_version: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+}
+
+// ── ROM update check (xqsystem/check_rom_update) ───────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckRomUpdateResponse {
+    #[serde(default)]
+    pub code: Option<i32>,
+    #[serde(default, rename = "needUpdate")]
+    pub need_update: Option<bool>,
+    #[serde(default)]
+    pub latest: Option<String>,
+}
+
+// ── WiFi detail (xqnetwork/wifi_detail_all) ─────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WifiBandDetail {
+    #[serde(default)]
+    pub ifname: Option<String>,
+    #[serde(default)]
+    pub ssid: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub bandwidth: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WifiDetailAllResponse {
+    #[serde(default)]
+    pub code: Option<i32>,
+    #[serde(default)]
+    pub info: Option<Vec<WifiBandDetail>>,
 }

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -135,6 +135,7 @@ import {
 } from "@/lib/api";
 import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
 import MikrotikRouter from "@/components/MikrotikRouter";
+import XiaomiRouter from "@/components/XiaomiRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -5891,26 +5892,32 @@ export default function RouterPage() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("mikrotik");
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
+  const [routerType, setRouterType] = useState<"vyos" | "mikrotik" | "xiaomi">("mikrotik");
 
   // Load settings to determine which routers are configured
   useEffect(() => {
     const loadSettings = async () => {
       let mtEnabled = false;
       let vyosConf = false;
+      let xiEnabled = false;
       try {
         const settings = await fetchSettings();
         mtEnabled = settings.mikrotik_enabled;
         vyosConf = !!settings.vyos_url && settings.vyos_api_key_set;
+        xiEnabled = settings.xiaomi_enabled;
       } catch {
         // ignore
       }
       setMikrotikEnabled(mtEnabled);
       setVyosConfigured(vyosConf);
+      setXiaomiEnabled(xiEnabled);
 
-      // Default to mikrotik if enabled, fallback to vyos only if mikrotik not available
+      // Default to first enabled router
       if (mtEnabled) {
         setRouterType("mikrotik");
+      } else if (xiEnabled) {
+        setRouterType("xiaomi");
       } else if (vyosConf) {
         setRouterType("vyos");
       }
@@ -5948,42 +5955,63 @@ export default function RouterPage() {
     loadVyosSummary();
   }, [routerType, summary]);
 
-  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled;
+  const hasAnyRouter = mikrotikEnabled || vyosConfigured || xiaomiEnabled;
+  const hasMultipleRouters = [mikrotikEnabled, vyosConfigured, xiaomiEnabled].filter(Boolean).length > 1;
+  const neitherConfigured = settingsLoaded && !hasAnyRouter;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, tabs when MikroTik is enabled */}
+        {/* Router type selector — skeleton while settings load, tabs when multiple routers */}
         {!settingsLoaded ? (
           <Skeleton className="h-9 w-48" />
-        ) : mikrotikEnabled ? (
+        ) : hasMultipleRouters ? (
           <div className="flex gap-2">
-            <Button
-              variant={routerType === "mikrotik" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("mikrotik")}
-              className={
-                routerType === "mikrotik"
-                  ? "bg-pink-600 text-white hover:bg-pink-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              MikroTik
-            </Button>
-            <Button
-              variant={routerType === "vyos" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("vyos")}
-              className={
-                routerType === "vyos"
-                  ? "bg-blue-600 text-white hover:bg-blue-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              VyOS (Optional)
-            </Button>
+            {mikrotikEnabled && (
+              <Button
+                variant={routerType === "mikrotik" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("mikrotik")}
+                className={
+                  routerType === "mikrotik"
+                    ? "bg-pink-600 text-white hover:bg-pink-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                MikroTik
+              </Button>
+            )}
+            {xiaomiEnabled && (
+              <Button
+                variant={routerType === "xiaomi" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("xiaomi")}
+                className={
+                  routerType === "xiaomi"
+                    ? "bg-orange-600 text-white hover:bg-orange-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                Xiaomi
+              </Button>
+            )}
+            {vyosConfigured && (
+              <Button
+                variant={routerType === "vyos" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("vyos")}
+                className={
+                  routerType === "vyos"
+                    ? "bg-blue-600 text-white hover:bg-blue-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                VyOS
+              </Button>
+            )}
           </div>
         ) : null}
 
@@ -5997,6 +6025,8 @@ export default function RouterPage() {
           <NotConfigured />
         ) : routerType === "mikrotik" && mikrotikEnabled ? (
           <MikrotikRouter />
+        ) : routerType === "xiaomi" && xiaomiEnabled ? (
+          <XiaomiRouter />
         ) : routerType === "vyos" && !vyosConfigured ? (
           <VyosNotConfigured />
         ) : routerType === "vyos" && !summary ? (

--- a/web/src/components/XiaomiRouter.tsx
+++ b/web/src/components/XiaomiRouter.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Router,
+  Cpu,
+  Clock,
+  MemoryStick,
+  Thermometer,
+  Globe,
+  Wifi,
+  Users,
+  HardDrive,
+  ArrowDown,
+  ArrowUp,
+  RefreshCw,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import {
+  fetchXiaomiStatus,
+  fetchXiaomiWanInfo,
+  fetchXiaomiFirmware,
+  fetchXiaomiWifi,
+} from "@/lib/api";
+import type {
+  XiaomiStatus,
+  XiaomiWanInfo,
+  XiaomiFirmware,
+  XiaomiWifi,
+} from "@/lib/types";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function formatUptime(seconds: string | null): string {
+  if (!seconds) return "\u2014";
+  const s = parseInt(seconds, 10);
+  if (isNaN(s)) return seconds;
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function formatSpeed(bytesPerSec: string | null): string {
+  if (!bytesPerSec) return "\u2014";
+  const n = parseInt(bytesPerSec, 10);
+  if (isNaN(n)) return bytesPerSec;
+  if (n < 1024) return `${n} B/s`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB/s`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB/s`;
+}
+
+/** Returns a Tailwind color class based on percentage thresholds. */
+function gaugeColor(pct: number): string {
+  if (pct >= 90) return "bg-rose-500";
+  if (pct >= 70) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function gaugeTextColor(pct: number): string {
+  if (pct >= 90) return "text-rose-400";
+  if (pct >= 70) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+// ── Generic data loader hook ────────────────────────────
+
+function useData<T>(fetcher: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetcher();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}
+
+// ── Status Header ───────────────────────────────────────
+
+function StatusHeader({
+  firmware,
+  status,
+}: {
+  firmware: XiaomiFirmware | null;
+  status: XiaomiStatus | null;
+}) {
+  const reachable = status?.reachable || firmware?.reachable;
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
+          <Router className="h-5 w-5 text-orange-400" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-white">
+            {firmware?.router_name ?? "Xiaomi Router"}
+          </h1>
+          <p className="text-xs text-slate-500">
+            {firmware?.hardware ?? "MiWiFi"}{" "}
+            {firmware?.rom_version && (
+              <span className="text-slate-600">
+                &middot; v{firmware.rom_version}
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {reachable ? (
+          <Badge
+            variant="outline"
+            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+          >
+            &#9679; Connected
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+          >
+            &#9679; Unreachable
+          </Badge>
+        )}
+        {status?.uptime && (
+          <Badge
+            variant="outline"
+            className="border-slate-800 text-slate-400"
+          >
+            Uptime: {formatUptime(status.uptime)}
+          </Badge>
+        )}
+        {firmware?.update_available && (
+          <Badge
+            variant="outline"
+            className="border-amber-500/30 bg-amber-500/10 text-amber-400"
+          >
+            Update available
+            {firmware.latest_version && `: ${firmware.latest_version}`}
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── System Stats Section ────────────────────────────────
+
+function SystemStatsSection({ status }: { status: XiaomiStatus }) {
+  const cpuPct = status.cpu_load ?? 0;
+  const memPct = (status.mem_usage ?? 0) * 100;
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base text-white">System Stats</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Stat cards row */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {/* CPU */}
+          <div className="space-y-2 rounded-lg border border-slate-800 bg-slate-950 p-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-amber-500/10">
+                <Cpu className="h-3.5 w-3.5 text-amber-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500">CPU</p>
+                <p className={`text-sm font-medium ${gaugeTextColor(cpuPct)}`}>
+                  {cpuPct.toFixed(0)}%
+                </p>
+              </div>
+            </div>
+            <Progress
+              value={cpuPct}
+              className={`h-1.5 [&>div]:${gaugeColor(cpuPct)}`}
+            />
+            <p className="text-[10px] text-slate-600">
+              {status.cpu_cores ?? "—"} cores @ {status.cpu_freq ?? "—"}
+            </p>
+          </div>
+
+          {/* Memory */}
+          <div className="space-y-2 rounded-lg border border-slate-800 bg-slate-950 p-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-purple-500/10">
+                <MemoryStick className="h-3.5 w-3.5 text-purple-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500">RAM</p>
+                <p
+                  className={`text-sm font-medium ${gaugeTextColor(memPct)}`}
+                >
+                  {memPct.toFixed(0)}%
+                </p>
+              </div>
+            </div>
+            <Progress
+              value={memPct}
+              className={`h-1.5 [&>div]:${gaugeColor(memPct)}`}
+            />
+            <p className="text-[10px] text-slate-600">
+              {status.mem_total ?? "—"} {status.mem_type ?? ""}{" "}
+              {status.mem_hz ? `@ ${status.mem_hz}` : ""}
+            </p>
+          </div>
+
+          {/* Temperature */}
+          <div className="space-y-2 rounded-lg border border-slate-800 bg-slate-950 p-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-rose-500/10">
+                <Thermometer className="h-3.5 w-3.5 text-rose-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500">Temperature</p>
+                <p className="text-sm font-medium text-white">
+                  {status.temperature != null
+                    ? `${status.temperature.toFixed(1)}\u00b0C`
+                    : "\u2014"}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Devices */}
+          <div className="space-y-2 rounded-lg border border-slate-800 bg-slate-950 p-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-blue-500/10">
+                <Users className="h-3.5 w-3.5 text-blue-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500">Devices</p>
+                <p className="text-sm font-medium text-white">
+                  {status.devices_online ?? 0} online
+                  <span className="text-slate-500">
+                    {" "}
+                    / {status.devices_total ?? 0} total
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* WAN throughput */}
+        {(status.wan_download || status.wan_upload) && (
+          <div className="flex gap-6 rounded-lg border border-slate-800 bg-slate-950 px-4 py-2">
+            <div className="flex items-center gap-2">
+              <ArrowDown className="h-3.5 w-3.5 text-emerald-400" />
+              <span className="text-xs text-slate-400">Download:</span>
+              <span className="text-xs font-medium text-white">
+                {formatSpeed(status.wan_download)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <ArrowUp className="h-3.5 w-3.5 text-blue-400" />
+              <span className="text-xs text-slate-400">Upload:</span>
+              <span className="text-xs font-medium text-white">
+                {formatSpeed(status.wan_upload)}
+              </span>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── WAN Info Section ────────────────────────────────────
+
+function WanInfoSection({ wan }: { wan: XiaomiWanInfo }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Globe className="h-4 w-4 text-blue-400" />
+          WAN Info
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {/* IPv4 */}
+          <div className="space-y-2">
+            <h3 className="text-xs font-medium text-slate-400">IPv4</h3>
+            <dl className="space-y-1">
+              <Row label="WAN IP" value={wan.wan_ip} />
+              <Row label="Gateway" value={wan.gateway} />
+              <Row label="Subnet Mask" value={wan.subnet_mask} />
+              <Row label="DNS 1" value={wan.dns1} />
+              <Row label="DNS 2" value={wan.dns2} />
+              <Row
+                label="WAN Type"
+                value={wan.wan_type?.toUpperCase()}
+              />
+            </dl>
+          </div>
+
+          {/* IPv6 */}
+          <div className="space-y-2">
+            <h3 className="text-xs font-medium text-slate-400">IPv6</h3>
+            {wan.ipv6_ip ? (
+              <dl className="space-y-1">
+                <Row label="Address" value={wan.ipv6_ip} />
+                <Row label="Gateway" value={wan.ipv6_gateway} />
+                <Row label="Prefix" value={wan.ipv6_prefix} />
+                <Row label="DNS 1" value={wan.ipv6_dns1} />
+                <Row label="DNS 2" value={wan.ipv6_dns2} />
+              </dl>
+            ) : (
+              <p className="text-xs text-slate-600">Not configured</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="text-xs text-slate-500">{label}</dt>
+      <dd className="font-mono text-xs text-white">{value ?? "\u2014"}</dd>
+    </div>
+  );
+}
+
+// ── WiFi Section ────────────────────────────────────────
+
+function WifiSection({ wifi }: { wifi: XiaomiWifi }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <Wifi className="h-4 w-4 text-cyan-400" />
+          WiFi Bands
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {wifi.bands.length === 0 ? (
+          <p className="text-xs text-slate-500">No WiFi bands detected</p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {wifi.bands.map((band, i) => (
+              <div
+                key={band.ifname ?? i}
+                className="rounded-lg border border-slate-800 bg-slate-950 p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-white">
+                    {band.ssid ?? "Hidden Network"}
+                  </span>
+                  <Badge
+                    variant="outline"
+                    className="border-slate-700 text-slate-400 text-[10px]"
+                  >
+                    {band.ifname ?? `Band ${i + 1}`}
+                  </Badge>
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                  {band.channel && (
+                    <span className="text-slate-400">
+                      Ch {band.channel}
+                    </span>
+                  )}
+                  {band.bandwidth && (
+                    <span className="text-slate-400">
+                      {band.bandwidth}
+                    </span>
+                  )}
+                  <span className="text-slate-400">
+                    <Users className="mr-0.5 inline h-3 w-3" />
+                    {band.clients ?? 0} clients
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Firmware Section ────────────────────────────────────
+
+function FirmwareSection({ firmware }: { firmware: XiaomiFirmware }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base text-white">
+          <HardDrive className="h-4 w-4 text-slate-400" />
+          Firmware &amp; Hardware
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard label="Firmware" value={firmware.rom_version} />
+          <StatCard label="Hardware" value={firmware.hardware} />
+          <StatCard label="Router Name" value={firmware.router_name} />
+          <StatCard label="Locale" value={firmware.locale} />
+        </div>
+        {firmware.update_available && firmware.latest_version && (
+          <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+            <p className="text-xs text-amber-400">
+              A firmware update is available: <strong>{firmware.latest_version}</strong>
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2">
+      <p className="text-[10px] text-slate-500">{label}</p>
+      <p className="truncate text-sm font-medium text-white">
+        {value ?? "\u2014"}
+      </p>
+    </div>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────
+
+export default function XiaomiRouter() {
+  const {
+    data: status,
+    loading: statusLoading,
+    reload: reloadStatus,
+  } = useData(fetchXiaomiStatus);
+  const { data: wan, loading: wanLoading, reload: reloadWan } =
+    useData(fetchXiaomiWanInfo);
+  const {
+    data: firmware,
+    loading: firmwareLoading,
+    reload: reloadFirmware,
+  } = useData(fetchXiaomiFirmware);
+  const { data: wifi, loading: wifiLoading, reload: reloadWifi } =
+    useData(fetchXiaomiWifi);
+
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await Promise.all([
+      reloadStatus(),
+      reloadWan(),
+      reloadFirmware(),
+      reloadWifi(),
+    ]);
+    setRefreshing(false);
+  };
+
+  const loading = statusLoading || wanLoading || firmwareLoading || wifiLoading;
+
+  if (loading && !status && !wan && !firmware && !wifi) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <StatusHeader firmware={firmware} status={status} />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="shrink-0 border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+        >
+          <RefreshCw
+            className={`mr-1.5 h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {/* System Stats */}
+      {status?.reachable && <SystemStatsSection status={status} />}
+
+      {/* WAN Info */}
+      {wan?.reachable && <WanInfoSection wan={wan} />}
+
+      {/* WiFi Bands */}
+      {wifi?.reachable && <WifiSection wifi={wifi} />}
+
+      {/* Firmware & Hardware */}
+      {firmware?.reachable && <FirmwareSection firmware={firmware} />}
+
+      {/* Unreachable state */}
+      {status && !status.reachable && status.configured && (
+        <Card className="border-slate-800 bg-slate-900">
+          <CardContent className="flex flex-col items-center gap-3 py-8">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-rose-500/10">
+              <Router className="h-6 w-6 text-rose-400" />
+            </div>
+            <p className="text-sm text-slate-400">
+              Cannot reach the Xiaomi router. Check the IP and password in
+              Settings.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -81,6 +81,10 @@ import type {
   MikrotikAddressListRequest,
   MikrotikDns,
   MikrotikWireguard,
+  XiaomiStatus,
+  XiaomiWanInfo,
+  XiaomiFirmware,
+  XiaomiWifi,
   Asset,
   AssetRequest,
   AssetImportRow,
@@ -861,6 +865,9 @@ export function updateSettings(body: {
   xiaomi_mesh_ip?: string;
   xiaomi_mesh_password?: string;
   xiaomi_mesh_poll_interval?: number;
+  xiaomi_ip?: string;
+  xiaomi_password?: string;
+  xiaomi_enabled?: boolean;
 }): Promise<SettingsData> {
   return apiPatch<SettingsData>("/api/v1/settings", body);
 }
@@ -1952,10 +1959,8 @@ export function fetchMeshTopology(): Promise<
 
 // ─── Xiaomi MiWiFi ───────────────────────────────────────
 
-export function fetchXiaomiStatus(): Promise<
-  import("./types").XiaomiStatus
-> {
-  return apiGet<import("./types").XiaomiStatus>("/api/v1/xiaomi/status");
+export function fetchXiaomiStatus(): Promise<XiaomiStatus> {
+  return apiGet<XiaomiStatus>("/api/v1/xiaomi/status");
 }
 
 export function fetchXiaomiTopology(): Promise<
@@ -1984,16 +1989,22 @@ export function fetchXiaomiWifiDevices(): Promise<
   );
 }
 
-export function fetchXiaomiWanInfo(): Promise<
-  import("./types").XiaomiWanInfo
-> {
-  return apiGet<import("./types").XiaomiWanInfo>("/api/v1/xiaomi/wan-info");
+export function fetchXiaomiWanInfo(): Promise<XiaomiWanInfo> {
+  return apiGet<XiaomiWanInfo>("/api/v1/xiaomi/wan-info");
 }
 
 export function fetchXiaomiLanInfo(): Promise<
   import("./types").XiaomiLanInfo
 > {
   return apiGet<import("./types").XiaomiLanInfo>("/api/v1/xiaomi/lan-info");
+}
+
+export function fetchXiaomiFirmware(): Promise<XiaomiFirmware> {
+  return apiGet<XiaomiFirmware>("/api/v1/xiaomi/firmware");
+}
+
+export function fetchXiaomiWifi(): Promise<XiaomiWifi> {
+  return apiGet<XiaomiWifi>("/api/v1/xiaomi/wifi");
 }
 
 // ─── Xiaomi Mesh Settings ────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -534,6 +534,10 @@ export interface SettingsData {
   xiaomi_mesh_ip: string | null;
   xiaomi_mesh_password_set: boolean;
   xiaomi_mesh_poll_interval: number | null;
+  // Xiaomi MiWiFi
+  xiaomi_ip: string | null;
+  xiaomi_password_set: boolean;
+  xiaomi_enabled: boolean;
 }
 
 // ─── Nginx Proxy Manager ─────────────────────────────────
@@ -1843,9 +1847,13 @@ export interface XiaomiStatus {
   mem_usage: number | null;
   mem_total: string | null;
   mem_type: string | null;
+  mem_hz: string | null;
   temperature: number | null;
+  uptime: string | null;
   wan_download: string | null;
   wan_upload: string | null;
+  wan_max_download: string | null;
+  wan_max_upload: string | null;
   devices_online: number | null;
   devices_total: number | null;
 }
@@ -1893,11 +1901,19 @@ export interface XiaomiWifiDevice {
 }
 
 export interface XiaomiWanInfo {
-  ip: string | null;
+  configured: boolean;
+  reachable: boolean;
+  wan_ip: string | null;
   gateway: string | null;
-  dns: string | null;
+  dns1: string | null;
+  dns2: string | null;
+  subnet_mask: string | null;
   wan_type: string | null;
-  mask: string | null;
+  ipv6_ip: string | null;
+  ipv6_gateway: string | null;
+  ipv6_prefix: string | null;
+  ipv6_dns1: string | null;
+  ipv6_dns2: string | null;
 }
 
 export interface XiaomiLanPort {
@@ -1919,6 +1935,31 @@ export interface XiaomiNewStatus {
   sn: string | null;
   devices_online: number | null;
   devices_total: number | null;
+}
+
+export interface XiaomiFirmware {
+  configured: boolean;
+  reachable: boolean;
+  router_name: string | null;
+  hardware: string | null;
+  rom_version: string | null;
+  locale: string | null;
+  update_available: boolean | null;
+  latest_version: string | null;
+}
+
+export interface XiaomiWifiBand {
+  ifname: string | null;
+  ssid: string | null;
+  channel: string | null;
+  bandwidth: string | null;
+  clients: number | null;
+}
+
+export interface XiaomiWifi {
+  configured: boolean;
+  reachable: boolean;
+  bands: XiaomiWifiBand[];
 }
 
 // ─── Xiaomi Mesh Settings ────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a new **Xiaomi** tab to the Router page alongside VyOS and MikroTik, with sections for WAN info (IPv4/IPv6), system stats (CPU/RAM gauges, temperature, device counts, WAN throughput), WiFi bands summary, and firmware & updates
- Extends the upstream Xiaomi MiWiFi API client (#292, #296) with firmware (`init_info`, `check_rom_update`), WiFi detail (`wifi_detail_all`), and a 30s TTL response cache (`XiaomiCache`)
- Adds Xiaomi MiWiFi settings to the backend settings API (`xiaomi_ip`, `xiaomi_password`, `xiaomi_enabled`)

## Changes
- **server/src/xiaomi/types.rs** — merged upstream types + added `InitInfoResponse`, `CheckRomUpdateResponse`, `WifiBandDetail`, `WifiDetailAllResponse`, `BandStatus`; enriched `SystemStatus` with `uptime`, `WanSpeed` with max speeds, `NewStatus` with per-band counts
- **server/src/xiaomi/client.rs** — merged upstream SHA256-auth client + added `XiaomiCache`, `init_info()`, `check_rom_update()`, `wifi_detail_all()` methods; `wan_info()` returns full response with IPv4/IPv6 detail
- **server/src/api/xiaomi.rs** — merged upstream handlers (status, topology, devices, new-status, wifi-devices, wan-info, lan-info) + added `firmware()` and `wifi()` handlers with cache support; enhanced `status` and `wan_info` responses with richer fields
- **server/src/api/settings.rs** — added Xiaomi MiWiFi settings (`xiaomi_ip`, `xiaomi_password`, `xiaomi_enabled`)
- **server/src/api/mod.rs** — registered `/xiaomi/firmware` and `/xiaomi/wifi` routes, added `xiaomi_cache` to AppState
- **web/src/components/XiaomiRouter.tsx** — new component with StatusHeader, SystemStatsSection (CPU/RAM gauges with color thresholds), WanInfoSection (IPv4/IPv6), WifiSection (per-band cards), FirmwareSection
- **web/src/app/(app)/router/page.tsx** — integrated Xiaomi tab with orange theme alongside VyOS (blue) and MikroTik (pink)
- **web/src/lib/types.ts** — added `XiaomiStatus`, `XiaomiWanInfo`, `XiaomiFirmware`, `XiaomiWifiBand`, `XiaomiWifi` types + Xiaomi MiWiFi settings fields
- **web/src/lib/api.ts** — added `fetchXiaomiFirmware()`, `fetchXiaomiWifi()`, Xiaomi MiWiFi settings params

## Test plan
- [ ] Configure Xiaomi router IP and password in Settings
- [ ] Verify the Xiaomi tab appears on the Router page when enabled
- [ ] Verify system stats section shows CPU/RAM gauges, temperature, device counts
- [ ] Verify WAN info shows IPv4 and IPv6 details
- [ ] Verify WiFi section shows per-band SSID, channel, and client counts
- [ ] Verify firmware section shows version, hardware, and update availability
- [ ] Verify refresh button reloads all data
- [ ] Verify unreachable state is shown when router is offline

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Xiaomi MiWiFi router tab to the Router page with WAN info (IPv4/IPv6), system stats (CPU/RAM gauges, temperature, device counts, throughput), WiFi bands summary, and firmware/update status. The backend adds three new endpoints (`/xiaomi/firmware`, `/xiaomi/wifi`, enhanced `/xiaomi/wan-info`) with a 30s TTL response cache, and exposes Xiaomi settings (`xiaomi_ip`, `xiaomi_password`, `xiaomi_enabled`) through the settings API.

- Backend follows existing MikroTik patterns closely: same cache design (DashMap TTL), same settings storage, same middleware invalidation
- Router page updated to support 3-way tab switching (MikroTik / Xiaomi / VyOS) with proper conditional rendering
- **Issue found**: CPU/RAM progress bar gauge colors in `XiaomiRouter.tsx` use dynamic Tailwind class interpolation that won't be detected at build time — bars will render with the default blue color instead of the intended green/amber/red thresholds

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one visual bug in the frontend gauge colors that should be addressed.
- The backend changes are well-structured, follow existing patterns exactly (cache, settings, error handling), and include unit tests. The frontend has a real but non-breaking visual bug with dynamic Tailwind classes on the Progress bars. No security, data, or logic issues found in the backend.
- Pay attention to `web/src/components/XiaomiRouter.tsx` — the dynamic gauge color classes on lines 196 and 220 won't work with Tailwind's static extraction.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/XiaomiRouter.tsx | New component with a visual bug: dynamic Tailwind class composition in Progress bars (lines 196, 220) won't work at build time — gauge colors will always be default blue-500. |
| server/src/api/xiaomi.rs | Added firmware, wifi, and wan-info handlers with caching. Well-structured, follows existing MikroTik patterns. Graceful error handling with configured/reachable flags. |
| server/src/xiaomi/client.rs | Added XiaomiCache (DashMap TTL), init_info, check_rom_update, wifi_detail_all methods. Cache implementation mirrors MikroTik. Includes good unit tests. |
| server/src/xiaomi/types.rs | Added types for WAN IPv4/IPv6, init info, ROM update, WiFi detail. Clean serde annotations with backward-compat flat fields in WanInfo. |
| server/src/api/mod.rs | Registered new routes, added xiaomi_cache to AppState, added Xiaomi cache invalidation to middleware. All consistent with existing patterns. |
| server/src/api/settings.rs | Added xiaomi_ip, xiaomi_password, xiaomi_enabled settings following the same pattern as MikroTik and mesh settings. |
| web/src/app/(app)/router/page.tsx | Integrated Xiaomi tab alongside VyOS and MikroTik with proper multi-router logic (shows tabs only when multiple routers are enabled). |
| web/src/lib/types.ts | Added XiaomiFirmware, XiaomiWifiBand, XiaomiWifi types and updated XiaomiWanInfo/XiaomiStatus with new fields. Types match backend response structs. |
| web/src/lib/api.ts | Added fetchXiaomiFirmware, fetchXiaomiWifi, and Xiaomi settings params. Clean refactor of existing imports from inline to top-level. |

</details>



<sub>Last reviewed commit: 3a39fd0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->