### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 
@@ -414,8 +418,15 @@ mod tests {
 
     #[test]
     fn uptime_deserializes_from_number() {
-        let payload = serde_json::json!({ "uptime": 123 });
+        let payload = serde_json::json!({ "upTime": 123 });
         let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
         assert_eq!(parsed.uptime, Some("123".to_string()));
+    }
+
+    #[test]
+    fn uptime_deserializes_from_string() {
+        let payload = serde_json::json!({ "upTime": "849715.25" });
+        let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
+        assert_eq!(parsed.uptime, Some("849715.25".to_string()));
     }
 }


### PR DESCRIPTION
Closes #364

## Summary

- Add `rename = "upTime"` to the `UptimeResponse` serde attribute so the camelCase `upTime` field from the Xiaomi `/api/misystem/status` endpoint is correctly deserialized
- The frontend `formatUptime()` helper already converts seconds to human-readable format (e.g. "9d 14h 5m") — it was just never receiving the data due to the field name mismatch
- Updated existing test and added a new test for string-valued uptime (e.g. `"849715.25"`)

## What was wrong

The Xiaomi router API returns `upTime` (camelCase) but the Rust `UptimeResponse` struct had the field as `uptime` (lowercase). Since serde matches field names exactly by default, the deserialization always resulted in `None`, causing the UI to display "—".

## Test plan

- [x] `cargo fmt --all` passes
- [x] Existing `uptime_deserializes_from_number` test updated to use correct `upTime` key
- [x] New `uptime_deserializes_from_string` test added for `"849715.25"` format
- [x] CI should verify the full build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed uptime display on Xiaomi router page by adding serde `rename = "upTime"` attribute to match the camelCase field name returned by the `/api/misystem/status` endpoint. Previously, the field name mismatch caused deserialization to always return `None`, displaying "—" in the UI. The frontend `formatUptime()` helper was already implemented correctly; it just never received the data.

- Added `rename = "upTime"` to `UptimeResponse` struct in `server/src/xiaomi/types.rs:377`
- Updated existing test `uptime_deserializes_from_number` to use correct `upTime` key
- Added new test `uptime_deserializes_from_string` to handle string-valued uptime responses (e.g. `"849715.25"`)
- Change follows existing pattern used throughout the file for other camelCase fields (`parentId`, `wanType`, `needUpdate`, etc.)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-tested, and follows established patterns in the codebase. It fixes a clear bug (field name mismatch) with a standard serde solution. Both the existing test was updated and a new test was added to cover string-valued uptime. The change only affects deserialization of one field and cannot introduce breaking changes or runtime errors.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` to deserialize camelCase field correctly; updated tests to match API format |

</details>



<sub>Last reviewed commit: 79b2a91</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->