### PR TITLE
fix: sidebar missing scroll and collapsible groups on mobile (#415)

### DIFF
--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu } from "lucide-react";
+import { ChevronDown, Menu, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { navItems } from "./Sidebar";
+import { navGroups, useGroupCollapse } from "./Sidebar";
 import {
   Sheet,
   SheetContent,
@@ -17,6 +17,10 @@ export function MobileSidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const wsConnected = useWsConnected();
+  const { collapsed: groupCollapsed, toggle: toggleGroup } = useGroupCollapse(
+    navGroups,
+    pathname,
+  );
 
   return (
     <>
@@ -31,11 +35,11 @@ export function MobileSidebar() {
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent
           side="left"
-          className="w-72 border-slate-800 bg-slate-950 p-0"
+          className="flex h-full w-72 flex-col border-slate-800 bg-slate-950 p-0"
         >
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           {/* Logo */}
-          <div className="flex h-14 items-center border-b border-slate-800 px-4">
+          <div className="flex h-14 shrink-0 items-center border-b border-slate-800 px-4">
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500 text-sm font-bold text-white">
               P
             </div>
@@ -45,32 +49,88 @@ export function MobileSidebar() {
           </div>
 
           {/* Navigation */}
-          <nav className="flex-1 space-y-1 overflow-y-auto p-2">
-            {navItems.map((item) => {
-              const active = pathname?.startsWith(item.href);
-              const Icon = item.icon;
+          <nav className="flex-1 overflow-y-auto p-2">
+            {navGroups.map((group) => {
+              const isCollapsed = groupCollapsed[group.key] ?? false;
+              const hasActive = group.items.some((i) =>
+                pathname?.startsWith(i.href),
+              );
 
               return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setOpen(false)}
-                  className={cn(
-                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    active
-                      ? "bg-blue-500/10 text-blue-500"
-                      : "text-slate-400 hover:bg-slate-800/60 hover:text-white"
-                  )}
-                >
-                  <Icon className="h-[18px] w-[18px] shrink-0" />
-                  <span>{item.label}</span>
-                </Link>
+                <div key={group.key} className="mb-1">
+                  <button
+                    onClick={() => toggleGroup(group.key)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider transition-colors",
+                      hasActive
+                        ? "text-blue-400"
+                        : "text-slate-500 hover:text-slate-300",
+                    )}
+                  >
+                    <ChevronDown
+                      className={cn(
+                        "h-3 w-3 shrink-0 transition-transform duration-200",
+                        isCollapsed && "-rotate-90",
+                      )}
+                    />
+                    <span>{group.label}</span>
+                  </button>
+                  <div
+                    className={cn(
+                      "grid transition-all duration-200",
+                      isCollapsed
+                        ? "grid-rows-[0fr] opacity-0"
+                        : "grid-rows-[1fr] opacity-100",
+                    )}
+                  >
+                    <div className="overflow-hidden">
+                      {group.items.map((item) => {
+                        const active = pathname?.startsWith(item.href);
+                        const Icon = item.icon;
+
+                        return (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            onClick={() => setOpen(false)}
+                            className={cn(
+                              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                              active
+                                ? "bg-blue-500/10 text-blue-500"
+                                : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
+                            )}
+                          >
+                            <Icon className="h-[18px] w-[18px] shrink-0" />
+                            <span>{item.label}</span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
               );
             })}
+
+            {/* Settings — pinned after groups */}
+            <div className="mt-1 border-t border-slate-800/50 pt-1">
+              <Link
+                href="/settings"
+                onClick={() => setOpen(false)}
+                className={cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  pathname?.startsWith("/settings")
+                    ? "bg-blue-500/10 text-blue-500"
+                    : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
+                )}
+              >
+                <Settings className="h-[18px] w-[18px] shrink-0" />
+                <span>Settings</span>
+              </Link>
+            </div>
           </nav>
 
           {/* Status */}
-          <div className="border-t border-slate-800 p-3">
+          <div className="shrink-0 border-t border-slate-800 p-3">
             <div className="flex items-center gap-1.5 px-2">
               <span
                 className={cn(

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -55,7 +55,7 @@ interface NavGroup {
   defaultCollapsed?: boolean;
 }
 
-const navGroups: NavGroup[] = [
+export const navGroups: NavGroup[] = [
   {
     key: "network",
     label: "Network",
@@ -128,7 +128,7 @@ const settingsItem: NavItem = {
 
 const STORAGE_KEY = "panoptikon-nav-groups";
 
-function useGroupCollapse(groups: NavGroup[], pathname: string | null) {
+export function useGroupCollapse(groups: NavGroup[], pathname: string | null) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
     const defaults: Record<string, boolean> = {};
     for (const g of groups) {


### PR DESCRIPTION
Closes #415

## Summary

- **Scroll fix**: Added `flex flex-col h-full` to `SheetContent` and `shrink-0` to the header/footer so the `<nav>` element properly fills the remaining space and `overflow-y-auto` activates when items overflow
- **Collapsible groups**: Replaced the flat `navItems` rendering with `navGroups` + `useGroupCollapse` hook (same as desktop sidebar), giving mobile users collapsible category headers with animated expand/collapse
- Settings link pinned below groups with separator, matching the desktop layout

## Changes

| File | What |
|------|------|
| `MobileSidebar.tsx` | Rewrote to use `navGroups` with collapsible headers, fixed flex layout for scroll |
| `Sidebar.tsx` | Exported `navGroups` and `useGroupCollapse` so mobile sidebar can reuse them |

## Smoke Test

- TypeScript typecheck passes (`tsc --noEmit` — clean)
- Collapse state shared via localStorage between desktop and mobile sidebars
- Group collapse/expand uses the same CSS grid animation as desktop

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed mobile sidebar scroll and added collapsible navigation groups. The implementation reuses the existing desktop sidebar's `navGroups` structure and `useGroupCollapse` hook, ensuring consistent behavior and shared state via localStorage.

- Applied flexbox layout pattern (`flex flex-col h-full` on container, `shrink-0` on header/footer, `flex-1` on nav) to enable proper scrolling when nav items overflow
- Replaced flat navigation list with grouped, collapsible sections using the same CSS grid animation as desktop
- Settings link now matches desktop layout (pinned below groups with separator)
- Collapse state persists across mobile/desktop sidebars via shared localStorage key

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- Clean implementation that reuses existing patterns and code. The flexbox layout fix follows standard CSS patterns, TypeScript typechecks pass, and the collapsible groups use the same animation and state management as the desktop sidebar. No logic errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/layout/MobileSidebar.tsx | Added collapsible nav groups with shared state and fixed scroll layout using flexbox pattern |
| web/src/components/layout/Sidebar.tsx | Exported navGroups and useGroupCollapse for mobile sidebar reuse |

</details>



<sub>Last reviewed commit: 6e4902c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->