### PR TITLE
fix: devices page cards layout stuck to top (#427)

### DIFF
--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -554,8 +554,8 @@ export default function DevicesPage() {
       ) : view === "grid" ? (
         <StaggerContainer className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
           {sorted.map((device) => (
-            <StaggerItem key={device.id}>
-              <MotionCard>
+            <StaggerItem key={device.id} className="h-full">
+              <MotionCard className="h-full">
                 <DeviceCard
                   device={device}
                   onClick={() => setSelectedDevice(device)}
@@ -639,7 +639,7 @@ function DeviceCard({
 
   return (
     <Card
-      className="cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:bg-slate-800/60 hover:border-blue-500/50"
+      className="h-full cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:bg-slate-800/60 hover:border-blue-500/50"
       onClick={onClick}
     >
       <CardContent className="p-5">


### PR DESCRIPTION
## Summary
- Add `h-full` to the `StaggerItem` → `MotionCard` → `Card` chain in the devices grid view
- This ensures all cards in a grid row stretch to equal height instead of being stuck to the top of their cell

## Root cause
In CSS Grid, direct children (StaggerItem) stretch to fill the row height by default, but nested elements (MotionCard, Card) don't inherit this stretching. Cards with less content (no mDNS badges, no agent stats, etc.) appeared shorter and misaligned.

## Changes
- `web/src/app/(app)/devices/page.tsx`: Added `h-full` className to `StaggerItem`, `MotionCard`, and `Card` in the grid rendering path

## Smoke Test
- Verified `next build` passes with no errors
- Confirmed the grid class `grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4` provides proper column sizing and gap spacing
- The `h-full` chain ensures cards fill their grid cells completely, distributing evenly across rows

Closes #427

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `h-full` className to the component chain (`StaggerItem` → `MotionCard` → `Card`) in the devices grid view to fix a layout issue where cards with less content appeared shorter and misaligned.

## Changes
- Added `h-full` to `StaggerItem` and `MotionCard` wrapper components in the grid rendering path
- Added `h-full` to the `Card` component in `DeviceCard` to complete the full-height chain

## Assessment
This is a clean, targeted fix for a CSS Grid layout issue. In CSS Grid, direct children stretch to fill row height by default, but nested elements don't inherit this behavior. By adding `h-full` to each level of the component hierarchy, all cards in a row now stretch to match the tallest card's height, creating a consistent, aligned grid layout.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple CSS styling fix with no logic changes, no new dependencies, and verified component compatibility. The change is localized to the grid view layout and addresses a specific visual issue.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Added `h-full` to StaggerItem, MotionCard, and Card in grid view to ensure cards stretch evenly across grid rows |

</details>



<sub>Last reviewed commit: dfc242f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->