### PR TITLE
fix: Devices page — cards layout stuck to top, needs proper grid/spacing (#427)

### DIFF
--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -554,8 +554,8 @@ export default function DevicesPage() {
       ) : view === "grid" ? (
         <StaggerContainer className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
           {sorted.map((device) => (
-            <StaggerItem key={device.id}>
-              <MotionCard>
+            <StaggerItem key={device.id} className="h-full">
+              <MotionCard className="h-full">
                 <DeviceCard
                   device={device}
                   onClick={() => setSelectedDevice(device)}
@@ -639,7 +639,7 @@ function DeviceCard({
 
   return (
     <Card
-      className="cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:bg-slate-800/60 hover:border-blue-500/50"
+      className="h-full cursor-pointer border-slate-800 bg-slate-900 transition-colors hover:bg-slate-800/60 hover:border-blue-500/50"
       onClick={onClick}
     >
       <CardContent className="p-5">


### PR DESCRIPTION
## Summary
- Added `h-full` to `StaggerItem` and `MotionCard` wrappers in the Devices grid view
- Added `h-full` to the `Card` element in `DeviceCard` component

## Root cause
Device cards are wrapped in `StaggerItem > MotionCard > Card`. CSS Grid stretches direct children (StaggerItem) to fill row height, but nested wrappers default to `height: auto` — only as tall as their content. Cards in the same row with different content heights left shorter cards visually stuck to the top of their cells with empty space below.

## Fix
Propagate `h-full` through the wrapper chain so all cards uniformly fill their grid cells, creating consistent row heights and proper visual alignment.

## Smoke Test
- Verified `h-full` classes are correctly applied to `StaggerItem`, `MotionCard`, and `DeviceCard`'s `Card` component
- Grepped codebase to confirm no other pages use the same `StaggerItem > MotionCard` pattern with grid, so changes are scoped to Devices page only
- Rust `cargo check` passes clean

Closes #427

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CSS Grid layout issue where device cards in the grid view were stuck to the top of their cells with uneven spacing. The fix properly propagates `h-full` through the wrapper chain (`StaggerItem` > `MotionCard` > `Card`) so all cards uniformly fill their grid cells.

- Fixed card alignment by adding `h-full` to three wrapper components
- Changes are scoped to devices page grid view only (verified no other pages use same pattern)
- No impact on animations or existing functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal (3 lines), well-scoped to a single view, use standard Tailwind CSS patterns, and have been verified to not affect other parts of the codebase. The fix addresses a clear CSS Grid layout issue without introducing side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Added h-full classes to StaggerItem, MotionCard, and Card to propagate grid cell height through wrapper chain, fixing card alignment in grid view |

</details>



<sub>Last reviewed commit: d3d073e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->