### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Fix `UptimeResponse` serde deserialization to match the actual `upTime` (camelCase) field name returned by the MiWiFi `misystem/status` API endpoint
- The existing `formatUptime()` function in the frontend already correctly parses seconds into human-readable format (e.g. "9d 14h 5m") — the issue was that the backend was silently returning `null` because the JSON field name didn't match

## What changed
- `server/src/xiaomi/types.rs`: Added `rename = "upTime"` to the serde attribute on `UptimeResponse.uptime` field

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes uptime field deserialization by adding `rename = "upTime"` serde attribute to match the Xiaomi MiWiFi API's camelCase field name. The backend was silently returning `null` because the Rust struct expected `uptime` but the API returns `upTime`.

- Fixed `UptimeResponse` struct in `server/src/xiaomi/types.rs` by adding `rename = "upTime"` to serde attributes
- The test case needs updating to use `"upTime"` instead of `"uptime"` to properly validate the fix

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one test fix needed
- The serde rename fix is correct and solves the deserialization issue, but the test doesn't validate the actual camelCase field name that was fixed
- The test in `server/src/xiaomi/types.rs` should use `"upTime"` instead of `"uptime"`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added serde rename attribute to fix uptime field deserialization, but test doesn't validate the camelCase fix |

</details>



<sub>Last reviewed commit: 2215abc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->