### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -372,7 +372,11 @@ pub struct RomUpdateInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UptimeResponse {
-    #[serde(default, deserialize_with = "de_opt_string_from_any")]
+    #[serde(
+        default,
+        rename = "upTime",
+        deserialize_with = "de_opt_string_from_any"
+    )]
     pub uptime: Option<String>,
 }
 
@@ -414,7 +418,7 @@ mod tests {
 
     #[test]
     fn uptime_deserializes_from_number() {
-        let payload = serde_json::json!({ "uptime": 123 });
+        let payload = serde_json::json!({ "upTime": 123 });
         let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
         assert_eq!(parsed.uptime, Some("123".to_string()));
     }


### PR DESCRIPTION
## Summary

- Fixed `UptimeResponse` serde deserialization to use `rename = "upTime"` matching the actual Xiaomi API field name
- The `/api/misystem/status` endpoint returns `upTime` (camelCase), but the Rust struct was looking for `uptime` (lowercase), causing it to always deserialize as `None`
- Updated the existing test to use the correct `"upTime"` JSON key
- The frontend already had `formatUptime()` and UI rendering in place — just wasn't receiving data

## Details

One-line fix in `server/src/xiaomi/types.rs`: added `rename = "upTime"` to the serde attribute on `UptimeResponse.uptime`. This allows the field to be correctly deserialized from the Xiaomi API response, enabling the frontend to display human-readable uptime (e.g. "9d 14h 5m") instead of "—".

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo check -p panoptikon-server` passes (pre-existing `WebOut` errors are unrelated)
- [x] `cargo test` for `xiaomi::types` module passes (both existing tests)
- [ ] CI pipeline validates

Closes #364

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes uptime display on Xiaomi router page by correcting the serde field name mapping from `uptime` to `"upTime"` to match the actual Xiaomi API response format. The Xiaomi `/api/misystem/status` endpoint returns camelCase `upTime`, but the Rust struct was looking for lowercase `uptime`, causing deserialization to always fail and return `None`.

- Added `rename = "upTime"` to `UptimeResponse.uptime` serde attribute
- Updated test to use correct `"upTime"` JSON key
- Follows existing pattern used throughout the file for other camelCase API fields (`parentId`, `wanType`, `needUpdate`, etc.)
- Frontend already had formatting and UI rendering in place

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a precise one-line serde attribute fix with a corresponding test update. It follows the established pattern used throughout the codebase for camelCase field mapping (12+ other fields use the same approach). The fix is well-isolated, doesn't affect any business logic, and the test validates the deserialization behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` to fix deserialization from Xiaomi API camelCase field |

</details>



<sub>Last reviewed commit: 605ba8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->