### PR TITLE
feat: Redmi/Xiaomi router tab — review and fix current state (#379)

### DIFF
--- a/server/src/api/xiaomi_mesh.rs
+++ b/server/src/api/xiaomi_mesh.rs
@@ -96,8 +96,10 @@ pub async fn test_connection(
                     })
                 }
                 Err(_) => Json(XiaomiMeshTestConnectionResponse {
-                    success: true,
-                    message: format!("Connected to {ip} but could not parse router info response."),
+                    success: false,
+                    message: format!(
+                        "Connected to {ip} but response is not valid Xiaomi router JSON."
+                    ),
                     router_model: None,
                     hardware: None,
                     firmware: None,


### PR DESCRIPTION
Closes #379

## Summary

Comprehensive review of the Xiaomi/Redmi router integration in Panoptikon. The integration is **substantially complete and functional** — all major features are implemented, not placeholder.

### Trivial Fix Included
- **Bug fix**: `POST /api/v1/xiaomi-mesh/test-connection` was returning `success: true` when the HTTP response body could not be parsed as JSON. Now correctly returns `success: false` with a clear error message.

## Review Findings

### What's Working (All Functional)

| Component | Status | Details |
|-----------|--------|---------|
| **SHA256 Auth (newEncryptMode=1)** | Working | Correct auth flow: extract key/deviceId from HTML → build nonce → SHA256(nonce + SHA256(password + key)) → POST login → get stok token |
| **Token Management** | Working | 30-min cache with auto-refresh, thread-safe via `Arc<RwLock>`, automatic retry on 401/403 |
| **System Status** | Working | CPU cores/freq/load, RAM usage/total/type, temperature, WAN speeds, device counts, uptime |
| **WAN Info** | Working | IP, gateway, DNS, subnet mask, WAN type (DHCP/Static), IPv6 status |
| **WiFi Bands** | Working | Per-band SSID, channel, bandwidth, encryption, signal, band steering |
| **Firmware Info** | Working | Version, hardware model, router name, language, country code, update check |
| **Mesh Topology** | Working | Node cards, connected devices, polling every 30s, manual refresh |
| **Settings Page** | Working | Enable/disable toggle, IP input with validation, password (saved indicator), poll interval (10-300s) |
| **Save Button** | Working | Dirty-state tracking, validates all fields before save, success/error messages |
| **Test Connection** | Working | Tests unauthenticated `init_info` endpoint, shows model/hardware/firmware on success |
| **Router Selector** | Working | Shows MikroTik/Xiaomi/VyOS buttons when 2+ routers configured |

### Backend Endpoints (9 GET + 1 POST)

All registered in `api/mod.rs` and fully implemented:
- `GET /xiaomi/status` — System health (CPU, RAM, temp, speeds)
- `GET /xiaomi/topology` — Mesh topology graph (no auth)
- `GET /xiaomi/devices` — All connected devices
- `GET /xiaomi/new-status` — Hardware info
- `GET /xiaomi/wifi-devices` — WiFi clients with signal/band
- `GET /xiaomi/wan-info` — WAN details + IPv6
- `GET /xiaomi/lan-info` — LAN IP, subnet, port status
- `GET /xiaomi/wifi-bands` — Per-band WiFi config
- `GET /xiaomi/firmware` — Firmware + update check
- `POST /xiaomi-mesh/test-connection` — Connectivity test

### Frontend Pages (All Functional)

- `/router/xiaomi` — Router detail page with full status dashboard
- `/xiaomi` — Mesh topology visualization with 30s polling
- `/settings/xiaomi-mesh` — Settings with validation, save, test connection

### Issues for Follow-up (Not Trivial — Separate Issues)

1. **Weak nonce randomness** (`client.rs:103`): Uses `timestamp XOR constant` instead of cryptographic random. Low risk on LAN but should use `rand::thread_rng()`.
2. **Plaintext password storage** (`settings.rs:397`): Router password stored unencrypted in SQLite. Acceptable for single-user self-hosted (consistent with VyOS/MikroTik pattern + documented TODO), but should be encrypted at rest long-term.
3. **Fragile JS variable extraction** (`client.rs:395-423`): HTML string matching for `key`/`deviceId` could break on firmware updates. Works with current firmware 1.0.87.
4. **Backend not rebuilt on production** (`.22`): The deployed backend at net.oklabs.uk hasn't been rebuilt after commit `ea80848`. Frontend is deployed but backend needs rebuild to pick up latest fixes.

## Smoke Test

- `cargo check` passes clean
- `cargo fmt --all` — no formatting changes needed
- `cargo test --lib xiaomi` — all 6 tests pass:
  - `extract_key_from_html` ✓
  - `extract_device_id_from_html` ✓
  - `hash_password_produces_correct_sha256` ✓
  - `nonce_format` ✓
  - `system_status_deserializes_mixed_scalar_types` ✓
  - `uptime_deserializes_from_number` ✓
- `bun run build` (web) — builds successfully with all Xiaomi pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a single targeted bug fix in `server/src/api/xiaomi_mesh.rs`: the `POST /api/v1/xiaomi-mesh/test-connection` handler was incorrectly returning `success: true` when the HTTP response could be retrieved but its body failed to parse as valid JSON. The fix correctly returns `success: false` with a clearer error message in that case, making the response semantically consistent with the rest of the handler's error paths.

- **Bug fix** (`xiaomi_mesh.rs:98-99`): Changed `success: true` → `success: false` and improved the error message to `"Connected to {ip} but response is not valid Xiaomi router JSON."` on JSON parse failure.
- The rest of the handler (non-success HTTP status, network error) was already returning `success: false` correctly — this aligns the JSON-parse-failure branch with those.
- No regressions or side effects; the happy path (`Ok(json)` branch) is unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, clearly correct one-line bug fix with no risk of regression.
- The change is a single boolean value correction (`true` → `false`) in one error branch of one function, accompanied by a minor message improvement. All other code paths are unchanged. The fix matches the obvious intended behavior and is consistent with the other error branches in the same match expression.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi_mesh.rs | Bug fix: corrects `success: true` to `success: false` when JSON parsing fails in `test_connection`. The fix is minimal, targeted, and correct — no new issues introduced. |

</details>



<sub>Last reviewed commit: 19016ee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->