### PR TITLE
feat: static DHCP mapping from MikroTik lease list (#380)

### DIFF
--- a/server/src/api/mikrotik.rs
+++ b/server/src/api/mikrotik.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use super::{audit, AppState};
 use crate::mikrotik::client::MikrotikClient;
 use crate::mikrotik::types::{
-    FirewallAddressListWriteRequest, FirewallFilterWriteRequest, FirewallNatWriteRequest,
-    VlanWriteRequest,
+    DhcpStaticLeaseWriteRequest, FirewallAddressListWriteRequest, FirewallFilterWriteRequest,
+    FirewallNatWriteRequest, VlanWriteRequest,
 };
 
 // ── Helper: build a MikroTik client from DB settings ───────
@@ -132,6 +132,13 @@ pub struct MikrotikDhcpLeaseResponse {
     pub server: Option<String>,
     pub dynamic: bool,
     pub disabled: bool,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MikrotikCreateDhcpStaticRequest {
+    pub address: String,
+    pub mac_address: String,
     pub comment: Option<String>,
 }
 
@@ -1309,6 +1316,75 @@ pub async fn delete_address_list(
             )
             .await;
             tracing::error!("MikroTik address list delete error: {e}");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// POST /api/v1/mikrotik/dhcp-static-mappings
+pub async fn create_dhcp_static_mapping(
+    State(state): State<AppState>,
+    Json(body): Json<MikrotikCreateDhcpStaticRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let req = DhcpStaticLeaseWriteRequest {
+        address: body.address.clone(),
+        mac_address: body.mac_address.clone(),
+        comment: body.comment.clone(),
+    };
+
+    let desc = format!(
+        "Create MikroTik static DHCP mapping: {} -> {}",
+        body.mac_address, body.address
+    );
+    let cmds = vec![format!(
+        "POST /ip/dhcp-server/lease address={} mac-address={}",
+        body.address, body.mac_address
+    )];
+
+    match client.create_dhcp_static_lease(&req).await {
+        Ok(()) => {
+            audit::log_success(&state.db, "mikrotik_dhcp_static_create", &desc, &cmds).await;
+            Ok(StatusCode::NO_CONTENT)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            audit::log_failure(&state.db, "mikrotik_dhcp_static_create", &desc, &cmds, &msg).await;
+            tracing::error!("MikroTik DHCP static mapping create error: {e}");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+/// DELETE /api/v1/mikrotik/dhcp-leases/:id
+pub async fn delete_dhcp_lease(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<StatusCode, StatusCode> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = mikrotik_client(&state)
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    let desc = format!("Delete MikroTik DHCP lease {id}");
+    let cmds = vec![format!("DELETE /ip/dhcp-server/lease/{id}")];
+
+    match client.delete_dhcp_lease(id).await {
+        Ok(()) => {
+            audit::log_success(&state.db, "mikrotik_dhcp_lease_delete", &desc, &cmds).await;
+            Ok(StatusCode::NO_CONTENT)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            audit::log_failure(&state.db, "mikrotik_dhcp_lease_delete", &desc, &cmds, &msg).await;
+            tracing::error!("MikroTik DHCP lease delete error: {e}");
             Err(StatusCode::BAD_GATEWAY)
         }
     }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -470,6 +470,14 @@ pub fn router(state: AppState) -> Router {
         .route("/mikrotik/vlans/:id", delete(mikrotik::delete_vlan))
         .route("/mikrotik/routes", get(mikrotik::routes))
         .route("/mikrotik/dhcp-leases", get(mikrotik::dhcp_leases))
+        .route(
+            "/mikrotik/dhcp-leases/:id",
+            delete(mikrotik::delete_dhcp_lease),
+        )
+        .route(
+            "/mikrotik/dhcp-static-mappings",
+            post(mikrotik::create_dhcp_static_mapping),
+        )
         .route("/mikrotik/firewall", get(mikrotik::firewall))
         .route(
             "/mikrotik/firewall/filter",

--- a/server/src/mikrotik/client.rs
+++ b/server/src/mikrotik/client.rs
@@ -304,6 +304,18 @@ impl MikrotikClient {
         Ok(res)
     }
 
+    /// Create a static DHCP lease (reservation).
+    pub async fn create_dhcp_static_lease(&self, req: &DhcpStaticLeaseWriteRequest) -> Result<()> {
+        self.send_json(Method::POST, "/ip/dhcp-server/lease", req)
+            .await
+    }
+
+    /// Delete a DHCP lease by RouterOS `.id`.
+    pub async fn delete_dhcp_lease(&self, id: &str) -> Result<()> {
+        self.send_no_body(Method::DELETE, &format!("/ip/dhcp-server/lease/{id}"))
+            .await
+    }
+
     /// Fetch firewall filter rules.
     pub async fn firewall_filter(&self) -> Result<Vec<FirewallFilter>> {
         let val = self.get("/ip/firewall/filter").await?;

--- a/server/src/mikrotik/types.rs
+++ b/server/src/mikrotik/types.rs
@@ -127,6 +127,32 @@ pub struct DhcpLease {
     pub comment: Option<String>,
 }
 
+/// MikroTik DHCP static mapping (`/rest/ip/dhcp-server/lease` with `dynamic=false`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DhcpStaticLease {
+    #[serde(rename = ".id")]
+    pub id: Option<String>,
+    pub address: Option<String>,
+    #[serde(rename = "mac-address")]
+    pub mac_address: Option<String>,
+    #[serde(rename = "host-name")]
+    pub host_name: Option<String>,
+    pub server: Option<String>,
+    pub comment: Option<String>,
+    pub disabled: Option<String>,
+    pub dynamic: Option<String>,
+}
+
+/// MikroTik DHCP static lease write payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct DhcpStaticLeaseWriteRequest {
+    pub address: String,
+    #[serde(rename = "mac-address")]
+    pub mac_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
 /// MikroTik firewall filter rule (`/rest/ip/firewall/filter`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FirewallFilter {

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -23,6 +23,7 @@ import {
   BarChart3,
   Power,
   List,
+  Pin,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -82,6 +83,7 @@ import {
   toggleMikrotikFirewallNat,
   createMikrotikAddressList,
   deleteMikrotikAddressList,
+  createMikrotikDhcpStaticMapping,
   fetchTrafficHistory,
 } from "@/lib/api";
 import { formatBps } from "@/lib/format";
@@ -917,11 +919,40 @@ function DhcpLeasesTable({
   data,
   loading,
   error,
+  reload,
 }: {
   data: MikrotikDhcpLease[] | null;
   loading: boolean;
   error: string | null;
+  reload: () => Promise<void>;
 }) {
+  const [pinning, setPinning] = useState<string | null>(null);
+
+  const handlePin = async (lease: MikrotikDhcpLease) => {
+    if (!lease.mac_address) return;
+    const key = `${lease.address}-${lease.mac_address}`;
+    setPinning(key);
+    try {
+      await createMikrotikDhcpStaticMapping({
+        address: lease.address,
+        mac_address: lease.mac_address,
+        comment: lease.host_name
+          ? `Reserved for ${lease.host_name}`
+          : undefined,
+      });
+      toast.success(
+        `Reserved ${lease.address} for ${lease.mac_address}`
+      );
+      await reload();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to create static mapping"
+      );
+    } finally {
+      setPinning(null);
+    }
+  };
+
   const headerCols = (
     <tr className="border-b border-slate-800 bg-slate-950 text-left">
       <th className="px-4 py-3 font-medium text-slate-400">IP Address</th>
@@ -930,6 +961,7 @@ function DhcpLeasesTable({
       <th className="px-4 py-3 font-medium text-slate-400">Server</th>
       <th className="px-4 py-3 font-medium text-slate-400">Expires</th>
       <th className="px-4 py-3 font-medium text-slate-400">State</th>
+      <th className="px-4 py-3 font-medium text-slate-400 w-16" />
     </tr>
   );
 
@@ -947,6 +979,7 @@ function DhcpLeasesTable({
                 <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
                 <td className="px-4 py-3"><Skeleton className="h-3 w-28" /></td>
                 <td className="px-4 py-3"><Skeleton className="h-5 w-14 rounded-full" /></td>
+                <td className="px-4 py-3" />
               </tr>
             ))}
           </tbody>
@@ -977,50 +1010,68 @@ function DhcpLeasesTable({
       <table className="w-full text-sm">
         <thead>{headerCols}</thead>
         <tbody>
-          {data.map((lease, idx) => (
-            <tr
-              key={`${lease.address}-${idx}`}
-              className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
-            >
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums font-medium text-white">
-                  {lease.address}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums text-xs text-slate-400">
-                  {lease.mac_address ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="text-slate-300">
-                  {lease.host_name ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="text-slate-300">
-                  {lease.server ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <span className="font-mono tabular-nums text-xs text-slate-400">
-                  {lease.expires_after ?? "\u2014"}
-                </span>
-              </td>
-              <td className="px-4 py-3">
-                <Badge
-                  variant="outline"
-                  className={
-                    lease.status === "bound"
-                      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
-                      : "border-slate-700 text-slate-500 text-xs"
-                  }
-                >
-                  {lease.status ?? "\u2014"}
-                </Badge>
-              </td>
-            </tr>
-          ))}
+          {data.map((lease, idx) => {
+            const key = `${lease.address}-${lease.mac_address}`;
+            const isPinning = pinning === key;
+            return (
+              <tr
+                key={`${lease.address}-${idx}`}
+                className="border-b border-slate-800 last:border-b-0 hover:bg-slate-800/60 transition-colors"
+              >
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums font-medium text-white">
+                    {lease.address}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums text-xs text-slate-400">
+                    {lease.mac_address ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-slate-300">
+                    {lease.host_name ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-slate-300">
+                    {lease.server ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="font-mono tabular-nums text-xs text-slate-400">
+                    {lease.expires_after ?? "\u2014"}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <Badge
+                    variant="outline"
+                    className={
+                      lease.status === "bound"
+                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400 text-xs"
+                        : "border-slate-700 text-slate-500 text-xs"
+                    }
+                  >
+                    {lease.dynamic ? lease.status ?? "\u2014" : "static"}
+                  </Badge>
+                </td>
+                <td className="px-4 py-3">
+                  {lease.dynamic && lease.mac_address && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-slate-400 hover:text-amber-400"
+                      title="Reserve (create static mapping)"
+                      disabled={isPinning}
+                      onClick={() => handlePin(lease)}
+                    >
+                      <Pin className={`h-3.5 w-3.5 ${isPinning ? "animate-pulse" : ""}`} />
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -2736,6 +2787,7 @@ export default function MikrotikRouter() {
                 data={dhcp.data}
                 loading={dhcp.loading}
                 error={dhcp.error}
+                reload={dhcp.reload}
               />
             </CardContent>
           </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,7 @@ import type {
   MikrotikVlanRequest,
   MikrotikRoute,
   MikrotikDhcpLease,
+  MikrotikDhcpStaticMappingRequest,
   MikrotikFirewall,
   MikrotikFirewallFilterRequest,
   MikrotikFirewallNatRequest,
@@ -1356,6 +1357,16 @@ export function fetchMikrotikRoutes(): Promise<MikrotikRoute[]> {
 
 export function fetchMikrotikDhcpLeases(): Promise<MikrotikDhcpLease[]> {
   return apiGet<MikrotikDhcpLease[]>("/api/v1/mikrotik/dhcp-leases");
+}
+
+export function createMikrotikDhcpStaticMapping(
+  body: MikrotikDhcpStaticMappingRequest
+): Promise<void> {
+  return apiPost<void>("/api/v1/mikrotik/dhcp-static-mappings", body);
+}
+
+export function deleteMikrotikDhcpLease(id: string): Promise<void> {
+  return apiDelete(`/api/v1/mikrotik/dhcp-leases/${encodeURIComponent(id)}`);
 }
 
 export function fetchMikrotikFirewall(): Promise<MikrotikFirewall> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1192,6 +1192,12 @@ export interface MikrotikDhcpLease {
   comment: string | null;
 }
 
+export interface MikrotikDhcpStaticMappingRequest {
+  address: string;
+  mac_address: string;
+  comment?: string;
+}
+
 export interface MikrotikFirewallRule {
   id: string | null;
   chain: string | null;


### PR DESCRIPTION
## Summary
- Adds a **Pin** button next to each dynamic DHCP lease in the MikroTik router view
- Clicking the button calls the MikroTik REST API to create a static DHCP reservation using the lease's current IP and MAC address
- No manual entry required — IP, MAC, and hostname are auto-populated from the existing dynamic lease
- After creation, the lease list refreshes to show the updated state

## Changes
**Backend (Rust):**
- `server/src/mikrotik/types.rs` — Added `DhcpStaticLease` and `DhcpStaticLeaseWriteRequest` types
- `server/src/mikrotik/client.rs` — Added `create_dhcp_static_lease()` and `delete_dhcp_lease()` client methods
- `server/src/api/mikrotik.rs` — Added `POST /api/v1/mikrotik/dhcp-static-mappings` and `DELETE /api/v1/mikrotik/dhcp-leases/:id` endpoints with audit logging
- `server/src/api/mod.rs` — Registered new routes

**Frontend (TypeScript):**
- `web/src/lib/types.ts` — Added `MikrotikDhcpStaticMappingRequest` interface
- `web/src/lib/api.ts` — Added `createMikrotikDhcpStaticMapping()` and `deleteMikrotikDhcpLease()` API functions
- `web/src/components/MikrotikRouter.tsx` — Added Pin button to DHCP leases table with loading state, toast notifications, and auto-refresh

## Smoke Test
- `cargo check` passes with no errors
- `cargo fmt --all` applied, no formatting issues
- All 301 unit tests + 18 integration tests pass
- API endpoint pattern follows existing MikroTik CRUD conventions (firewall rules, VLANs, address lists)

## Test plan
- [ ] Open MikroTik router page → DHCP tab
- [ ] Verify Pin button appears only on dynamic leases (not static ones)
- [ ] Click Pin on a dynamic lease → verify toast success and lease list refreshes
- [ ] Verify the static mapping appears on the MikroTik router
- [ ] Verify audit log entry is created

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented one-click static DHCP reservation from the MikroTik lease list. The feature adds a Pin button to dynamic leases that creates a static mapping with the current IP and MAC address, eliminating manual entry.

**Key changes:**
- Backend adds two REST endpoints with proper audit logging and error handling
- Frontend adds Pin button UI with loading states, toast notifications, and automatic list refresh
- Type definitions are consistent between frontend and backend
- Implementation follows existing patterns for MikroTik CRUD operations (VLANs, firewall rules, address lists)
- All 301 unit tests + 18 integration tests pass

**Notes:**
- The `deleteMikrotikDhcpLease` API function and `DhcpStaticLease` type are defined but not currently used in the UI—likely for future features or API completeness
- Pin button correctly only appears for dynamic leases with MAC addresses

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, follows existing codebase patterns, has proper error handling and audit logging, and all tests pass. The changes are well-scoped and don't introduce security vulnerabilities or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mikrotik.rs | Added two new endpoints for DHCP management: `create_dhcp_static_mapping` and `delete_dhcp_lease`, both with proper audit logging and error handling following existing patterns |
| server/src/mikrotik/client.rs | Added `create_dhcp_static_lease` and `delete_dhcp_lease` client methods using existing HTTP primitives |
| web/src/components/MikrotikRouter.tsx | Added Pin button to DHCP leases table with state management, error handling, success notifications, and automatic reload; button only shown for dynamic leases with MAC addresses |

</details>



<sub>Last reviewed commit: fa2a862</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->