### PR TITLE
feat: bug: "Import from Devices" button on Assets page does not work (#337)

### DIFF
--- a/server/src/api/assets.rs
+++ b/server/src/api/assets.rs
@@ -833,10 +833,6 @@ pub async fn sync_from_devices(
 
 #[cfg(test)]
 mod tests {
-    use axum::extract::State;
-
-    use crate::api::AppState;
-    use crate::config::AppConfig;
     use crate::db;
 
     use super::{asset_from_row, sync_from_devices, GET_ONE_QUERY, LIST_QUERY};


### PR DESCRIPTION
Closes #337

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the "Import from Devices" button by refactoring the `sync_from_devices` function to explicitly check for already-linked devices in application code rather than relying on SQL filtering.

**Key changes:**
- Query now fetches all devices and adds `linked_asset_id` subquery to check existing asset links
- Application code explicitly skips devices that already have linked assets with detailed logging
- Improved MAC address handling by filtering empty strings
- Enhanced error messages to include actual error details when asset creation fails
- Minor code cleanup (variable rename `raw` → `v` in `non_empty_trimmed`)

The previous SQL-based filtering with `LEFT JOIN assets a ON a.device_id = d.id WHERE a.id IS NULL` was replaced with explicit application-level checks, making the logic more reliable and easier to reason about.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes correctly fix the reported bug by making the filtering logic more explicit and reliable. The refactoring from SQL-based filtering to application-level checks is a sound architectural decision. All changes are well-structured, include proper error handling and logging, and the existing test suite validates the core functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/assets.rs | Fixed sync-from-devices by moving filtering logic from SQL to application code, improved error messages and MAC address handling |

</details>



<sub>Last reviewed commit: 389301c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->