### PR TITLE
fix: mesh page empty — parse topology from graph.nodes (#394)

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -27,12 +27,22 @@ async fn mesh_router_ip(state: &AppState) -> String {
 
 // ── Raw Xiaomi topo_graph response shapes ───────────────────
 
+/// Inner graph object containing nodes (and optionally leafs).
+#[derive(Debug, Deserialize)]
+struct XiaomiTopoGraph {
+    #[serde(default)]
+    nodes: Vec<XiaomiTopoNode>,
+}
+
 /// Root response from `api/misystem/topo_graph`.
+///
+/// The actual Xiaomi response nests the node list inside `graph.nodes`,
+/// **not** at the top-level `list` key.
 #[derive(Debug, Deserialize)]
 struct XiaomiTopoResponse {
     code: i32,
     #[serde(default)]
-    list: Vec<XiaomiTopoNode>,
+    graph: Option<XiaomiTopoGraph>,
 }
 
 /// A single node in the Xiaomi mesh topology.
@@ -133,9 +143,10 @@ pub async fn topology(
         return Err(StatusCode::BAD_GATEWAY);
     }
 
+    let topo_nodes = raw.graph.map(|g| g.nodes).unwrap_or_default();
+
     let mut total_devices = 0i32;
-    let nodes: Vec<MeshNode> = raw
-        .list
+    let nodes: Vec<MeshNode> = topo_nodes
         .into_iter()
         .map(|n| {
             total_devices += n.online;


### PR DESCRIPTION
## Summary
- Fixed `/mesh` page showing empty topology (zero nodes)
- Root cause: the `mesh.rs` handler expected the Xiaomi `topo_graph` API response to have nodes at a top-level `list` key, but the actual response nests them inside `graph.nodes`
- Since `list` had `#[serde(default)]`, deserialization silently succeeded with an empty vec

## Changes
- Added `XiaomiTopoGraph` struct to model the `graph` wrapper object
- Changed `XiaomiTopoResponse` to use `graph: Option<XiaomiTopoGraph>` instead of `list: Vec<XiaomiTopoNode>`
- Updated handler to extract nodes from `raw.graph.map(|g| g.nodes).unwrap_or_default()`

## Smoke Test
- `cargo check -p panoptikon-server` passes with no errors
- `cargo fmt --all` produces no changes
- The fix aligns with the existing `XiaomiClient::topo_graph()` in `xiaomi/client.rs` which correctly parses `MiWiFiResponse<TopoGraph>` where `TopoGraph` has `graph: Option<TopoGraphInner>`

Closes #394

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the mesh topology endpoint which was returning zero nodes due to incorrect response parsing structure. The API response nests nodes inside `graph.nodes`, not at a top-level `list` key. This fix aligns the parsing logic with the actual Xiaomi API response format, consistent with how the authenticated topology endpoint (`xiaomi/client.rs`) already parses the same API.

**Changes:**
- Added `XiaomiTopoGraph` struct to model the `graph` wrapper object containing `nodes`
- Updated `XiaomiTopoResponse` to use `graph: Option<XiaomiTopoGraph>` instead of `list: Vec<XiaomiTopoNode>`
- Modified handler to extract nodes via `raw.graph.map(|g| g.nodes).unwrap_or_default()`

The fix includes appropriate null handling with `Option` and `#[serde(default)]` attributes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward correction of a data structure mismatch that caused a functional bug (empty mesh topology). The change aligns the parsing logic with the actual API response format and matches the pattern already used elsewhere in the codebase (xiaomi/types.rs). All fields have appropriate null-handling with `#[serde(default)]` and `Option` types, making the parsing resilient.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mesh.rs | Fixed mesh topology parsing to correctly read nodes from `graph.nodes` structure instead of top-level `list` field |

</details>



<sub>Last reviewed commit: a20f0fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->