### PR TITLE
feat: add Tailscale to Docker Compose stack — 5th service (#319)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "8080:8080"
     volumes:
       - panoptikon-data:/data
+      - tailscale-run:/var/run/tailscale:ro
     environment:
       - DATABASE_PATH=/data/panoptikon.db
       # VyOS router connection
@@ -81,6 +82,24 @@ services:
       caddy:
         condition: service_started
 
+  # ── Tailscale — secure remote access via WireGuard mesh VPN ───────────────
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: panoptikon-tailscale
+    restart: unless-stopped
+    networks:
+      - panoptikon-net
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_EXTRA_ARGS=--advertise-routes=10.10.0.0/24
+      - TS_STATE_DIR=/var/lib/tailscale
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - tailscale-run:/var/run/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+
 networks:
   panoptikon-net:
     name: panoptikon-net
@@ -90,3 +109,5 @@ volumes:
   panoptikon-data:
   caddy-data:
   caddy-config:
+  tailscale-state:
+  tailscale-run:

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -44,6 +44,7 @@ pub mod settings;
 pub mod setup;
 pub mod speedtest;
 pub mod ssh_targets;
+pub mod tailscale;
 pub mod topology;
 pub mod traffic;
 pub mod unbound;
@@ -546,6 +547,8 @@ pub fn router(state: AppState) -> Router {
         .route("/qos/mikrotik/queue-tree", get(qos::mikrotik_queue_tree))
         // VPN Status Dashboard
         .route("/vpn-status", get(vpn_status::vpn_status))
+        // Tailscale
+        .route("/tailscale/status", get(tailscale::status))
         // NAT / Port Forwarding
         .route("/nat/summary", get(nat::summary))
         .route("/nat/vyos/rules", get(nat::vyos_list))

--- a/server/src/api/tailscale.rs
+++ b/server/src/api/tailscale.rs
@@ -1,0 +1,237 @@
+//! Tailscale status API endpoint.
+//!
+//! Queries the Tailscale daemon's local API via its Unix socket to retrieve
+//! the current node status, connected peers, subnet routes, and exit node state.
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::AppState;
+
+// ── Default socket path ─────────────────────────────────────
+
+const DEFAULT_SOCKET_PATH: &str = "/var/run/tailscale/tailscaled.sock";
+
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+fn socket_path(state: &AppState) -> String {
+    state
+        .config
+        .tailscale_socket
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SOCKET_PATH.to_string())
+}
+
+// ── Tailscale local API types (deserialized from daemon) ────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct TsStatus {
+    backend_state: Option<String>,
+    #[serde(rename = "Self")]
+    self_node: Option<TsNode>,
+    #[serde(default)]
+    peer: HashMap<String, TsNode>,
+    magic_dns_suffix: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct TsNode {
+    #[serde(default)]
+    host_name: String,
+    #[serde(rename = "DNSName", default)]
+    dns_name: String,
+    #[serde(rename = "OS", default)]
+    os: String,
+    #[serde(rename = "TailscaleIPs", default)]
+    tailscale_ips: Vec<String>,
+    #[serde(default)]
+    online: bool,
+    #[serde(default)]
+    exit_node: bool,
+    #[serde(default)]
+    exit_node_option: bool,
+    #[serde(default)]
+    active: bool,
+    #[serde(default)]
+    primary_routes: Option<Vec<String>>,
+    #[serde(default)]
+    rx_bytes: Option<u64>,
+    #[serde(default)]
+    tx_bytes: Option<u64>,
+    #[serde(default)]
+    last_seen: Option<String>,
+}
+
+// ── Public response types ───────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct TailscaleStatusResponse {
+    pub connected: bool,
+    pub backend_state: String,
+    pub hostname: String,
+    pub dns_name: String,
+    pub tailscale_ips: Vec<String>,
+    pub os: String,
+    pub exit_node: bool,
+    pub exit_node_option: bool,
+    pub subnet_routes: Vec<String>,
+    pub magic_dns_suffix: String,
+    pub peers: Vec<TailscalePeer>,
+    pub online_peers: usize,
+    pub total_peers: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TailscalePeer {
+    pub hostname: String,
+    pub dns_name: String,
+    pub os: String,
+    pub tailscale_ips: Vec<String>,
+    pub online: bool,
+    pub active: bool,
+    pub exit_node: bool,
+    pub exit_node_option: bool,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub last_seen: Option<String>,
+}
+
+// ── Unix socket HTTP helper ─────────────────────────────────
+
+/// Make a GET request to the Tailscale local API over its Unix socket.
+async fn ts_api_get(socket: &str, path: &str) -> Result<Vec<u8>, String> {
+    let mut stream = tokio::net::UnixStream::connect(socket)
+        .await
+        .map_err(|e| format!("Cannot connect to Tailscale socket at {socket}: {e}"))?;
+
+    let request = format!("GET {path} HTTP/1.0\r\nHost: local-tailscaled.sock\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to write to Tailscale socket: {e}"))?;
+    stream
+        .shutdown()
+        .await
+        .map_err(|e| format!("Failed to shutdown write: {e}"))?;
+
+    let mut buf = Vec::new();
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| format!("Failed to read from Tailscale socket: {e}"))?;
+
+    // Split HTTP headers from body
+    let header_end = buf
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .ok_or("Invalid HTTP response from Tailscale")?;
+
+    Ok(buf[header_end + 4..].to_vec())
+}
+
+// ── Handler ─────────────────────────────────────────────────
+
+/// GET /api/v1/tailscale/status
+pub async fn status(
+    State(state): State<AppState>,
+) -> Result<Json<TailscaleStatusResponse>, (StatusCode, String)> {
+    let sock = get_setting(&state, "tailscale_socket")
+        .await
+        .unwrap_or_else(|| socket_path(&state));
+
+    let body = match ts_api_get(&sock, "/localapi/v0/status").await {
+        Ok(b) => b,
+        Err(_) => {
+            // Socket not available → Tailscale not running / not configured
+            return Ok(Json(TailscaleStatusResponse {
+                connected: false,
+                backend_state: "NotRunning".to_string(),
+                hostname: String::new(),
+                dns_name: String::new(),
+                tailscale_ips: vec![],
+                os: String::new(),
+                exit_node: false,
+                exit_node_option: false,
+                subnet_routes: vec![],
+                magic_dns_suffix: String::new(),
+                peers: vec![],
+                online_peers: 0,
+                total_peers: 0,
+            }));
+        }
+    };
+
+    let ts: TsStatus = serde_json::from_slice(&body).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to parse Tailscale status: {e}"),
+        )
+    })?;
+
+    let backend_state = ts.backend_state.unwrap_or_default();
+    let connected = backend_state == "Running";
+
+    let self_node = ts.self_node.unwrap_or(TsNode {
+        host_name: String::new(),
+        dns_name: String::new(),
+        os: String::new(),
+        tailscale_ips: vec![],
+        online: false,
+        exit_node: false,
+        exit_node_option: false,
+        active: false,
+        primary_routes: None,
+        rx_bytes: None,
+        tx_bytes: None,
+        last_seen: None,
+    });
+
+    let peers: Vec<TailscalePeer> = ts
+        .peer
+        .into_values()
+        .map(|p| TailscalePeer {
+            hostname: p.host_name,
+            dns_name: p.dns_name,
+            os: p.os,
+            tailscale_ips: p.tailscale_ips,
+            online: p.online,
+            active: p.active,
+            exit_node: p.exit_node,
+            exit_node_option: p.exit_node_option,
+            rx_bytes: p.rx_bytes.unwrap_or(0),
+            tx_bytes: p.tx_bytes.unwrap_or(0),
+            last_seen: p.last_seen,
+        })
+        .collect();
+
+    let online_peers = peers.iter().filter(|p| p.online).count();
+    let total_peers = peers.len();
+
+    Ok(Json(TailscaleStatusResponse {
+        connected,
+        backend_state,
+        hostname: self_node.host_name,
+        dns_name: self_node.dns_name,
+        tailscale_ips: self_node.tailscale_ips,
+        os: self_node.os,
+        exit_node: self_node.exit_node,
+        exit_node_option: self_node.exit_node_option,
+        subnet_routes: self_node.primary_routes.unwrap_or_default(),
+        magic_dns_suffix: ts.magic_dns_suffix.unwrap_or_default(),
+        peers,
+        online_peers,
+        total_peers,
+    }))
+}

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -33,6 +33,10 @@ pub struct AppConfig {
     /// Expected layout: <dir>/panoptikon-agent-<platform>[.exe]
     #[serde(default)]
     pub agent_binaries_dir: Option<String>,
+
+    /// Path to the Tailscale daemon Unix socket.
+    #[serde(default)]
+    pub tailscale_socket: Option<String>,
 }
 
 fn default_listen() -> Option<String> {
@@ -205,6 +209,7 @@ impl Default for AppConfig {
             auth: AuthConfig::default(),
             retention: RetentionConfig::default(),
             agent_binaries_dir: None,
+            tailscale_socket: None,
         }
     }
 }

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -15,6 +15,7 @@ import {
   ShieldAlert,
   Server,
   Wifi,
+  Network,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageTransition } from "@/components/PageTransition";
@@ -64,6 +65,13 @@ const settingsGroups: SettingsGroup[] = [
         iconBg: "bg-orange-500/10",
         title: "Xiaomi Mesh",
         description: "Configure Xiaomi mesh router integration.",
+      },
+      {
+        href: "/settings/tailscale",
+        icon: <Network className="h-4 w-4 text-indigo-400" />,
+        iconBg: "bg-indigo-500/10",
+        title: "Tailscale",
+        description: "Secure remote access via WireGuard mesh VPN.",
       },
       {
         href: "/settings/webhook",

--- a/web/src/app/(app)/settings/tailscale/page.tsx
+++ b/web/src/app/(app)/settings/tailscale/page.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Globe,
+  MonitorSmartphone,
+  Network,
+  RefreshCw,
+  Shield,
+  Wifi,
+  WifiOff,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PageTransition } from "@/components/PageTransition";
+import { fetchTailscaleStatus } from "@/lib/api";
+import type { TailscaleStatusResponse, TailscalePeer } from "@/lib/types";
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
+  const val = bytes / Math.pow(1024, i);
+  return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export default function TailscaleSettingsPage() {
+  const [data, setData] = useState<TailscaleStatusResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchTailscaleStatus();
+      setData(result);
+    } catch {
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 30_000);
+    return () => clearInterval(id);
+  }, [load]);
+
+  const sortedPeers = useMemo(() => {
+    if (!data) return [];
+    return [...data.peers].sort((a, b) => {
+      if (a.online !== b.online) return a.online ? -1 : 1;
+      return a.hostname.localeCompare(b.hostname);
+    });
+  }, [data]);
+
+  const isConnected = data?.connected ?? false;
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-6xl space-y-6 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Shield className="h-6 w-6 text-blue-500" />
+            <h1 className="text-2xl font-semibold text-white">Tailscale</h1>
+            {data && (
+              <Badge
+                variant="outline"
+                className={
+                  isConnected
+                    ? "border-emerald-500/30 text-emerald-400"
+                    : "border-slate-700 text-slate-500"
+                }
+              >
+                {data.backend_state || "Unknown"}
+              </Badge>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={load}
+            className="border-slate-800 text-slate-300 hover:bg-slate-800"
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Summary Cards */}
+        <div className="grid gap-4 sm:grid-cols-4">
+          <SummaryCard
+            title="Status"
+            value={data?.backend_state ?? null}
+            loading={loading && !data}
+            icon={<Shield className="h-4 w-4 text-blue-400" />}
+            isText
+          />
+          <SummaryCard
+            title="Peers Online"
+            value={data?.online_peers ?? null}
+            loading={loading && !data}
+            icon={<Wifi className="h-4 w-4 text-emerald-400" />}
+            subtitle={data ? `of ${data.total_peers} total` : undefined}
+          />
+          <SummaryCard
+            title="Tailscale IP"
+            value={data?.tailscale_ips?.[0] ?? null}
+            loading={loading && !data}
+            icon={<Globe className="h-4 w-4 text-cyan-400" />}
+            isText
+          />
+          <SummaryCard
+            title="Subnet Routes"
+            value={
+              data
+                ? data.subnet_routes.length > 0
+                  ? data.subnet_routes.join(", ")
+                  : "None"
+                : null
+            }
+            loading={loading && !data}
+            icon={<Network className="h-4 w-4 text-amber-400" />}
+            isText
+          />
+        </div>
+
+        {/* Node Info Card */}
+        {data && isConnected && (
+          <Card className="border-slate-800 bg-slate-900">
+            <CardHeader>
+              <CardTitle className="text-white">This Node</CardTitle>
+              <CardDescription className="text-slate-400">
+                Local Tailscale node information for this Panoptikon instance.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-3 text-sm sm:grid-cols-2">
+                <InfoRow label="Hostname" value={data.hostname} />
+                <InfoRow label="DNS Name" value={data.dns_name} />
+                <InfoRow label="OS" value={data.os} />
+                <InfoRow
+                  label="Tailscale IPs"
+                  value={data.tailscale_ips.join(", ") || "—"}
+                />
+                <InfoRow
+                  label="Exit Node"
+                  value={
+                    data.exit_node
+                      ? "Active"
+                      : data.exit_node_option
+                        ? "Available"
+                        : "Disabled"
+                  }
+                />
+                <InfoRow
+                  label="Subnet Routes"
+                  value={data.subnet_routes.join(", ") || "None"}
+                />
+                <InfoRow
+                  label="MagicDNS Suffix"
+                  value={data.magic_dns_suffix || "—"}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Not Connected State */}
+        {!loading && !isConnected && (
+          <Card className="border-slate-800 bg-slate-900">
+            <CardContent className="py-12 text-center">
+              <WifiOff className="mx-auto mb-3 h-10 w-10 text-slate-600" />
+              <p className="text-sm text-slate-400">
+                Tailscale is not connected. Make sure the{" "}
+                <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300">
+                  panoptikon-tailscale
+                </code>{" "}
+                container is running and{" "}
+                <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-300">
+                  TS_AUTHKEY
+                </code>{" "}
+                is set in your environment.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Peers Table */}
+        {data && isConnected && (
+          <Card className="border-slate-800 bg-slate-900">
+            <CardHeader>
+              <CardTitle className="text-white">Connected Peers</CardTitle>
+              <CardDescription className="text-slate-400">
+                Devices on your Tailscale network. Data refreshes every 30
+                seconds.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-slate-800 hover:bg-transparent">
+                    <TableHead className="text-slate-400">Status</TableHead>
+                    <TableHead className="text-slate-400">Hostname</TableHead>
+                    <TableHead className="text-slate-400">OS</TableHead>
+                    <TableHead className="text-slate-400">
+                      Tailscale IP
+                    </TableHead>
+                    <TableHead className="text-slate-400">Exit Node</TableHead>
+                    <TableHead className="text-right text-slate-400">
+                      RX
+                    </TableHead>
+                    <TableHead className="text-right text-slate-400">
+                      TX
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedPeers.length === 0 ? (
+                    <TableRow className="border-slate-800 hover:bg-transparent">
+                      <TableCell
+                        colSpan={7}
+                        className="py-8 text-center text-slate-500"
+                      >
+                        No peers found.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    sortedPeers.map((peer, idx) => (
+                      <PeerRow key={peer.dns_name || idx} peer={peer} />
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Loading skeleton */}
+        {loading && !data && (
+          <Card className="border-slate-800 bg-slate-900">
+            <CardContent className="space-y-3 py-6">
+              <Skeleton className="h-4 w-3/4 bg-slate-800" />
+              <Skeleton className="h-4 w-1/2 bg-slate-800" />
+              <Skeleton className="h-4 w-2/3 bg-slate-800" />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </PageTransition>
+  );
+}
+
+// ─── Summary Card ──────────────────────────────────────────
+
+function SummaryCard({
+  title,
+  value,
+  loading,
+  icon,
+  subtitle,
+  isText,
+}: {
+  title: string;
+  value: number | string | null;
+  loading: boolean;
+  icon: React.ReactNode;
+  subtitle?: string;
+  isText?: boolean;
+}) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardContent className="flex items-center gap-4 p-5">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-800">
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs text-slate-500">{title}</p>
+          {loading ? (
+            <Skeleton className="mt-1 h-6 w-16 bg-slate-800" />
+          ) : isText ? (
+            <p className="truncate text-lg font-bold text-white">
+              {value ?? "—"}
+            </p>
+          ) : (
+            <p className="text-2xl font-bold text-white">{value ?? 0}</p>
+          )}
+          {subtitle && <p className="text-xs text-slate-500">{subtitle}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Info Row ──────────────────────────────────────────────
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <span className="text-slate-500">{label}:</span>{" "}
+      <span className="font-medium text-white">{value || "—"}</span>
+    </div>
+  );
+}
+
+// ─── Peer Table Row ────────────────────────────────────────
+
+function PeerRow({ peer }: { peer: TailscalePeer }) {
+  return (
+    <TableRow className="border-slate-800 hover:bg-slate-800/30">
+      <TableCell>
+        <div className="flex items-center gap-2">
+          {peer.online ? (
+            <Wifi className="h-3.5 w-3.5 text-emerald-400" />
+          ) : (
+            <WifiOff className="h-3.5 w-3.5 text-slate-600" />
+          )}
+          <Badge
+            variant="outline"
+            className={
+              peer.online
+                ? "border-emerald-500/30 text-emerald-400"
+                : "border-slate-700 text-slate-500"
+            }
+          >
+            {peer.online ? "online" : "offline"}
+          </Badge>
+        </div>
+      </TableCell>
+      <TableCell>
+        <div>
+          <p className="font-medium text-white">{peer.hostname || "—"}</p>
+          {peer.dns_name && (
+            <p className="text-xs text-slate-500">{peer.dns_name}</p>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-1.5">
+          <MonitorSmartphone className="h-3.5 w-3.5 text-slate-500" />
+          <span className="text-sm text-slate-400">{peer.os || "—"}</span>
+        </div>
+      </TableCell>
+      <TableCell className="font-mono text-xs text-slate-400">
+        {peer.tailscale_ips?.[0] ?? "—"}
+      </TableCell>
+      <TableCell>
+        {peer.exit_node ? (
+          <Badge
+            variant="outline"
+            className="border-blue-500/30 text-blue-400"
+          >
+            Active
+          </Badge>
+        ) : peer.exit_node_option ? (
+          <span className="text-xs text-slate-500">Available</span>
+        ) : (
+          <span className="text-xs text-slate-600">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs text-slate-400">
+        {formatBytes(peer.rx_bytes)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs text-slate-400">
+        {formatBytes(peer.tx_bytes)}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2044,3 +2044,13 @@ export function deleteCloudflareTunnelRoute(
     `/api/v1/cloudflare-tunnel/routes/${encodeURIComponent(hostname)}`
   ) as unknown as Promise<import("./types").CloudflareTunnelWriteResponse>;
 }
+
+// ─── Tailscale ──────────────────────────────────────────────
+
+export function fetchTailscaleStatus(): Promise<
+  import("./types").TailscaleStatusResponse
+> {
+  return apiGet<import("./types").TailscaleStatusResponse>(
+    "/api/v1/tailscale/status"
+  );
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1989,3 +1989,35 @@ export interface AddCloudflareRouteRequest {
   service: string;
   path?: string;
 }
+
+// ─── Tailscale ──────────────────────────────────────────────
+
+export interface TailscalePeer {
+  hostname: string;
+  dns_name: string;
+  os: string;
+  tailscale_ips: string[];
+  online: boolean;
+  active: boolean;
+  exit_node: boolean;
+  exit_node_option: boolean;
+  rx_bytes: number;
+  tx_bytes: number;
+  last_seen: string | null;
+}
+
+export interface TailscaleStatusResponse {
+  connected: boolean;
+  backend_state: string;
+  hostname: string;
+  dns_name: string;
+  tailscale_ips: string[];
+  os: string;
+  exit_node: boolean;
+  exit_node_option: boolean;
+  subnet_routes: string[];
+  magic_dns_suffix: string;
+  peers: TailscalePeer[];
+  online_peers: number;
+  total_peers: number;
+}


### PR DESCRIPTION
Closes #319

## Summary

- Adds `tailscale` as the 5th Docker Compose service using the official `tailscale/tailscale` image with `NET_ADMIN` capability and `/dev/net/tun` device access
- Auth via `TS_AUTHKEY` env var, optional subnet routing via `TS_EXTRA_ARGS=--advertise-routes=10.10.0.0/24`
- Shares the Tailscale daemon socket with the Panoptikon container via a `tailscale-run` volume for status monitoring
- Backend API endpoint (`GET /api/v1/tailscale/status`) queries the Tailscale local API over the Unix socket — returns node info, connected peers, subnet routes, and exit node status
- New **Settings > Tailscale** UI page with summary cards (status, online peers, IP, subnet routes), node info panel, and sortable peers table with 30s auto-refresh
- Gracefully handles the case where Tailscale is not running/configured

## Implementation notes

- The Panoptikon container mounts `tailscale-run:/var/run/tailscale:ro` to access the daemon socket without requiring the Tailscale binary
- Backend uses `tokio::net::UnixStream` to speak HTTP/1.0 directly to the Tailscale local API — no additional dependencies needed
- Socket path is configurable via `tailscale_socket` in the app config or the `tailscale_socket` setting in the database

## Test plan

- [ ] Verify `docker compose config` parses the updated compose file correctly
- [ ] Start the stack with `TS_AUTHKEY` set — confirm `panoptikon-tailscale` container authenticates
- [ ] Visit Settings > Tailscale — verify peers, IPs, subnet routes, and exit node status display
- [ ] Without Tailscale running — verify the "not connected" state renders correctly
- [ ] Verify no regressions on existing Settings page cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Tailscale VPN integration to the Panoptikon Docker stack. The implementation includes a new `tailscale` service in Docker Compose, a backend API endpoint that queries the Tailscale daemon via Unix socket, and a comprehensive frontend UI for monitoring connection status and peers.

**Key changes:**
- Added Tailscale container with `NET_ADMIN` capability and `/dev/net/tun` device access
- Shared volume mount (`tailscale-run`) enables the main container to read Tailscale status without requiring the Tailscale binary
- Backend implements custom HTTP/1.0 client over Unix socket to query Tailscale local API
- Frontend displays node info, peer list, subnet routes, and exit node status with 30s auto-refresh
- Gracefully handles non-running Tailscale daemon

**Notable implementation details:**
- The HTTP response parser in `ts_api_get` doesn't validate status codes, which could silently accept error responses
- All type definitions properly match between Rust backend and TypeScript frontend
- Docker Compose configuration follows best practices with proper network isolation and volume management

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor HTTP parsing improvement recommended
- The implementation is well-structured with proper error handling, graceful degradation, and follows existing code patterns. The HTTP status code validation issue is non-critical since the Tailscale local API is unlikely to return errors in normal operation, but adding validation would make it more robust.
- Pay attention to `server/src/api/tailscale.rs` — consider adding HTTP status code validation to the response parser

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker-compose.yml | Added Tailscale service with proper networking, volumes, and capabilities. Configuration looks correct. |
| server/src/api/tailscale.rs | Implemented Unix socket HTTP client for Tailscale local API. HTTP header parsing has a minor edge case issue with status code validation. |
| web/src/app/(app)/settings/tailscale/page.tsx | Comprehensive Tailscale status UI with auto-refresh, peer management, and graceful error handling. |

</details>



<sub>Last reviewed commit: fb2b269</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->