### PR TITLE
feat: bug: Xiaomi router shows "unreachable" error despite being connected (#357)

### DIFF
--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -215,10 +215,17 @@ pub async fn status(
             }))
         }
         Err(e) => {
-            tracing::error!(error = %e, "MiWiFi status request failed");
+            tracing::warn!(
+                error = %e,
+                "MiWiFi status request failed, probing connectivity via init_info"
+            );
+            let reachable = client.init_info().await.is_ok();
+            if !reachable {
+                tracing::error!("MiWiFi status and init_info probes both failed");
+            }
             Ok(Json(XiaomiStatusResponse {
                 configured: true,
-                reachable: false,
+                reachable,
                 cpu_cores: None,
                 cpu_freq: None,
                 cpu_load: None,

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -1,6 +1,55 @@
 //! Deserialization types for Xiaomi MiWiFi API responses.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+fn de_opt_string_from_any<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|v| match v {
+        serde_json::Value::String(s) => {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }))
+}
+
+fn de_opt_f64_from_any<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|v| match v {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok(),
+        serde_json::Value::Bool(b) => Some(if b { 1.0 } else { 0.0 }),
+        _ => None,
+    }))
+}
+
+fn de_opt_i32_from_any<'de, D>(deserializer: D) -> Result<Option<i32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|v| match v {
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .and_then(|v| i32::try_from(v).ok())
+            .or_else(|| n.as_u64().and_then(|v| i32::try_from(v).ok()))
+            .or_else(|| n.as_f64().map(|v| v.round() as i32)),
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok().map(|v| v.round() as i32),
+        serde_json::Value::Bool(b) => Some(if b { 1 } else { 0 }),
+        _ => None,
+    }))
+}
 
 // ── Wrapper: every MiWiFi response has `{ "code": 0, ... }` ──
 
@@ -71,39 +120,39 @@ pub struct TopoGraphInner {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemInfo {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_f64_from_any")]
     pub usage: Option<f64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub total: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub hz: Option<String>,
-    #[serde(default, rename = "type")]
+    #[serde(default, rename = "type", deserialize_with = "de_opt_string_from_any")]
     pub mem_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CpuInfo {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
     pub core: Option<i32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub hz: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_f64_from_any")]
     pub load: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WanSpeed {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub downspeed: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub upspeed: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceCount {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
     pub online: Option<i32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
     pub all: Option<i32>,
 }
 
@@ -117,7 +166,7 @@ pub struct SystemStatus {
     pub wan: Option<WanSpeed>,
     #[serde(default)]
     pub count: Option<DeviceCount>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
     pub temperature: Option<i32>,
 }
 
@@ -323,6 +372,50 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub uptime: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_status_deserializes_mixed_scalar_types() {
+        let payload = serde_json::json!({
+            "code": 0,
+            "mem": {
+                "usage": "0.42",
+                "total": 256,
+                "hz": 2400,
+                "type": 1
+            },
+            "cpu": {
+                "core": "4",
+                "hz": 880,
+                "load": "12.5"
+            },
+            "wan": {
+                "downspeed": 12345,
+                "upspeed": "9876"
+            },
+            "count": {
+                "online": "7",
+                "all": 11
+            },
+            "temperature": "46"
+        });
+
+        let parsed: SystemStatus = serde_json::from_value(payload).expect("status should parse");
+        assert_eq!(parsed.mem.and_then(|m| m.total), Some("256".to_string()));
+        assert_eq!(parsed.cpu.and_then(|c| c.core), Some(4));
+        assert_eq!(parsed.temperature, Some(46));
+    }
+
+    #[test]
+    fn uptime_deserializes_from_number() {
+        let payload = serde_json::json!({ "uptime": 123 });
+        let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
+        assert_eq!(parsed.uptime, Some("123".to_string()));
+    }
 }


### PR DESCRIPTION
Closes #357

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the "unreachable" error for Xiaomi routers by implementing a two-pronged solution: (1) adds custom deserializers to handle inconsistent scalar types from the Xiaomi API (strings/numbers/bools can be used interchangeably), and (2) implements a fallback connectivity probe using `init_info()` when `system_status()` fails, preventing false negatives.

**Key changes:**
- Custom deserializers (`de_opt_string_from_any`, `de_opt_f64_from_any`, `de_opt_i32_from_any`) gracefully coerce mixed types
- Fallback connectivity check tries `init_info()` when `system_status()` fails before marking router unreachable
- Improved logging: downgraded initial failure to `warn`, only logs `error` if both probes fail
- Added comprehensive unit tests for type coercion edge cases

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The changes are well-targeted bug fixes with defensive fallback logic and comprehensive tests. The custom deserializers handle type drift gracefully, and the fallback probe adds resilience. Minor concern: potential for the fallback to mask underlying issues with `system_status()`, but logging adequately addresses observability
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi.rs | Added fallback connectivity probe using `init_info()` when `system_status()` fails, with appropriate logging at warn/error levels |
| server/src/xiaomi/types.rs | Added custom deserializers to handle mixed scalar types from Xiaomi API (strings/numbers/bools), with comprehensive unit tests covering type coercion |

</details>



<sub>Last reviewed commit: 4385b86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->