### PR TITLE
feat: compat: ensure existing VyOS configs remain functional when legacy toggle on (#334)

### DIFF
--- a/server/src/api/qos.rs
+++ b/server/src/api/qos.rs
@@ -53,9 +53,7 @@ async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {
 }
 
 async fn vyos_client(state: &AppState) -> Option<VyosClient> {
-    let url = get_setting(state, "vyos_url").await?;
-    let key = get_setting(state, "vyos_api_key").await?;
-    Some(VyosClient::with_http(&url, &key, state.vyos_http.clone()))
+    super::vyos::get_vyos_client_from_db(&state.db, &state.config, &state.vyos_http).await
 }
 
 fn is_true(val: &Option<String>) -> bool {

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -112,9 +112,19 @@ pub async fn get_settings(
 ) -> Result<Json<SettingsResponse>, StatusCode> {
     let webhook_url = webhook::get_webhook_url(&state.db).await;
 
-    let vyos_url = get_setting(&state, "vyos_url").await;
+    // Prefer DB overrides, but keep legacy file/env-based VyOS config visible
+    // so existing setups remain functional without re-saving settings.
+    let vyos_url = get_setting(&state, "vyos_url")
+        .await
+        .or_else(|| state.config.vyos.url.clone().filter(|v| !v.is_empty()));
 
-    let vyos_api_key_set = get_setting(&state, "vyos_api_key").await.is_some();
+    let vyos_api_key_set = get_setting(&state, "vyos_api_key").await.is_some()
+        || state
+            .config
+            .vyos
+            .api_key
+            .as_ref()
+            .is_some_and(|k| !k.is_empty());
 
     // Network Scanner settings (fall back to config defaults).
     let scan_interval_seconds = get_setting(&state, "scan_interval_seconds")

--- a/server/src/api/vpn_status.rs
+++ b/server/src/api/vpn_status.rs
@@ -23,9 +23,7 @@ async fn get_setting(state: &AppState, key: &str) -> Option<String> {
 }
 
 async fn vyos_client(state: &AppState) -> Option<VyosClient> {
-    let url = get_setting(state, "vyos_url").await?;
-    let key = get_setting(state, "vyos_api_key").await?;
-    Some(VyosClient::with_http(&url, &key, state.vyos_http.clone()))
+    super::vyos::get_vyos_client_from_db(&state.db, &state.config, &state.vyos_http).await
 }
 
 async fn mikrotik_client(state: &AppState) -> Option<MikrotikClient> {

--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -385,8 +385,9 @@ export default function DdnsPage() {
     fetchSettings()
       .then((settings) => {
         const vyosConfigured = !!settings.vyos_url && settings.vyos_api_key_set;
+        const legacyRoutersEnabled = settings.show_legacy_routers;
         const types: string[] = ["mikrotik"];
-        if (vyosConfigured) types.push("vyos");
+        if (legacyRoutersEnabled && vyosConfigured) types.push("vyos");
         setRouterTypes(types);
       })
       .catch(() => {

--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -51,6 +51,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
 import {
+  fetchSettings,
   fetchNatSummary,
   fetchVyosNatRules,
   createVyosNatRule,
@@ -70,10 +71,12 @@ import { toast } from "sonner";
 
 export default function NatPage() {
   const [summary, setSummary] = useState<NatSummary | null>(null);
+  const [legacyRoutersEnabled, setLegacyRoutersEnabled] = useState(false);
   const [vyosRules, setVyosRules] = useState<NatDestinationRule[] | null>(null);
   const [mtRules, setMtRules] = useState<MikrotikNatRuleWithId[] | null>(null);
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState("overview");
+  const vyosVisible = legacyRoutersEnabled && !!summary?.vyos_available;
 
   // Dialogs
   const [showAddVyos, setShowAddVyos] = useState(false);
@@ -121,9 +124,21 @@ export default function NatPage() {
   }, [load]);
 
   useEffect(() => {
+    fetchSettings()
+      .then((settings) => setLegacyRoutersEnabled(settings.show_legacy_routers))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     if (activeTab === "vyos") loadVyos();
     if (activeTab === "mikrotik") loadMt();
   }, [activeTab, loadVyos, loadMt]);
+
+  useEffect(() => {
+    if (!vyosVisible && activeTab === "vyos") {
+      setActiveTab("overview");
+    }
+  }, [activeTab, vyosVisible]);
 
   // -- Filter helpers --
   const filteredVyos = useMemo(() => {
@@ -215,11 +230,11 @@ export default function NatPage() {
 
         {/* Summary Cards */}
         <div className="grid gap-4 sm:grid-cols-2">
-          {summary?.vyos_available && (
+          {vyosVisible && (
             <SummaryCard
               title="VyOS DNAT Rules"
               value={summary?.vyos_rule_count ?? null}
-              available={summary?.vyos_available ?? null}
+              available={vyosVisible}
               icon={<Router className="h-4 w-4 text-blue-400" />}
             />
           )}
@@ -240,7 +255,7 @@ export default function NatPage() {
             >
               Overview
             </TabsTrigger>
-            {summary?.vyos_available && (
+            {vyosVisible && (
               <TabsTrigger
                 value="vyos"
                 className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
@@ -280,7 +295,7 @@ export default function NatPage() {
                 </CardTitle>
                 <CardDescription className="text-slate-400">
                   Manage destination NAT (port forwarding) rules on your
-                  {summary?.vyos_available ? " VyOS and MikroTik routers" : " MikroTik router"}.
+                  {vyosVisible ? " VyOS and MikroTik routers" : " MikroTik router"}.
                   Select a tab above to view and manage rules for each router type.
                 </CardDescription>
               </CardHeader>
@@ -292,7 +307,7 @@ export default function NatPage() {
                   </div>
                 ) : (
                   <div className="text-sm text-slate-400 space-y-2">
-                    {summary.vyos_available && (
+                    {vyosVisible && (
                       <p>
                         VyOS router connected with {summary.vyos_rule_count} DNAT rule(s).
                       </p>

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -52,6 +52,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
 import {
+  fetchSettings,
   fetchQosSummary,
   fetchVyosTrafficPolicies,
   createVyosTrafficPolicy,
@@ -72,6 +73,7 @@ import { toast } from "sonner";
 
 export default function QosPage() {
   const [summary, setSummary] = useState<QosSummary | null>(null);
+  const [legacyRoutersEnabled, setLegacyRoutersEnabled] = useState(false);
   const [vyosPolicies, setVyosPolicies] = useState<
     VyosTrafficPolicy[] | null
   >(null);
@@ -79,6 +81,7 @@ export default function QosPage() {
   const [mtTree, setMtTree] = useState<MikrotikQueueTree[] | null>(null);
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState("overview");
+  const vyosVisible = legacyRoutersEnabled && !!summary?.vyos_available;
 
   // Dialogs
   const [showAddVyos, setShowAddVyos] = useState(false);
@@ -128,9 +131,21 @@ export default function QosPage() {
   }, [load]);
 
   useEffect(() => {
+    fetchSettings()
+      .then((settings) => setLegacyRoutersEnabled(settings.show_legacy_routers))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     if (activeTab === "vyos") loadVyos();
     if (activeTab === "mikrotik") loadMtQueues();
   }, [activeTab, loadVyos, loadMtQueues]);
+
+  useEffect(() => {
+    if (!vyosVisible && activeTab === "vyos") {
+      setActiveTab("overview");
+    }
+  }, [activeTab, vyosVisible]);
 
   // -- Filter helpers --
   const filteredVyos = useMemo(() => {
@@ -232,12 +247,12 @@ export default function QosPage() {
         </div>
 
         {/* Summary Cards */}
-        <div className={`grid gap-4 ${summary?.vyos_available ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
-          {summary?.vyos_available && (
+        <div className={`grid gap-4 ${vyosVisible ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
+          {vyosVisible && (
             <SummaryCard
               title="VyOS Policies"
               value={summary?.vyos_policy_count ?? null}
-              available={summary?.vyos_available ?? null}
+              available={vyosVisible}
               icon={<Router className="h-4 w-4 text-blue-400" />}
             />
           )}
@@ -264,7 +279,7 @@ export default function QosPage() {
             >
               Overview
             </TabsTrigger>
-            {summary?.vyos_available && (
+            {vyosVisible && (
               <TabsTrigger
                 value="vyos"
                 className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
@@ -294,12 +309,12 @@ export default function QosPage() {
                 </CardTitle>
                 <CardDescription className="text-slate-400">
                   Manage bandwidth queues and traffic policies across your
-                  routers.{summary?.vyos_available ? " Use VyOS traffic policies for HTB/HFSC shaping, or MikroTik" : " Use MikroTik"} simple queues for per-device bandwidth limits.
+                  routers.{vyosVisible ? " Use VyOS traffic policies for HTB/HFSC shaping, or MikroTik" : " Use MikroTik"} simple queues for per-device bandwidth limits.
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-3 text-sm text-slate-400">
-                  {summary?.vyos_available && (
+                  {vyosVisible && (
                     <p>
                       VyOS router configured with{" "}
                       <span className="font-medium text-white">
@@ -330,7 +345,7 @@ export default function QosPage() {
                       .
                     </p>
                   )}
-                  {!summary?.vyos_available && !summary?.mikrotik_available && (
+                  {!vyosVisible && !summary?.mikrotik_available && (
                     <p>
                       No router is configured. Go to{" "}
                       <span className="font-medium text-white">Settings</span>{" "}

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -99,12 +99,14 @@ const VYOS_ONLY_SETTINGS = new Set([
 
 export default function SettingsPage() {
   const [vyosConfigured, setVyosConfigured] = useState(false);
+  const [legacyRoutersEnabled, setLegacyRoutersEnabled] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     fetchSettings()
       .then((settings) => {
         setVyosConfigured(!!settings.vyos_url && settings.vyos_api_key_set);
+        setLegacyRoutersEnabled(settings.show_legacy_routers);
       })
       .catch(() => {})
       .finally(() => setLoaded(true));
@@ -118,7 +120,9 @@ export default function SettingsPage() {
         {settingsNav.map((group) => {
           const visibleItems = loaded
             ? group.items.filter(
-                (item) => vyosConfigured || !VYOS_ONLY_SETTINGS.has(item.href)
+                (item) =>
+                  (legacyRoutersEnabled && vyosConfigured) ||
+                  !VYOS_ONLY_SETTINGS.has(item.href)
               )
             : group.items;
 
@@ -140,7 +144,8 @@ export default function SettingsPage() {
                 {visibleItems.map((item) => {
                   const visual = iconMap[item.href];
                   const description =
-                    item.href === "/settings/router" && !vyosConfigured
+                    item.href === "/settings/router" &&
+                    (!legacyRoutersEnabled || !vyosConfigured)
                       ? "Configure MikroTik router integration."
                       : item.description;
 

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
-import { fetchVpnStatus } from "@/lib/api";
+import { fetchSettings, fetchVpnStatus } from "@/lib/api";
 import type { VpnStatusResponse, VpnInterfaceStatus } from "@/lib/types";
 
 /** Format bytes into a human-readable string. */
@@ -60,9 +60,11 @@ function timeAgo(ts: number | null): string {
 
 export default function VpnStatusPage() {
   const [data, setData] = useState<VpnStatusResponse | null>(null);
+  const [legacyRoutersEnabled, setLegacyRoutersEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState("overview");
+  const vyosVisible = legacyRoutersEnabled && !!data?.vyos_available;
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -82,6 +84,18 @@ export default function VpnStatusPage() {
     const id = setInterval(load, 30_000);
     return () => clearInterval(id);
   }, [load]);
+
+  useEffect(() => {
+    fetchSettings()
+      .then((settings) => setLegacyRoutersEnabled(settings.show_legacy_routers))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!vyosVisible && activeTab === "vyos") {
+      setActiveTab("overview");
+    }
+  }, [activeTab, vyosVisible]);
 
   const filteredInterfaces = useMemo(() => {
     if (!data) return null;
@@ -113,6 +127,12 @@ export default function VpnStatusPage() {
     () => filteredInterfaces?.filter((i) => i.source === "mikrotik") ?? [],
     [filteredInterfaces],
   );
+  const overviewInterfaces = useMemo(() => {
+    if (!data) return [];
+    return vyosVisible
+      ? data.interfaces
+      : data.interfaces.filter((i) => i.source !== "vyos");
+  }, [data, vyosVisible]);
 
   return (
     <PageTransition>
@@ -138,7 +158,7 @@ export default function VpnStatusPage() {
         <div className="grid gap-4 sm:grid-cols-4">
           <SummaryCard
             title="Interfaces"
-            value={data?.interfaces.length ?? null}
+            value={data ? overviewInterfaces.length : null}
             loading={loading && !data}
             icon={<Shield className="h-4 w-4 text-blue-400" />}
           />
@@ -178,7 +198,7 @@ export default function VpnStatusPage() {
             >
               Overview
             </TabsTrigger>
-            {data?.vyos_available && (
+            {vyosVisible && (
               <TabsTrigger
                 value="vyos"
                 className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
@@ -211,7 +231,7 @@ export default function VpnStatusPage() {
               </CardHeader>
               <CardContent>
                 <div className="space-y-3 text-sm text-slate-400">
-                  {data?.vyos_available && (
+                  {vyosVisible && (
                     <p>
                       VyOS:{" "}
                       <span className="font-medium text-white">
@@ -265,7 +285,7 @@ export default function VpnStatusPage() {
                       )
                     </p>
                   )}
-                  {!data?.vyos_available && !data?.mikrotik_available && !loading && (
+                  {!vyosVisible && !data?.mikrotik_available && !loading && (
                     <p>
                       No router is configured. Go to{" "}
                       <span className="font-medium text-white">Settings</span>{" "}
@@ -277,9 +297,9 @@ export default function VpnStatusPage() {
             </Card>
 
             {/* All interfaces overview */}
-            {data && data.interfaces.length > 0 && (
+            {overviewInterfaces.length > 0 && (
               <div className="space-y-4">
-                {data.interfaces.map((iface) => (
+                {overviewInterfaces.map((iface) => (
                   <InterfaceCard key={`${iface.source}-${iface.name}`} iface={iface} />
                 ))}
               </div>

--- a/web/src/lib/router-config.ts
+++ b/web/src/lib/router-config.ts
@@ -15,7 +15,10 @@ export type RouterType = (typeof ROUTER_TYPES)[number];
 export function getDefaultRouterType(
   _settings: Pick<
     SettingsData,
-    "mikrotik_enabled" | "vyos_url" | "vyos_api_key_set"
+    | "mikrotik_enabled"
+    | "vyos_url"
+    | "vyos_api_key_set"
+    | "show_legacy_routers"
   > | null,
 ): RouterType {
   return "mikrotik";

--- a/web/tests/unit/router-config.test.ts
+++ b/web/tests/unit/router-config.test.ts
@@ -28,6 +28,7 @@ describe("getDefaultRouterType", () => {
         mikrotik_enabled: true,
         vyos_url: null,
         vyos_api_key_set: false,
+        show_legacy_routers: false,
       }),
     ).toBe("mikrotik");
   });
@@ -38,18 +39,31 @@ describe("getDefaultRouterType", () => {
         mikrotik_enabled: true,
         vyos_url: "https://vyos.local",
         vyos_api_key_set: true,
+        show_legacy_routers: true,
       }),
     ).toBe("mikrotik");
   });
 
-  it("returns vyos when only vyos is configured", () => {
+  it("returns mikrotik when only vyos is configured and legacy is enabled", () => {
     expect(
       getDefaultRouterType({
         mikrotik_enabled: false,
         vyos_url: "https://vyos.local",
         vyos_api_key_set: true,
+        show_legacy_routers: true,
       }),
-    ).toBe("vyos");
+    ).toBe("mikrotik");
+  });
+
+  it("returns mikrotik when vyos is configured but legacy is disabled", () => {
+    expect(
+      getDefaultRouterType({
+        mikrotik_enabled: false,
+        vyos_url: "https://vyos.local",
+        vyos_api_key_set: true,
+        show_legacy_routers: false,
+      }),
+    ).toBe("mikrotik");
   });
 
   it("returns mikrotik when vyos_url is set but api key is not", () => {
@@ -58,6 +72,7 @@ describe("getDefaultRouterType", () => {
         mikrotik_enabled: false,
         vyos_url: "https://vyos.local",
         vyos_api_key_set: false,
+        show_legacy_routers: true,
       }),
     ).toBe("mikrotik");
   });
@@ -68,6 +83,7 @@ describe("getDefaultRouterType", () => {
         mikrotik_enabled: false,
         vyos_url: null,
         vyos_api_key_set: false,
+        show_legacy_routers: false,
       }),
     ).toBe("mikrotik");
   });

--- a/web/tests/unit/settings-nav.test.ts
+++ b/web/tests/unit/settings-nav.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from "vitest";
 import { settingsNav } from "@/lib/settings-nav";
 
 describe("settingsNav visibility gating", () => {
-  const legacyGroup = settingsNav.find((g) => g.label === "Legacy / Optional");
+  const legacyGroup = settingsNav.find((g) => g.label === "Advanced / Legacy");
   const integrationsGroup = settingsNav.find(
     (g) => g.label === "Integrations",
   );
 
-  it("has a 'Legacy / Optional' section", () => {
+  it("has an 'Advanced / Legacy' section", () => {
     expect(legacyGroup).toBeDefined();
   });
 
@@ -19,8 +19,8 @@ describe("settingsNav visibility gating", () => {
     expect(npmItem!.title).toBe("Nginx Proxy Manager");
   });
 
-  it("legacy section has a subtitle guiding users toward Caddy", () => {
-    expect(legacyGroup!.subtitle).toMatch(/caddy/i);
+  it("legacy section has a subtitle describing legacy integrations", () => {
+    expect(legacyGroup!.subtitle).toMatch(/legacy integrations/i);
   });
 
   it("NPM is NOT in the primary Integrations section", () => {


### PR DESCRIPTION
Closes #334

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ensures existing VyOS configurations (set via env vars or config files) remain visible and functional when the `show_legacy_routers` toggle is enabled. Changes span both backend and frontend:

- **Backend**: The settings API now falls back to env/file-based VyOS config when no DB override exists, and `qos.rs`/`vpn_status.rs` use a shared `get_vyos_client_from_db` helper with the same fallback logic.
- **Frontend**: All pages (NAT, QoS, VPN Status, DDNS, Settings) now gate VyOS UI elements behind `legacyRoutersEnabled && vyosConfigured`, with a safety `useEffect` to redirect the active tab away from "vyos" when it becomes hidden.
- **Tests**: Updated to include `show_legacy_routers` in all fixtures, with a new test case for VyOS-configured-but-legacy-disabled.

One inconsistency remains in `vpn-status/page.tsx`: the "Interfaces" summary card is correctly filtered by the legacy toggle, but the "Peers Online", "Total RX", and "Total TX" cards still use unfiltered server aggregates that include VyOS data.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor data inconsistency in VPN status summary cards.
- The changes are well-structured and consistently applied across all affected pages. The backend refactor to use a shared VyOS client helper with config fallback is clean. The one issue — mismatched summary card data on the VPN status page — is a UI inconsistency rather than a correctness or security problem, bringing the score to 4 instead of 5.
- Pay close attention to `web/src/app/(app)/vpn-status/page.tsx` where summary card values (peers, rx, tx) don't respect the legacy filter.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/settings.rs | Adds fallback to env/file config for `vyos_url` and `vyos_api_key_set` in GET /api/v1/settings, ensuring legacy VyOS configs are surfaced to the frontend without requiring re-saving. |
| server/src/api/qos.rs | Replaces inline VyOS client construction with shared `get_vyos_client_from_db` helper, gaining the DB-then-config fallback logic. |
| server/src/api/vpn_status.rs | Same refactor as qos.rs — uses shared `get_vyos_client_from_db` for VyOS client construction with config fallback. |
| web/src/app/(app)/ddns/page.tsx | Gates VyOS router type in the DDNS selector behind both `show_legacy_routers` and VyOS being configured. |
| web/src/app/(app)/nat/page.tsx | Adds `legacyRoutersEnabled` state and `vyosVisible` computed value to gate all VyOS UI elements behind the legacy toggle. Correctly redirects active VyOS tab to overview when legacy is disabled. |
| web/src/app/(app)/qos/page.tsx | Same pattern as NAT — gates all VyOS QoS UI behind `legacyRoutersEnabled && vyos_available`. |
| web/src/app/(app)/vpn-status/page.tsx | Gates VyOS visibility behind legacy toggle. The Interfaces summary card is filtered correctly, but Peers Online, Total RX, and Total TX summary cards still use server-aggregated totals that include VyOS data — inconsistent when legacy is off. |
| web/src/app/(app)/settings/page.tsx | Gates VyOS-only settings (audit-log, config-backup) behind both `legacyRoutersEnabled` and `vyosConfigured`. Updates router description fallback accordingly. |
| web/src/lib/router-config.ts | Adds `show_legacy_routers` to the `Pick` type for settings parameter. Function still always returns "mikrotik" as default. |
| web/tests/unit/router-config.test.ts | Adds `show_legacy_routers` field to all test fixtures and adds a new test case for vyos-configured-but-legacy-disabled scenario. |
| web/tests/unit/settings-nav.test.ts | Updates test expectations to match the renamed "Advanced / Legacy" group label and updated subtitle wording. |

</details>



<sub>Last reviewed commit: e878871</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->