### PR TITLE
fix: navigation UX — Xiaomi in Router selector, collapse Mesh/Xiaomi Mesh sidebar items (#378)

### DIFF
--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -40,7 +40,7 @@ export function RouterSelector({ active }: RouterSelectorProps) {
   }
 
   const count = [mikrotikEnabled, xiaomiEnabled, vyosConfigured].filter(Boolean).length;
-  if (count <= 1) return null;
+  if (count === 0) return null;
 
   return (
     <div className="space-y-3">

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Settings,
   Share2,
   Shield,
-  Wifi,
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -46,7 +45,6 @@ const navItems = [
   { href: "/services", label: "Services", icon: Workflow },
   { href: "/topology", label: "Topology", icon: Network },
   { href: "/mesh", label: "Mesh", icon: Share2 },
-  { href: "/xiaomi", label: "Xiaomi Mesh", icon: Wifi },
   { href: "/traffic", label: "Traffic", icon: Activity },
   { href: "/vpn-status", label: "VPN Status", icon: Shield },
   { href: "/nat", label: "NAT", icon: ArrowRightLeft },


### PR DESCRIPTION
Closes #378

## Summary
- **RouterSelector**: Changed guard from `count <= 1` to `count === 0` so tabs always render when at least one router is enabled. Previously the selector was hidden when only one router was configured, making Xiaomi unreachable after the `/router/` → MikroTik redirect.
- **Sidebar**: Removed redundant "Xiaomi Mesh" (`/xiaomi`) nav entry, keeping the single "Mesh" (`/mesh`) link that points to the mesh topology page.

## Smoke Test
- Verified `RouterSelector.tsx` now returns `null` only when zero routers are enabled (`count === 0`), so when both MikroTik and Xiaomi are enabled, tabs for both appear
- Verified `Sidebar.tsx` no longer has a "Xiaomi Mesh" entry — only "Mesh" remains
- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Removed unused `Wifi` import from Sidebar to keep imports clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes navigation UX issues related to accessing the Xiaomi router when it's the only configured router.

**Changes:**
- **`RouterSelector.tsx`**: Changed visibility condition from `count <= 1` to `count === 0`, ensuring the router selector tabs appear when at least one router is enabled. Previously, the selector was hidden when only one router was configured, which caused Xiaomi to be unreachable after the `/router/` redirect (which defaults to MikroTik).
- **`Sidebar.tsx`**: Removed the redundant "Xiaomi Mesh" navigation entry (`/xiaomi`), keeping only the single "Mesh" link (`/mesh`) for mesh topology. Also cleaned up the unused `Wifi` import.

The logic changes are sound and directly address the issue described. The code is clean with no syntax errors or logical flaws.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Both changes are minimal, focused, and directly address the described navigation issues. The RouterSelector logic fix is a straightforward conditional change that correctly handles the edge case. The Sidebar changes are simple removals that simplify navigation. No breaking changes, security issues, or logical errors detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/RouterSelector.tsx | Fixed selector visibility logic — now shows tabs when at least 1 router is enabled instead of requiring 2+ |
| web/src/components/layout/Sidebar.tsx | Removed redundant "Xiaomi Mesh" nav entry and cleaned up unused `Wifi` import |

</details>



<sub>Last reviewed commit: 96f033c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->