### PR TITLE
feat: ui/badges: show Legacy badge + note on VyOS detail pages (#333)

### DIFF
--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -224,10 +224,15 @@ function DdnsFormDialog({
               >
                 {ROUTER_TYPES.map((t) => (
                   <option key={t} value={t}>
-                    {t === "vyos" ? "VyOS" : "MikroTik"}
+                    {t === "vyos" ? "VyOS (Legacy)" : "MikroTik"}
                   </option>
                 ))}
               </select>
+              {routerType === "vyos" && (
+                <p className="text-[11px] text-amber-400">
+                  VyOS is legacy — MikroTik is recommended for new deployments.
+                </p>
+              )}
             </div>
           </div>
 

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -268,6 +268,9 @@ export default function QosPage() {
                 className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
               >
                 VyOS Policies
+                <span className="ml-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0 text-[10px] text-amber-400">
+                  Legacy
+                </span>
               </TabsTrigger>
             )}
             {summary?.mikrotik_available && (

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -223,6 +223,12 @@ function StatusHeader({ status }: { status: RouterStatus }) {
         </div>
       </div>
       <div className="flex items-center gap-2">
+        <Badge
+          variant="outline"
+          className="border-amber-500/30 bg-amber-500/10 text-amber-400"
+        >
+          Legacy
+        </Badge>
         {status.reachable ? (
           <Badge
             variant="outline"
@@ -6008,10 +6014,23 @@ export default function RouterPage() {
               >
                 <Router className="mr-1.5 h-3.5 w-3.5" />
                 VyOS
+                <Badge variant="outline" className="ml-1.5 border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px] px-1.5 py-0">
+                  Legacy
+                </Badge>
               </Button>
             )}
           </div>
         ) : null}
+
+        {/* VyOS legacy note */}
+        {settingsLoaded && routerType === "vyos" && (
+          <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+            <p className="text-xs text-amber-400">
+              VyOS support is legacy. MikroTik is the recommended router platform for new deployments.
+            </p>
+          </div>
+        )}
 
         {/* Content area — skeletons until settings arrive, then router-specific content */}
         {!settingsLoaded ? (

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   CheckCircle,
   AlertCircle,
+  AlertTriangle,
   ArrowLeft,
 } from "lucide-react";
 import {
@@ -118,6 +119,12 @@ function VyosPanel() {
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+        <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+        <p className="text-xs text-amber-400">
+          Legacy — MikroTik is the recommended router platform for new deployments.
+        </p>
+      </div>
       <div className="space-y-1.5">
         <Label htmlFor="vyos-url" className="text-xs text-slate-400">
           Router URL
@@ -495,7 +502,7 @@ export default function RouterSettingsPage() {
                   className="flex-1 data-[state=active]:bg-blue-600 data-[state=active]:text-white"
                 >
                   <Router className="mr-1.5 h-3.5 w-3.5" />
-                  VyOS (Optional)
+                  VyOS (Legacy)
                 </TabsTrigger>
               </TabsList>
               <TabsContent value="mikrotik">


### PR DESCRIPTION
Closes #333

## Summary
- **Router page**: Added a `Legacy` badge on the VyOS tab selector button, an amber warning banner when VyOS tab is active explaining MikroTik is recommended, and a `Legacy` badge in the VyOS StatusHeader next to connection status.
- **Settings → Router**: Changed VyOS tab label from "VyOS (Optional)" to "VyOS (Legacy)" and added an amber legacy note at the top of the VyOS configuration panel.
- **QoS page**: Added a `Legacy` badge on the "VyOS Policies" tab trigger.
- **DDNS page**: Changed the VyOS dropdown option to "VyOS (Legacy)" and added an inline legacy note when VyOS is selected as router type.

All legacy indicators use the existing amber warning style (`border-amber-500/30 bg-amber-500/10 text-amber-400`) consistent with the NPM legacy pattern in the codebase.

## Test plan
- [ ] Navigate to Router page → verify VyOS tab button shows "Legacy" badge
- [ ] Select VyOS tab → verify amber note appears: "VyOS support is legacy..."
- [ ] View VyOS router detail → verify "Legacy" badge in status header
- [ ] Go to Settings → Router → verify VyOS tab says "VyOS (Legacy)"
- [ ] Open VyOS settings panel → verify amber legacy note at top
- [ ] Go to QoS page → verify VyOS Policies tab shows "Legacy" badge
- [ ] Go to DDNS page → verify router type dropdown shows "VyOS (Legacy)"
- [ ] Select VyOS in DDNS form → verify inline legacy note appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds consistent "Legacy" branding across all VyOS-related UI components to indicate MikroTik is the recommended platform.

- **Router page**: Legacy badge on tab button, in status header, and amber warning banner when VyOS tab is active
- **Settings → Router**: Tab label changed to "VyOS (Legacy)" with amber note at top of configuration panel  
- **QoS page**: Legacy badge added to VyOS Policies tab trigger
- **DDNS page**: Dropdown shows "VyOS (Legacy)" with inline note when selected

All changes use the consistent amber warning style (`border-amber-500/30 bg-amber-500/10 text-amber-400`) matching existing patterns in the codebase (e.g., NPM certificates). The implementation is clean, well-tested per the test plan, and effectively communicates the deprecation status without breaking functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- All changes are purely presentational, adding visual indicators for VyOS legacy status. The code follows existing patterns, uses consistent styling, has proper imports, and doesn't modify any functional logic. The comprehensive test plan covers all affected areas.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/ddns/page.tsx | Added "(Legacy)" label to VyOS dropdown option and inline legacy note when VyOS is selected - implementation is clean and consistent |
| web/src/app/(app)/qos/page.tsx | Added inline Legacy badge to VyOS Policies tab trigger using consistent amber styling |
| web/src/app/(app)/router/page.tsx | Added Legacy badge to VyOS tab button, status header, and amber warning banner when VyOS is active - all changes follow existing patterns |
| web/src/app/(app)/settings/router/page.tsx | Changed VyOS tab label to "VyOS (Legacy)" and added amber legacy note at top of VyOS panel - properly imports AlertTriangle icon |

</details>



<sub>Last reviewed commit: 636f52f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->