### PR TITLE
feat: compat: ensure existing VyOS configs remain functional when legacy toggle on (#334)

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -1,4 +1,5 @@
 use crate::api::AppState;
+use crate::mikrotik::client::MikrotikClient;
 use axum::{
     extract::{Query, State},
     Json,
@@ -50,50 +51,44 @@ pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
         .await
         .unwrap_or(0);
 
-    // Check VyOS connectivity — read settings from DB first, fall back to config.
+    // Check router connectivity — try MikroTik first (primary), then VyOS (legacy).
     let router_status = {
-        let db_url: Option<String> =
-            sqlx::query_scalar(r#"SELECT value FROM settings WHERE key = 'vyos_url'"#)
-                .fetch_optional(&state.db)
-                .await
-                .ok()
-                .flatten();
-        let db_key: Option<String> =
-            sqlx::query_scalar(r#"SELECT value FROM settings WHERE key = 'vyos_api_key'"#)
-                .fetch_optional(&state.db)
-                .await
-                .ok()
-                .flatten();
+        let mut status = "unconfigured".to_string();
 
-        let url = db_url
-            .filter(|s| !s.is_empty())
-            .or_else(|| state.config.vyos.url.clone());
-        let key = db_key
-            .filter(|s| !s.is_empty())
-            .or_else(|| state.config.vyos.api_key.clone());
+        // Try MikroTik first (primary router)
+        if let Some(client) = mikrotik_client(&state).await {
+            match tokio::time::timeout(Duration::from_secs(5), client.system_resource()).await {
+                Ok(Ok(_)) => status = "connected".to_string(),
+                _ => status = "disconnected".to_string(),
+            }
+        }
 
-        match (url, key) {
-            (Some(u), Some(k)) if !u.is_empty() && !k.is_empty() => {
-                let client = crate::vyos::client::VyosClient::new(&u, &k);
+        // Fall back to VyOS if MikroTik is not configured
+        if status == "unconfigured" {
+            if let Some(client) =
+                super::vyos::get_vyos_client_from_db(&state.db, &state.config, &state.vyos_http)
+                    .await
+            {
                 match tokio::time::timeout(
                     Duration::from_secs(5),
                     client.show(&["system", "uptime"]),
                 )
                 .await
                 {
-                    Ok(Ok(_)) => "connected".to_string(),
-                    _ => "disconnected".to_string(),
+                    Ok(Ok(_)) => status = "connected".to_string(),
+                    _ => status = "disconnected".to_string(),
                 }
             }
-            _ => "unconfigured".to_string(),
         }
+
+        status
     };
 
-    // Latest WAN traffic from traffic_samples (source = 'vyos'), most recent entry
+    // Latest WAN traffic — check both MikroTik and VyOS sources, use the most recent.
     let (wan_rx_bps, wan_tx_bps): (i64, i64) = sqlx::query_as(
         "SELECT COALESCE(rx_bps, 0), COALESCE(tx_bps, 0)
          FROM traffic_samples
-         WHERE source = 'vyos'
+         WHERE source IN ('vyos', 'mikrotik')
          ORDER BY sampled_at DESC LIMIT 1",
     )
     .fetch_optional(&state.db)
@@ -109,6 +104,44 @@ pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
         wan_rx_bps,
         wan_tx_bps,
     })
+}
+
+/// Try to construct a MikroTik client from saved settings.
+async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
+    let get_setting = |key: &str| {
+        let db = state.db.clone();
+        let key = key.to_string();
+        async move {
+            sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+                .bind(&key)
+                .fetch_optional(&db)
+                .await
+                .ok()
+                .flatten()
+                .filter(|v| !v.is_empty())
+        }
+    };
+
+    let enabled = get_setting("mikrotik_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let url = get_setting("mikrotik_url").await?;
+    let user = get_setting("mikrotik_user")
+        .await
+        .unwrap_or_else(|| "admin".to_string());
+    let password = get_setting("mikrotik_password").await.unwrap_or_default();
+
+    Some(MikrotikClient::with_http(
+        &url,
+        &user,
+        &password,
+        state.mikrotik_http.clone(),
+    ))
 }
 
 /// GET /api/v1/dashboard/top-devices?limit=5

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -12,6 +12,9 @@ pub struct SettingsResponse {
     pub vyos_url: Option<String>,
     /// Masked API key — never return the full key to the frontend.
     pub vyos_api_key_set: bool,
+    /// Whether VyOS is fully configured (URL + API key both set).
+    /// This serves as the "legacy router enabled" indicator.
+    pub vyos_configured: bool,
     // --- Network Scanner ---
     pub scan_interval_seconds: Option<u64>,
     pub scan_subnets: Option<String>,
@@ -191,10 +194,14 @@ pub async fn get_settings(
     let cloudflare_account_id = get_setting(&state, "cloudflare_account_id").await;
     let cloudflare_tunnel_id = get_setting(&state, "cloudflare_tunnel_id").await;
 
+    // VyOS is "configured" (legacy toggle on) when both URL and API key are set.
+    let vyos_configured = vyos_url.is_some() && vyos_api_key_set;
+
     Ok(Json(SettingsResponse {
         webhook_url,
         vyos_url,
         vyos_api_key_set,
+        vyos_configured,
         scan_interval_seconds,
         scan_subnets,
         ping_sweep_enabled,

--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -369,13 +369,15 @@ export default function DdnsPage() {
   const [search, setSearch] = useState("");
   const [defaultRouterType, setDefaultRouterType] = useState("mikrotik");
 
-  // Determine default router type from settings
+  // Determine default router type from settings.
+  // Prefer MikroTik when enabled; fall back to VyOS when it's the only
+  // configured router (legacy/optional toggle).
   useEffect(() => {
     fetchSettings()
       .then((settings) => {
         if (settings.mikrotik_enabled) {
           setDefaultRouterType("mikrotik");
-        } else if (settings.vyos_url && settings.vyos_api_key_set) {
+        } else if (settings.vyos_configured) {
           setDefaultRouterType("vyos");
         } else {
           setDefaultRouterType("mikrotik");

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -5904,7 +5904,7 @@ export default function RouterPage() {
       try {
         const settings = await fetchSettings();
         mtEnabled = settings.mikrotik_enabled;
-        vyosConf = !!settings.vyos_url && settings.vyos_api_key_set;
+        vyosConf = settings.vyos_configured;
         xiEnabled = settings.xiaomi_mesh_enabled;
       } catch {
         // ignore

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -505,6 +505,8 @@ export interface SettingsData {
   webhook_url: string | null;
   vyos_url: string | null;
   vyos_api_key_set: boolean;
+  /** Whether VyOS is fully configured (URL + API key both set) — legacy router toggle. */
+  vyos_configured: boolean;
   // Network Scanner
   scan_interval_seconds: number | null;
   scan_subnets: string | null;


### PR DESCRIPTION
Closes #334

## Summary

Ensures backward compatibility for existing VyOS configurations when the legacy router is enabled (VyOS URL + API key both set):

- **Dashboard multi-router support**: `router_status` now checks MikroTik first (primary), then falls back to VyOS (legacy). Previously it only checked VyOS, so MikroTik-only users saw "unconfigured" and mixed setups only reflected VyOS status.
- **Dashboard WAN traffic**: Query now considers both `vyos` and `mikrotik` traffic sources (uses most recent sample). Previously hardcoded to `source = 'vyos'` only.
- **`vyos_configured` settings field**: Added a computed boolean to the settings API response (`vyos_url` + `vyos_api_key` both set). This serves as the explicit "legacy router enabled" indicator, mirroring `mikrotik_enabled`.
- **Frontend uses `vyos_configured`**: DDNS page and Router page now use the new field instead of manually checking `vyos_url && vyos_api_key_set`.

## Backward compatibility guarantees

- VyOS-only users: dashboard, DDNS, NAT, QoS, VPN, topology all continue to work unchanged
- MikroTik-only users: dashboard now properly detects router status
- Mixed setups: MikroTik is primary, VyOS is fallback — existing VyOS DDNS entries and configs are preserved
- No database migrations required — `vyos_configured` is computed at runtime from existing settings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements backward compatibility for existing VyOS configurations by adding multi-router support to the dashboard and introducing a `vyos_configured` field. The dashboard now correctly detects router status for VyOS-only, MikroTik-only, and mixed setups. The `vyos_configured` field provides a clean API for checking if VyOS is enabled, replacing manual checks across the frontend.

**Key changes:**
- Dashboard router status checks MikroTik first, falls back to VyOS when MikroTik is not configured
- WAN traffic query now includes both `vyos` and `mikrotik` sources
- Added `vyos_configured` computed field to settings API (true when both URL and API key are set)
- Frontend components updated to use `vyos_configured` instead of manual checks

**Assessment:**
The implementation is clean and achieves the stated goal of maintaining backward compatibility. The changes are well-documented and follow existing patterns. No database migrations are required since `vyos_configured` is computed at runtime.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for the fallback behavior
- The implementation is solid and well-tested. The changes are straightforward refactoring that improves code clarity. Minor point deduction due to the router status fallback logic only checking VyOS when MikroTik is unconfigured (not when disconnected), which could be clarified in documentation but appears intentional based on the PR description.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Refactored router status to check MikroTik first, then VyOS. Added helper function to build MikroTik client from DB settings. Updated WAN traffic query to include both sources. |
| server/src/api/settings.rs | Added `vyos_configured` computed field to settings response, indicating when both VyOS URL and API key are set. |
| web/src/app/(app)/ddns/page.tsx | Updated to use `vyos_configured` field instead of manually checking `vyos_url && vyos_api_key_set` for determining default router type. |
| web/src/app/(app)/router/page.tsx | Updated to use `vyos_configured` field instead of manually checking `vyos_url && vyos_api_key_set`. |
| web/src/lib/types.ts | Added `vyos_configured` boolean field to `SettingsData` interface with documentation. |

</details>



<sub>Last reviewed commit: a8112dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->