### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 
@@ -414,7 +418,7 @@ mod tests {
 
     #[test]
     fn uptime_deserializes_from_number() {
-        let payload = serde_json::json!({ "uptime": 123 });
+        let payload = serde_json::json!({ "upTime": 123 });
         let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
         assert_eq!(parsed.uptime, Some("123".to_string()));
     }


### PR DESCRIPTION
Closes #364

## Summary
- Added `#[serde(rename = "upTime")]` to `UptimeResponse.uptime` in `server/src/xiaomi/types.rs` so the camelCase `upTime` field from the Xiaomi MiWiFi `/api/misystem/status` endpoint is correctly mapped
- The frontend already had a `formatUptime()` helper that converts seconds to human-readable format (e.g. "9d 14h 5m") — it was just never receiving the data due to the field name mismatch
- Updated existing test to use the correct `upTime` field name

## What was wrong
The Xiaomi router returns `upTime` (capital T) in its JSON response, but the `UptimeResponse` serde struct expected lowercase `uptime`. With `#[serde(default)]`, the missing field silently defaulted to `None`, causing the UI to show "—".

## Test plan
- [ ] Verify `cargo test` passes (uptime deserialization test updated to use `"upTime"` key)
- [ ] Confirm Xiaomi router page shows uptime like "9d 14h 5m" instead of "—"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the `UptimeResponse` struct to correctly deserialize the `upTime` field from the Xiaomi MiWiFi API by adding `#[serde(rename = "upTime")]` attribute. The API returns camelCase `upTime` but the struct was expecting lowercase `uptime`, causing the field to silently default to `None` and display "—" in the UI instead of the actual uptime value.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a straightforward deserialization fix that adds the correct field name mapping. The change is minimal, well-tested, and follows existing patterns in the codebase (similar `rename` attributes exist for other camelCase API fields). The test was updated to match the correct field name.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` to fix field name mismatch with Xiaomi API response, and updated test to use correct field name |

</details>



<sub>Last reviewed commit: 1488d81</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->