### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 


### PR DESCRIPTION
## Summary

- The Xiaomi `/api/misystem/status` endpoint returns the uptime field as `upTime` (camelCase), but `UptimeResponse` was deserializing the lowercase `uptime` key. This caused the field to always be `None`, displaying "—" on the router page.
- Added `rename = "upTime"` to the serde attribute on `UptimeResponse.uptime` so the field is correctly parsed from the API response.
- The frontend `formatUptime()` function already handles converting seconds to human-readable format (e.g. "9d 14h 5m"), so no frontend changes were needed.

Closes #364

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Xiaomi router uptime display by adding `rename = "upTime"` serde attribute to correctly deserialize the camelCase field from the `/api/misystem/status` endpoint.

- Correctly maps API's `upTime` field to Rust's `uptime` struct field
- Existing test case uses incorrect key and will fail after this change

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the test case
- The fix correctly addresses the API field name mismatch, but the existing test will fail and needs to be updated to use `upTime` instead of `uptime`
- server/src/xiaomi/types.rs - update test to use correct field name

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` to fix field deserialization from Xiaomi API, but test case needs updating to match |

</details>



<sub>Last reviewed commit: ad3b4f6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->