### PR TITLE
test: e2e Playwright tests for Settings save/load — MikroTik, Xiaomi, VyOS (#377)

### DIFF
--- a/web/tests/e2e/settings-router.spec.ts
+++ b/web/tests/e2e/settings-router.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Router Settings — MikroTik", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/settings/router/");
+    // MikroTik tab is active by default
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("default URL placeholder shows 10.10.0.125", async ({ page }) => {
+    await expect(page.locator("#mt-url")).toHaveAttribute(
+      "placeholder",
+      "http://10.10.0.125",
+    );
+  });
+
+  test("save and reload persists URL, user and password", async ({ page }) => {
+    const testUrl = "http://10.10.0.125";
+    const testUser = "e2e-admin";
+
+    await page.locator("#mt-url").fill(testUrl);
+    await page.locator("#mt-user").fill(testUser);
+    await page.locator("#mt-password").fill("e2e-pass-123");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("MikroTik settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+
+    await expect(page.locator("#mt-url")).toHaveValue(testUrl);
+    await expect(page.locator("#mt-user")).toHaveValue(testUser);
+    // Password is never returned; the "(saved)" badge confirms it was stored
+    await expect(
+      page.locator('label[for="mt-password"]'),
+    ).toContainText("(saved)");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-mikrotik-persisted.png",
+    });
+  });
+
+  test("toggle enabled persists after reload", async ({ page }) => {
+    const toggle = page.locator("#mt-enabled");
+    const before = await toggle.getAttribute("aria-checked");
+    const expected = before === "true" ? "false" : "true";
+
+    await toggle.click();
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("MikroTik settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(toggle).toBeVisible({ timeout: 15000 });
+    await expect(toggle).toHaveAttribute("aria-checked", expected);
+  });
+
+  test("Test Connection works with unsaved form values", async ({ page }) => {
+    // Fill URL without saving
+    await page.locator("#mt-url").fill("http://192.168.88.1");
+    await page.locator("#mt-user").fill("admin");
+
+    const testBtn = page.getByRole("button", { name: "Test Connection" });
+    await expect(testBtn).toBeEnabled();
+
+    await testBtn.click();
+
+    // Any response (success or error) means the button worked without prior save.
+    // "Router URL is required." would indicate unsaved values were ignored.
+    await expect(
+      page.getByText(/Connected|unreachable|Failed to test/),
+    ).toBeVisible({ timeout: 15000 });
+  });
+});
+
+test.describe("Router Settings — VyOS", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/settings/router/");
+    // Switch to VyOS tab
+    await page.getByRole("tab", { name: /VyOS/ }).click();
+    await expect(page.locator("#vyos-url")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("save and reload persists URL and API key", async ({ page }) => {
+    const testUrl = "https://10.10.0.50";
+
+    await page.locator("#vyos-url").fill(testUrl);
+    await page.locator("#vyos-key").fill("e2e-api-key-123");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("VyOS settings saved.")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.reload();
+    await page.getByRole("tab", { name: /VyOS/ }).click();
+    await expect(page.locator("#vyos-url")).toBeVisible({ timeout: 15000 });
+
+    await expect(page.locator("#vyos-url")).toHaveValue(testUrl);
+    await expect(
+      page.locator('label[for="vyos-key"]'),
+    ).toContainText("(saved)");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-vyos-persisted.png",
+    });
+  });
+});

--- a/web/tests/e2e/settings-xiaomi.spec.ts
+++ b/web/tests/e2e/settings-xiaomi.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Xiaomi Mesh Settings", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/settings/xiaomi-mesh/");
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("save default IP 10.10.0.199 persists after reload", async ({
+    page,
+  }) => {
+    // The default IP is pre-filled in the form
+    await expect(page.locator("#xiaomi-ip")).toHaveValue("10.10.0.199");
+
+    // Tweak poll interval to make the form dirty so Save is enabled
+    await page.locator("#xiaomi-poll-interval").fill("60");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Xiaomi Mesh settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+
+    // IP must be 10.10.0.199 — not empty or null
+    await expect(page.locator("#xiaomi-ip")).toHaveValue("10.10.0.199");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-xiaomi-default-ip.png",
+    });
+  });
+
+  test("save non-default IP 10.10.0.1 persists after reload", async ({
+    page,
+  }) => {
+    await page.locator("#xiaomi-ip").fill("10.10.0.1");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Xiaomi Mesh settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+
+    await expect(page.locator("#xiaomi-ip")).toHaveValue("10.10.0.1");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-xiaomi-custom-ip.png",
+    });
+  });
+
+  test("toggle enabled persists after reload", async ({ page }) => {
+    const toggle = page.locator("#xiaomi-enabled");
+
+    // Enable the integration
+    const currentState = await toggle.getAttribute("aria-checked");
+    if (currentState !== "true") {
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+    }
+
+    // Password is required when enabled
+    await page.locator("#xiaomi-password").fill("e2e-xiaomi-pass");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Xiaomi Mesh settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(toggle).toBeVisible({ timeout: 15000 });
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-xiaomi-enabled.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #377

## Summary
- Add e2e Playwright tests for settings pages save/load cycle to prevent regressions like #376
- Covers MikroTik, VyOS, and Xiaomi Mesh settings pages
- Tests verify that filled-and-saved values survive page reloads, toggle state persists, and Test Connection works with unsaved form values

## Tests added

### `settings-router.spec.ts` (MikroTik + VyOS)
- **MikroTik**: default URL placeholder, save/reload URL+user+password, toggle enabled persistence, Test Connection with unsaved values
- **VyOS**: save/reload URL + API key

### `settings-xiaomi.spec.ts` (Xiaomi Mesh)
- Save default IP `10.10.0.199` persists after reload (regression for the bug where default value was not saved)
- Save non-default IP `10.10.0.1` persists after reload
- Toggle enabled persists after reload

## Smoke Test
- Verified test files follow existing e2e test patterns (`auth.spec.ts`, `agents.spec.ts`)
- Tests use the same fixtures (`login`, `expect`) from `e2e/fixtures.ts`
- All selectors match actual element IDs in the settings pages (`#mt-url`, `#mt-user`, `#mt-password`, `#mt-enabled`, `#xiaomi-ip`, `#xiaomi-enabled`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive e2e Playwright tests for settings pages to prevent regressions like #376. The tests follow existing patterns from `auth.spec.ts` and `agents.spec.ts`, using proper fixtures and selectors.

**Key test coverage:**
- **MikroTik**: Default URL placeholder validation, save/reload persistence for URL/user/password, toggle enabled state persistence, Test Connection with unsaved values
- **VyOS**: Save/reload persistence for URL and API key
- **Xiaomi Mesh**: Default IP `10.10.0.199` persistence (regression test for #376), custom IP persistence, toggle enabled state persistence

The tests properly verify that settings survive page reloads and that Test Connection works with unsaved form values (addressing the bug from #376). All selectors match actual element IDs in the settings pages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — adds test coverage without modifying production code
- Perfect score: adds comprehensive e2e test coverage following established patterns, no production code changes, and directly addresses regression prevention from issue #376
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/tests/e2e/settings-router.spec.ts | Adds comprehensive e2e tests for MikroTik and VyOS router settings — validates save/load persistence, toggle state, and unsaved form values in Test Connection |
| web/tests/e2e/settings-xiaomi.spec.ts | Adds e2e tests for Xiaomi Mesh settings — specifically validates default IP persistence (regression test for #376) and toggle enabled state |

</details>



<sub>Last reviewed commit: 26b1501</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->