### PR TITLE
fix: default router to MikroTik instead of VyOS in DDNS page (#301)

### DIFF
--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -55,6 +55,7 @@ import {
   deleteDdnsEntry,
   toggleDdnsEntry,
   fetchDdnsStatus,
+  fetchSettings,
 } from "@/lib/api";
 import type { DdnsEntry, DdnsEntryRequest, DdnsStatus } from "@/lib/types";
 import { toast } from "sonner";
@@ -74,7 +75,7 @@ const PROVIDERS = [
 
 const PROTOCOLS = ["ipv4", "ipv6", "both"];
 const IP_SOURCES = ["wan", "interface", "web"];
-const ROUTER_TYPES = ["vyos", "mikrotik"];
+const ROUTER_TYPES = ["mikrotik", "vyos"];
 
 function StatusBadge({ status }: { status: string }) {
   switch (status) {
@@ -118,11 +119,13 @@ function DdnsFormDialog({
   onClose,
   onSave,
   initial,
+  defaultRouterType,
 }: {
   open: boolean;
   onClose: () => void;
   onSave: (body: DdnsEntryRequest) => Promise<void>;
   initial?: DdnsEntry | null;
+  defaultRouterType: string;
 }) {
   const [provider, setProvider] = useState(initial?.provider ?? "cloudflare");
   const [hostname, setHostname] = useState(initial?.hostname ?? "");
@@ -136,7 +139,7 @@ function DdnsFormDialog({
   const [ipSource, setIpSource] = useState(initial?.ip_source ?? "wan");
   const [protocol, setProtocol] = useState(initial?.protocol ?? "ipv4");
   const [routerType, setRouterType] = useState(
-    initial?.router_type ?? "vyos"
+    initial?.router_type ?? defaultRouterType
   );
   const [enabled, setEnabled] = useState(initial?.enabled ?? true);
   const [saving, setSaving] = useState(false);
@@ -152,10 +155,10 @@ function DdnsFormDialog({
       setInterfaceName(initial?.interface_name ?? "");
       setIpSource(initial?.ip_source ?? "wan");
       setProtocol(initial?.protocol ?? "ipv4");
-      setRouterType(initial?.router_type ?? "vyos");
+      setRouterType(initial?.router_type ?? defaultRouterType);
       setEnabled(initial?.enabled ?? true);
     }
-  }, [open, initial]);
+  }, [open, initial, defaultRouterType]);
 
   const handleSubmit = async () => {
     if (!hostname.trim()) {
@@ -364,6 +367,24 @@ export default function DdnsPage() {
   const [editItem, setEditItem] = useState<DdnsEntry | null>(null);
   const [pendingDelete, setPendingDelete] = useState<DdnsEntry | null>(null);
   const [search, setSearch] = useState("");
+  const [defaultRouterType, setDefaultRouterType] = useState("mikrotik");
+
+  // Determine default router type from settings
+  useEffect(() => {
+    fetchSettings()
+      .then((settings) => {
+        if (settings.mikrotik_enabled) {
+          setDefaultRouterType("mikrotik");
+        } else if (settings.vyos_url && settings.vyos_api_key_set) {
+          setDefaultRouterType("vyos");
+        } else {
+          setDefaultRouterType("mikrotik");
+        }
+      })
+      .catch(() => {
+        // Keep mikrotik as default on error
+      });
+  }, []);
 
   const loadData = useCallback(async () => {
     try {
@@ -683,6 +704,7 @@ export default function DdnsPage() {
         open={showAdd}
         onClose={() => setShowAdd(false)}
         onSave={handleCreate}
+        defaultRouterType={defaultRouterType}
       />
 
       {/* Edit dialog */}
@@ -691,6 +713,7 @@ export default function DdnsPage() {
         onClose={() => setEditItem(null)}
         onSave={handleUpdate}
         initial={editItem}
+        defaultRouterType={defaultRouterType}
       />
 
       {/* Delete confirmation */}


### PR DESCRIPTION
## Summary

- Changed DDNS form dialog default router type from VyOS to MikroTik
- Added settings-aware defaulting: fetches user settings on page load to prefer MikroTik if enabled, falling back to VyOS only when MikroTik is not configured
- Reordered `ROUTER_TYPES` dropdown to list MikroTik first

## Context

The DDNS page was the only page still defaulting to VyOS as the router type. The main router page already correctly defaults to MikroTik. Other pages (VPN Status, NAT, QoS) use availability flags from API responses rather than hardcoded defaults, so they were unaffected.

## Test plan

- [ ] Open the DDNS page and click "Add Entry" — router type dropdown should default to MikroTik
- [ ] Verify MikroTik appears first in the router type dropdown
- [ ] If MikroTik is not configured in settings but VyOS is, verify VyOS is selected as default
- [ ] Edit an existing DDNS entry — should preserve the original router_type, not override it

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the DDNS page to default to MikroTik router instead of VyOS, bringing it in line with the rest of the application. The implementation includes settings-aware defaulting that checks user configuration on page load:

- If MikroTik is enabled in settings, defaults to MikroTik
- If MikroTik is not configured but VyOS is (both URL and API key set), defaults to VyOS  
- Otherwise, defaults to MikroTik as the fallback
- Reordered the router type dropdown to show MikroTik first
- Preserved existing entries' router type when editing (no override)

The change is straightforward and correctly implements the fallback logic. The `useEffect` properly fetches settings once on mount, and the `defaultRouterType` prop is threaded through to both the Add and Edit dialogs correctly.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risks
- Simple, well-implemented change with clear logic, proper prop threading, and no breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/ddns/page.tsx | Changed default router from VyOS to MikroTik with settings-aware fallback logic |

</details>



<sub>Last reviewed commit: 2e6ef4a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->