### PR TITLE
feat: Xiaomi router tab — WAN, system status, WiFi overview (#295)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -520,6 +520,8 @@ pub fn router(state: AppState) -> Router {
         .route("/xiaomi/wifi-devices", get(xiaomi::wifi_devices))
         .route("/xiaomi/wan-info", get(xiaomi::wan_info))
         .route("/xiaomi/lan-info", get(xiaomi::lan_info))
+        .route("/xiaomi/wifi-bands", get(xiaomi::wifi_bands))
+        .route("/xiaomi/firmware", get(xiaomi::firmware))
         // QoS / Traffic Shaping
         .route("/qos/summary", get(qos::qos_summary))
         .route("/qos/vyos/policies", get(qos::vyos_traffic_policies))

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -24,7 +24,7 @@ async fn get_setting(state: &AppState, key: &str) -> Option<String> {
 /// Try to construct a Xiaomi client from saved settings.
 /// Returns `None` if Xiaomi integration is not configured or not enabled.
 async fn xiaomi_client(state: &AppState) -> Option<XiaomiClient> {
-    let enabled = get_setting(state, "xiaomi_enabled")
+    let enabled = get_setting(state, "xiaomi_mesh_enabled")
         .await
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
@@ -32,10 +32,10 @@ async fn xiaomi_client(state: &AppState) -> Option<XiaomiClient> {
         return None;
     }
 
-    let ip = get_setting(state, "xiaomi_ip")
+    let ip = get_setting(state, "xiaomi_mesh_ip")
         .await
         .unwrap_or_else(|| "10.10.0.199".to_string());
-    let password = get_setting(state, "xiaomi_password").await?;
+    let password = get_setting(state, "xiaomi_mesh_password").await?;
 
     Some(XiaomiClient::new(&ip, &password, state.xiaomi_http.clone()))
 }
@@ -57,6 +57,7 @@ pub struct XiaomiStatusResponse {
     pub wan_upload: Option<String>,
     pub devices_online: Option<i32>,
     pub devices_total: Option<i32>,
+    pub uptime: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -113,6 +114,7 @@ pub struct XiaomiWanInfoResponse {
     pub dns: Option<String>,
     pub wan_type: Option<String>,
     pub mask: Option<String>,
+    pub ipv6_status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -139,6 +141,31 @@ pub struct XiaomiNewStatusResponse {
     pub devices_total: Option<i32>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiWifiBandResponse {
+    pub ssid: Option<String>,
+    pub channel: Option<String>,
+    pub bandwidth: Option<String>,
+    pub encryption: Option<String>,
+    pub signal: Option<i32>,
+    pub status: Option<String>,
+    pub band_steering: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XiaomiFirmwareResponse {
+    pub configured: bool,
+    pub reachable: bool,
+    pub router_name: Option<String>,
+    pub language: Option<String>,
+    pub rom_version: Option<String>,
+    pub hardware: Option<String>,
+    pub model: Option<String>,
+    pub country_code: Option<String>,
+    pub update_available: bool,
+    pub update_version: Option<String>,
+}
+
 // ── Handlers ───────────────────────────────────────────────
 
 /// GET /xiaomi/status — system status (CPU, memory, temp, speeds).
@@ -162,26 +189,31 @@ pub async fn status(
                 wan_upload: None,
                 devices_online: None,
                 devices_total: None,
+                uptime: None,
             }));
         }
     };
 
     match client.system_status().await {
-        Ok(s) => Ok(Json(XiaomiStatusResponse {
-            configured: true,
-            reachable: true,
-            cpu_cores: s.cpu.as_ref().and_then(|c| c.core),
-            cpu_freq: s.cpu.as_ref().and_then(|c| c.hz.clone()),
-            cpu_load: s.cpu.as_ref().and_then(|c| c.load),
-            mem_usage: s.mem.as_ref().and_then(|m| m.usage),
-            mem_total: s.mem.as_ref().and_then(|m| m.total.clone()),
-            mem_type: s.mem.as_ref().and_then(|m| m.mem_type.clone()),
-            temperature: s.temperature,
-            wan_download: s.wan.as_ref().and_then(|w| w.downspeed.clone()),
-            wan_upload: s.wan.as_ref().and_then(|w| w.upspeed.clone()),
-            devices_online: s.count.as_ref().and_then(|c| c.online),
-            devices_total: s.count.as_ref().and_then(|c| c.all),
-        })),
+        Ok(s) => {
+            let uptime = client.uptime().await.ok().flatten();
+            Ok(Json(XiaomiStatusResponse {
+                configured: true,
+                reachable: true,
+                cpu_cores: s.cpu.as_ref().and_then(|c| c.core),
+                cpu_freq: s.cpu.as_ref().and_then(|c| c.hz.clone()),
+                cpu_load: s.cpu.as_ref().and_then(|c| c.load),
+                mem_usage: s.mem.as_ref().and_then(|m| m.usage),
+                mem_total: s.mem.as_ref().and_then(|m| m.total.clone()),
+                mem_type: s.mem.as_ref().and_then(|m| m.mem_type.clone()),
+                temperature: s.temperature,
+                wan_download: s.wan.as_ref().and_then(|w| w.downspeed.clone()),
+                wan_upload: s.wan.as_ref().and_then(|w| w.upspeed.clone()),
+                devices_online: s.count.as_ref().and_then(|c| c.online),
+                devices_total: s.count.as_ref().and_then(|c| c.all),
+                uptime,
+            }))
+        }
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi status request failed");
             Ok(Json(XiaomiStatusResponse {
@@ -198,6 +230,7 @@ pub async fn status(
                 wan_upload: None,
                 devices_online: None,
                 devices_total: None,
+                uptime: None,
             }))
         }
     }
@@ -351,13 +384,29 @@ pub async fn wan_info(
     };
 
     match client.wan_info().await {
-        Ok(info) => Ok(Json(XiaomiWanInfoResponse {
-            ip: info.ip,
-            gateway: info.gateway,
-            dns: info.dns,
-            wan_type: info.wan_type,
-            mask: info.mask,
-        })),
+        Ok(info) => {
+            let ipv6_status = info.ipv6.as_ref().map(|v| {
+                if v.is_null() {
+                    "disabled".to_string()
+                } else if let Some(obj) = v.as_object() {
+                    if obj.is_empty() {
+                        "disabled".to_string()
+                    } else {
+                        "enabled".to_string()
+                    }
+                } else {
+                    format!("{v}")
+                }
+            });
+            Ok(Json(XiaomiWanInfoResponse {
+                ip: info.ip,
+                gateway: info.gateway,
+                dns: info.dns,
+                wan_type: info.wan_type,
+                mask: info.mask,
+                ipv6_status,
+            }))
+        }
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi WAN info request failed");
             Err(StatusCode::BAD_GATEWAY)
@@ -393,4 +442,102 @@ pub async fn lan_info(
             Err(StatusCode::BAD_GATEWAY)
         }
     }
+}
+
+/// GET /xiaomi/wifi-bands — per-band WiFi details (SSID, channel, band steering).
+pub async fn wifi_bands(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<XiaomiWifiBandResponse>>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    match client.wifi_detail_all().await {
+        Ok(bands) => Ok(Json(
+            bands
+                .into_iter()
+                .map(|b| XiaomiWifiBandResponse {
+                    ssid: b.ssid,
+                    channel: b.channel,
+                    bandwidth: b.bandwidth,
+                    encryption: b.encryption,
+                    signal: b.signal,
+                    status: b.status,
+                    band_steering: b.band_steering,
+                })
+                .collect(),
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi wifi bands request failed");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// GET /xiaomi/firmware — firmware version, hardware info, update check.
+pub async fn firmware(
+    State(state): State<AppState>,
+) -> Result<Json<XiaomiFirmwareResponse>, StatusCode> {
+    let client = match xiaomi_client(&state).await {
+        Some(c) => c,
+        None => {
+            return Ok(Json(XiaomiFirmwareResponse {
+                configured: false,
+                reachable: false,
+                router_name: None,
+                language: None,
+                rom_version: None,
+                hardware: None,
+                model: None,
+                country_code: None,
+                update_available: false,
+                update_version: None,
+            }));
+        }
+    };
+
+    let init = match client.init_info().await {
+        Ok(info) => info,
+        Err(e) => {
+            tracing::error!(error = %e, "MiWiFi init_info request failed");
+            return Ok(Json(XiaomiFirmwareResponse {
+                configured: true,
+                reachable: false,
+                router_name: None,
+                language: None,
+                rom_version: None,
+                hardware: None,
+                model: None,
+                country_code: None,
+                update_available: false,
+                update_version: None,
+            }));
+        }
+    };
+
+    let (update_available, update_version) = match client.check_rom_update().await {
+        Ok(Some(upd)) => {
+            let available = upd.need_update.unwrap_or(0) != 0;
+            (available, upd.version)
+        }
+        Ok(None) => (false, None),
+        Err(e) => {
+            tracing::warn!(error = %e, "MiWiFi check_rom_update failed, assuming no update");
+            (false, None)
+        }
+    };
+
+    Ok(Json(XiaomiFirmwareResponse {
+        configured: true,
+        reachable: true,
+        router_name: init.router_name,
+        language: init.language,
+        rom_version: init.rom_version,
+        hardware: init.hardware,
+        model: init.model,
+        country_code: init.countrycode,
+        update_available,
+        update_version,
+    }))
 }

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -358,6 +358,36 @@ impl XiaomiClient {
             serde_json::from_value(val).context("failed to parse LAN info")?;
         res.info.context("LAN info field missing from response")
     }
+
+    /// Fetch per-band WiFi details (SSID, channel, bandwidth, band steering).
+    pub async fn wifi_detail_all(&self) -> Result<Vec<WifiBandDetail>> {
+        let val = self.get_authed("xqnetwork/wifi_detail_all").await?;
+        let res: WifiDetailAllResponse =
+            serde_json::from_value(val).context("failed to parse wifi detail all")?;
+        Ok(res.info)
+    }
+
+    /// Fetch init info (firmware version, hardware model, router name).
+    pub async fn init_info(&self) -> Result<InitInfo> {
+        let val = self.get_authed("xqsystem/init_info").await?;
+        let res: InitInfo = serde_json::from_value(val).context("failed to parse init info")?;
+        Ok(res)
+    }
+
+    /// Check for ROM/firmware updates.
+    pub async fn check_rom_update(&self) -> Result<Option<RomUpdateInfo>> {
+        let val = self.get_authed("xqsystem/check_rom_update").await?;
+        // The update info may be absent if no update is available.
+        let update: Option<RomUpdateInfo> = serde_json::from_value(val).ok();
+        Ok(update)
+    }
+
+    /// Fetch system uptime.
+    pub async fn uptime(&self) -> Result<Option<String>> {
+        let val = self.get_authed("misystem/status").await?;
+        let res: UptimeResponse = serde_json::from_value(val).context("failed to parse uptime")?;
+        Ok(res.uptime)
+    }
 }
 
 /// Extract a JavaScript variable value from HTML source.

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -258,3 +258,71 @@ pub struct LanInfoResponse {
     #[serde(default)]
     pub info: Option<LanInfo>,
 }
+
+// ── WiFi detail per band ─────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WifiBandDetail {
+    #[serde(default)]
+    pub ssid: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub bandwidth: Option<String>,
+    #[serde(default)]
+    pub encryption: Option<String>,
+    #[serde(default)]
+    pub signal: Option<i32>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default, rename = "bandsteering")]
+    pub band_steering: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WifiDetailAllResponse {
+    #[serde(default)]
+    pub info: Vec<WifiBandDetail>,
+}
+
+// ── Init info (firmware / hardware) ──────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitInfo {
+    #[serde(default, rename = "routername")]
+    pub router_name: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default, rename = "romversion")]
+    pub rom_version: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub countrycode: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+// ── ROM update check ─────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RomUpdateInfo {
+    #[serde(default, rename = "needUpdate")]
+    pub need_update: Option<i32>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default, rename = "changelogUrl")]
+    pub changelog_url: Option<String>,
+    #[serde(default, rename = "fileSize")]
+    pub file_size: Option<String>,
+}
+
+// ── System status with uptime ────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UptimeResponse {
+    #[serde(default)]
+    pub uptime: Option<String>,
+}

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -135,6 +135,7 @@ import {
 } from "@/lib/api";
 import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
 import MikrotikRouter from "@/components/MikrotikRouter";
+import XiaomiRouter from "@/components/XiaomiRouter";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -5891,26 +5892,32 @@ export default function RouterPage() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik">("mikrotik");
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
+  const [routerType, setRouterType] = useState<"vyos" | "mikrotik" | "xiaomi">("mikrotik");
 
   // Load settings to determine which routers are configured
   useEffect(() => {
     const loadSettings = async () => {
       let mtEnabled = false;
       let vyosConf = false;
+      let xiEnabled = false;
       try {
         const settings = await fetchSettings();
         mtEnabled = settings.mikrotik_enabled;
         vyosConf = !!settings.vyos_url && settings.vyos_api_key_set;
+        xiEnabled = settings.xiaomi_mesh_enabled;
       } catch {
         // ignore
       }
       setMikrotikEnabled(mtEnabled);
       setVyosConfigured(vyosConf);
+      setXiaomiEnabled(xiEnabled);
 
-      // Default to mikrotik if enabled, fallback to vyos only if mikrotik not available
+      // Default to mikrotik if enabled, fallback to xiaomi, then vyos
       if (mtEnabled) {
         setRouterType("mikrotik");
+      } else if (xiEnabled) {
+        setRouterType("xiaomi");
       } else if (vyosConf) {
         setRouterType("vyos");
       }
@@ -5948,42 +5955,61 @@ export default function RouterPage() {
     loadVyosSummary();
   }, [routerType, summary]);
 
-  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled;
+  const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled && !xiaomiEnabled;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, tabs when MikroTik is enabled */}
+        {/* Router type selector — skeleton while settings load, tabs when multiple routers available */}
         {!settingsLoaded ? (
           <Skeleton className="h-9 w-48" />
-        ) : mikrotikEnabled ? (
+        ) : [mikrotikEnabled, vyosConfigured, xiaomiEnabled].filter(Boolean).length > 1 ? (
           <div className="flex gap-2">
-            <Button
-              variant={routerType === "mikrotik" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("mikrotik")}
-              className={
-                routerType === "mikrotik"
-                  ? "bg-pink-600 text-white hover:bg-pink-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              MikroTik
-            </Button>
-            <Button
-              variant={routerType === "vyos" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setRouterType("vyos")}
-              className={
-                routerType === "vyos"
-                  ? "bg-blue-600 text-white hover:bg-blue-500"
-                  : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-              }
-            >
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              VyOS (Optional)
-            </Button>
+            {mikrotikEnabled && (
+              <Button
+                variant={routerType === "mikrotik" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("mikrotik")}
+                className={
+                  routerType === "mikrotik"
+                    ? "bg-pink-600 text-white hover:bg-pink-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                MikroTik
+              </Button>
+            )}
+            {xiaomiEnabled && (
+              <Button
+                variant={routerType === "xiaomi" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("xiaomi")}
+                className={
+                  routerType === "xiaomi"
+                    ? "bg-orange-600 text-white hover:bg-orange-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                Xiaomi
+              </Button>
+            )}
+            {vyosConfigured && (
+              <Button
+                variant={routerType === "vyos" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setRouterType("vyos")}
+                className={
+                  routerType === "vyos"
+                    ? "bg-blue-600 text-white hover:bg-blue-500"
+                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+                }
+              >
+                <Router className="mr-1.5 h-3.5 w-3.5" />
+                VyOS
+              </Button>
+            )}
           </div>
         ) : null}
 
@@ -5995,6 +6021,8 @@ export default function RouterPage() {
           </div>
         ) : neitherConfigured ? (
           <NotConfigured />
+        ) : routerType === "xiaomi" && xiaomiEnabled ? (
+          <XiaomiRouter />
         ) : routerType === "mikrotik" && mikrotikEnabled ? (
           <MikrotikRouter />
         ) : routerType === "vyos" && !vyosConfigured ? (

--- a/web/src/components/XiaomiRouter.tsx
+++ b/web/src/components/XiaomiRouter.tsx
@@ -1,0 +1,548 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Router,
+  Globe,
+  AlertCircle,
+  Cpu,
+  Clock,
+  MemoryStick,
+  Thermometer,
+  Wifi,
+  ArrowDown,
+  ArrowUp,
+  HardDrive,
+  Download,
+  Users,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import {
+  fetchXiaomiStatus,
+  fetchXiaomiWanInfo,
+  fetchXiaomiWifiBands,
+  fetchXiaomiWifiDevices,
+  fetchXiaomiFirmware,
+} from "@/lib/api";
+import type {
+  XiaomiStatus,
+  XiaomiWanInfo,
+  XiaomiWifiBand,
+  XiaomiWifiDevice,
+  XiaomiFirmware,
+} from "@/lib/types";
+
+// ── Generic data loader hook ──────────────────────────────
+
+function useData<T>(fetcher: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetcher();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}
+
+// ── Helpers ───────────────────────────────────────────────
+
+function formatUptime(seconds: string | null): string {
+  if (!seconds) return "\u2014";
+  const s = parseInt(seconds, 10);
+  if (isNaN(s)) return seconds;
+  const days = Math.floor(s / 86400);
+  const hours = Math.floor((s % 86400) / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function progressColor(value: number): string {
+  if (value >= 90) return "bg-red-500";
+  if (value >= 70) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function tempColor(temp: number): string {
+  if (temp >= 80) return "text-red-400";
+  if (temp >= 60) return "text-amber-400";
+  return "text-emerald-400";
+}
+
+// ── System Stats Section ─────────────────────────────────
+
+function SystemStats({ status }: { status: XiaomiStatus }) {
+  const cpuLoad = status.cpu_load ?? 0;
+  const memUsage = status.mem_usage ? Math.round(status.mem_usage * 100) : 0;
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-300">
+          <Cpu className="h-4 w-4 text-orange-400" />
+          System Stats
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* CPU */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-slate-400">
+              CPU ({status.cpu_cores ?? "?"}-core @ {status.cpu_freq ?? "?"})
+            </span>
+            <span className="font-mono text-slate-200">{cpuLoad}%</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`h-full rounded-full transition-all ${progressColor(cpuLoad)}`}
+              style={{ width: `${cpuLoad}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Memory */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-slate-400">
+              RAM ({status.mem_total ?? "?"} {status.mem_type ?? ""})
+            </span>
+            <span className="font-mono text-slate-200">{memUsage}%</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`h-full rounded-full transition-all ${progressColor(memUsage)}`}
+              style={{ width: `${memUsage}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Temperature + Uptime row */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="rounded-lg bg-slate-800/50 p-3">
+            <div className="flex items-center gap-2 text-xs text-slate-500">
+              <Thermometer className="h-3.5 w-3.5" />
+              Temperature
+            </div>
+            <p
+              className={`mt-1 text-lg font-semibold ${status.temperature != null ? tempColor(status.temperature) : "text-slate-400"}`}
+            >
+              {status.temperature != null ? `${status.temperature}\u00b0C` : "\u2014"}
+            </p>
+          </div>
+          <div className="rounded-lg bg-slate-800/50 p-3">
+            <div className="flex items-center gap-2 text-xs text-slate-500">
+              <Clock className="h-3.5 w-3.5" />
+              Uptime
+            </div>
+            <p className="mt-1 text-lg font-semibold text-slate-200">
+              {formatUptime(status.uptime)}
+            </p>
+          </div>
+        </div>
+
+        {/* Devices + Bandwidth row */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="rounded-lg bg-slate-800/50 p-3">
+            <div className="flex items-center gap-2 text-xs text-slate-500">
+              <Users className="h-3.5 w-3.5" />
+              Devices Online
+            </div>
+            <p className="mt-1 text-lg font-semibold text-slate-200">
+              {status.devices_online ?? 0}
+              <span className="ml-1 text-sm font-normal text-slate-500">
+                / {status.devices_total ?? 0}
+              </span>
+            </p>
+          </div>
+          <div className="rounded-lg bg-slate-800/50 p-3">
+            <div className="flex items-center gap-2 text-xs text-slate-500">
+              WAN Speed
+            </div>
+            <div className="mt-1 flex items-center gap-3 text-sm">
+              <span className="flex items-center gap-1 text-emerald-400">
+                <ArrowDown className="h-3 w-3" />
+                {status.wan_download ?? "0"} B/s
+              </span>
+              <span className="flex items-center gap-1 text-blue-400">
+                <ArrowUp className="h-3 w-3" />
+                {status.wan_upload ?? "0"} B/s
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── WAN Info Section ─────────────────────────────────────
+
+function WanInfoSection({ wan }: { wan: XiaomiWanInfo }) {
+  const dnsServers = wan.dns?.split(",").map((d) => d.trim()) ?? [];
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-300">
+          <Globe className="h-4 w-4 text-blue-400" />
+          WAN Info
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <span className="text-slate-500">WAN IP</span>
+            <p className="font-mono text-slate-200">{wan.ip ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Gateway</span>
+            <p className="font-mono text-slate-200">{wan.gateway ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Subnet Mask</span>
+            <p className="font-mono text-slate-200">{wan.mask ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">WAN Type</span>
+            <p className="text-slate-200">
+              <Badge
+                variant="outline"
+                className="border-slate-700 text-slate-300"
+              >
+                {wan.wan_type ?? "\u2014"}
+              </Badge>
+            </p>
+          </div>
+          <div>
+            <span className="text-slate-500">DNS Servers</span>
+            <div className="mt-0.5 flex flex-wrap gap-1.5">
+              {dnsServers.length > 0
+                ? dnsServers.map((d) => (
+                    <Badge
+                      key={d}
+                      variant="outline"
+                      className="border-slate-700 font-mono text-slate-300"
+                    >
+                      {d}
+                    </Badge>
+                  ))
+                : <span className="text-slate-400">{"\u2014"}</span>}
+            </div>
+          </div>
+          <div>
+            <span className="text-slate-500">IPv6 Status</span>
+            <p className="text-slate-200">
+              <Badge
+                variant="outline"
+                className={
+                  wan.ipv6_status === "enabled"
+                    ? "border-emerald-700 text-emerald-400"
+                    : "border-slate-700 text-slate-400"
+                }
+              >
+                {wan.ipv6_status ?? "unknown"}
+              </Badge>
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── WiFi Bands Section ───────────────────────────────────
+
+function WifiBandsSection({
+  bands,
+  wifiDevices,
+}: {
+  bands: XiaomiWifiBand[];
+  wifiDevices: XiaomiWifiDevice[];
+}) {
+  // Count connected clients per band
+  const clientsByBand = wifiDevices.reduce<Record<string, number>>(
+    (acc, d) => {
+      const b = d.band ?? "unknown";
+      acc[b] = (acc[b] ?? 0) + 1;
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-300">
+          <Wifi className="h-4 w-4 text-violet-400" />
+          WiFi Bands
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {bands.length === 0 ? (
+          <p className="text-sm text-slate-500">No WiFi bands detected.</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {bands.map((band, i) => {
+              const bandLabel = band.channel
+                ? parseInt(band.channel, 10) > 14
+                  ? "5 GHz"
+                  : "2.4 GHz"
+                : `Band ${i + 1}`;
+              const clientCount = Object.entries(clientsByBand).reduce(
+                (sum, [key, count]) => {
+                  if (
+                    (bandLabel === "5 GHz" && key.includes("5g")) ||
+                    (bandLabel === "2.4 GHz" && key.includes("2.4g")) ||
+                    key.includes(bandLabel)
+                  ) {
+                    return sum + count;
+                  }
+                  return sum;
+                },
+                0
+              );
+
+              return (
+                <div
+                  key={i}
+                  className="rounded-lg border border-slate-800 bg-slate-800/30 p-4"
+                >
+                  <div className="mb-3 flex items-center justify-between">
+                    <Badge className="bg-violet-500/20 text-violet-300">
+                      {bandLabel}
+                    </Badge>
+                    <Badge
+                      variant="outline"
+                      className={
+                        band.status === "1"
+                          ? "border-emerald-700 text-emerald-400"
+                          : "border-slate-700 text-slate-500"
+                      }
+                    >
+                      {band.status === "1" ? "Active" : "Off"}
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-sm">
+                    <div>
+                      <span className="text-slate-500">SSID</span>
+                      <p className="truncate text-slate-200">
+                        {band.ssid ?? "\u2014"}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Channel</span>
+                      <p className="text-slate-200">{band.channel ?? "\u2014"}</p>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Clients</span>
+                      <p className="text-slate-200">{clientCount}</p>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Band Steering</span>
+                      <p className="text-slate-200">
+                        <Badge
+                          variant="outline"
+                          className={
+                            band.band_steering === "1"
+                              ? "border-emerald-700 text-emerald-400"
+                              : "border-slate-700 text-slate-400"
+                          }
+                        >
+                          {band.band_steering === "1" ? "On" : "Off"}
+                        </Badge>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Firmware Section ─────────────────────────────────────
+
+function FirmwareSection({ firmware }: { firmware: XiaomiFirmware }) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-300">
+          <HardDrive className="h-4 w-4 text-cyan-400" />
+          Firmware & Updates
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <span className="text-slate-500">Firmware Version</span>
+            <p className="font-mono text-slate-200">
+              {firmware.rom_version ?? "\u2014"}
+            </p>
+          </div>
+          <div>
+            <span className="text-slate-500">Hardware</span>
+            <p className="text-slate-200">{firmware.hardware ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Model</span>
+            <p className="text-slate-200">{firmware.model ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Router Name</span>
+            <p className="text-slate-200">{firmware.router_name ?? "\u2014"}</p>
+          </div>
+          <div>
+            <span className="text-slate-500">Locale</span>
+            <p className="text-slate-200">
+              {firmware.language ?? firmware.country_code ?? "\u2014"}
+            </p>
+          </div>
+          <div>
+            <span className="text-slate-500">Update Available</span>
+            <p>
+              {firmware.update_available ? (
+                <Badge className="bg-amber-500/20 text-amber-300">
+                  <Download className="mr-1 h-3 w-3" />
+                  {firmware.update_version ?? "Yes"}
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-emerald-700 text-emerald-400"
+                >
+                  Up to date
+                </Badge>
+              )}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Main Component ───────────────────────────────────────
+
+export default function XiaomiRouter() {
+  const [status, setStatus] = useState<XiaomiStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchXiaomiStatus()
+      .then(setStatus)
+      .catch(() =>
+        setStatus({
+          configured: false,
+          reachable: false,
+          cpu_cores: null,
+          cpu_freq: null,
+          cpu_load: null,
+          mem_usage: null,
+          mem_total: null,
+          mem_type: null,
+          temperature: null,
+          wan_download: null,
+          wan_upload: null,
+          devices_online: null,
+          devices_total: null,
+          uptime: null,
+        })
+      )
+      .finally(() => setLoading(false));
+  }, []);
+
+  const wan = useData(useCallback(() => fetchXiaomiWanInfo(), []));
+  const bands = useData(useCallback(() => fetchXiaomiWifiBands(), []));
+  const wifiDevices = useData(useCallback(() => fetchXiaomiWifiDevices(), []));
+  const firmware = useData(useCallback(() => fetchXiaomiFirmware(), []));
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (!status?.configured || !status?.reachable) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-12 text-center">
+        <AlertCircle className="h-10 w-10 text-amber-400" />
+        <p className="text-sm text-slate-400">
+          {!status?.configured
+            ? "Xiaomi router is not configured. Enable it in Settings \u2192 Integrations \u2192 Xiaomi Mesh."
+            : "Xiaomi router is unreachable. Check connection settings."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
+            <Router className="h-5 w-5 text-orange-400" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-white">Xiaomi Router</h2>
+            <p className="text-xs text-slate-500">
+              {status.devices_online ?? 0} devices online
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* System Stats */}
+      <SystemStats status={status} />
+
+      {/* WAN Info */}
+      {wan.loading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : wan.data ? (
+        <WanInfoSection wan={wan.data} />
+      ) : null}
+
+      {/* WiFi Bands */}
+      {bands.loading || wifiDevices.loading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : bands.data ? (
+        <WifiBandsSection
+          bands={bands.data}
+          wifiDevices={wifiDevices.data ?? []}
+        />
+      ) : null}
+
+      {/* Firmware */}
+      {firmware.loading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : firmware.data?.reachable ? (
+        <FirmwareSection firmware={firmware.data} />
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1999,6 +1999,20 @@ export function fetchXiaomiLanInfo(): Promise<
   return apiGet<import("./types").XiaomiLanInfo>("/api/v1/xiaomi/lan-info");
 }
 
+export function fetchXiaomiWifiBands(): Promise<
+  import("./types").XiaomiWifiBand[]
+> {
+  return apiGet<import("./types").XiaomiWifiBand[]>(
+    "/api/v1/xiaomi/wifi-bands"
+  );
+}
+
+export function fetchXiaomiFirmware(): Promise<
+  import("./types").XiaomiFirmware
+> {
+  return apiGet<import("./types").XiaomiFirmware>("/api/v1/xiaomi/firmware");
+}
+
 // ─── Xiaomi Mesh Settings ────────────────────────────────
 
 export function testXiaomiMeshConnection(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1852,6 +1852,7 @@ export interface XiaomiStatus {
   wan_upload: string | null;
   devices_online: number | null;
   devices_total: number | null;
+  uptime: string | null;
 }
 
 export interface XiaomiTopoNode {
@@ -1902,6 +1903,7 @@ export interface XiaomiWanInfo {
   dns: string | null;
   wan_type: string | null;
   mask: string | null;
+  ipv6_status: string | null;
 }
 
 export interface XiaomiLanPort {
@@ -1923,6 +1925,29 @@ export interface XiaomiNewStatus {
   sn: string | null;
   devices_online: number | null;
   devices_total: number | null;
+}
+
+export interface XiaomiWifiBand {
+  ssid: string | null;
+  channel: string | null;
+  bandwidth: string | null;
+  encryption: string | null;
+  signal: number | null;
+  status: string | null;
+  band_steering: string | null;
+}
+
+export interface XiaomiFirmware {
+  configured: boolean;
+  reachable: boolean;
+  router_name: string | null;
+  language: string | null;
+  rom_version: string | null;
+  hardware: string | null;
+  model: string | null;
+  country_code: string | null;
+  update_available: boolean;
+  update_version: string | null;
 }
 
 // ─── Xiaomi Mesh Settings ────────────────────────────────


### PR DESCRIPTION
## Summary

- Add **Xiaomi** as a third router tab on the Router page (alongside VyOS/MikroTik)
- Adds 4 dashboard sections: System Stats, WAN Info, WiFi Bands, Firmware & Updates
- Extends the Xiaomi MiWiFi API client with `wifi_detail_all`, `init_info`, `check_rom_update`, and `uptime` methods
- Adds `/xiaomi/wifi-bands` and `/xiaomi/firmware` backend API endpoints
- Fixes settings key mismatch (`xiaomi_enabled` → `xiaomi_mesh_enabled`) so the router tab reads from the same settings as the Xiaomi Mesh integration page

## What's included

### Backend (Rust)
- **New client methods**: `wifi_detail_all()`, `init_info()`, `check_rom_update()`, `uptime()` in `server/src/xiaomi/client.rs`
- **New types**: `WifiBandDetail`, `InitInfo`, `RomUpdateInfo`, `UptimeResponse` in `server/src/xiaomi/types.rs`
- **New API endpoints**: `GET /xiaomi/wifi-bands`, `GET /xiaomi/firmware` in `server/src/api/xiaomi.rs`
- **Updated responses**: IPv6 status added to WAN info, uptime added to system status
- **Settings fix**: Handler now reads `xiaomi_mesh_*` keys matching the settings page

### Frontend (TypeScript/React)
- **New component**: `XiaomiRouter.tsx` with 4 sections:
  - System Stats — CPU/RAM progress bars with color thresholds, temperature, uptime, device count, WAN speed
  - WAN Info — IP, gateway, DNS servers, WAN type, subnet mask, IPv6 status
  - WiFi Bands — per-band SSID, channel, connected clients, band steering status
  - Firmware & Updates — firmware version, hardware model, router name, locale, update availability
- **Router page**: 3-way router selector (MikroTik / Xiaomi / VyOS) shown when multiple routers are enabled
- **New types**: `XiaomiWifiBand`, `XiaomiFirmware` in `types.ts`
- **New API functions**: `fetchXiaomiWifiBands()`, `fetchXiaomiFirmware()` in `api.ts`

## Test plan

- [ ] Enable Xiaomi Mesh in Settings → Integrations → Xiaomi Mesh with valid IP and password
- [ ] Navigate to Router page — Xiaomi tab should appear
- [ ] Verify System Stats section shows CPU/RAM gauges, temperature, uptime
- [ ] Verify WAN Info section shows IP, gateway, DNS, WAN type, IPv6 status
- [ ] Verify WiFi Bands section shows per-band SSID, channel, client count
- [ ] Verify Firmware section shows version, hardware, update status
- [ ] Verify router selector buttons appear when multiple routers are enabled

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Xiaomi router as a third router option in the Router page alongside VyOS and MikroTik. The implementation includes comprehensive dashboard sections for system statistics, WAN configuration, WiFi band details, and firmware information.

**Key changes:**
- Fixed settings key mismatch (`xiaomi_enabled` → `xiaomi_mesh_enabled`) ensuring consistency with the integration settings page
- Extended Xiaomi API client with 4 new methods: `wifi_detail_all()`, `init_info()`, `check_rom_update()`, and `uptime()`
- Added 2 new backend API endpoints: `/xiaomi/wifi-bands` and `/xiaomi/firmware`
- Enhanced existing responses with uptime (system status) and IPv6 status (WAN info)
- Created new `XiaomiRouter.tsx` component with 4 dashboard sections displaying CPU/RAM usage, temperature, WAN details, per-band WiFi info, and firmware version
- Router page now shows tabs when multiple routers are enabled (MikroTik, Xiaomi, VyOS)

**Minor optimization opportunity:**
- The status endpoint makes duplicate calls to `misystem/status` for both system status and uptime data

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor optimization opportunity
- The implementation is well-structured with proper error handling, type safety, and consistent patterns. The settings key fix resolves a real integration issue. One minor inefficiency exists where the status endpoint makes duplicate API calls to the same endpoint, but this doesn't affect correctness.
- server/src/api/xiaomi.rs contains a duplicate API call that could be optimized

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi.rs | Fixed settings keys, added uptime/IPv6 fields, new WiFi bands and firmware endpoints with duplicate API call inefficiency |
| server/src/xiaomi/client.rs | Added four new API methods: wifi_detail_all, init_info, check_rom_update, and uptime for enhanced router data |
| web/src/app/(app)/router/page.tsx | Added Xiaomi router tab to router selector, integrated XiaomiRouter component with proper state management |
| web/src/components/XiaomiRouter.tsx | New component with 4 dashboard sections displaying system stats, WAN info, WiFi bands, and firmware details |

</details>



<sub>Last reviewed commit: 3237e57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->