### PR TITLE
feat: test environment — LXC containers on DevBox as real DHCP/mDNS test devices (#405)

### DIFF
--- a/docs/test-environment.md
+++ b/docs/test-environment.md
@@ -1,24 +1,32 @@
-# MikroTik Test Environment
+# Test Environment — LXC Containers on DevBox Proxmox
 
-Setup guide for the Panoptikon MikroTik integration test environment. Uses 2-3 lightweight LXC containers on Proxmox with a MikroTik CHR instance as the gateway.
+Setup guide for the Panoptikon test environment. Uses lightweight LXC containers on Proxmox DevBox as real DHCP clients and mDNS devices for testing device discovery, DHCP lease tracking, and mDNS identification.
+
+## Why LXC Containers?
+
+- Static DHCP leases don't test the discovery logic end-to-end
+- Mock data doesn't exercise the real network stack
+- LXC containers are real DHCP clients with real ARP entries and real mDNS announcements
+- Lightweight: each container uses 128–512 MB RAM
 
 ## Network Topology
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Proxmox Host                                                   │
+│  Proxmox Host (DevBox 10.10.0.11)                               │
 │                                                                 │
 │  ┌──────────────────┐     vmbr0 (10.10.0.0/24)                 │
 │  │ MikroTik CHR     │◄────────────────┐                        │
 │  │ 10.10.0.125      │                 │                        │
-│  │ (gateway/router)  │    ┌────────────┼────────────┐           │
+│  │ (DHCP / gateway)  │    ┌────────────┼────────────┐           │
 │  └──────────────────┘    │            │            │           │
 │                          │            │            │           │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │ pan-test-web │  │ pan-test-db  │  │ pan-test-iot │         │
-│  │ CT 200       │  │ CT 201       │  │ CT 202       │         │
-│  │ .200         │  │ .201         │  │ .202         │         │
-│  │ 256MB / 1CPU │  │ 256MB / 1CPU │  │ 128MB / 1CPU │         │
+│  │ test-alpine  │  │ test-ubuntu  │  │ test-debian  │         │
+│  │ CT 201       │  │ CT 202       │  │ CT 203       │         │
+│  │ DHCP         │  │ DHCP         │  │ DHCP         │         │
+│  │ 128MB / 1CPU │  │ 512MB / 1CPU │  │ 512MB / 1CPU │         │
+│  │ Alpine       │  │ Ubuntu 22.04 │  │ Debian 12    │         │
 │  └──────────────┘  └──────────────┘  └──────────────┘         │
 │          │                │                │                    │
 │          └────────────────┼────────────────┘                    │
@@ -34,36 +42,63 @@ Setup guide for the Panoptikon MikroTik integration test environment. Uses 2-3 l
 
 ## Prerequisites
 
-- **Proxmox VE** host (Forge/DevBox) with `pct` available
+- **Proxmox VE** host (DevBox 10.10.0.11) with `pct` available
 - **MikroTik CHR** VM already running at `10.10.0.125` with:
   - RouterOS 7+ installed
   - REST API enabled (`/ip/service set api-ssl address=10.10.0.0/24`)
   - DHCP server configured on the `10.10.0.0/24` subnet
   - Bridge `vmbr0` connected to the MikroTik interface
-- **Debian 12 LXC template** available (script downloads automatically if missing)
-
-## Quick Start
-
-```bash
-# Create the test containers (run on Proxmox host)
-sudo bash scripts/setup-test-env.sh create
-
-# Check status
-sudo bash scripts/setup-test-env.sh status
-
-# Tear down when done
-sudo bash scripts/setup-test-env.sh destroy
-```
+- LXC templates: Alpine, Ubuntu 22.04, Debian 12 (scripts download automatically if missing)
 
 ## Container Details
 
-| CTID | Hostname       | IP           | RAM   | Disk | Purpose                              |
-|------|----------------|--------------|-------|------|--------------------------------------|
-| 200  | pan-test-web   | 10.10.0.200  | 256MB | 2GB  | Web server (nginx) — HTTP traffic    |
-| 201  | pan-test-db    | 10.10.0.201  | 256MB | 2GB  | Database — heavier workload sim      |
-| 202  | pan-test-iot   | 10.10.0.202  | 128MB | 1GB  | IoT device — minimal DHCP client     |
+| CTID | Hostname     | OS           | RAM   | Disk | Purpose                                   |
+|------|--------------|--------------|-------|------|-------------------------------------------|
+| 201  | test-alpine  | Alpine       | 128MB | 2GB  | Minimal Linux — basic DHCP lease discovery |
+| 202  | test-ubuntu  | Ubuntu 22.04 | 512MB | 2GB  | mDNS via avahi-daemon                      |
+| 203  | test-debian  | Debian 12    | 512MB | 2GB  | Different vendor fingerprint               |
 
-All containers use MikroTik CHR (`10.10.0.125`) as their default gateway.
+All containers:
+- Get their IP via DHCP from MikroTik (no static assignments)
+- Are connected to `vmbr0` (same LAN as Panoptikon)
+- Run `avahi-daemon` for mDNS `.local` name announcements
+- Have hostname visible in MikroTik DHCP leases
+- Start on boot (`onboot: 1`)
+- Use unprivileged mode for security
+
+## Quick Start
+
+### 1. Create the containers
+
+```bash
+scp scripts/test-env/setup-lxc.sh root@10.10.0.11:/tmp/
+ssh root@10.10.0.11 bash /tmp/setup-lxc.sh
+```
+
+The script is idempotent — running it again skips existing containers and ensures they're started.
+
+### 2. Verify the environment
+
+```bash
+scp scripts/test-env/verify-lxc.sh root@10.10.0.11:/tmp/
+ssh root@10.10.0.11 bash /tmp/verify-lxc.sh
+```
+
+This checks:
+- All containers are running
+- Each container has a DHCP lease
+- avahi-daemon is running (for mDNS)
+- mDNS `.local` names resolve
+- Containers can reach MikroTik gateway
+
+### 3. Tear down (optional)
+
+```bash
+scp scripts/test-env/teardown-lxc.sh root@10.10.0.11:/tmp/
+ssh root@10.10.0.11 bash /tmp/teardown-lxc.sh
+```
+
+This stops and destroys all 3 containers.
 
 ## MikroTik CHR Setup
 
@@ -102,12 +137,6 @@ If the MikroTik CHR VM is not yet configured, follow these steps from the Router
 
 Panoptikon runs Unbound as a network-wide DNS resolver on LXC 115 (`10.10.0.22`). The setup script configures test containers to use it automatically.
 
-### What the setup script does
-
-1. **Opens port 53** on the Proxmox firewall for CT 115 (UDP + TCP, source `10.10.0.0/24`)
-2. **Sets `10.10.0.22`** as the nameserver for all test containers
-3. **Installs `dnsutils`** in test containers so `dig` is available for verification
-
 ### MikroTik DHCP — hand out Unbound as DNS
 
 If test containers use DHCP (instead of static IPs), update the MikroTik DHCP network to hand out Panoptikon's Unbound:
@@ -120,36 +149,31 @@ If test containers use DHCP (instead of static IPs), update the MikroTik DHCP ne
 ### Verify DNS from a test client
 
 ```bash
-# External DNS forwarding (should resolve via Unbound → root hints)
-pct exec 200 -- dig @10.10.0.22 google.com +short
-
-# Local record resolution (ok.labs test zone configured in unbound.conf)
-pct exec 200 -- dig @10.10.0.22 local.ok.labs +short
-# Expected: 10.10.0.22
+# External DNS forwarding (should resolve via Unbound -> root hints)
+pct exec 201 -- sh -c "nslookup google.com 10.10.0.22"
 
 # Verify the container's default resolver is Unbound
-pct exec 200 -- dig google.com +short
+pct exec 202 -- bash -c "dig google.com +short"
 ```
 
-### Manual firewall setup (if not using the setup script)
+## Verification in Panoptikon
 
-If CT 115 already exists and you need to open port 53 manually:
+After the containers are running, verify in Panoptikon:
+
+1. **Devices page** — 3 new devices should appear (may take up to 60s for the next scan cycle)
+2. **Hostnames** — `test-alpine`, `test-ubuntu`, `test-debian` pulled from MikroTik DHCP leases
+3. **mDNS names** — `test-ubuntu.local` and `test-debian.local` visible for Ubuntu/Debian containers
+4. **Device identification** — each container should be identified with its OS type
+
+### API check
 
 ```bash
-# Add rules to /etc/pve/firewall/115.fw
-cat >> /etc/pve/firewall/115.fw <<'EOF'
-[OPTIONS]
-enable: 1
-
-[RULES]
-IN ACCEPT -p udp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-udp
-IN ACCEPT -p tcp -dport 53 -source +10.10.0.0/24 -log nolog -comment allow-dns-tcp
-EOF
+# Check MikroTik DHCP leases (should include test-* hostnames)
+curl -sb cookies.txt http://localhost:8080/api/v1/mikrotik/dhcp-leases | \
+  jq '.[] | select(.host_name | startswith("test-"))'
 ```
 
 ## Validation Scenarios
-
-Use these test containers to validate each MikroTik integration feature:
 
 ### 1. DHCP Lease Tracking
 
@@ -157,118 +181,97 @@ Use these test containers to validate each MikroTik integration feature:
 
 ```bash
 # On the Proxmox host — restart a container to trigger DHCP
-pct stop 202 && pct start 202
+pct stop 201 && pct start 201
 
-# In Panoptikon UI → Devices page
-# Expect: pan-test-iot appears with IP 10.10.0.202, source "DHCP"
+# In Panoptikon UI -> Devices page
+# Expect: test-alpine appears with a DHCP-assigned IP, source "DHCP"
 ```
 
-**API check:**
-```bash
-curl -s http://10.10.0.14:8080/api/v1/devices | jq '.[] | select(.ip == "10.10.0.202")'
-```
+### 2. mDNS Discovery
 
-### 2. Traffic Monitoring
-
-**Goal:** Verify per-device bandwidth charts show traffic from test containers.
+**Goal:** Verify containers with avahi-daemon are discovered via mDNS.
 
 ```bash
-# Generate traffic from pan-test-web
-pct exec 200 -- bash -c "curl -s -o /dev/null http://example.com; sleep 1; curl -s -o /dev/null http://example.com"
+# From any machine on the LAN with avahi-browse:
+avahi-browse -art | grep test-
 
-# Generate heavier traffic from pan-test-db
-pct exec 201 -- bash -c "dd if=/dev/urandom bs=1M count=10 | curl -X POST -d @- http://example.com 2>/dev/null || true"
-
-# In Panoptikon UI → Device detail → Bandwidth tab
-# Expect: TX/RX bytes increase for the respective devices
+# Expected: test-ubuntu.local and test-debian.local entries appear
+# test-alpine.local should also appear (avahi installed by setup script)
 ```
 
-### 3. Firewall Rule Visibility
+### 3. Device Identification (Vendor Fingerprint)
 
-**Goal:** Verify Panoptikon displays MikroTik firewall rules.
+**Goal:** Verify Panoptikon correctly identifies different OS types.
+
+The three containers present different DHCP vendor class identifiers:
+- Alpine: minimal dhclient fingerprint
+- Ubuntu 22.04: standard Ubuntu dhclient
+- Debian 12: Debian-specific dhclient
+
+Check the Panoptikon Devices page — each device should show the correct OS in its identification details.
+
+### 4. Firewall Rule Testing
+
+**Goal:** Verify Panoptikon can manage firewall rules that affect test containers.
 
 ```routeros
 # Add a test firewall rule on MikroTik
-/ip firewall filter add chain=forward src-address=10.10.0.202 action=drop comment="block-iot-test"
+/ip firewall filter add chain=forward src-address=10.10.0.202 action=drop comment="block-test-ubuntu"
 ```
 
 ```bash
-# In Panoptikon UI → Router → Firewall tab
-# Expect: "block-iot-test" rule visible
+# In Panoptikon UI -> Router -> Firewall tab
+# Expect: "block-test-ubuntu" rule visible
 
-# Verify IoT container is blocked
-pct exec 202 -- ping -c2 8.8.8.8  # Should fail
+# Verify container is blocked
+pct exec 202 -- bash -c "ping -c2 8.8.8.8"  # Should fail
 
 # Clean up
-# /ip firewall filter remove [find comment="block-iot-test"]
+# /ip firewall filter remove [find comment="block-test-ubuntu"]
 ```
 
-### 4. VLAN Integration
-
-**Goal:** Verify VLAN assignment and tagging works through Panoptikon.
-
-```routeros
-# On MikroTik — assign test container to VLAN 100
-/interface bridge port add bridge=bridge-test interface=ether2 pvid=100
-```
-
-```bash
-# In Panoptikon UI → Router → VLANs tab
-# Expect: VLAN 100 visible with associated interfaces
-
-# In Panoptikon UI → Topology view
-# Expect: VLAN grouping shown for tagged devices
-```
-
-### 5. Device Discovery (ARP + mDNS)
+### 5. ARP Discovery
 
 **Goal:** Verify containers appear via ARP scanning (not just DHCP).
 
 ```bash
-# All three containers should appear in Panoptikon device list
-# even if DHCP leases expire — ARP scanner picks them up
-
 # Generate ARP traffic
-pct exec 200 -- ping -c3 10.10.0.125
-pct exec 201 -- ping -c3 10.10.0.125
+pct exec 201 -- sh -c "ping -c3 10.10.0.125"
+pct exec 202 -- bash -c "ping -c3 10.10.0.125"
+pct exec 203 -- bash -c "ping -c3 10.10.0.125"
 
-# Check Panoptikon API
-curl -s http://10.10.0.14:8080/api/v1/devices | jq '.[].ip' | sort
-# Expect: 10.10.0.200, 10.10.0.201, 10.10.0.202 in the list
-```
-
-## Generating Sustained Test Traffic
-
-For longer validation sessions, run background traffic generators:
-
-```bash
-# On pan-test-web (CT 200) — periodic HTTP requests
-pct exec 200 -- bash -c "while true; do curl -s -o /dev/null http://example.com; sleep 5; done" &
-
-# On pan-test-db (CT 201) — periodic DNS + larger transfers
-pct exec 201 -- bash -c "while true; do curl -s -o /dev/null https://speed.cloudflare.com/__down?bytes=1000000; sleep 10; done" &
+# Check Panoptikon API — all three should be present
+curl -sb cookies.txt http://localhost:8080/api/v1/devices | jq '.[].ip' | sort
 ```
 
 ## Troubleshooting
 
 | Problem | Check |
 |---------|-------|
-| Containers can't reach gateway | `pct exec 200 -- ping 10.10.0.125` — verify bridge connectivity |
+| Containers can't reach gateway | `pct exec 201 -- ping 10.10.0.125` — verify bridge connectivity |
 | No DHCP leases on MikroTik | Verify DHCP server is running: `/ip dhcp-server print` |
 | Panoptikon doesn't see containers | Verify ARP scanner subnet includes `10.10.0.0/24` in `panoptikon.toml` |
 | REST API connection refused | Check MikroTik: `/ip service print` — api-ssl should be enabled |
 | Containers have no internet | Check NAT masquerade: `/ip firewall nat print` |
+| mDNS not working | Verify avahi-daemon: `pct exec 202 -- systemctl status avahi-daemon` |
 | DNS queries to 10.10.0.22 fail | Verify Unbound container is running: `docker compose ps unbound` |
 | DNS queries timeout | Check CT 115 firewall allows port 53: `cat /etc/pve/firewall/115.fw` |
-| `local.ok.labs` not resolving | Verify unbound.conf has `local-data` entry and restart: `docker compose restart unbound` |
 
 ## Cleanup
 
 ```bash
 # Remove all test containers
-sudo bash scripts/setup-test-env.sh destroy
+scp scripts/test-env/teardown-lxc.sh root@10.10.0.11:/tmp/
+ssh root@10.10.0.11 bash /tmp/teardown-lxc.sh
 
 # Remove MikroTik test rules (from RouterOS terminal)
-/ip firewall filter remove [find comment="block-iot-test"]
+/ip firewall filter remove [find comment~"block-test"]
 /user remove panoptikon
 ```
+
+## Notes
+
+- Proxmox API: `https://10.10.0.11:8006` (credentials in Infisical under `/proxmox-devbox`)
+- Root password for all containers: `panoptikon-test` (test environment only)
+- The containers can be left running permanently as a stable test environment
+- Storage: `local-lvm`, 2 GB root disk each

--- a/scripts/test-env/setup-lxc.sh
+++ b/scripts/test-env/setup-lxc.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# setup-lxc.sh — Create LXC test containers on Proxmox DevBox
+#
+# Run this script ON the Proxmox host (10.10.0.11) as root.
+# It creates 3 lightweight containers that act as real DHCP clients
+# on vmbr0, visible to MikroTik and Panoptikon for device discovery testing.
+#
+# Usage:
+#   scp scripts/test-env/setup-lxc.sh root@10.10.0.11:/tmp/
+#   ssh root@10.10.0.11 bash /tmp/setup-lxc.sh
+#
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+BRIDGE="vmbr0"
+STORAGE="local-lvm"
+
+# Container definitions: CT_ID|OS_TEMPLATE|HOSTNAME|MEMORY_MB|PURPOSE
+CONTAINERS=(
+  "201|alpine|test-alpine|128|minimal Linux test device"
+  "202|ubuntu-22.04|test-ubuntu|512|mDNS via avahi-daemon"
+  "203|debian-12|test-debian|512|different vendor fingerprint"
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+log() { printf '\033[1;32m[test-env]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[test-env]\033[0m %s\n' "$*" >&2; }
+
+template_for() {
+  local os="$1"
+  # Find the most recent matching template already downloaded
+  local tpl
+  case "$os" in
+    alpine)
+      tpl=$(pveam list "$STORAGE" 2>/dev/null | awk '/alpine/ {print $1}' | sort -V | tail -1) ;;
+    ubuntu-22.04)
+      tpl=$(pveam list "$STORAGE" 2>/dev/null | awk '/ubuntu-22.04/ {print $1}' | sort -V | tail -1) ;;
+    debian-12)
+      tpl=$(pveam list "$STORAGE" 2>/dev/null | awk '/debian-12/ {print $1}' | sort -V | tail -1) ;;
+    *)
+      err "Unknown OS: $os"; return 1 ;;
+  esac
+
+  if [ -z "$tpl" ]; then
+    log "Template for $os not found locally, downloading..."
+    pveam update
+    case "$os" in
+      alpine)
+        tpl=$(pveam available --section system | awk '/alpine/ {print $2}' | sort -V | tail -1) ;;
+      ubuntu-22.04)
+        tpl=$(pveam available --section system | awk '/ubuntu-22.04/ {print $2}' | sort -V | tail -1) ;;
+      debian-12)
+        tpl=$(pveam available --section system | awk '/debian-12/ {print $2}' | sort -V | tail -1) ;;
+    esac
+    [ -z "$tpl" ] && { err "No template available for $os"; return 1; }
+    pveam download "$STORAGE" "$tpl"
+    tpl="${STORAGE}:vztmpl/${tpl}"
+  fi
+
+  echo "$tpl"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+log "Setting up Panoptikon LXC test environment"
+
+for entry in "${CONTAINERS[@]}"; do
+  IFS='|' read -r ct_id os hostname mem_mb purpose <<< "$entry"
+
+  if pct status "$ct_id" &>/dev/null; then
+    log "CT $ct_id ($hostname) already exists, skipping creation"
+    # Ensure it's running
+    if ! pct status "$ct_id" | grep -q running; then
+      pct start "$ct_id"
+      log "CT $ct_id started"
+    fi
+    continue
+  fi
+
+  log "Creating CT $ct_id: $hostname ($os, ${mem_mb}MB) — $purpose"
+
+  tpl=$(template_for "$os")
+
+  pct create "$ct_id" "$tpl" \
+    --hostname "$hostname" \
+    --memory "$mem_mb" \
+    --swap 0 \
+    --cores 1 \
+    --rootfs "${STORAGE}:2" \
+    --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp" \
+    --unprivileged 1 \
+    --start 0 \
+    --onboot 1 \
+    --password "panoptikon-test"
+
+  log "Starting CT $ct_id..."
+  pct start "$ct_id"
+
+  # Wait for container to boot and get an IP
+  log "Waiting for CT $ct_id to get a DHCP lease..."
+  for i in $(seq 1 30); do
+    ip=$(pct exec "$ct_id" -- sh -c "ip -4 addr show eth0 2>/dev/null | grep -oP 'inet \K[0-9.]+'") || true
+    if [ -n "$ip" ] && [ "$ip" != "127.0.0.1" ]; then
+      log "CT $ct_id ($hostname) got IP: $ip"
+      break
+    fi
+    sleep 2
+  done
+
+  # ── Per-OS post-setup ────────────────────────────────────────────────────
+  case "$os" in
+    alpine)
+      log "CT $ct_id: Installing avahi on Alpine..."
+      pct exec "$ct_id" -- sh -c "
+        apk update && apk add --no-cache avahi dbus
+        rc-update add dbus default
+        rc-update add avahi-daemon default
+        rc-service dbus start
+        rc-service avahi-daemon start
+      " || log "CT $ct_id: avahi setup had warnings (may be normal for Alpine)"
+      ;;
+
+    ubuntu-22.04)
+      log "CT $ct_id: Installing avahi on Ubuntu..."
+      pct exec "$ct_id" -- bash -c "
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y -qq avahi-daemon avahi-utils >/dev/null
+        systemctl enable avahi-daemon
+        systemctl start avahi-daemon
+      "
+      ;;
+
+    debian-12)
+      log "CT $ct_id: Installing avahi on Debian..."
+      pct exec "$ct_id" -- bash -c "
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y -qq avahi-daemon avahi-utils >/dev/null
+        systemctl enable avahi-daemon
+        systemctl start avahi-daemon
+      "
+      ;;
+  esac
+
+  log "CT $ct_id ($hostname) ready"
+done
+
+log ""
+log "Test environment ready. Container summary:"
+log "──────────────────────────────────────────"
+for entry in "${CONTAINERS[@]}"; do
+  IFS='|' read -r ct_id os hostname mem_mb purpose <<< "$entry"
+  ip=$(pct exec "$ct_id" -- sh -c "ip -4 addr show eth0 2>/dev/null | grep -oP 'inet \K[0-9.]+'") || ip="(no IP yet)"
+  status=$(pct status "$ct_id" 2>/dev/null | awk '{print $2}')
+  printf '  CT %-4s  %-14s  %-16s  %s  %s\n' "$ct_id" "$hostname" "$ip" "$status" "($purpose)"
+done
+log ""
+log "Next steps:"
+log "  1. Verify containers appear in MikroTik DHCP leases"
+log "  2. Check Panoptikon Devices page for the 3 new devices"
+log "  3. Run: bash /tmp/verify-lxc.sh  (to verify mDNS and DHCP)"

--- a/scripts/test-env/teardown-lxc.sh
+++ b/scripts/test-env/teardown-lxc.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# teardown-lxc.sh — Remove LXC test containers from Proxmox DevBox
+#
+# Run this script ON the Proxmox host (10.10.0.11) as root.
+#
+# Usage:
+#   ssh root@10.10.0.11 bash /tmp/teardown-lxc.sh
+#
+set -euo pipefail
+
+CONTAINER_IDS=(201 202 203)
+
+log() { printf '\033[1;32m[test-env]\033[0m %s\n' "$*"; }
+
+log "Tearing down Panoptikon LXC test environment"
+
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    log "CT $ct_id does not exist, skipping"
+    continue
+  fi
+
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+
+  if pct status "$ct_id" | grep -q running; then
+    log "Stopping CT $ct_id ($hostname)..."
+    pct stop "$ct_id"
+  fi
+
+  log "Destroying CT $ct_id ($hostname)..."
+  pct destroy "$ct_id" --purge
+
+  log "CT $ct_id removed"
+done
+
+log "Test environment teardown complete"

--- a/scripts/test-env/verify-lxc.sh
+++ b/scripts/test-env/verify-lxc.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# verify-lxc.sh — Verify LXC test containers are running and discoverable
+#
+# Run this script ON the Proxmox host (10.10.0.11) as root.
+#
+# Usage:
+#   ssh root@10.10.0.11 bash /tmp/verify-lxc.sh
+#
+set -euo pipefail
+
+CONTAINER_IDS=(201 202 203)
+MIKROTIK_IP="${MIKROTIK_IP:-10.10.0.125}"
+
+log()  { printf '\033[1;32m[verify]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[verify]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[FAIL]\033[0m  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf '\033[1;32m[OK]\033[0m    %s\n' "$*"; }
+
+FAILURES=0
+
+log "Verifying Panoptikon LXC test environment"
+log ""
+
+# ── 1. Check containers are running ─────────────────────────────────────────
+log "1. Container status"
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    fail "CT $ct_id does not exist"
+    continue
+  fi
+
+  status=$(pct status "$ct_id" | awk '{print $2}')
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+
+  if [ "$status" = "running" ]; then
+    pass "CT $ct_id ($hostname) is running"
+  else
+    fail "CT $ct_id ($hostname) is $status (expected: running)"
+  fi
+done
+log ""
+
+# ── 2. Check DHCP leases (each container has an IP) ─────────────────────────
+log "2. DHCP leases"
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    continue
+  fi
+
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+  ip=$(pct exec "$ct_id" -- sh -c "ip -4 addr show eth0 2>/dev/null | grep -oP 'inet \K[0-9.]+'") || ip=""
+
+  if [ -n "$ip" ] && [ "$ip" != "127.0.0.1" ]; then
+    pass "CT $ct_id ($hostname) has IP $ip"
+  else
+    fail "CT $ct_id ($hostname) has no DHCP lease"
+  fi
+done
+log ""
+
+# ── 3. Check mDNS (avahi-daemon running) ────────────────────────────────────
+log "3. mDNS (avahi-daemon)"
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    continue
+  fi
+
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+  avahi_running=$(pct exec "$ct_id" -- sh -c "pgrep avahi-daemon >/dev/null 2>&1 && echo yes || echo no") || avahi_running="no"
+
+  if [ "$avahi_running" = "yes" ]; then
+    pass "CT $ct_id ($hostname) has avahi-daemon running"
+  else
+    warn "CT $ct_id ($hostname) avahi-daemon not running (expected for: ubuntu, debian)"
+  fi
+done
+log ""
+
+# ── 4. Check hostname resolves via mDNS (.local) ────────────────────────────
+log "4. mDNS resolution (.local)"
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    continue
+  fi
+
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+
+  if command -v avahi-resolve-host-name &>/dev/null; then
+    resolved=$(avahi-resolve-host-name -4 "${hostname}.local" 2>/dev/null | awk '{print $2}') || resolved=""
+    if [ -n "$resolved" ]; then
+      pass "CT $ct_id ${hostname}.local resolves to $resolved"
+    else
+      warn "CT $ct_id ${hostname}.local not resolvable (avahi may need time to propagate)"
+    fi
+  else
+    warn "avahi-resolve-host-name not available on this host, skipping mDNS resolution check"
+    break
+  fi
+done
+log ""
+
+# ── 5. Network connectivity ─────────────────────────────────────────────────
+log "5. Network connectivity (ping gateway)"
+for ct_id in "${CONTAINER_IDS[@]}"; do
+  if ! pct status "$ct_id" &>/dev/null; then
+    continue
+  fi
+
+  hostname=$(pct config "$ct_id" | grep hostname | awk '{print $2}')
+  ping_ok=$(pct exec "$ct_id" -- sh -c "ping -c 1 -W 2 $MIKROTIK_IP >/dev/null 2>&1 && echo yes || echo no") || ping_ok="no"
+
+  if [ "$ping_ok" = "yes" ]; then
+    pass "CT $ct_id ($hostname) can reach MikroTik ($MIKROTIK_IP)"
+  else
+    fail "CT $ct_id ($hostname) cannot reach MikroTik ($MIKROTIK_IP)"
+  fi
+done
+log ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+if [ "$FAILURES" -eq 0 ]; then
+  log "All checks passed"
+else
+  err() { printf '\033[1;31m[verify]\033[0m %s\n' "$*"; }
+  err "$FAILURES check(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
Closes #405

## Summary
- Add `scripts/test-env/setup-lxc.sh` — creates 3 LXC containers (test-alpine CT 201, test-ubuntu CT 202, test-debian CT 203) on DevBox Proxmox as real DHCP clients with mDNS via avahi-daemon
- Add `scripts/test-env/verify-lxc.sh` — verifies containers are running, have DHCP leases, avahi-daemon is active, mDNS resolves, and can reach MikroTik
- Add `scripts/test-env/teardown-lxc.sh` — stops and destroys all test containers
- Update `docs/test-environment.md` with new container definitions, topology diagram, setup instructions, and validation scenarios

## Details

| CT ID | OS | Hostname | Memory | Purpose |
|-------|-----|----------|--------|---------|
| 201 | Alpine | test-alpine | 128 MB | Minimal Linux — basic DHCP discovery |
| 202 | Ubuntu 22.04 | test-ubuntu | 512 MB | mDNS via avahi-daemon |
| 203 | Debian 12 | test-debian | 512 MB | Different vendor fingerprint |

All containers:
- Get IP via DHCP from MikroTik (10.10.0.125)
- Run avahi-daemon for mDNS `.local` announcements
- Connected to vmbr0 bridge (10.10.0.0/24 LAN)
- Setup script is idempotent and auto-downloads OS templates

## Smoke Test

Scripts pass bash syntax check (`bash -n`). No application code changes — this is infrastructure/docs only. Verified that `cargo check` passes (no Rust changes) and existing `docs/test-environment.md` is properly updated from the old container layout to the new one.

## Test plan
- [ ] Run `setup-lxc.sh` on DevBox Proxmox — containers created and started
- [ ] Run `verify-lxc.sh` — all checks pass (DHCP, mDNS, connectivity)
- [ ] Check Panoptikon Devices page — 3 new devices visible
- [ ] Verify hostnames pulled from MikroTik DHCP leases
- [ ] Run `teardown-lxc.sh` — containers cleanly removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three well-structured shell scripts for managing LXC test containers on Proxmox DevBox, plus comprehensive documentation. The scripts use proper error handling (`set -euo pipefail`), idempotent design, and provide clear user feedback. The setup script automatically downloads templates if needed, installs avahi-daemon for mDNS, and waits for DHCP leases. Documentation is thorough with detailed setup instructions, validation scenarios, and troubleshooting guidance.

**Key changes:**
- `setup-lxc.sh` — Creates 3 LXC containers (Alpine, Ubuntu, Debian) as real DHCP clients
- `teardown-lxc.sh` — Cleanly removes all test containers  
- `verify-lxc.sh` — Validates containers are running, have DHCP leases, mDNS working, and network connectivity
- Documentation updated with new container topology, usage instructions, and test scenarios

**Minor suggestion:**
- Firewall test example assumes CT 202 gets IP .202, but DHCP doesn't guarantee this — consider adding a note to check actual IP first

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — infrastructure/docs only, no application code changes
- All scripts pass bash syntax validation, use proper error handling with `set -euo pipefail`, and implement idempotent behavior. The documentation is comprehensive and well-organized. Only one minor style suggestion about clarifying DHCP IP assumptions in an example. No security concerns since this is test environment infrastructure with appropriate security model (root passwords documented as test-only, unprivileged containers).
- No files require special attention — all changes are well-implemented infrastructure scripts and documentation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/test-env/setup-lxc.sh | Well-structured script that creates LXC containers with proper error handling, idempotent design, and good user feedback |
| scripts/test-env/teardown-lxc.sh | Simple, clean teardown script with appropriate error handling and user feedback |
| scripts/test-env/verify-lxc.sh | Comprehensive verification script with clear pass/fail/warn feedback for all checks |
| docs/test-environment.md | Thorough documentation with one example that assumes DHCP IP assignment matches container ID, which may not be true |

</details>



<sub>Last reviewed commit: b9f0bc5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->