### PR TITLE
fix: router page shows unreachable despite successful connection in settings (#421)

### DIFF
--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -216,7 +216,11 @@ pub async fn status(
                 error = %e,
                 "MiWiFi status request failed, probing connectivity via init_info"
             );
-            let reachable = client.init_info().await.is_ok();
+            // Use unauthenticated init_info for the reachability probe.
+            // The xqsystem/init_info endpoint does not require a stok token,
+            // so this succeeds even when login/auth is broken — matching the
+            // behaviour of the settings-page test-connection check.
+            let reachable = client.init_info_no_auth().await.is_ok();
             if !reachable {
                 tracing::error!("MiWiFi status and init_info probes both failed");
             }

--- a/server/src/xiaomi/client.rs
+++ b/server/src/xiaomi/client.rs
@@ -374,6 +374,16 @@ impl XiaomiClient {
         Ok(res)
     }
 
+    /// Fetch init info without authentication (for reachability probes).
+    ///
+    /// The `xqsystem/init_info` endpoint on Xiaomi routers does not require
+    /// a stok token, so this can succeed even when login/auth is broken.
+    pub async fn init_info_no_auth(&self) -> Result<InitInfo> {
+        let val = self.get_no_auth("xqsystem/init_info").await?;
+        let res: InitInfo = serde_json::from_value(val).context("failed to parse init info")?;
+        Ok(res)
+    }
+
     /// Check for ROM/firmware updates.
     pub async fn check_rom_update(&self) -> Result<Option<RomUpdateInfo>> {
         let val = self.get_authed("xqsystem/check_rom_update").await?;


### PR DESCRIPTION
## Summary

- The Xiaomi router page showed "unreachable" even when the Settings page confirmed connectivity
- **Root cause**: The status endpoint's reachability fallback used `init_info()` through the authenticated path (`get_authed`). When authentication failed (stale token, wrong password, etc.), both `system_status()` and the `init_info()` fallback failed — resulting in `reachable: false`
- The Settings page's test-connection endpoint used an **unauthenticated** `init_info` request directly, which succeeded regardless of auth state — creating the inconsistency
- **Fix**: Added `init_info_no_auth()` method to `XiaomiClient` and switched the status endpoint's reachability probe to use it, matching the settings page behavior

## Changes

- `server/src/xiaomi/client.rs`: Added `init_info_no_auth()` method that uses `get_no_auth` instead of `get_authed`
- `server/src/api/xiaomi.rs`: Changed the status handler's fallback from `client.init_info()` to `client.init_info_no_auth()`

## Smoke Test

- Verified all 6 existing xiaomi tests pass (`cargo test --lib -p panoptikon-server -- xiaomi`)
- Verified `cargo check` passes (pre-existing `web/out/` RustEmbed error is unrelated)
- Verified `cargo fmt` produces no changes
- Confirmed the `xqsystem/init_info` endpoint does not require authentication on Xiaomi routers (the test-connection handler already uses it without auth successfully)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly identifies and fixes a reachability inconsistency in the Xiaomi router integration: the status endpoint's fallback probe used the authenticated `init_info()` path, while the settings page used an unauthenticated probe — causing the router page to report "unreachable" even when the settings page confirmed connectivity. The fix is minimal, well-scoped, and well-documented.

**Key changes:**
- Added `init_info_no_auth()` to `XiaomiClient`, a thin wrapper over `get_no_auth("xqsystem/init_info")` — clean and consistent with existing patterns.
- Switched the `status` handler's reachability fallback to use `init_info_no_auth()`, aligning it with the settings-page behaviour.

**Minor observations:**
- The `firmware` handler (`/xiaomi/firmware`) still uses the authenticated `client.init_info()` to determine `reachable`, meaning it is subject to the same inconsistency that this PR fixes for the status handler. If the firmware page displays a reachability indicator, it would still show "unreachable" when auth is broken despite the router being up.
- The `warn!` tracing log on the changed code path still reads `"probing connectivity via init_info"` without mentioning the no-auth distinction; a small update would improve log clarity.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the change is minimal, targeted, and has been smoke-tested; only a potential follow-up for the firmware handler remains.
- The core fix is correct and well-reasoned. The new method is a clean addition with no side-effects on other callers. The only concern is the `firmware` handler still using the authenticated path for reachability, which is a pre-existing issue not introduced by this PR. All existing tests pass.
- `server/src/api/xiaomi.rs` — specifically the `firmware` handler around line 508 which has the same reachability pattern as the pre-fix status handler.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/client.rs | Adds `init_info_no_auth()` — a clean, well-documented thin wrapper over `get_no_auth("xqsystem/init_info")`. Mirrors the existing `init_info()` structure exactly; no issues introduced. |
| server/src/api/xiaomi.rs | Status handler fallback correctly switched to `init_info_no_auth()`, fixing the described inconsistency. The `firmware` handler (line 508) still uses the authenticated `init_info()` for both data fetch and implicit reachability, leaving it with the same potential mismatch — this is a pre-existing issue but worth addressing for consistency. |

</details>



<sub>Last reviewed commit: 2fdf720</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->