### PR TITLE
feat: ui/visibility: hide VyOS in normal flows when legacy toggle off (#331)

### DIFF
--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -120,12 +120,14 @@ function DdnsFormDialog({
   onSave,
   initial,
   defaultRouterType,
+  routerTypes,
 }: {
   open: boolean;
   onClose: () => void;
   onSave: (body: DdnsEntryRequest) => Promise<void>;
   initial?: DdnsEntry | null;
   defaultRouterType: string;
+  routerTypes: string[];
 }) {
   const [provider, setProvider] = useState(initial?.provider ?? "cloudflare");
   const [hostname, setHostname] = useState(initial?.hostname ?? "");
@@ -215,25 +217,27 @@ function DdnsFormDialog({
                 ))}
               </select>
             </div>
-            <div className="space-y-2">
-              <Label>Router Type</Label>
-              <select
-                className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100"
-                value={routerType}
-                onChange={(e) => setRouterType(e.target.value)}
-              >
-                {ROUTER_TYPES.map((t) => (
-                  <option key={t} value={t}>
-                    {t === "vyos" ? "VyOS (Legacy)" : "MikroTik"}
-                  </option>
-                ))}
-              </select>
-              {routerType === "vyos" && (
-                <p className="text-[11px] text-amber-400">
-                  VyOS is legacy — MikroTik is recommended for new deployments.
-                </p>
-              )}
-            </div>
+            {routerTypes.length > 1 && (
+              <div className="space-y-2">
+                <Label>Router Type</Label>
+                <select
+                  className="w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100"
+                  value={routerType}
+                  onChange={(e) => setRouterType(e.target.value)}
+                >
+                  {routerTypes.map((t) => (
+                    <option key={t} value={t}>
+                      {t === "vyos" ? "VyOS (Legacy)" : "MikroTik"}
+                    </option>
+                  ))}
+                </select>
+                {routerType === "vyos" && (
+                  <p className="text-[11px] text-amber-400">
+                    VyOS is legacy — MikroTik is recommended for new deployments.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -373,11 +377,16 @@ export default function DdnsPage() {
   const [pendingDelete, setPendingDelete] = useState<DdnsEntry | null>(null);
   const [search, setSearch] = useState("");
   const [defaultRouterType, setDefaultRouterType] = useState("mikrotik");
+  const [routerTypes, setRouterTypes] = useState<string[]>(["mikrotik"]);
 
-  // Determine default router type from settings
+  // Determine default router type and available types from settings
   useEffect(() => {
     fetchSettings()
       .then((settings) => {
+        const vyosConfigured = !!settings.vyos_url && settings.vyos_api_key_set;
+        const types: string[] = ["mikrotik"];
+        if (vyosConfigured) types.push("vyos");
+        setRouterTypes(types);
         setDefaultRouterType(getDefaultRouterType(settings));
       })
       .catch(() => {
@@ -704,6 +713,7 @@ export default function DdnsPage() {
         onClose={() => setShowAdd(false)}
         onSave={handleCreate}
         defaultRouterType={defaultRouterType}
+        routerTypes={routerTypes}
       />
 
       {/* Edit dialog */}
@@ -713,6 +723,7 @@ export default function DdnsPage() {
         onSave={handleUpdate}
         initial={editItem}
         defaultRouterType={defaultRouterType}
+        routerTypes={routerTypes}
       />
 
       {/* Delete confirmation */}

--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -215,12 +215,14 @@ export default function NatPage() {
 
         {/* Summary Cards */}
         <div className="grid gap-4 sm:grid-cols-2">
-          <SummaryCard
-            title="VyOS DNAT Rules"
-            value={summary?.vyos_rule_count ?? null}
-            available={summary?.vyos_available ?? null}
-            icon={<Router className="h-4 w-4 text-blue-400" />}
-          />
+          {summary?.vyos_available && (
+            <SummaryCard
+              title="VyOS DNAT Rules"
+              value={summary?.vyos_rule_count ?? null}
+              available={summary?.vyos_available ?? null}
+              icon={<Router className="h-4 w-4 text-blue-400" />}
+            />
+          )}
           <SummaryCard
             title="MikroTik NAT Rules"
             value={summary?.mikrotik_rule_count ?? null}
@@ -277,9 +279,9 @@ export default function NatPage() {
                   NAT / Port Forwarding Overview
                 </CardTitle>
                 <CardDescription className="text-slate-400">
-                  Manage destination NAT (port forwarding) rules on your VyOS
-                  and MikroTik routers. Select a tab above to view and manage
-                  rules for each router type.
+                  Manage destination NAT (port forwarding) rules on your
+                  {summary?.vyos_available ? " VyOS and MikroTik routers" : " MikroTik router"}.
+                  Select a tab above to view and manage rules for each router type.
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -290,11 +292,11 @@ export default function NatPage() {
                   </div>
                 ) : (
                   <div className="text-sm text-slate-400 space-y-2">
-                    <p>
-                      {summary.vyos_available
-                        ? `VyOS router connected with ${summary.vyos_rule_count} DNAT rule(s).`
-                        : "VyOS router not configured."}
-                    </p>
+                    {summary.vyos_available && (
+                      <p>
+                        VyOS router connected with {summary.vyos_rule_count} DNAT rule(s).
+                      </p>
+                    )}
                     <p>
                       {summary.mikrotik_available
                         ? `MikroTik router connected with ${summary.mikrotik_rule_count} NAT rule(s).`

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -232,13 +232,15 @@ export default function QosPage() {
         </div>
 
         {/* Summary Cards */}
-        <div className="grid gap-4 sm:grid-cols-3">
-          <SummaryCard
-            title="VyOS Policies"
-            value={summary?.vyos_policy_count ?? null}
-            available={summary?.vyos_available ?? null}
-            icon={<Router className="h-4 w-4 text-blue-400" />}
-          />
+        <div className={`grid gap-4 ${summary?.vyos_available ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
+          {summary?.vyos_available && (
+            <SummaryCard
+              title="VyOS Policies"
+              value={summary?.vyos_policy_count ?? null}
+              available={summary?.vyos_available ?? null}
+              icon={<Router className="h-4 w-4 text-blue-400" />}
+            />
+          )}
           <SummaryCard
             title="MikroTik Simple Queues"
             value={summary?.mikrotik_simple_queue_count ?? null}
@@ -292,8 +294,7 @@ export default function QosPage() {
                 </CardTitle>
                 <CardDescription className="text-slate-400">
                   Manage bandwidth queues and traffic policies across your
-                  routers. Use VyOS traffic policies for HTB/HFSC shaping, or
-                  MikroTik simple queues for per-device bandwidth limits.
+                  routers.{summary?.vyos_available ? " Use VyOS traffic policies for HTB/HFSC shaping, or MikroTik" : " Use MikroTik"} simple queues for per-device bandwidth limits.
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -333,7 +334,7 @@ export default function QosPage() {
                     <p>
                       No router is configured. Go to{" "}
                       <span className="font-medium text-white">Settings</span>{" "}
-                      to configure a VyOS or MikroTik router.
+                      to configure a router.
                     </p>
                   )}
                 </div>

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   Router,
@@ -19,6 +20,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageTransition } from "@/components/PageTransition";
+import { fetchSettings } from "@/lib/api";
 import { settingsNav } from "@/lib/settings-nav";
 
 /** Map href → icon + iconBg for each settings item. */
@@ -85,55 +87,88 @@ const iconMap: Record<string, { icon: React.ReactNode; iconBg: string }> = {
   },
 };
 
+const VYOS_ONLY_SETTINGS = new Set([
+  "/settings/audit-log",
+  "/settings/config-backup",
+]);
+
 export default function SettingsPage() {
+  const [vyosConfigured, setVyosConfigured] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetchSettings()
+      .then((settings) => {
+        setVyosConfigured(!!settings.vyos_url && settings.vyos_api_key_set);
+      })
+      .catch(() => {})
+      .finally(() => setLoaded(true));
+  }, []);
+
   return (
     <PageTransition>
       <div className="mx-auto max-w-5xl space-y-8 py-8">
         <h1 className="text-2xl font-semibold text-white">Settings</h1>
 
-        {settingsNav.map((group) => (
-          <section key={group.label} className="space-y-3">
-            <div>
-              <h2 className="text-xs font-medium uppercase tracking-wider text-slate-500">
-                {group.label}
-              </h2>
-              {group.subtitle && (
-                <p className="mt-1 text-xs text-slate-600">
-                  {group.subtitle}
-                </p>
-              )}
-            </div>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {group.items.map((item) => {
-                const visual = iconMap[item.href];
-                return (
-                  <Link key={item.href} href={item.href} className="group">
-                    <Card className="h-full border-slate-800 bg-slate-900 transition-colors group-hover:border-slate-700">
-                      <CardContent className="flex items-center gap-3 py-3">
-                        {visual && (
-                          <div
-                            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${visual.iconBg}`}
-                          >
-                            {visual.icon}
+        {settingsNav.map((group) => {
+          const visibleItems = loaded
+            ? group.items.filter(
+                (item) =>
+                  vyosConfigured || !VYOS_ONLY_SETTINGS.has(item.href)
+              )
+            : group.items;
+
+          if (visibleItems.length === 0) return null;
+
+          return (
+            <section key={group.label} className="space-y-3">
+              <div>
+                <h2 className="text-xs font-medium uppercase tracking-wider text-slate-500">
+                  {group.label}
+                </h2>
+                {group.subtitle && (
+                  <p className="mt-1 text-xs text-slate-600">
+                    {group.subtitle}
+                  </p>
+                )}
+              </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {visibleItems.map((item) => {
+                  const visual = iconMap[item.href];
+                  const description =
+                    item.href === "/settings/router" && !vyosConfigured
+                      ? "Configure MikroTik router integration."
+                      : item.description;
+
+                  return (
+                    <Link key={item.href} href={item.href} className="group">
+                      <Card className="h-full border-slate-800 bg-slate-900 transition-colors group-hover:border-slate-700">
+                        <CardContent className="flex items-center gap-3 py-3">
+                          {visual && (
+                            <div
+                              className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${visual.iconBg}`}
+                            >
+                              {visual.icon}
+                            </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm font-medium text-white">
+                              {item.title}
+                            </p>
+                            <p className="truncate text-xs text-slate-500">
+                              {description}
+                            </p>
                           </div>
-                        )}
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm font-medium text-white">
-                            {item.title}
-                          </p>
-                          <p className="truncate text-xs text-slate-500">
-                            {item.description}
-                          </p>
-                        </div>
-                        <ChevronRight className="h-4 w-4 shrink-0 text-slate-600 transition-colors group-hover:text-slate-400" />
-                      </CardContent>
-                    </Card>
-                  </Link>
-                );
-              })}
-            </div>
-          </section>
-        ))}
+                          <ChevronRight className="h-4 w-4 shrink-0 text-slate-600 transition-colors group-hover:text-slate-400" />
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -269,7 +269,7 @@ export default function VpnStatusPage() {
                     <p>
                       No router is configured. Go to{" "}
                       <span className="font-medium text-white">Settings</span>{" "}
-                      to configure a VyOS or MikroTik router.
+                      to configure a router.
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

- Hide VyOS options from standard UI flows when VyOS is not configured (no URL + API key set)
- DDNS page: router type dropdown is hidden when only MikroTik is available (single option)
- NAT/QoS pages: VyOS summary cards and overview text are conditionally shown only when VyOS is available
- Settings page: VyOS-only items (Audit Log, Config Backup) and VyOS mentions in descriptions are hidden when not configured
- VPN Status: simplified "no router configured" message

VyOS configuration remains fully accessible via Settings > Router for users who wish to enable it.

Closes #331

## Test plan

- [ ] Verify with VyOS **not** configured: VyOS options should not appear in DDNS form, NAT/QoS summary cards, or Settings menu (Audit Log, Config Backup)
- [ ] Verify with VyOS **configured** (URL + API key set): all VyOS options should appear as before
- [ ] Verify DDNS form still works correctly when creating/editing entries with only MikroTik available
- [ ] Verify Settings page loads without flash of VyOS-only items disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements conditional visibility gating for VyOS UI elements based on router configuration status (URL + API key presence). The implementation is clean and consistent across all affected pages.

**Key Changes:**
- DDNS page: Router type dropdown hidden when only MikroTik available (single-option scenario)
- NAT/QoS pages: VyOS summary cards and descriptive text conditionally shown
- Settings page: VyOS-only items (Audit Log, Config Backup) filtered from menu when not configured
- VPN Status page: Simplified error message removes router-specific mentions

**Approach:**
The implementation uses `fetchSettings()` to check `vyos_url` and `vyos_api_key_set` flags, then conditionally renders UI elements. The DDNS page derives a `routerTypes` array and hides the dropdown when only one option exists, while NAT/QoS pages rely on API-provided availability flags.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- The implementation is well-structured, consistent across all pages, and follows existing patterns in the codebase. All changes are UI visibility gating with no logic bugs or security issues. The PR has clear test plans and closes a tracked issue.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/ddns/page.tsx | Adds conditional router type dropdown visibility and derives available router types from VyOS configuration status. Dropdown hidden when only MikroTik available (single option scenario). |
| web/src/app/(app)/nat/page.tsx | Conditionally hides VyOS DNAT summary card and references to VyOS in descriptive text based on `vyos_available` flag from API. |
| web/src/app/(app)/qos/page.tsx | Conditionally hides VyOS policies summary card, adjusts grid layout, and removes VyOS mentions from overview text when not configured. |
| web/src/app/(app)/settings/page.tsx | Fetches VyOS configuration status and filters out VyOS-only settings items (Audit Log, Config Backup) when not configured. Updates Router description to remove VyOS mention. |
| web/src/app/(app)/vpn-status/page.tsx | Removes mention of VyOS from "no router configured" message to simplify generic error state. |

</details>



<sub>Last reviewed commit: 89d849b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->