### PR TITLE
feat: deep links for router pages (/router/mikrotik and /router/xiaomi) (#362)

### DIFF
--- a/web/src/app/(app)/router/mikrotik/page.tsx
+++ b/web/src/app/(app)/router/mikrotik/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Router, Settings } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchSettings } from "@/lib/api";
+import MikrotikRouter from "@/components/MikrotikRouter";
+import { PageTransition } from "@/components/PageTransition";
+import { RouterSelector } from "@/components/RouterSelector";
+
+export default function MikrotikRouterPage() {
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const settings = await fetchSettings();
+        setMikrotikEnabled(settings.mikrotik_enabled);
+      } catch {
+        // ignore
+      }
+      setSettingsLoaded(true);
+    };
+    loadSettings();
+  }, []);
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        <RouterSelector active="mikrotik" />
+
+        {!settingsLoaded ? (
+          <div className="space-y-6">
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-96 w-full" />
+          </div>
+        ) : mikrotikEnabled ? (
+          <MikrotikRouter />
+        ) : (
+          <div className="flex min-h-[60vh] items-center justify-center">
+            <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+              <CardContent className="flex flex-col items-center gap-4 py-12">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/10">
+                  <Router className="h-8 w-8 text-amber-400" />
+                </div>
+                <h1 className="text-xl font-semibold text-white">
+                  MikroTik Not Configured
+                </h1>
+                <p className="text-center text-sm text-slate-500">
+                  Enable MikroTik integration in Settings to use this page.
+                </p>
+                <Link href="/settings/router">
+                  <Button
+                    variant="outline"
+                    className="border-slate-800 text-slate-300 hover:bg-slate-800"
+                  >
+                    <Settings className="mr-2 h-4 w-4" />
+                    Configure Router
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -130,12 +130,10 @@ import {
   deleteDnsDomainOverride,
   fetchSystemInfo,
   fetchSyslog,
-  fetchMikrotikStatus,
   fetchSettings,
 } from "@/lib/api";
-import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, MikrotikStatus, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
-import MikrotikRouter from "@/components/MikrotikRouter";
-import XiaomiRouter from "@/components/XiaomiRouter";
+import type { FirewallConfig, FirewallChain, FirewallRule, FirewallRuleRequest, FirewallGroups, RouterStatus, RouterSummary, SpeedTestResult, SpeedTestHistoryEntry, VyosDhcpLease, VyosInterface, VyosRoute, DhcpStaticMapping, DhcpServerConfig, DhcpSubnetConfig, WireguardInterface, ClientConfigResponse, DnsForwardingConfig, DnsDomainOverride, SystemInfo, SyslogResponse, SettingsData, OpenVpnInterface, OpenVpnConnectedClient } from "@/lib/types";
+import { RouterSelector } from "@/components/RouterSelector";
 import QRCode from "qrcode";
 import { Progress } from "@/components/ui/progress";
 import { PageTransition } from "@/components/PageTransition";
@@ -5894,14 +5892,14 @@ function OpenVpnInterfaceCard({
 // ── Main Page ───────────────────────────────────────────
 
 export default function RouterPage() {
+  const router = useRouter();
   const [summary, setSummary] = useState<RouterSummary | null>(null);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
   const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
-  const [routerType, setRouterType] = useState<"vyos" | "mikrotik" | "xiaomi">("mikrotik");
 
-  // Load settings to determine which routers are configured
+  // Load settings and redirect to sub-route for MikroTik/Xiaomi
   useEffect(() => {
     const loadSettings = async () => {
       let mtEnabled = false;
@@ -5919,23 +5917,24 @@ export default function RouterPage() {
       setVyosConfigured(vyosConf);
       setXiaomiEnabled(xiEnabled);
 
-      // Default to mikrotik if enabled, fallback to xiaomi, then vyos
+      // Redirect to deep-link sub-routes for MikroTik/Xiaomi
       if (mtEnabled) {
-        setRouterType("mikrotik");
+        router.replace("/router/mikrotik");
+        return;
       } else if (xiEnabled) {
-        setRouterType("xiaomi");
-      } else if (vyosConf) {
-        setRouterType("vyos");
+        router.replace("/router/xiaomi");
+        return;
       }
 
       setSettingsLoaded(true);
     };
     loadSettings();
-  }, []);
+  }, [router]);
 
-  // Lazy-load VyOS summary only when VyOS tab is selected
+  // Lazy-load VyOS summary
   useEffect(() => {
-    if (routerType !== "vyos") return;
+    if (!settingsLoaded) return;
+    if (!vyosConfigured) return;
     if (summary) return; // already loaded
 
     const loadVyosSummary = async () => {
@@ -5959,80 +5958,16 @@ export default function RouterPage() {
       }
     };
     loadVyosSummary();
-  }, [routerType, summary]);
+  }, [settingsLoaded, vyosConfigured, summary]);
 
   const neitherConfigured = settingsLoaded && !vyosConfigured && !mikrotikEnabled && !xiaomiEnabled;
 
   return (
     <PageTransition>
       <div className="space-y-6">
-        {/* Router type selector — skeleton while settings load, tabs when multiple routers available */}
-        {!settingsLoaded ? (
-          <Skeleton className="h-9 w-48" />
-        ) : [mikrotikEnabled, vyosConfigured, xiaomiEnabled].filter(Boolean).length > 1 ? (
-          <div className="flex gap-2">
-            {mikrotikEnabled && (
-              <Button
-                variant={routerType === "mikrotik" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setRouterType("mikrotik")}
-                className={
-                  routerType === "mikrotik"
-                    ? "bg-pink-600 text-white hover:bg-pink-500"
-                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-                }
-              >
-                <Router className="mr-1.5 h-3.5 w-3.5" />
-                MikroTik
-              </Button>
-            )}
-            {xiaomiEnabled && (
-              <Button
-                variant={routerType === "xiaomi" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setRouterType("xiaomi")}
-                className={
-                  routerType === "xiaomi"
-                    ? "bg-orange-600 text-white hover:bg-orange-500"
-                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-                }
-              >
-                <Router className="mr-1.5 h-3.5 w-3.5" />
-                Xiaomi
-              </Button>
-            )}
-            {vyosConfigured && (
-              <Button
-                variant={routerType === "vyos" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setRouterType("vyos")}
-                className={
-                  routerType === "vyos"
-                    ? "bg-blue-600 text-white hover:bg-blue-500"
-                    : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-                }
-              >
-                <Router className="mr-1.5 h-3.5 w-3.5" />
-                VyOS
-                <Badge variant="outline" className="ml-1.5 border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px] px-1.5 py-0">
-                  Legacy
-                </Badge>
-              </Button>
-            )}
-          </div>
-        ) : null}
+        <RouterSelector active="vyos" />
 
-        {/* VyOS legacy note */}
-        {settingsLoaded && routerType === "vyos" && (
-          <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
-            <p className="text-xs text-amber-400">
-              VyOS support is legacy. MikroTik is the recommended router platform for new deployments.
-            </p>
-          </div>
-        )}
-
-        {/* Content area — skeletons until settings arrive, then router-specific content */}
+        {/* Content area — skeletons until settings arrive, then VyOS content */}
         {!settingsLoaded ? (
           <div className="space-y-6">
             <Skeleton className="h-10 w-64" />
@@ -6040,24 +5975,20 @@ export default function RouterPage() {
           </div>
         ) : neitherConfigured ? (
           <NotConfigured />
-        ) : routerType === "xiaomi" && xiaomiEnabled ? (
-          <XiaomiRouter />
-        ) : routerType === "mikrotik" && mikrotikEnabled ? (
-          <MikrotikRouter />
-        ) : routerType === "vyos" && !vyosConfigured ? (
+        ) : !vyosConfigured ? (
           <VyosNotConfigured />
-        ) : routerType === "vyos" && !summary ? (
+        ) : !summary ? (
           <div className="space-y-6">
             <Skeleton className="h-10 w-64" />
             <Skeleton className="h-96 w-full" />
           </div>
-        ) : routerType === "vyos" && summary?.status.configured ? (
+        ) : summary.status.configured ? (
           <Suspense fallback={null}>
             <RouterTabs summary={summary} />
           </Suspense>
-        ) : routerType === "vyos" ? (
+        ) : (
           <VyosNotConfigured />
-        ) : null}
+        )}
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/router/xiaomi/page.tsx
+++ b/web/src/app/(app)/router/xiaomi/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Router, Settings } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchSettings } from "@/lib/api";
+import XiaomiRouter from "@/components/XiaomiRouter";
+import { PageTransition } from "@/components/PageTransition";
+import { RouterSelector } from "@/components/RouterSelector";
+
+export default function XiaomiRouterPage() {
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const settings = await fetchSettings();
+        setXiaomiEnabled(settings.xiaomi_mesh_enabled);
+      } catch {
+        // ignore
+      }
+      setSettingsLoaded(true);
+    };
+    loadSettings();
+  }, []);
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        <RouterSelector active="xiaomi" />
+
+        {!settingsLoaded ? (
+          <div className="space-y-6">
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-96 w-full" />
+          </div>
+        ) : xiaomiEnabled ? (
+          <XiaomiRouter />
+        ) : (
+          <div className="flex min-h-[60vh] items-center justify-center">
+            <Card className="w-full max-w-md border-slate-800 bg-slate-900">
+              <CardContent className="flex flex-col items-center gap-4 py-12">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/10">
+                  <Router className="h-8 w-8 text-amber-400" />
+                </div>
+                <h1 className="text-xl font-semibold text-white">
+                  Xiaomi Mesh Not Configured
+                </h1>
+                <p className="text-center text-sm text-slate-500">
+                  Enable Xiaomi mesh integration in Settings to use this page.
+                </p>
+                <Link href="/settings/xiaomi-mesh">
+                  <Button
+                    variant="outline"
+                    className="border-slate-800 text-slate-300 hover:bg-slate-800"
+                  >
+                    <Settings className="mr-2 h-4 w-4" />
+                    Configure Xiaomi Mesh
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Router, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchSettings } from "@/lib/api";
+
+type ActiveRouter = "mikrotik" | "xiaomi" | "vyos";
+
+interface RouterSelectorProps {
+  active: ActiveRouter;
+}
+
+export function RouterSelector({ active }: RouterSelectorProps) {
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
+  const [vyosConfigured, setVyosConfigured] = useState(false);
+  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const settings = await fetchSettings();
+        setMikrotikEnabled(settings.mikrotik_enabled);
+        setVyosConfigured(!!settings.vyos_url && settings.vyos_api_key_set);
+        setXiaomiEnabled(settings.xiaomi_mesh_enabled);
+      } catch {
+        // ignore
+      }
+      setSettingsLoaded(true);
+    };
+    loadSettings();
+  }, []);
+
+  if (!settingsLoaded) {
+    return <Skeleton className="h-9 w-48" />;
+  }
+
+  const count = [mikrotikEnabled, xiaomiEnabled, vyosConfigured].filter(Boolean).length;
+  if (count <= 1) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {mikrotikEnabled && (
+          <Button
+            variant={active === "mikrotik" ? "default" : "outline"}
+            size="sm"
+            asChild
+            className={
+              active === "mikrotik"
+                ? "bg-pink-600 text-white hover:bg-pink-500"
+                : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            }
+          >
+            <Link href="/router/mikrotik">
+              <Router className="mr-1.5 h-3.5 w-3.5" />
+              MikroTik
+            </Link>
+          </Button>
+        )}
+        {xiaomiEnabled && (
+          <Button
+            variant={active === "xiaomi" ? "default" : "outline"}
+            size="sm"
+            asChild
+            className={
+              active === "xiaomi"
+                ? "bg-orange-600 text-white hover:bg-orange-500"
+                : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            }
+          >
+            <Link href="/router/xiaomi">
+              <Router className="mr-1.5 h-3.5 w-3.5" />
+              Xiaomi
+            </Link>
+          </Button>
+        )}
+        {vyosConfigured && (
+          <Button
+            variant={active === "vyos" ? "default" : "outline"}
+            size="sm"
+            asChild
+            className={
+              active === "vyos"
+                ? "bg-blue-600 text-white hover:bg-blue-500"
+                : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            }
+          >
+            <Link href="/router">
+              <Router className="mr-1.5 h-3.5 w-3.5" />
+              VyOS
+              <Badge
+                variant="outline"
+                className="ml-1.5 border-amber-500/30 bg-amber-500/10 text-amber-400 text-[10px] px-1.5 py-0"
+              >
+                Legacy
+              </Badge>
+            </Link>
+          </Button>
+        )}
+      </div>
+      {active === "vyos" && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
+          <p className="text-xs text-amber-400">
+            VyOS support is legacy. MikroTik is the recommended router platform for new deployments.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `/router/mikrotik` deep-linkable route that directly renders the MikroTik router component
- Add `/router/xiaomi` deep-linkable route that directly renders the Xiaomi router component
- Extract shared `RouterSelector` component with link-based navigation between router types
- `/router` now auto-redirects to the appropriate sub-route (MikroTik → Xiaomi → VyOS fallback)

## Details

Previously, `/router` was a single page that toggled between MikroTik, Xiaomi, and VyOS using local state — no way to bookmark or share a direct link to a specific router view.

Now each router type has its own URL:
- `/router/mikrotik` — MikroTik router page (bookmarkable)
- `/router/xiaomi` — Xiaomi router page (bookmarkable)
- `/router` — VyOS (legacy) or redirects to the default router

The shared `RouterSelector` component appears on all router pages when multiple routers are configured, using `<Link>` navigation for proper client-side routing.

Closes #362

## Test plan

- [ ] Visit `/router/mikrotik` directly — should render MikroTik component
- [ ] Visit `/router/xiaomi` directly — should render Xiaomi component
- [ ] Visit `/router` — should redirect to default router sub-route
- [ ] Router selector links navigate between sub-routes correctly
- [ ] Sidebar "Router" link still highlights for all sub-routes
- [ ] Pages show "not configured" state when the router type isn't enabled

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully adds deep-linkable routes for MikroTik and Xiaomi routers, enabling bookmarkable URLs for each router type. The implementation extracts a shared `RouterSelector` component and refactors `/router` to redirect to the appropriate sub-route based on configuration.

**Key changes:**
- Created `/router/mikrotik` and `/router/xiaomi` routes with dedicated pages
- Extracted `RouterSelector` component with Next.js Link-based navigation
- `/router` now redirects to MikroTik → Xiaomi → VyOS fallback hierarchy
- Sidebar highlighting works correctly for all sub-routes via `pathname.startsWith("/router")`
- Each page handles "not configured" states with proper error messages and settings links

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that follows Next.js App Router conventions, proper error handling, no breaking changes to existing VyOS functionality, and sidebar highlighting automatically works via pathname prefix matching
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/RouterSelector.tsx | New shared component for router navigation with proper Link-based routing |
| web/src/app/(app)/router/mikrotik/page.tsx | New deep-linkable MikroTik router page with proper error states |
| web/src/app/(app)/router/xiaomi/page.tsx | New deep-linkable Xiaomi router page with proper error states |
| web/src/app/(app)/router/page.tsx | Refactored to redirect to sub-routes and serve only VyOS (legacy) content |

</details>



<sub>Last reviewed commit: 34762f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->