### PR TITLE
feat: compat: ensure existing VyOS configs remain functional when legacy toggle on (#334)

### DIFF
--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -112,19 +112,28 @@ pub async fn get_settings(
 ) -> Result<Json<SettingsResponse>, StatusCode> {
     let webhook_url = webhook::get_webhook_url(&state.db).await;
 
-    // Prefer DB overrides, but keep legacy file/env-based VyOS config visible
-    // so existing setups remain functional without re-saving settings.
-    let vyos_url = get_setting(&state, "vyos_url")
-        .await
-        .or_else(|| state.config.vyos.url.clone().filter(|v| !v.is_empty()));
-
-    let vyos_api_key_set = get_setting(&state, "vyos_api_key").await.is_some()
-        || state
+    // Keep legacy compatibility: if DB settings are absent, fall back to
+    // values from panoptikon.toml so existing VyOS setups remain detected.
+    let vyos_url = get_setting(&state, "vyos_url").await.or_else(|| {
+        state
             .config
             .vyos
-            .api_key
-            .as_ref()
-            .is_some_and(|k| !k.is_empty());
+            .url
+            .clone()
+            .filter(|v| !v.trim().is_empty())
+    });
+
+    let vyos_api_key_set = get_setting(&state, "vyos_api_key")
+        .await
+        .or_else(|| {
+            state
+                .config
+                .vyos
+                .api_key
+                .clone()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .is_some();
 
     // Network Scanner settings (fall back to config defaults).
     let scan_interval_seconds = get_setting(&state, "scan_interval_seconds")

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -17,6 +17,13 @@ use serde_json::Value;
 /// Returns `(base_url, pool)` — the base URL includes the scheme and address,
 /// e.g. `"http://127.0.0.1:54321"`.
 async fn spawn_test_server() -> (String, sqlx::SqlitePool) {
+    spawn_test_server_with_config(config::AppConfig::default()).await
+}
+
+/// Spawn a real axum server with an explicit config.
+async fn spawn_test_server_with_config(
+    app_config: config::AppConfig,
+) -> (String, sqlx::SqlitePool) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("failed to bind random port");
@@ -27,8 +34,7 @@ async fn spawn_test_server() -> (String, sqlx::SqlitePool) {
         .await
         .expect("in-memory DB init failed");
 
-    let config = config::AppConfig::default();
-    let state = api::AppState::new(pool.clone(), config);
+    let state = api::AppState::new(pool.clone(), app_config);
     let app = api::router(state);
 
     // CRITICAL: must use `into_make_service_with_connect_info` so that
@@ -56,7 +62,15 @@ fn http_client() -> reqwest::Client {
 /// Helper: run setup on a fresh DB and return the client (with session cookie)
 /// and base URL.
 async fn setup_fresh(password: &str) -> (reqwest::Client, String) {
-    let (base_url, _pool) = spawn_test_server().await;
+    setup_fresh_with_config(password, config::AppConfig::default()).await
+}
+
+/// Same as `setup_fresh` but allows passing an explicit config.
+async fn setup_fresh_with_config(
+    password: &str,
+    app_config: config::AppConfig,
+) -> (reqwest::Client, String) {
+    let (base_url, _pool) = spawn_test_server_with_config(app_config).await;
     let client = http_client();
 
     let resp = client
@@ -277,6 +291,64 @@ async fn test_setup_with_vyos_settings() {
 }
 
 // ── Test 7: Login before setup returns 428 ──────────────────────────
+
+#[tokio::test]
+async fn test_settings_vyos_falls_back_to_config_when_db_empty() {
+    let mut app_config = config::AppConfig::default();
+    app_config.vyos.url = Some("http://127.0.0.1:9".to_string());
+    app_config.vyos.api_key = Some("legacy-config-key".to_string());
+
+    let (client, base_url) = setup_fresh_with_config("settings_fallback_pw", app_config).await;
+
+    let resp = client
+        .get(format!("{base_url}/api/v1/settings"))
+        .send()
+        .await
+        .expect("settings request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("settings json parse failed");
+    assert_eq!(body["vyos_url"].as_str(), Some("http://127.0.0.1:9"));
+    assert_eq!(body["vyos_api_key_set"].as_bool(), Some(true));
+}
+
+#[tokio::test]
+async fn test_qos_summary_vyos_available_from_config_fallback() {
+    let mut app_config = config::AppConfig::default();
+    app_config.vyos.url = Some("http://127.0.0.1:9".to_string());
+    app_config.vyos.api_key = Some("legacy-config-key".to_string());
+
+    let (client, base_url) = setup_fresh_with_config("qos_fallback_pw", app_config).await;
+
+    let resp = client
+        .get(format!("{base_url}/api/v1/qos/summary"))
+        .send()
+        .await
+        .expect("qos summary request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("qos summary json parse failed");
+    assert_eq!(body["vyos_available"].as_bool(), Some(true));
+}
+
+#[tokio::test]
+async fn test_vpn_status_vyos_available_from_config_fallback() {
+    let mut app_config = config::AppConfig::default();
+    app_config.vyos.url = Some("http://127.0.0.1:9".to_string());
+    app_config.vyos.api_key = Some("legacy-config-key".to_string());
+
+    let (client, base_url) = setup_fresh_with_config("vpn_fallback_pw", app_config).await;
+
+    let resp = client
+        .get(format!("{base_url}/api/v1/vpn-status"))
+        .send()
+        .await
+        .expect("vpn status request failed");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("vpn status json parse failed");
+    assert_eq!(body["vyos_available"].as_bool(), Some(true));
+}
 
 #[tokio::test]
 async fn test_login_before_setup_returns_precondition() {


### PR DESCRIPTION
Closes #334

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where existing VyOS configurations defined in `panoptikon.toml` (the legacy file-based config) were no longer detected after the settings system migrated to a database-backed store. When the DB has no VyOS entries, `get_settings` now falls back to the in-memory `AppConfig` for both `vyos_url` and `vyos_api_key`, ensuring that users who have not re-saved their settings through the UI remain fully functional.

Key changes:
- **`server/src/api/settings.rs`**: The `vyos_url` fallback now trims whitespace before the empty-string check (`.trim().is_empty()` instead of `.is_empty()`). The `vyos_api_key_set` flag was refactored from a boolean OR expression to an `or_else` chain followed by `.is_some()`, matching the style of the URL fallback — functionally equivalent, with the same whitespace-trim improvement. A minor point: the `or_else` closure clones the `api_key` string even though only its presence is needed; using `as_deref()` would avoid the allocation.
- **`server/tests/integration.rs`**: `spawn_test_server` and `setup_fresh` are refactored to delegate to new `_with_config` variants that accept an explicit `AppConfig`, enabling config-driven integration tests. Three new end-to-end tests verify the fallback path for the settings endpoint, QoS summary, and VPN status endpoints. The section-number comment for the pre-existing "Test 7" test was not updated after the three new tests were inserted before it.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the logic change is narrow and well-tested; only minor style issues remain.
- The functional change is small (two `or_else` fallbacks with a trim improvement), well-covered by a direct integration test, and does not affect any write paths. The only issues found are a negligible unnecessary clone, a stale section-comment number, and a question about whether the QoS/VPN tests actually exercise the new fallback end-to-end through the handlers rather than just asserting on the downstream field.
- No files require special attention; `server/src/api/settings.rs` line 126-136 has the minor clone issue worth a quick look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/settings.rs | Refactors VyOS config fallback logic for `vyos_url` and `vyos_api_key_set` to use `.trim()` and `or_else` chaining; functionally correct with a minor unnecessary clone. |
| server/tests/integration.rs | Refactors test helpers to accept an explicit `AppConfig`, and adds three new integration tests for the VyOS config fallback; a stale section comment and a missing DB-priority test are the only minor gaps. |

</details>



<sub>Last reviewed commit: 8b9857b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->