### PR TITLE
feat: mobile responsive UI — sidebar burger menu, single-column layout (#388)

### DIFF
--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -119,7 +119,7 @@ export default function AgentsPage() {
     <PageTransition>
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold text-white">Agents</h1>
         <AddAgentDialog
           onCreated={() => {

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -262,8 +262,8 @@ export default function AlertsPage() {
     <PageTransition>
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-semibold text-white">Alerts</h1>
           {activeCount > 0 && (
             <Badge variant="secondary" className="gap-1">

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -412,7 +412,7 @@ ${filtered
     <PageTransition>
       <div className="space-y-6">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold text-white">Assets</h1>
           <div className="flex items-center gap-2">
             <Button

--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -295,7 +295,7 @@ export default function CertificatesPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-semibold text-white">
             SSL Certificates

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -296,7 +296,7 @@ export default function DevicesPage() {
     <PageTransition>
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold text-white">Devices</h1>
         <div className="flex items-center gap-2">
           <Button

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from "@/components/layout/Sidebar";
 import { TopBar } from "@/components/layout/TopBar";
+import { MobileSidebar } from "@/components/layout/MobileSidebar";
 import { CommandPalette } from "@/components/CommandPalette";
 import { WebSocketProvider } from "@/components/providers/WebSocketProvider";
 
@@ -16,8 +17,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <div className="flex h-screen overflow-hidden">
         <Sidebar />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <TopBar />
-          <main className="min-h-0 flex-1 overflow-y-auto p-6">{children}</main>
+          <TopBar mobileMenu={<MobileSidebar />} />
+          <main className="min-h-0 flex-1 overflow-y-auto p-3 md:p-6">{children}</main>
         </div>
       </div>
       <CommandPalette />

--- a/web/src/app/(app)/npm/page.tsx
+++ b/web/src/app/(app)/npm/page.tsx
@@ -2244,9 +2244,9 @@ export default function NpmPage() {
   const reachable = status?.reachable ?? false;
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 p-6">
+    <div className="mx-auto max-w-6xl space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
             <Globe className="h-5 w-5 text-orange-400" />

--- a/web/src/app/(app)/services/page.tsx
+++ b/web/src/app/(app)/services/page.tsx
@@ -481,7 +481,7 @@ export default function ServicesPage() {
     <PageTransition>
       <div className="space-y-6">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold text-white">Services</h1>
             <p className="mt-1 text-sm text-slate-400">

--- a/web/src/app/(app)/ssh-hosts/page.tsx
+++ b/web/src/app/(app)/ssh-hosts/page.tsx
@@ -122,7 +122,7 @@ export default function SshHostsPage() {
     <PageTransition>
       <div className="space-y-6">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold text-white">SSH Hosts</h1>
           <SshTargetFormDialog
             open={addOpen}

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { navItems } from "./Sidebar";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useWsConnected } from "@/components/providers/WebSocketProvider";
+
+export function MobileSidebar() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const wsConnected = useWsConnected();
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="flex h-9 w-9 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800 hover:text-white transition-colors md:hidden"
+        aria-label="Open menu"
+      >
+        <Menu className="h-5 w-5" />
+      </button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="left"
+          className="w-72 border-slate-800 bg-slate-950 p-0"
+        >
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          {/* Logo */}
+          <div className="flex h-14 items-center border-b border-slate-800 px-4">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500 text-sm font-bold text-white">
+              P
+            </div>
+            <span className="ml-2 text-lg font-semibold text-white">
+              Panoptikon
+            </span>
+          </div>
+
+          {/* Navigation */}
+          <nav className="flex-1 space-y-1 overflow-y-auto p-2">
+            {navItems.map((item) => {
+              const active = pathname?.startsWith(item.href);
+              const Icon = item.icon;
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    active
+                      ? "bg-blue-500/10 text-blue-500"
+                      : "text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                  )}
+                >
+                  <Icon className="h-[18px] w-[18px] shrink-0" />
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+
+          {/* Status */}
+          <div className="border-t border-slate-800 p-3">
+            <div className="flex items-center gap-1.5 px-2">
+              <span
+                className={cn(
+                  "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
+                  wsConnected
+                    ? "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online"
+                    : "bg-slate-600"
+                )}
+              />
+              <span className="text-xs text-slate-500">
+                {wsConnected ? "Live" : "Disconnected"}
+              </span>
+              <p className="ml-auto text-[10px] text-slate-700">
+                Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.5.0"}
+              </p>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -108,6 +108,12 @@ const navGroups: NavGroup[] = [
   },
 ];
 
+/** Flat list of all nav items — used by MobileSidebar. */
+export const navItems: NavItem[] = [
+  ...navGroups.flatMap((g) => g.items),
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
 /** Settings link — always visible at the bottom, outside groups. */
 const settingsItem: NavItem = {
   href: "/settings",
@@ -262,7 +268,7 @@ export function Sidebar() {
     <TooltipProvider delayDuration={0}>
       <aside
         className={cn(
-          "flex flex-col border-r border-slate-800 bg-slate-950 transition-all duration-200",
+          "hidden md:flex flex-col border-r border-slate-800 bg-slate-950 transition-all duration-200",
           sidebarCollapsed ? "w-16" : "w-60",
         )}
       >

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { type ReactNode, useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
 import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, logout } from "@/lib/api";
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-export function TopBar() {
+export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResponse | null>(null);
@@ -204,7 +204,10 @@ export function TopBar() {
   let runningIndex = 0;
 
   return (
-    <header className="flex h-14 items-center justify-between border-b border-slate-800 bg-slate-950 px-6">
+    <header className="flex h-14 items-center justify-between border-b border-slate-800 bg-slate-950 px-3 md:px-6 gap-2">
+      {/* Mobile menu button */}
+      {mobileMenu}
+
       {/* Search */}
       <div className="relative flex-1 max-w-md" ref={containerRef}>
         <input


### PR DESCRIPTION
Closes #388

## Summary
- **Sidebar burger menu**: On mobile (<768px), the sidebar is hidden and replaced with a hamburger menu button in the TopBar that opens a Sheet-based drawer with full navigation
- **Responsive padding**: Main content area uses `p-3` on mobile, `p-6` on desktop; TopBar padding also responsive
- **Page header wrapping**: All page headers (Devices, Assets, Alerts, Agents, SSH Hosts, NPM, Services, Certificates) now use `flex-wrap` to prevent overflow on narrow screens
- **Tables**: Already handled — the shadcn Table component wraps in `overflow-auto`
- **Grids**: Dashboard and Router pages already use responsive `grid-cols-1 lg:grid-cols-*` patterns

## Changes
| File | Change |
|------|--------|
| `MobileSidebar.tsx` | New component — Sheet-based mobile navigation drawer with burger menu trigger |
| `Sidebar.tsx` | Hidden on mobile (`hidden md:flex`), exported `navItems` for reuse |
| `TopBar.tsx` | Accepts `mobileMenu` prop, responsive padding, gap between items |
| `layout.tsx` | Integrates MobileSidebar, responsive main padding (`p-3 md:p-6`) |
| 8 page files | Added `flex-wrap gap-3` to page headers |

## Smoke Test
- `next build` passes cleanly with all 48 routes compiled
- No TypeScript errors
- Verified sidebar is `hidden md:flex` (hidden below 768px)
- Verified MobileSidebar renders Sheet with `side="left"` and all 21 nav items
- Verified nav links close the Sheet on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements mobile responsiveness with a hamburger menu and responsive layout adjustments. The `MobileSidebar` component provides Sheet-based navigation with proper accessibility features, while the desktop `Sidebar` is hidden below 768px breakpoint. All page headers now wrap gracefully on narrow screens.

- Clean implementation following Next.js and React best practices
- Proper accessibility: `aria-label` on hamburger button, `sr-only` title for screen readers
- Consistent responsive utilities: `md:` breakpoint for mobile/desktop toggle
- Sheet auto-closes on navigation for good UX
- Removed duplicate padding from NPM page (now handled centrally in layout)
- Build passes cleanly with no TypeScript errors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- All changes are well-implemented with proper responsive design patterns, accessibility features, and consistent code quality. No bugs, type errors, or logical issues detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/layout/MobileSidebar.tsx | New mobile navigation component with Sheet-based drawer, hamburger menu, proper accessibility (aria-label, sr-only title), and auto-close on navigation |
| web/src/components/layout/Sidebar.tsx | Hidden on mobile with `hidden md:flex`, exports `navItems` array for MobileSidebar reuse |
| web/src/components/layout/TopBar.tsx | Added optional `mobileMenu` prop for hamburger button, responsive padding `px-3 md:px-6` |
| web/src/app/(app)/layout.tsx | Integrates MobileSidebar via TopBar prop, responsive main padding `p-3 md:p-6` |
| web/src/app/(app)/npm/page.tsx | Removed duplicate `p-6` padding (now handled by layout), added `flex-wrap gap-3` to header |

</details>



<sub>Last reviewed commit: 1eb931e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->