### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- The Xiaomi `/api/misystem/status` endpoint returns uptime as `upTime` (camelCase), but the `UptimeResponse` serde struct was looking for `uptime` (lowercase). Added `#[serde(rename = "upTime")]` so the field deserializes correctly.
- The frontend `formatUptime()` function already handles seconds-to-human-readable conversion (e.g. "849715.25" → "9d 14h 5m") — it just wasn't receiving data due to the field name mismatch.

## Test plan
- [ ] Verify Xiaomi router status page shows human-readable uptime instead of "—"
- [ ] Confirm other status fields (CPU, memory, temperature) still display correctly

Closes #364

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `#[serde(rename = "upTime")]` to the `UptimeResponse` struct to correctly deserialize the uptime field from the Xiaomi API, which returns camelCase `upTime` instead of lowercase `uptime`.

- Fixed deserialization mismatch causing uptime to always be `None`
- The frontend `formatUptime()` function already handles the conversion to human-readable format
- One test needs updating to use the correct field name `"upTime"` instead of `"uptime"`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Simple serde attribute fix that correctly aligns with the actual API response format. The change is minimal, well-explained, and addresses a clear bug. One test needs a small update to match the corrected field name.
- Fix the test in `server/src/xiaomi/types.rs` to use `"upTime"` instead of `"uptime"`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added serde rename to match Xiaomi API camelCase field; test needs update to use `"upTime"` |

</details>



<sub>Last reviewed commit: 8ba5c33</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->