### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Add `rename = "upTime"` serde attribute to `UptimeResponse.uptime` field so the camelCase `upTime` key from the Xiaomi `/api/misystem/status` API is correctly deserialized
- The frontend `formatUptime()` function and UI display were already implemented — the issue was purely that the backend silently dropped the value due to field name mismatch

## What was wrong
The Xiaomi API returns `{"upTime": "849715.25", ...}` but the Rust `UptimeResponse` struct had `pub uptime: Option<String>` without a `#[serde(rename = "upTime")]` attribute. Since `#[serde(default)]` was set, the field silently defaulted to `None`, causing the UI to show "—".

## Test plan
- [ ] Verify uptime displays as human-readable duration (e.g. "9d 14h 5m") on the Xiaomi router page
- [ ] Verify other Xiaomi status fields (CPU, memory, temperature) still display correctly

Closes #364

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a deserialization issue where the Xiaomi API's camelCase `upTime` field wasn't being mapped to the Rust struct's `uptime` field. The fix correctly adds `#[serde(rename = "upTime")]` to match the API response format, following the existing pattern used throughout the file for other camelCase fields like `parentId`, `wanType`, etc.

**Issues found:**
- The test at line 421 uses lowercase `uptime` in the test payload instead of camelCase `upTime`, so it's not actually testing the real-world scenario where the API returns `{"upTime": "849715.25"}`. The test will pass but doesn't validate the `rename` attribute works correctly.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor test issue that should be fixed
- The core fix is correct and follows established patterns in the codebase. The serde rename attribute properly maps the API's camelCase field to the Rust field. However, the test doesn't actually validate the rename attribute since it uses the wrong field name, which reduces confidence slightly.
- Fix the test in `server/src/xiaomi/types.rs` to use `upTime` instead of `uptime`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` to fix deserialization, but test uses wrong field name |

</details>



<sub>Last reviewed commit: 202f765</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->