### PR TITLE
feat: Xiaomi mesh topology view (#365)

### DIFF
--- a/web/src/app/(app)/xiaomi/page.tsx
+++ b/web/src/app/(app)/xiaomi/page.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Cable,
+  Crown,
+  Loader2,
+  MonitorSmartphone,
+  RefreshCw,
+  Router,
+  Wifi,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageTransition } from "@/components/PageTransition";
+import { fetchXiaomiTopology } from "@/lib/api";
+import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types";
+
+// ─── Helpers ─────────────────────────────────────────────
+
+/** Count leafs attached to a given node MAC. */
+function leafCountForNode(
+  nodeMac: string | null,
+  leafs: XiaomiTopoLeaf[],
+): number {
+  if (!nodeMac) return 0;
+  return leafs.filter((l) => l.parent_id === nodeMac).length;
+}
+
+/** Get leafs attached to a given node MAC. */
+function leafsForNode(
+  nodeMac: string | null,
+  leafs: XiaomiTopoLeaf[],
+): XiaomiTopoLeaf[] {
+  if (!nodeMac) return [];
+  return leafs.filter((l) => l.parent_id === nodeMac);
+}
+
+// ─── Node Card ───────────────────────────────────────────
+
+function NodeCard({
+  node,
+  leafs,
+  isMain,
+}: {
+  node: XiaomiTopoNode;
+  leafs: XiaomiTopoLeaf[];
+  isMain: boolean;
+}) {
+  const connectedLeafs = leafsForNode(node.mac, leafs);
+  const onlineDevices = node.online ?? 0;
+
+  return (
+    <Card
+      className={`border-slate-800 bg-slate-900/50 transition-shadow hover:shadow-lg ${
+        isMain
+          ? "border-amber-500/30 shadow-amber-500/5"
+          : "hover:border-slate-700"
+      }`}
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+              isMain ? "bg-amber-500/20" : "bg-blue-500/20"
+            }`}
+          >
+            {isMain ? (
+              <Crown className="h-5 w-5 text-amber-400" />
+            ) : (
+              <Router className="h-5 w-5 text-blue-400" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="truncate text-sm font-semibold text-white">
+              {node.locale || node.name || "Mesh Node"}
+            </CardTitle>
+            <p className="truncate font-mono text-xs text-slate-400">
+              {node.ip || "No IP"}
+            </p>
+          </div>
+          <span
+            className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+              node.ip
+                ? "bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.5)]"
+                : "bg-slate-600"
+            }`}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Stats row */}
+        <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+          <span className="flex items-center gap-1.5">
+            <MonitorSmartphone className="h-3.5 w-3.5" />
+            {onlineDevices} device{onlineDevices !== 1 ? "s" : ""} online
+          </span>
+          {connectedLeafs.length > 0 && (
+            <span className="flex items-center gap-1.5">
+              <Wifi className="h-3.5 w-3.5" />
+              {connectedLeafs.length} connected
+            </span>
+          )}
+        </div>
+
+        {/* Badges */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          {node.model && (
+            <Badge
+              variant="outline"
+              className="border-slate-700 text-[10px] text-slate-500"
+            >
+              {node.model}
+            </Badge>
+          )}
+          {node.hardware && node.hardware !== node.model && (
+            <Badge
+              variant="outline"
+              className="border-slate-700 text-[10px] text-slate-500"
+            >
+              {node.hardware}
+            </Badge>
+          )}
+          {isMain && (
+            <Badge className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-400">
+              Main Router
+            </Badge>
+          )}
+        </div>
+
+        {/* MAC address */}
+        {node.mac && (
+          <p className="font-mono text-[10px] text-slate-600">
+            MAC: {node.mac}
+          </p>
+        )}
+
+        {/* Connected devices list */}
+        {connectedLeafs.length > 0 && (
+          <div className="mt-2 space-y-1 border-t border-slate-800 pt-2">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-slate-500">
+              Connected Devices
+            </p>
+            <div className="max-h-32 space-y-0.5 overflow-y-auto">
+              {connectedLeafs.map((leaf) => (
+                <div
+                  key={leaf.mac || leaf.ip}
+                  className="flex items-center justify-between rounded px-1.5 py-0.5 text-[11px] hover:bg-slate-800/50"
+                >
+                  <span className="truncate text-slate-300">
+                    {leaf.name || leaf.mac || "Unknown"}
+                  </span>
+                  <span className="shrink-0 font-mono text-slate-500">
+                    {leaf.ip || "—"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Loading skeleton ────────────────────────────────────
+
+function NodeCardSkeleton() {
+  return (
+    <Card className="border-slate-800 bg-slate-900/50">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-10 w-10 rounded-lg" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-3 w-32" />
+        <div className="flex gap-1.5">
+          <Skeleton className="h-4 w-16 rounded-full" />
+          <Skeleton className="h-4 w-12 rounded-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Page ───────────────────────────────────────────
+
+export default function XiaomiMeshPage() {
+  const [data, setData] = useState<XiaomiTopology | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const result = await fetchXiaomiTopology();
+      setData(result);
+      setLastRefresh(new Date());
+      setError(null);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load Xiaomi topology",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll every 30s
+  useEffect(() => {
+    const interval = setInterval(load, 30_000);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  // Determine which node is "main" (first node, typically the primary router)
+  const { sortedNodes, mainMac } = useMemo(() => {
+    if (!data) return { sortedNodes: [], mainMac: null };
+    // The first node in the list is usually the main router
+    const main = data.nodes[0] ?? null;
+    const mainMac = main?.mac ?? null;
+    // Sort: main first, then by online device count descending
+    const sorted = [...data.nodes].sort((a, b) => {
+      if (a.mac === mainMac) return -1;
+      if (b.mac === mainMac) return 1;
+      return (b.online ?? 0) - (a.online ?? 0);
+    });
+    return { sortedNodes: sorted, mainMac };
+  }, [data]);
+
+  // Stats
+  const stats = useMemo(() => {
+    if (!data) return { nodeCount: 0, totalDevices: 0, totalLeafs: 0 };
+    const totalDevices = data.nodes.reduce(
+      (sum, n) => sum + (n.online ?? 0),
+      0,
+    );
+    return {
+      nodeCount: data.nodes.length,
+      totalDevices,
+      totalLeafs: data.leafs.length,
+    };
+  }, [data]);
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">
+              Xiaomi Mesh Topology
+            </h1>
+            <p className="mt-1 text-sm text-slate-400">
+              Network mesh nodes from the Xiaomi router topology graph
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            {lastRefresh && (
+              <span className="text-[11px] text-slate-500">
+                Updated {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={load}
+              className="border-slate-700 bg-slate-900 text-slate-300 hover:bg-slate-800"
+            >
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {/* Summary stats */}
+        {!loading && data && (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <Card className="border-slate-800 bg-slate-900/50">
+              <CardContent className="flex items-center gap-3 p-4">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/20">
+                  <Router className="h-4.5 w-4.5 text-blue-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white">
+                    {stats.nodeCount}
+                  </p>
+                  <p className="text-xs text-slate-400">Mesh Nodes</p>
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="border-slate-800 bg-slate-900/50">
+              <CardContent className="flex items-center gap-3 p-4">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/20">
+                  <MonitorSmartphone className="h-4.5 w-4.5 text-emerald-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white">
+                    {stats.totalDevices}
+                  </p>
+                  <p className="text-xs text-slate-400">Online Devices</p>
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="border-slate-800 bg-slate-900/50">
+              <CardContent className="flex items-center gap-3 p-4">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/20">
+                  <Wifi className="h-4.5 w-4.5 text-purple-400" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white">
+                    {stats.totalLeafs}
+                  </p>
+                  <p className="text-xs text-slate-400">Connected Clients</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        {/* Error state */}
+        {error && (
+          <Card className="border-rose-500/20 bg-rose-500/5">
+            <CardContent className="p-4">
+              <p className="text-sm text-rose-400">{error}</p>
+              <button
+                onClick={() => {
+                  setLoading(true);
+                  load();
+                }}
+                className="mt-2 text-xs text-blue-400 hover:underline"
+              >
+                Retry
+              </button>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <NodeCardSkeleton key={i} />
+            ))}
+          </div>
+        )}
+
+        {/* Node cards */}
+        {!loading && data && sortedNodes.length > 0 && (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {sortedNodes.map((node) => (
+              <NodeCard
+                key={node.mac || node.ip}
+                node={node}
+                leafs={data.leafs}
+                isMain={node.mac === mainMac}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && data && sortedNodes.length === 0 && (
+          <Card className="border-slate-800 bg-slate-900/50">
+            <CardContent className="flex flex-col items-center gap-3 py-12">
+              <Router className="h-10 w-10 text-slate-600" />
+              <p className="text-sm text-slate-400">
+                No mesh nodes found. Make sure the Xiaomi mesh integration is
+                configured in Settings.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Settings,
   Share2,
   Shield,
+  Wifi,
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -45,6 +46,7 @@ const navItems = [
   { href: "/services", label: "Services", icon: Workflow },
   { href: "/topology", label: "Topology", icon: Network },
   { href: "/mesh", label: "Mesh", icon: Share2 },
+  { href: "/xiaomi", label: "Xiaomi Mesh", icon: Wifi },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/vpn-status", label: "VPN Status", icon: Shield },
   { href: "/nat", label: "NAT", icon: ArrowRightLeft },


### PR DESCRIPTION
## Summary
- Add a new `/xiaomi` page displaying the Xiaomi mesh network topology from the `topo_graph` API
- Each mesh node shown as a card with name (locale), IP, online device count, hardware/model info, and connected client devices (leafs)
- Summary stats bar showing total mesh nodes, online devices, and connected clients
- Auto-refresh polling every 30 seconds with manual refresh button
- Sidebar navigation entry added next to the existing "Mesh" link

## Implementation notes
- Backend endpoint (`/api/v1/xiaomi/topology`), TypeScript types (`XiaomiTopoNode`, `XiaomiTopoLeaf`, `XiaomiTopology`), and API function (`fetchXiaomiTopology()`) already existed — this PR only adds the frontend page and sidebar nav entry
- Uses the existing Card, Badge, Button, Skeleton shadcn/ui components following the project's dark-theme slate color palette
- No new dependencies added

## Test plan
- [ ] Navigate to `/xiaomi` page and verify mesh nodes are displayed as cards
- [ ] Verify each card shows node name, IP, device count, and hardware info
- [ ] Verify connected devices (leafs) are listed under each node card
- [ ] Verify auto-refresh updates data every 30 seconds
- [ ] Verify manual refresh button works
- [ ] Verify sidebar shows "Xiaomi Mesh" link and navigates correctly
- [ ] Verify error state displays when Xiaomi integration is not configured

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `/xiaomi` page that renders Xiaomi mesh network topology as a responsive card grid, with summary stats, auto-refresh polling (30s), and a manual refresh button. A sidebar nav entry ("Xiaomi Mesh") is added next to the existing "Mesh" link. The page follows established project patterns (polling, `PageTransition`, `useMemo` for derived state) and reuses existing backend types and API function.

- **Duplicate React keys**: Both the node and leaf lists use `mac || ip` as React keys, but all identifier fields are nullable — if both are null, keys become `undefined` causing potential rendering bugs
- **Dead code**: `leafCountForNode` helper and two lucide-react imports (`Cable`, `Loader2`) are unused

<h3>Confidence Score: 3/5</h3>

- Low-risk frontend-only addition with minor issues that should be cleaned up before merge
- The PR is a self-contained frontend page with no backend changes. The duplicate React key issue could cause incorrect rendering when nodes or leafs have null identifiers, and there is unused code that should be cleaned up. No security or data-integrity concerns.
- web/src/app/(app)/xiaomi/page.tsx — duplicate React keys and dead code

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/xiaomi/page.tsx | New Xiaomi mesh topology page with card-based layout. Has unused imports (Cable, Loader2), dead code (leafCountForNode), and potentially duplicate React keys when node/leaf mac and ip are both null. |
| web/src/components/layout/Sidebar.tsx | Clean addition of "Xiaomi Mesh" nav entry with Wifi icon, placed logically next to the existing Mesh link. No issues found. |

</details>



<sub>Last reviewed commit: 44e2f65</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->