### PR TITLE
fix: navigation UX — Xiaomi in Router selector, collapse Mesh/Xiaomi Mesh sidebar items (#378)

### DIFF
--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -16,17 +16,13 @@ interface RouterSelectorProps {
 
 export function RouterSelector({ active }: RouterSelectorProps) {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
-  const [mikrotikEnabled, setMikrotikEnabled] = useState(false);
   const [vyosConfigured, setVyosConfigured] = useState(false);
-  const [xiaomiEnabled, setXiaomiEnabled] = useState(false);
 
   useEffect(() => {
     const loadSettings = async () => {
       try {
         const settings = await fetchSettings();
-        setMikrotikEnabled(settings.mikrotik_enabled);
         setVyosConfigured(!!settings.vyos_url && settings.vyos_api_key_set);
-        setXiaomiEnabled(settings.xiaomi_mesh_enabled);
       } catch {
         // ignore
       }
@@ -39,46 +35,39 @@ export function RouterSelector({ active }: RouterSelectorProps) {
     return <Skeleton className="h-9 w-48" />;
   }
 
-  const count = [mikrotikEnabled, xiaomiEnabled, vyosConfigured].filter(Boolean).length;
-  if (count <= 1) return null;
-
   return (
     <div className="space-y-3">
       <div className="flex gap-2">
-        {mikrotikEnabled && (
-          <Button
-            variant={active === "mikrotik" ? "default" : "outline"}
-            size="sm"
-            asChild
-            className={
-              active === "mikrotik"
-                ? "bg-pink-600 text-white hover:bg-pink-500"
-                : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-            }
-          >
-            <Link href="/router/mikrotik">
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              MikroTik
-            </Link>
-          </Button>
-        )}
-        {xiaomiEnabled && (
-          <Button
-            variant={active === "xiaomi" ? "default" : "outline"}
-            size="sm"
-            asChild
-            className={
-              active === "xiaomi"
-                ? "bg-orange-600 text-white hover:bg-orange-500"
-                : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-            }
-          >
-            <Link href="/router/xiaomi">
-              <Router className="mr-1.5 h-3.5 w-3.5" />
-              Xiaomi
-            </Link>
-          </Button>
-        )}
+        <Button
+          variant={active === "mikrotik" ? "default" : "outline"}
+          size="sm"
+          asChild
+          className={
+            active === "mikrotik"
+              ? "bg-pink-600 text-white hover:bg-pink-500"
+              : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+          }
+        >
+          <Link href="/router/mikrotik">
+            <Router className="mr-1.5 h-3.5 w-3.5" />
+            MikroTik
+          </Link>
+        </Button>
+        <Button
+          variant={active === "xiaomi" ? "default" : "outline"}
+          size="sm"
+          asChild
+          className={
+            active === "xiaomi"
+              ? "bg-orange-600 text-white hover:bg-orange-500"
+              : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+          }
+        >
+          <Link href="/router/xiaomi">
+            <Router className="mr-1.5 h-3.5 w-3.5" />
+            Xiaomi
+          </Link>
+        </Button>
         {vyosConfigured && (
           <Button
             variant={active === "vyos" ? "default" : "outline"}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Settings,
   Share2,
   Shield,
-  Wifi,
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -46,7 +45,6 @@ const navItems = [
   { href: "/services", label: "Services", icon: Workflow },
   { href: "/topology", label: "Topology", icon: Network },
   { href: "/mesh", label: "Mesh", icon: Share2 },
-  { href: "/xiaomi", label: "Xiaomi Mesh", icon: Wifi },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/vpn-status", label: "VPN Status", icon: Shield },
   { href: "/nat", label: "NAT", icon: ArrowRightLeft },


### PR DESCRIPTION
Closes #378

## Summary
- **RouterSelector**: MikroTik and Xiaomi tabs now always render (not gated on integration enabled state). Each router page already handles the "not configured" state with a config card. VyOS tab remains conditional (legacy).
- **Sidebar**: Removed redundant "Xiaomi Mesh" entry. A single "Mesh" item links to the mesh topology page (which shows Xiaomi by default, others in the future).

## Changes
- `web/src/components/RouterSelector.tsx` — Removed `mikrotikEnabled`/`xiaomiEnabled` state and the `count <= 1` guard. MikroTik and Xiaomi buttons always render; only VyOS remains conditional on settings.
- `web/src/components/layout/Sidebar.tsx` — Removed `{ href: "/xiaomi", label: "Xiaomi Mesh" }` nav item and unused `Wifi` icon import.

## Smoke Test
- `next build` passes cleanly
- All 19 unit tests pass (`vitest run`)
- Verified RouterSelector always renders both MikroTik and Xiaomi tabs in the built output
- Verified sidebar no longer contains "Xiaomi Mesh" entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves navigation UX by making MikroTik and Xiaomi router tabs always visible in `RouterSelector` (instead of being gated on integration-enabled state) and consolidating the sidebar's two mesh-related entries down to one "Mesh" link.

The changes are clean and the intent is clear. Two minor follow-up items worth addressing:

- **Orphaned `/xiaomi` page**: `web/src/app/(app)/xiaomi/page.tsx` still exists and is served, but is now unreachable via the UI (no sidebar link, no internal links). Since `/mesh` is the intended canonical view, the old page should either be deleted or redirected.
- **Skeleton blocks always-visible buttons**: The `settingsLoaded` skeleton guard in `RouterSelector` now delays rendering MikroTik and Xiaomi tabs (which are unconditionally shown) while waiting for the settings API call that is only needed to determine VyOS visibility. This causes a brief unnecessary flash on every router page.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — no logic errors or regressions; two minor cleanup items (orphaned page, unnecessary skeleton delay) can be addressed in follow-up.
- The changes are straightforward and the router pages correctly handle the "not configured" state. The only concerns are a style-level skeleton UX regression and an orphaned page that should be cleaned up, neither of which blocks merging.
- No files require critical attention; `web/src/app/(app)/xiaomi/page.tsx` (not in this diff) should be considered for deletion or redirect in a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/RouterSelector.tsx | Removed `mikrotikEnabled`/`xiaomiEnabled` state and the `count <= 1` guard so that MikroTik and Xiaomi tabs always render. Only VyOS remains conditional. The `settingsLoaded` skeleton gate now only serves the VyOS check but still blocks rendering of the always-visible MikroTik/Xiaomi buttons. |
| web/src/components/layout/Sidebar.tsx | Removed the `{ href: "/xiaomi", label: "Xiaomi Mesh" }` nav item and unused `Wifi` import cleanly. The `/xiaomi` route/page still exists in the codebase but is now unlinked from the sidebar. |

</details>



<sub>Last reviewed commit: a0ed2f5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->