### PR TITLE
feat: show uptime on Xiaomi router page (#364)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn uptime_deserializes_from_number() {
-        let payload = serde_json::json!({ "uptime": 123 });
+        let payload = serde_json::json!({ "upTime": 123 });
         let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
         assert_eq!(parsed.uptime, Some("123".to_string()));
     }


### PR DESCRIPTION
Closes #364

## Summary
- Added `#[serde(rename = "upTime")]` to the `UptimeResponse` struct in `server/src/xiaomi/types.rs`
- The Xiaomi `/api/misystem/status` endpoint returns the uptime field as `upTime` (camelCase), but the Rust struct field was named `uptime` (lowercase)
- Since the field had `#[serde(default)]`, the mismatch silently deserialized to `None`, causing the frontend to always display "—" for uptime
- The frontend already had proper `formatUptime()` logic to convert seconds to human-readable format (e.g. "9d 14h 5m") — it just never received the data

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo check` passes
- [x] All 298 unit tests + 18 integration tests pass
- [ ] Verify on a live Xiaomi router that uptime displays correctly (e.g. "9d 14h 5m" instead of "—")

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed uptime deserialization for Xiaomi routers by adding the correct field name mapping. The Xiaomi API returns `upTime` in camelCase, but the struct was looking for lowercase `uptime`, causing silent failures with `#[serde(default)]`.

- Correctly mapped the API field name using `#[serde(rename = "upTime")]`
- Updated the test to use the correct field name
- The frontend `formatUptime()` function was already implemented and ready to display uptime (e.g., "9d 14h 5m")
- Consistent with other Xiaomi API fields that already use camelCase renaming (`parentId`, `wanType`, `needUpdate`, etc.)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple, well-tested field name mapping fix that addresses a clear deserialization issue. The test was updated to match the correct API field name, and the change is consistent with existing patterns in the codebase for handling Xiaomi's camelCase API responses
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `rename = "upTime"` serde attribute to match Xiaomi API's camelCase field naming, fixing silent deserialization failure that caused uptime to always be `None` |

</details>



<sub>Last reviewed commit: fff7b74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->