### PR TITLE
feat: auto-deploy on merge — GitHub Actions self-hosted runner + maestro deploy hook (#419)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,13 @@
+name: Deploy to LXC
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Build & Deploy to LXC 115
+    runs-on: self-hosted
+    steps:
+      - name: Run deploy script
+        run: /home/shtrudel/src/panoptikon/scripts/deploy-lxc.sh

--- a/scripts/deploy-lxc.sh
+++ b/scripts/deploy-lxc.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# deploy-lxc.sh — Build and deploy panoptikon to LXC 115 via DevBox (10.10.0.11).
+#
+# Used by:
+#   - GitHub Actions self-hosted runner (deploy.yml)
+#   - Maestro deploy hook (maestro-panoptikon.yaml)
+#
+# Topology:
+#   shtrudel (10.10.0.14) → scp binary → DevBox (10.10.0.11) → pct push → LXC 115 (10.10.0.22)
+#
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/home/shtrudel/src/panoptikon}"
+DEVBOX="root@10.10.0.11"
+LXC_ID="115"
+BUN="${BUN:-$HOME/.bun/bin/bun}"
+CARGO="${CARGO:-$HOME/.cargo/bin/cargo}"
+
+cd "$REPO_ROOT"
+
+echo "=== Step 1/4: Pulling latest main ==="
+git checkout main
+git pull origin main
+
+echo "=== Step 2/4: Building web frontend ==="
+cd web
+"$BUN" install --frozen-lockfile
+"$BUN" run build
+cd "$REPO_ROOT"
+
+echo "=== Step 3/4: Building Rust server ==="
+"$CARGO" build --release -p panoptikon-server
+
+echo "=== Step 4/4: Deploying to LXC $LXC_ID ==="
+scp target/release/panoptikon-server "$DEVBOX":/tmp/panoptikon-server
+ssh "$DEVBOX" "pct exec $LXC_ID -- systemctl stop panoptikon; pct push $LXC_ID /tmp/panoptikon-server /usr/local/bin/panoptikon-server; pct exec $LXC_ID -- systemctl start panoptikon"
+
+echo ""
+echo "Deploy complete — panoptikon is running on LXC $LXC_ID"


### PR DESCRIPTION
Closes #419

## Summary
- Added `scripts/deploy-lxc.sh` — shared deploy script that pulls main, builds frontend (bun) + server (cargo), then deploys to LXC 115 via DevBox (10.10.0.11)
- Added `.github/workflows/deploy.yml` — triggers on push to main, runs on self-hosted runner (shtrudel), executes the deploy script
- Updated `maestro-panoptikon.yaml` deploy_cmd to point to the new shared script

## How it works
1. Code merges to `main`
2. Self-hosted runner on shtrudel picks up the workflow
3. Deploy script: `git pull` → `bun build` → `cargo build --release` → `scp` binary to DevBox → `pct push` into LXC 115 → `systemctl restart`

## Smoke Test
- Verified deploy script is executable and has correct shebang
- Verified workflow YAML is valid and triggers on push to main
- Verified maestro config points to the new script path
- No Rust/TS code changes — CI should pass as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

adds auto-deployment to LXC 115 via GitHub Actions self-hosted runner — triggers on push to main, runs shared deploy script that pulls code, builds frontend + backend, and deploys to production

**Key changes:**
- New GitHub Actions workflow (`deploy.yml`) runs on self-hosted runner and executes the deploy script
- New deployment script (`deploy-lxc.sh`) handles git pull, bun build, cargo build, and deployment to LXC via DevBox
- Script uses `set -euo pipefail` for error handling and has clear step-by-step progress logging

**Issues found:**
- Deployment stops the service before pushing the new binary, creating downtime risk if push fails
- No concurrency control means simultaneous deployments could interfere
- No health check to verify service is working after deployment

<h3>Confidence Score: 3/5</h3>

- safe to merge with minor deployment reliability risks
- the deployment automation is well-structured with clear error handling (`set -euo pipefail`), but the service stop-before-push pattern creates unnecessary downtime risk if the deployment fails midway — this should be addressed but doesn't block merging
- `scripts/deploy-lxc.sh` needs atomic deployment logic to prevent service downtime during failed pushes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | new deploy workflow for LXC — runs on self-hosted runner, needs concurrency control |
| scripts/deploy-lxc.sh | deploy script with service downtime risk — stops service before push, needs atomic swap logic |

</details>



<sub>Last reviewed commit: f381076</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->