### PR TITLE
fix: "Import from Devices" button on Assets page (#337)

### DIFF
--- a/server/src/api/assets.rs
+++ b/server/src/api/assets.rs
@@ -124,6 +124,14 @@ pub struct AutoLinkResponse {
     pub details: Vec<String>,
 }
 
+/// Response for sync-from-devices operation.
+#[derive(Debug, Serialize)]
+pub struct SyncFromDevicesResponse {
+    pub created: usize,
+    pub skipped: usize,
+    pub details: Vec<String>,
+}
+
 // ─── Helpers ─────────────────────────────────────────────
 
 fn asset_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Asset, sqlx::Error> {
@@ -655,14 +663,6 @@ pub async fn auto_link(State(state): State<AppState>) -> Result<Json<AutoLinkRes
     info!(linked, "Auto-link assets to devices completed");
 
     Ok(Json(AutoLinkResponse { linked, details }))
-}
-
-/// Response for sync-from-devices operation.
-#[derive(Debug, Serialize)]
-pub struct SyncFromDevicesResponse {
-    pub created: usize,
-    pub skipped: usize,
-    pub details: Vec<String>,
 }
 
 /// POST /api/v1/assets/sync-from-devices — create assets for discovered

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -316,13 +316,13 @@ function AssetsListPage() {
     try {
       const result = await syncAssetsFromDevices();
       if (result.created > 0) {
-        toast.success(`Created ${result.created} asset(s) from discovered devices`);
+        toast.success(`Imported ${result.created} asset(s) from discovered devices`);
         load();
       } else {
         toast.info("All discovered devices already have linked assets");
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Sync failed");
+      toast.error(err instanceof Error ? err.message : "Import from devices failed");
     } finally {
       setSyncing(false);
     }
@@ -417,7 +417,7 @@ ${filtered
               disabled={syncing}
             >
               <RefreshCw className={`h-3.5 w-3.5 ${syncing ? "animate-spin" : ""}`} />
-              {syncing ? "Syncing..." : "Import from Devices"}
+              {syncing ? "Importing..." : "Import from Devices"}
             </Button>
             <Button
               variant="outline"


### PR DESCRIPTION
Closes #337

## Summary
- Moved `SyncFromDevicesResponse` struct to the types section (top of assets.rs) for consistency with other response types
- Improved button UX: changed loading text to "Importing..." and toast messages to use "Imported" language matching the button label
- Changed error message to "Import from devices failed" for clarity

## Context
The `sync-from-devices` backend endpoint and frontend wiring were already implemented on main. This PR fixes the remaining UX issues with the button text and organizes the response type correctly.

## Test plan
- [ ] Navigate to Assets page (`/assets`)
- [ ] Click "Import from Devices" button
- [ ] Verify toast shows "Imported N asset(s)" when devices exist
- [ ] Verify toast shows "All discovered devices already have linked assets" when no new devices
- [ ] Verify button shows "Importing..." with spinning icon during loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves UX consistency by standardizing terminology around the "Import from Devices" feature. The changes include moving a response struct to the types section for better code organization and updating all user-facing text to use "Import/Importing/Imported" language consistently.

- Relocated `SyncFromDevicesResponse` struct to types section alongside other response types in `assets.rs`
- Changed button loading state from "Syncing..." to "Importing..." to match button label
- Updated success toast from "Created" to "Imported" for consistent terminology
- Improved error message clarity from "Sync failed" to "Import from devices failed"

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are purely cosmetic UX improvements with no logic modifications. The code refactoring simply relocates a type definition without changing its structure or usage. All changes improve user experience by standardizing terminology
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/assets.rs | Moved `SyncFromDevicesResponse` struct to types section for better organization |
| web/src/app/(app)/assets/page.tsx | Updated button text and toast messages to use "Import" terminology consistently |

</details>



<sub>Last reviewed commit: ec27e4a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->