### PR TITLE
feat: ui/defaults: all router selectors default to MikroTik (#330)

### DIFF
--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -58,7 +58,7 @@ import {
   fetchSettings,
 } from "@/lib/api";
 import type { DdnsEntry, DdnsEntryRequest, DdnsStatus } from "@/lib/types";
-import { ROUTER_TYPES, getDefaultRouterType } from "@/lib/router-config";
+import { ROUTER_TYPES } from "@/lib/router-config";
 import { toast } from "sonner";
 
 const PROVIDERS = [
@@ -376,10 +376,11 @@ export default function DdnsPage() {
   const [editItem, setEditItem] = useState<DdnsEntry | null>(null);
   const [pendingDelete, setPendingDelete] = useState<DdnsEntry | null>(null);
   const [search, setSearch] = useState("");
-  const [defaultRouterType, setDefaultRouterType] = useState("mikrotik");
+  const defaultRouterType = "mikrotik";
   const [routerTypes, setRouterTypes] = useState<string[]>(["mikrotik"]);
 
-  // Determine default router type and available types from settings
+  // Default router type is always MikroTik (#330).
+  // We still fetch settings to determine available router types for the selector.
   useEffect(() => {
     fetchSettings()
       .then((settings) => {
@@ -387,10 +388,9 @@ export default function DdnsPage() {
         const types: string[] = ["mikrotik"];
         if (vyosConfigured) types.push("vyos");
         setRouterTypes(types);
-        setDefaultRouterType(getDefaultRouterType(settings));
       })
       .catch(() => {
-        // Keep mikrotik as default on error
+        // Keep mikrotik only on error
       });
   }, []);
 

--- a/web/src/lib/router-config.ts
+++ b/web/src/lib/router-config.ts
@@ -9,22 +9,14 @@ export const ROUTER_TYPES = ["mikrotik", "vyos"] as const;
 export type RouterType = (typeof ROUTER_TYPES)[number];
 
 /**
- * Derive the default router type from the current settings.
- *
- * Priority:
- * 1. MikroTik if explicitly enabled
- * 2. VyOS if configured (url + api key set)
- * 3. MikroTik as fallback
+ * Default router type is always MikroTik (#330).
+ * Users can still select VyOS explicitly per-entry.
  */
 export function getDefaultRouterType(
-  settings: Pick<
+  _settings: Pick<
     SettingsData,
     "mikrotik_enabled" | "vyos_url" | "vyos_api_key_set"
   > | null,
 ): RouterType {
-  if (!settings) return "mikrotik";
-
-  if (settings.mikrotik_enabled) return "mikrotik";
-  if (settings.vyos_url && settings.vyos_api_key_set) return "vyos";
   return "mikrotik";
 }


### PR DESCRIPTION
Closes #330

## Summary
- Updated `getDefaultRouterType()` in `web/src/lib/router-config.ts` to always return `"mikrotik"`, removing the VyOS fallback when MikroTik is not enabled
- Simplified the DDNS page to use a constant `"mikrotik"` default instead of dynamically determining the router type from settings
- Available router types in the DDNS selector dropdown are still fetched from settings (VyOS appears as an option only when configured), but the **preselected** value is always MikroTik

## Test plan
- [ ] Open DDNS page with MikroTik enabled — router type selector defaults to MikroTik
- [ ] Open DDNS page with only VyOS configured — router type selector still defaults to MikroTik
- [ ] Open DDNS page with neither router configured — router type selector defaults to MikroTik
- [ ] Verify VyOS can still be manually selected per-entry in the DDNS form
- [ ] Verify router settings page still shows MikroTik tab by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the router type selection logic to always default to MikroTik across the application, removing the dynamic fallback to VyOS that existed previously. The changes align with the product direction to position MikroTik as the primary router option and VyOS as a legacy alternative.

**Key changes:**
- `getDefaultRouterType()` now always returns `"mikrotik"` regardless of settings
- DDNS page uses a constant `"mikrotik"` default instead of dynamically determining from settings
- Available router types in dropdowns still respect settings (VyOS only shown when configured)
- Function signature preserved with unused parameter for API compatibility

**Issue identified:**
- Unit test at `web/tests/unit/router-config.test.ts:45-52` expects `getDefaultRouterType()` to return `"vyos"` when only VyOS is configured, but this test will now fail since the function always returns `"mikrotik"`. This was already noted in a previous review thread.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after updating the failing unit test to match the new behavior
- The code changes are straightforward and well-aligned with the product direction. The only blocker is a known test failure that needs to be addressed. The logic is simpler and more maintainable than before, with no functional bugs introduced in the implementation itself.
- `web/tests/unit/router-config.test.ts` requires updates to fix failing test case

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/router-config.ts | Simplified `getDefaultRouterType()` to always return `"mikrotik"`, ignoring settings parameter (now prefixed with underscore). Function still exported for compatibility but no longer uses dynamic logic. |
| web/src/app/(app)/ddns/page.tsx | Removed `getDefaultRouterType` import and changed `defaultRouterType` from state to constant `"mikrotik"`. Simplified `useEffect` to only fetch available router types without setting default. |

</details>



<sub>Last reviewed commit: 3377dc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->