### PR TITLE
feat: static mapping (#380)

### DIFF
--- a/server/src/api/mikrotik.rs
+++ b/server/src/api/mikrotik.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use super::{audit, AppState};
 use crate::mikrotik::client::MikrotikClient;
 use crate::mikrotik::types::{
-    FirewallAddressListWriteRequest, FirewallFilterWriteRequest, FirewallNatWriteRequest,
-    VlanWriteRequest,
+    DhcpLeaseWriteRequest, FirewallAddressListWriteRequest, FirewallFilterWriteRequest,
+    FirewallNatWriteRequest, VlanWriteRequest,
 };
 
 // ── Helper: build a MikroTik client from DB settings ───────
@@ -227,6 +227,14 @@ pub struct MikrotikToggleRequest {
 pub struct MikrotikAddressListRequest {
     pub list: String,
     pub address: String,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikDhcpStaticMappingRequest {
+    pub address: String,
+    pub mac_address: String,
+    pub server: Option<String>,
     pub comment: Option<String>,
 }
 
@@ -673,6 +681,64 @@ pub async fn dhcp_leases(
         state.mikrotik_cache.set("dhcp-leases".into(), val);
     }
     Ok(Json(result))
+}
+
+/// POST /api/v1/mikrotik/dhcp-leases/static
+///
+/// Create a static DHCP mapping (reservation) from a dynamic lease's IP and MAC.
+pub async fn create_dhcp_static_mapping(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikDhcpStaticMappingRequest>,
+) -> Result<StatusCode, StatusCode> {
+    if body.address.trim().is_empty() || body.mac_address.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let req = DhcpLeaseWriteRequest {
+        address: body.address.trim().to_string(),
+        mac_address: body.mac_address.trim().to_string(),
+        server: body.server.as_deref().map(|s| s.trim().to_string()),
+        comment: body.comment.clone(),
+    };
+
+    let desc = format!(
+        "Create static DHCP mapping: {} -> {}",
+        body.address, body.mac_address
+    );
+    let cmds = vec![format!(
+        "POST /ip/dhcp-server/lease address={} mac-address={}",
+        body.address, body.mac_address
+    )];
+
+    match client.create_dhcp_lease(&req).await {
+        Ok(()) => {
+            audit::log_success(
+                &state.db,
+                "mikrotik_dhcp_static_mapping_create",
+                &desc,
+                &cmds,
+            )
+            .await;
+            Ok(StatusCode::NO_CONTENT)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            audit::log_failure(
+                &state.db,
+                "mikrotik_dhcp_static_mapping_create",
+                &desc,
+                &cmds,
+                &msg,
+            )
+            .await;
+            tracing::error!("MikroTik DHCP static mapping create error: {e}");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
 }
 
 /// GET /api/v1/mikrotik/firewall

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -470,6 +470,10 @@ pub fn router(state: AppState) -> Router {
         .route("/mikrotik/vlans/:id", delete(mikrotik::delete_vlan))
         .route("/mikrotik/routes", get(mikrotik::routes))
         .route("/mikrotik/dhcp-leases", get(mikrotik::dhcp_leases))
+        .route(
+            "/mikrotik/dhcp-leases/static",
+            post(mikrotik::create_dhcp_static_mapping),
+        )
         .route("/mikrotik/firewall", get(mikrotik::firewall))
         .route(
             "/mikrotik/firewall/filter",

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -304,6 +304,12 @@ impl MikrotikClient {
         Ok(res)
     }
 
+    /// Create a static DHCP lease (reservation).
+    pub async fn create_dhcp_lease(&self, req: &DhcpLeaseWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/ip/dhcp-server/lease", req)
+            .await
+    }
+
     /// Fetch firewall filter rules.
     pub async fn firewall_filter(&self) -> Result<Vec<FirewallFilter>> {
         let val = self.get("/ip/firewall/filter").await?;

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -127,6 +127,18 @@ pub struct DhcpLease {
     pub comment: Option<String>,
 }
 
+/// MikroTik DHCP static lease write payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct DhcpLeaseWriteRequest {
+    pub address: String,
+    #[serde(rename = "mac-address")]
+    pub mac_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
 /// MikroTik firewall filter rule (`/rest/ip/firewall/filter`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FirewallFilter {

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -23,6 +23,7 @@ import {
   BarChart3,
   Power,
   List,
+  Pin,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -82,6 +83,7 @@ import {
   toggleMikrotikFirewallNat,
   createMikrotikAddressList,
   deleteMikrotikAddressList,
+  createMikrotikDhcpStaticMapping,
   fetchTrafficHistory,
 } from "@/lib/api";
 import { formatBps } from "@/lib/format";
@@ -917,11 +919,38 @@ function DhcpLeasesTable({
   data,
   loading,
   error,
+  reload,
 }: {
   data: MikrotikDhcpLease[] | null;
   loading: boolean;
   error: string | null;
+  reload: () => void;
 }) {
+  const [reserving, setReserving] = useState<string | null>(null);
+
+  const handleReserve = async (lease: MikrotikDhcpLease) => {
+    if (!lease.mac_address) return;
+    const key = `${lease.address}-${lease.mac_address}`;
+    setReserving(key);
+    try {
+      await createMikrotikDhcpStaticMapping({
+        address: lease.address,
+        mac_address: lease.mac_address,
+        server: lease.server ?? undefined,
+        comment: `Reserved via Panoptikon`,
+      });
+      toast.success(
+        `Static mapping created for ${lease.address} (${lease.mac_address})`
+      );
+      reload();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to create static mapping: ${msg}`);
+    } finally {
+      setReserving(null);
+    }
+  };
+
   const headerCols = (
     <tr className="border-b border-slate-800 bg-slate-950 text-left">
       <th className="px-4 py-3 font-medium text-slate-400">IP Address</th>
@@ -930,6 +959,7 @@ function DhcpLeasesTable({
       <th className="px-4 py-3 font-medium text-slate-400">Server</th>
       <th className="px-4 py-3 font-medium text-slate-400">Expires</th>
       <th className="px-4 py-3 font-medium text-slate-400">State</th>
+      <th className="px-4 py-3 font-medium text-slate-400 w-20" />
     </tr>
   );
 
@@ -947,6 +977,7 @@ function DhcpLeasesTable({
                 <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
                 <td className="px-4 py-3"><Skeleton className="h-3 w-28" /></td>
                 <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-7 w-7 rounded" /></td>
               </tr>
             ))}
           </tbody>
@@ -977,50 +1008,76 @@ function DhcpLeasesTable({
       <table className="w-full text-sm">
         <thead>{headerCols}</thead>
         <tbody>
-          {data.map((lease, idx) => (
-            <tr
-              key={`${lease.address}-${idx}`}
-              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
-            >
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums font-medium text-white">
-                  {lease.address}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums text-xs text-slate-400">
-                  {lease.mac_address ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="text-slate-300">
-                  {lease.host_name ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="text-slate-300">
-                  {lease.server ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums text-xs text-slate-400">
-                  {lease.expires_after ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <Badge
-                  variant="outline"
-                  className={
-                    lease.status === "bound"
-                      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
-                      : "border-slate-700 text-slate-500 text-xs"
-                  }
-                >
-                  {lease.status ?? "\u2014"}
-                </Badge>
-              </td>
-            </tr>
-          ))}
+          {data.map((lease, idx) => {
+            const key = `${lease.address}-${lease.mac_address}`;
+            const isReserving = reserving === key;
+            return (
+              <tr
+                key={`${lease.address}-${idx}`}
+                className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+              >
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums font-medium text-white">
+                    {lease.address}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums text-xs text-slate-400">
+                    {lease.mac_address ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-slate-300">
+                    {lease.host_name ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-slate-300">
+                    {lease.server ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums text-xs text-slate-400">
+                    {lease.expires_after ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <Badge
+                    variant="outline"
+                    className={
+                      lease.status === "bound"
+                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                        : "border-slate-700 text-slate-500 text-xs"
+                    }
+                  >
+                    {lease.status ?? "\u2014"}
+                  </Badge>
+                </td>
+                <td className="px-4 py-3">
+                  {lease.dynamic && lease.mac_address && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-slate-400 hover:text-amber-400"
+                      title="Reserve — create static DHCP mapping"
+                      disabled={isReserving}
+                      onClick={() => handleReserve(lease)}
+                    >
+                      <Pin className={`h-3.5 w-3.5 ${isReserving ? "animate-pulse" : ""}`} />
+                    </Button>
+                  )}
+                  {!lease.dynamic && (
+                    <Badge
+                      variant="outline"
+                      className="border-amber-500/30 bg-amber-500/10 text-amber-400 text-xs"
+                    >
+                      static
+                    </Badge>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -2736,6 +2793,7 @@ export default function MikrotikRouter() {
                 data={dhcp.data}
                 loading={dhcp.loading}
                 error={dhcp.error}
+                reload={dhcp.reload}
               />
             </CardContent>
           </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,7 @@ import type {
   MikrotikVlanRequest,
   MikrotikRoute,
   MikrotikDhcpLease,
+  MikrotikDhcpStaticMappingRequest,
   MikrotikFirewall,
   MikrotikFirewallFilterRequest,
   MikrotikFirewallNatRequest,
@@ -1356,6 +1357,12 @@ export function fetchMikrotikRoutes(): Promise<MikrotikRoute[]> {
 
 export function fetchMikrotikDhcpLeases(): Promise<MikrotikDhcpLease[]> {
   return apiGet<MikrotikDhcpLease[]>("/api/v1/mikrotik/dhcp-leases");
+}
+
+export function createMikrotikDhcpStaticMapping(
+  body: MikrotikDhcpStaticMappingRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/dhcp-leases/static", body);
 }
 
 export function fetchMikrotikFirewall(): Promise<MikrotikFirewall> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1192,6 +1192,13 @@ export interface MikrotikDhcpLease {
   comment: string | null;
 }
 
+export interface MikrotikDhcpStaticMappingRequest {
+  address: string;
+  mac_address: string;
+  server?: string;
+  comment?: string;
+}
+
 export interface MikrotikFirewallRule {
   id: string | null;
   chain: string | null;


### PR DESCRIPTION
## Summary
- Add one-click "Reserve" (Pin) button next to each dynamic DHCP lease in the MikroTik DHCP tab
- Clicking it creates a static DHCP mapping via the MikroTik REST API using the lease's current IP and MAC address
- Static leases are visually distinguished with an amber "static" badge; dynamic leases show a Pin button
- Full audit logging for static mapping creation (success/failure)

## Changes
**Backend (Rust):**
- `server/src/mikrotik/types.rs` — new `DhcpLeaseWriteRequest` struct
- `server/src/mikrotik/client.rs` — new `create_dhcp_lease()` method (POST to `/ip/dhcp-server/lease`)
- `server/src/api/mikrotik.rs` — new `create_dhcp_static_mapping` handler with input validation and audit logging
- `server/src/api/mod.rs` — register `POST /mikrotik/dhcp-leases/static` route

**Frontend (TypeScript):**
- `web/src/lib/types.ts` — new `MikrotikDhcpStaticMappingRequest` interface
- `web/src/lib/api.ts` — new `createMikrotikDhcpStaticMapping()` API function
- `web/src/components/MikrotikRouter.tsx` — Pin button on dynamic leases, "static" badge on static leases, toast notifications, table auto-refresh after reservation

## Smoke Test
- `cargo check` passes cleanly
- `cargo fmt --all` produces no changes
- `cargo test` — all 301 unit tests + 18 integration tests pass
- Verified the new endpoint is registered and handler compiles correctly

Closes #380

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds one-click static DHCP reservation from the MikroTik lease list — clean implementation with proper audit logging and UI feedback.

**Key Changes:**
- Backend creates static DHCP mappings via MikroTik REST API with full audit trail
- Frontend shows Pin button on dynamic leases, "static" badge on existing static leases
- Input validation, error handling, and toast notifications work correctly

**Issues:**
- Backend cache not invalidated after creating reservation → UI shows stale data for up to 30 seconds until cache expires
- Frontend missing defensive check for IP address field (only validates MAC)

<h3>Confidence Score: 3/5</h3>

- Safe to merge but will have UX issue due to cache staleness
- Implementation is solid with proper error handling and audit logging, but the missing cache invalidation creates a noticeable UX issue where newly created static mappings won't appear immediately (up to 30s delay). Not a data corruption or security issue, but impacts user experience.
- `server/src/api/mikrotik.rs` — needs cache invalidation after successful creation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/mikrotik/client.rs | Added create_dhcp_lease method that posts to MikroTik REST API endpoint |
| server/src/api/mikrotik.rs | Added create_dhcp_static_mapping handler with validation and audit logging, but missing cache invalidation |
| web/src/components/MikrotikRouter.tsx | Added Pin button for dynamic leases and static badge, with handleReserve function and toast notifications. Minor: missing address validation |

</details>



<sub>Last reviewed commit: 0b64a7d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->