### PR TITLE
chore: bump version to 0.6.0 in Cargo.toml (#326)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["server", "agent"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/BeFeast/panoptikon"


### PR DESCRIPTION
## Summary
- Bumped `[workspace.package] version` in root `Cargo.toml` from `"0.5.0"` to `"0.6.0"`
- `server/Cargo.toml` and `agent/Cargo.toml` both use `version.workspace = true`, so they inherit automatically — no changes needed

Closes #326

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumped workspace version from `"0.5.0"` to `"0.6.0"` in root `Cargo.toml`. Both `panoptikon-server` and `panoptikon-agent` use `version.workspace = true`, so they automatically inherit the new version without requiring manual updates.

- Clean version bump following semantic versioning conventions
- Workspace inheritance is correctly configured in both member crates
- No other changes needed or included

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line version bump in workspace configuration with verified workspace inheritance, no logic changes, no dependencies affected
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Workspace version bumped from 0.5.0 to 0.6.0, automatically propagates to all workspace members |

</details>



<sub>Last reviewed commit: 5710841</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->