### PR TITLE
feat: bug: assets page shows "No assets yet" despite discovered devices existing (P1) (#328)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "panoptikon-agent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "panoptikon-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -76,6 +76,7 @@ import {
 import type { Asset, AssetRequest, AssetType, AssetStatus, AssetImportRow } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 import { downloadExport } from "@/lib/export";
+import { loadAssetsWithDeviceSync } from "@/lib/assets";
 import { PageTransition } from "@/components/PageTransition";
 import { toast } from "sonner";
 import { motion } from "framer-motion";
@@ -235,7 +236,12 @@ function AssetsListPage() {
 
   const load = useCallback(async () => {
     try {
-      setAssets(await fetchAssets());
+      const loadedAssets = await loadAssetsWithDeviceSync({
+        fetchAssets,
+        syncAssetsFromDevices,
+      });
+      setAssets(loadedAssets);
+      setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load assets");
     }

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -1,0 +1,26 @@
+import type { Asset, AssetSyncFromDevicesResponse } from "./types";
+
+interface LoadAssetsWithDeviceSyncDeps {
+  fetchAssets: () => Promise<Asset[]>;
+  syncAssetsFromDevices: () => Promise<AssetSyncFromDevicesResponse>;
+}
+
+/**
+ * Ensure discovered devices are surfaced on Assets by running a sync pass when
+ * the inventory is empty, then reloading assets.
+ */
+export async function loadAssetsWithDeviceSync(
+  deps: LoadAssetsWithDeviceSyncDeps
+): Promise<Asset[]> {
+  const assets = await deps.fetchAssets();
+  if (assets.length > 0) {
+    return assets;
+  }
+
+  const sync = await deps.syncAssetsFromDevices();
+  if (sync.created <= 0) {
+    return assets;
+  }
+
+  return deps.fetchAssets();
+}

--- a/web/tests/unit/assets.test.ts
+++ b/web/tests/unit/assets.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Asset } from "@/lib/types";
+import { loadAssetsWithDeviceSync } from "@/lib/assets";
+
+function buildAsset(id: string): Asset {
+  return {
+    id,
+    name: `asset-${id}`,
+    asset_type: "unknown",
+    status: "active",
+    location: null,
+    owner: null,
+    tags: null,
+    notes: null,
+    purchase_date: null,
+    serial_number: null,
+    device_id: null,
+    agent_id: null,
+    ssh_target_id: null,
+    created_at: "2026-01-01 00:00:00",
+    updated_at: "2026-01-01 00:00:00",
+    ip: null,
+    mac: null,
+    device_online: null,
+    device_last_seen: null,
+    agent_name: null,
+    agent_os: null,
+    agent_online: null,
+    ssh_name: null,
+    ssh_os: null,
+    ssh_online: null,
+  };
+}
+
+describe("loadAssetsWithDeviceSync", () => {
+  it("returns existing assets without running sync", async () => {
+    const existing = [buildAsset("a1")];
+    const fetchAssets = vi.fn().mockResolvedValue(existing);
+    const syncAssetsFromDevices = vi.fn();
+
+    const result = await loadAssetsWithDeviceSync({
+      fetchAssets,
+      syncAssetsFromDevices,
+    });
+
+    expect(result).toEqual(existing);
+    expect(fetchAssets).toHaveBeenCalledTimes(1);
+    expect(syncAssetsFromDevices).not.toHaveBeenCalled();
+  });
+
+  it("syncs discovered devices when assets are empty, then reloads", async () => {
+    const afterSync = [buildAsset("a1"), buildAsset("a2")];
+    const fetchAssets = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(afterSync);
+    const syncAssetsFromDevices = vi.fn().mockResolvedValue({
+      created: 2,
+      skipped: 0,
+      details: [],
+    });
+
+    const result = await loadAssetsWithDeviceSync({
+      fetchAssets,
+      syncAssetsFromDevices,
+    });
+
+    expect(result).toEqual(afterSync);
+    expect(fetchAssets).toHaveBeenCalledTimes(2);
+    expect(syncAssetsFromDevices).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps empty list when no assets and no devices were synced", async () => {
+    const fetchAssets = vi.fn().mockResolvedValue([]);
+    const syncAssetsFromDevices = vi.fn().mockResolvedValue({
+      created: 0,
+      skipped: 0,
+      details: [],
+    });
+
+    const result = await loadAssetsWithDeviceSync({
+      fetchAssets,
+      syncAssetsFromDevices,
+    });
+
+    expect(result).toEqual([]);
+    expect(fetchAssets).toHaveBeenCalledTimes(1);
+    expect(syncAssetsFromDevices).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #328

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the Assets page would show "No assets yet" even when discovered network devices existed. It introduces a new `loadAssetsWithDeviceSync` helper in `web/src/lib/assets.ts` that automatically triggers a device-to-asset sync when the asset list is empty on page load, then reloads the assets. The page component is updated to use this helper, and three unit tests cover all branches. Cargo.lock reflects a version bump to 0.6.0.

- **Core fix**: When assets are empty, `syncAssetsFromDevices` is called before displaying the empty state. If devices are created, assets are re-fetched.
- **Error handling improvement**: `setError(null)` is now called on successful load, clearing any transient error state from prior failed polls.
- **Minor concern**: The sync call runs on every 30-second poll when assets remain empty, generating unnecessary POST requests. This is not harmful (the endpoint is idempotent) but could be optimized with a "synced once" guard.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — the fix is well-scoped, well-tested, and the backend sync endpoint is idempotent.
- The core logic is correct and all three branches are covered by unit tests. The dependency injection pattern makes the function easy to test. The only concern is a minor performance consideration around repeated sync calls on the poll interval, which doesn't affect correctness.
- No files require special attention. `web/src/lib/assets.ts` has a minor optimization opportunity but no correctness issues.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/assets.ts | New helper that auto-syncs discovered devices into the asset inventory when the list is empty. Logic is clean and well-tested. Minor concern: repeated sync POST on 30s interval when assets are genuinely empty, though the backend is idempotent so impact is low. |
| web/src/app/(app)/assets/page.tsx | Integrates `loadAssetsWithDeviceSync` into the `load` callback and adds `setError(null)` on success to clear transient errors. Changes are minimal and well-scoped. |
| web/tests/unit/assets.test.ts | Comprehensive unit tests covering all three branches of `loadAssetsWithDeviceSync`: assets exist (no sync), empty + sync creates (double fetch), and empty + no devices synced (stays empty). |
| Cargo.lock | Version bumps from 0.5.0 to 0.6.0 for `panoptikon-agent` and `panoptikon-server`, consistent with workspace version in root `Cargo.toml`. |

</details>



<sub>Last reviewed commit: ed75b45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->