### PR TITLE
fix: Xiaomi Mesh settings — Router IP field resets to 'admin' instead of saved IP (#425)

### DIFF
--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -255,6 +255,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="text"
                 value={ip}
                 onChange={(e) => setIp(e.target.value)}
+                autoComplete="off"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="10.10.0.199"
               />
@@ -281,6 +282,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                autoComplete="off"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder={
                   passwordSet


### PR DESCRIPTION
Closes #425

## Summary
- The Router IP field on the Xiaomi Mesh settings page displayed "admin" instead of the saved IP after page reload
- **Root cause**: Browser password managers detect the text input + password input pattern and autofill the text field with a saved username ("admin"), overwriting the correct value loaded from the backend
- **Fix**: Added `autoComplete="off"` to both the Router IP and Password inputs to prevent browser autofill

## Analysis
- Backend code verified correct: `settings.rs` reads/writes `xiaomi_mesh_ip` with the right DB key, serialization is correct
- No other code path writes to the `xiaomi_mesh_ip` setting key
- The existing IPv4 validation already prevents "admin" from being saved (Save button is disabled when IP is not a valid IPv4), confirming this is a display-only issue caused by browser autofill
- The text+password input pattern is a well-known trigger for browser credential autofill

## Smoke Test
- Verified the `autoComplete="off"` prop is correctly placed on both `<Input>` elements
- The shadcn/ui `Input` component passes all props through to the native `<input>` element via `{...props}`
- Rust build passes (`cargo check` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a browser autofill issue where the Router IP field was displaying "admin" instead of the saved IP address after page reload. The root cause was password managers detecting the text input + password input pattern and autofilling the IP field with a saved username. The fix adds `autoComplete="off"` to both the Router IP and Password inputs, preventing unwanted browser autofill behavior.

The change is minimal, targeted, and correctly addresses the reported issue. The shadcn/ui `Input` component properly passes the `autoComplete` prop through to the native input element via `{...props}`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-understood fix for a common browser autofill issue. It adds two `autoComplete="off"` attributes to form inputs, which is a standard, non-breaking approach. The Input component correctly passes props through, and the fix directly addresses the reported bug without affecting any other functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | Added `autoComplete="off"` to Router IP and Password inputs to prevent browser autofill from overwriting the IP field with "admin" |

</details>



<sub>Last reviewed commit: cf65ce6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->