### PR TITLE
fix: deduplicate alerts and add clear-all to notification bell (#422)

### DIFF
--- a/server/src/api/alerts.rs
+++ b/server/src/api/alerts.rs
@@ -313,6 +313,34 @@ where
     result.is_some()
 }
 
+/// Check if a recent alert of the same type already exists for a device
+/// within the given cooldown window (in seconds). Used to deduplicate
+/// alerts from device state flapping (e.g. repeated online/offline cycles).
+pub async fn recent_alert_exists<'e, E>(
+    executor: E,
+    device_id: &str,
+    alert_type: &str,
+    cooldown_secs: i64,
+) -> bool
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    let result: Option<i64> = sqlx::query_scalar(
+        r#"SELECT 1 FROM alerts
+           WHERE device_id = ? AND type = ?
+             AND created_at > datetime('now', '-' || ? || ' seconds')
+           LIMIT 1"#,
+    )
+    .bind(device_id)
+    .bind(alert_type)
+    .bind(cooldown_secs)
+    .fetch_optional(executor)
+    .await
+    .unwrap_or(None);
+
+    result.is_some()
+}
+
 /// Determine the severity level for an alert type.
 pub fn severity_for_alert_type(alert_type: &str) -> &'static str {
     match alert_type {

--- a/server/src/scanner/mod.rs
+++ b/server/src/scanner/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
-use crate::api::alerts::{is_device_muted, severity_for_alert_type};
+use crate::api::alerts::{is_device_muted, recent_alert_exists, severity_for_alert_type};
 use crate::config::ScannerConfig;
 
 /// Enrichment target tuple: (device_id, ip, mac, hostname, vendor, mdns_services).
@@ -266,8 +266,10 @@ pub async fn process_scan_results(
                     .execute(&mut *tx)
                     .await?;
 
-                    // Create alert (skip if device is muted).
-                    if !is_device_muted(&mut *tx, &device_id).await {
+                    // Create alert (skip if device is muted or duplicate).
+                    if !is_device_muted(&mut *tx, &device_id).await
+                        && !recent_alert_exists(&mut *tx, &device_id, "device_online", 600).await
+                    {
                         let alert_id = uuid::Uuid::new_v4().to_string();
                         let severity = severity_for_alert_type("device_online");
                         sqlx::query(
@@ -498,8 +500,10 @@ pub async fn process_scan_results(
         .execute(&mut *tx)
         .await?;
 
-        // Create alert (skip if device is muted).
-        if !is_device_muted(&mut *tx, device_id).await {
+        // Create alert (skip if device is muted or duplicate).
+        if !is_device_muted(&mut *tx, device_id).await
+            && !recent_alert_exists(&mut *tx, device_id, "device_offline", 600).await
+        {
             let alert_id = uuid::Uuid::new_v4().to_string();
             let severity = severity_for_alert_type("device_offline");
             sqlx::query(

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -3,7 +3,7 @@
 import { type ReactNode, useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
-import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, logout } from "@/lib/api";
+import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, deleteAllAlerts, logout } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
 import { timeAgo } from "@/lib/format";
 import type { SearchResponse, SearchDevice, SearchAgent, SearchAlert, SearchSshTarget, SearchAsset, Alert } from "@/lib/types";
@@ -52,10 +52,20 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
     return () => clearInterval(interval);
   }, [refreshAlerts]);
 
+  // Debounced refresh — coalesce rapid WS events into a single API call
+  const wsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedRefresh = useCallback(() => {
+    if (wsDebounceRef.current) clearTimeout(wsDebounceRef.current);
+    wsDebounceRef.current = setTimeout(() => {
+      refreshAlerts();
+      wsDebounceRef.current = null;
+    }, 2_000);
+  }, [refreshAlerts]);
+
   // Refresh on WebSocket device/agent events (often accompany alerts)
   useWsEvent(
     ["device_online", "device_offline", "new_device", "agent_offline"],
-    refreshAlerts,
+    debouncedRefresh,
   );
 
   // Click outside to close bell dropdown
@@ -74,6 +84,16 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
       await markAllAlertsRead();
       setUnreadCount(0);
       setAlerts((prev) => prev.map((a) => ({ ...a, is_read: true })));
+    } catch {
+      // ignore
+    }
+  }
+
+  async function handleClearAll() {
+    try {
+      await deleteAllAlerts();
+      setUnreadCount(0);
+      setAlerts([]);
     } catch {
       // ignore
     }
@@ -428,14 +448,24 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
             <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-md border border-slate-800 bg-slate-950 shadow-xl">
               <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2.5">
                 <span className="text-sm font-semibold text-white">Notifications</span>
-                {unreadCount > 0 && (
-                  <button
-                    onClick={handleMarkAllRead}
-                    className="text-xs text-accent hover:text-accent/80 transition-colors"
-                  >
-                    Mark all read
-                  </button>
-                )}
+                <div className="flex items-center gap-3">
+                  {unreadCount > 0 && (
+                    <button
+                      onClick={handleMarkAllRead}
+                      className="text-xs text-accent hover:text-accent/80 transition-colors"
+                    >
+                      Mark all read
+                    </button>
+                  )}
+                  {alerts.length > 0 && (
+                    <button
+                      onClick={handleClearAll}
+                      className="text-xs text-slate-400 hover:text-rose-400 transition-colors"
+                    >
+                      Clear all
+                    </button>
+                  )}
+                </div>
               </div>
 
               <div className="max-h-72 overflow-y-auto">


### PR DESCRIPTION
Closes #422

## Summary

- **Backend alert deduplication**: Added a 10-minute cooldown check (`recent_alert_exists`) before creating `device_online` and `device_offline` alerts. If an alert of the same type for the same device was created within the last 10 minutes, the duplicate is skipped. This prevents notification spam from network instability causing device state flapping.
- **"Clear all" button**: Added a "Clear all" button in the notification bell dropdown that deletes all alerts (calls `DELETE /api/v1/alerts`), giving users a way to dismiss accumulated notifications.
- **WebSocket debouncing**: Debounced the WebSocket event handler (2-second window) so rapid device state changes are coalesced into a single API refresh instead of hammering the server.

## Changes

| File | Change |
|------|--------|
| `server/src/api/alerts.rs` | Added `recent_alert_exists()` — checks for duplicate alerts within a cooldown window |
| `server/src/scanner/mod.rs` | Added dedup guard before `device_online` and `device_offline` alert creation |
| `web/src/components/layout/TopBar.tsx` | Added "Clear all" button, debounced WS refresh |

## Smoke Test

- `cargo check` passes clean (no errors in my code)
- All 14 existing tests in `alerts::tests` and `scanner::tests` pass
- Verified `recent_alert_exists` is called with 600s (10 min) cooldown
- Verified frontend imports `deleteAllAlerts` and calls it on "Clear all" click
- `cargo fmt` passes (confirmed by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Successfully implements alert deduplication (10-minute cooldown), "Clear all" button, and WebSocket debouncing to prevent notification spam from network instability.

- **Backend**: Added `recent_alert_exists()` helper with SQLite datetime arithmetic to check for duplicates. Clean implementation, though error logging would improve observability.
- **Frontend**: Added "Clear all" functionality and debounced WS events (2s window) to reduce API hammering. Missing cleanup for debounce timeout could cause state updates on unmounted component.
- **Testing concern**: No new tests added for deduplication behavior. Consider adding tests to verify the 10-minute cooldown works correctly and prevents duplicate alerts.
- **Minor**: Cooldown constant (600s) is duplicated across two call sites — extract to named constant for maintainability.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor cleanup recommended — core logic is sound but missing cleanup and test coverage
- Implementation is straightforward and achieves the stated goals. One logic issue (missing debounce cleanup) could cause console warnings, and lack of test coverage for new functionality is a gap. Style issues are minor.
- Pay attention to `web/src/components/layout/TopBar.tsx` for the missing cleanup logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/alerts.rs | Added `recent_alert_exists()` helper to check for duplicate alerts within a cooldown window. Implementation is clean but could benefit from error logging. |
| server/src/scanner/mod.rs | Integrated deduplication guards for `device_online` and `device_offline` alerts with 10-minute cooldown. Hardcoded constant should be extracted. |
| web/src/components/layout/TopBar.tsx | Added "Clear all" button and WebSocket debouncing (2s window). Missing cleanup for debounce timeout could cause state updates on unmounted component. |

</details>



<sub>Last reviewed commit: 7f4e9f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->