### PR TITLE
fix: router page mobile layout — scrollable tabs + responsive cards (#416)

### DIFF
--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -18,7 +18,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <Sidebar />
         <div className="flex flex-1 flex-col overflow-hidden">
           <TopBar mobileMenu={<MobileSidebar />} />
-          <main className="min-h-0 flex-1 overflow-y-auto p-3 md:p-6">{children}</main>
+          <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 md:p-6">{children}</main>
         </div>
       </div>
       <CommandPalette />

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -220,7 +220,7 @@ function StatusHeader({ status }: { status: RouterStatus }) {
           </p>
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Badge
           variant="outline"
           className="border-amber-500/30 bg-amber-500/10 text-amber-400"
@@ -6092,66 +6092,66 @@ function RouterTabs({ summary }: { summary: RouterSummary }) {
   }, [interfaces, configIfaces]);
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <StatusHeader status={status} />
 
-      <Tabs value={tab} onValueChange={setTab}>
+      <Tabs value={tab} onValueChange={setTab} className="min-w-0">
         <TabsList className="border-slate-800 bg-slate-950">
           <TabsTrigger
             value="system"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Activity className="mr-1.5 h-3.5 w-3.5" />
-            System
+            <Activity className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">System</span>
           </TabsTrigger>
           <TabsTrigger
             value="interfaces"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Network className="mr-1.5 h-3.5 w-3.5" />
-            Interfaces
+            <Network className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Interfaces</span>
           </TabsTrigger>
           <TabsTrigger
             value="routes"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Globe className="mr-1.5 h-3.5 w-3.5" />
-            Routes
+            <Globe className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Routes</span>
           </TabsTrigger>
           <TabsTrigger
             value="dhcp"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Server className="mr-1.5 h-3.5 w-3.5" />
-            DHCP
+            <Server className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">DHCP</span>
           </TabsTrigger>
           <TabsTrigger
             value="dns"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Search className="mr-1.5 h-3.5 w-3.5" />
-            DNS
+            <Search className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">DNS</span>
           </TabsTrigger>
           <TabsTrigger
             value="firewall"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Shield className="mr-1.5 h-3.5 w-3.5" />
-            Firewall
+            <Shield className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Firewall</span>
           </TabsTrigger>
           <TabsTrigger
             value="vpn"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Lock className="mr-1.5 h-3.5 w-3.5" />
-            VPN
+            <Lock className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">VPN</span>
           </TabsTrigger>
           <TabsTrigger
             value="speedtest"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Gauge className="mr-1.5 h-3.5 w-3.5" />
-            Speed Test
+            <Gauge className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Speed Test</span>
           </TabsTrigger>
         </TabsList>
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -87,3 +87,12 @@
 .status-glow-offline-pulse {
   animation: glow-pulse-rose 2s ease-in-out infinite;
 }
+
+/* Hide scrollbar while preserving scroll behavior */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -2658,64 +2658,64 @@ export default function MikrotikRouter() {
             value="system"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Activity className="mr-1.5 h-3.5 w-3.5" />
-            System
+            <Activity className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">System</span>
           </TabsTrigger>
           <TabsTrigger
             value="interfaces"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Network className="mr-1.5 h-3.5 w-3.5" />
-            Interfaces
+            <Network className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Interfaces</span>
           </TabsTrigger>
           <TabsTrigger
             value="vlans"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Layers className="mr-1.5 h-3.5 w-3.5" />
-            VLANs
+            <Layers className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">VLANs</span>
           </TabsTrigger>
           <TabsTrigger
             value="routes"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Globe className="mr-1.5 h-3.5 w-3.5" />
-            Routes
+            <Globe className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Routes</span>
           </TabsTrigger>
           <TabsTrigger
             value="dhcp"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Server className="mr-1.5 h-3.5 w-3.5" />
-            DHCP
+            <Server className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">DHCP</span>
           </TabsTrigger>
           <TabsTrigger
             value="dns"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Search className="mr-1.5 h-3.5 w-3.5" />
-            DNS
+            <Search className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">DNS</span>
           </TabsTrigger>
           <TabsTrigger
             value="firewall"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Shield className="mr-1.5 h-3.5 w-3.5" />
-            Firewall
+            <Shield className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Firewall</span>
           </TabsTrigger>
           <TabsTrigger
             value="vpn"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <Lock className="mr-1.5 h-3.5 w-3.5" />
-            VPN
+            <Lock className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">VPN</span>
           </TabsTrigger>
           <TabsTrigger
             value="traffic"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
           >
-            <BarChart3 className="mr-1.5 h-3.5 w-3.5" />
-            Traffic
+            <BarChart3 className="sm:mr-1.5 h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Traffic</span>
           </TabsTrigger>
         </TabsList>
 

--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -37,7 +37,7 @@ export function RouterSelector({ active }: RouterSelectorProps) {
 
   return (
     <div className="space-y-3">
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button
           variant={active === "mikrotik" ? "default" : "outline"}
           size="sm"

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4 sm:p-6", className)}
     {...props}
   />
 ))
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0 sm:p-6 sm:pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -15,7 +15,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground max-w-full overflow-x-auto scrollbar-hide",
       className
     )}
     {...props}


### PR DESCRIPTION
Closes #416

## Summary
- **Scrollable tab bar**: `TabsList` now uses `max-w-full overflow-x-auto` with a hidden scrollbar so tabs scroll horizontally within the viewport instead of causing page-wide horizontal overflow
- **Icon-only tabs on mobile**: Tab labels are hidden below `640px` (`sm:` breakpoint), showing only icons — keeps all 8-9 tabs visible without scrolling on most phones
- **Responsive card padding**: `CardHeader` and `CardContent` use `p-4` on mobile, `p-6` on `sm+` for tighter card layouts on small screens
- **Overflow containment**: Main content area gets `min-w-0` and `overflow-x-hidden` to prevent any child from causing horizontal page scroll
- **Flex-wrap on badges/buttons**: `StatusHeader` badges and `RouterSelector` buttons now wrap gracefully on narrow screens
- Applied consistently to both VyOS and MikroTik router pages

## Smoke Test
- Verified all changes are CSS/Tailwind class adjustments only — no logic changes
- Grep confirmed all 8 VyOS tab triggers and all 9 MikroTik tab triggers have the responsive pattern applied
- `cargo fmt` passed (pre-push hook)
- Rust server unchanged — all changes are in `web/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully addresses mobile layout issues by implementing a comprehensive responsive design strategy across router pages. The changes are CSS-only with no logic modifications, focusing on three key improvements: icon-only tabs on mobile (labels hidden below 640px with `sm:` breakpoint), scrollable tab bars with hidden scrollbars, and responsive card padding.

- All 8 VyOS tabs and 9 MikroTik tabs updated consistently with the responsive pattern
- Added overflow containment (`min-w-0`, `overflow-x-hidden`) to prevent horizontal page scroll
- Flex-wrap applied to badge/button containers for proper wrapping on narrow screens
- Custom `.scrollbar-hide` utility provides cross-browser scrollbar hiding
- Responsive padding reduces card density on mobile (`p-4`) while maintaining desktop spacing (`p-6`)

One minor style optimization found: redundant `sm:pt-0` class in `CardContent` (can be removed since `pt-0` already applies to all breakpoints).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — CSS-only changes with consistent implementation
- All changes are purely presentational (Tailwind CSS classes) with no logic modifications, reducing risk of runtime errors. The responsive patterns are applied consistently across both VyOS and MikroTik router pages. Only minor style optimization identified (redundant Tailwind class).
- No files require special attention — the one style comment in `card.tsx` is optional cleanup

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/router/page.tsx | Implemented responsive tabs (icon-only below 640px) and flex-wrap for badges — all 8 VyOS tabs updated consistently |
| web/src/components/MikrotikRouter.tsx | Applied same responsive tab pattern to all 9 MikroTik tabs — consistent with VyOS implementation |
| web/src/components/ui/card.tsx | Responsive padding (`p-4` mobile, `p-6` sm+) for CardHeader and CardContent — minor redundant class in CardContent |
| web/src/components/ui/tabs.tsx | Added horizontal scroll with hidden scrollbar to TabsList for overflow handling on small screens |

</details>



<sub>Last reviewed commit: e9fe22e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->