### PR TITLE
fix: auto-mark devices as known when identified (#426)

### DIFF
--- a/server/src/device_resolver.rs
+++ b/server/src/device_resolver.rs
@@ -193,11 +193,12 @@ pub async fn resolve_devices(db: &SqlitePool) -> ResolveResult {
 
     for (mac, mapping) in &mac_to_hostname {
         // Update hostname for devices that don't have one yet.
-        // Also set name if it's null (display name).
+        // Also set name if it's null (display name), and mark as known.
         let updated = sqlx::query(
             "UPDATE devices SET \
              hostname = ?, \
              name = COALESCE(name, ?), \
+             is_known = 1, \
              updated_at = ? \
              WHERE mac = ? AND hostname IS NULL",
         )

--- a/server/src/dhcp.rs
+++ b/server/src/dhcp.rs
@@ -107,9 +107,10 @@ pub async fn enrich_from_dhcp_leases(pool: &SqlitePool, config: &AppConfig) {
 
         // Update hostname for devices that don't already have one.
         let result = sqlx::query(
-            r#"UPDATE devices SET hostname = ?, updated_at = datetime('now')
+            r#"UPDATE devices SET hostname = ?, name = COALESCE(name, ?), is_known = 1, updated_at = datetime('now')
                WHERE mac = ? AND (hostname IS NULL OR hostname = '')"#,
         )
+        .bind(hostname)
         .bind(hostname)
         .bind(&mac_normalized)
         .execute(pool)

--- a/server/src/enrichment.rs
+++ b/server/src/enrichment.rs
@@ -138,6 +138,7 @@ pub async fn persist_enrichment(
             device_model = COALESCE(?, device_model),
             device_brand = COALESCE(?, device_brand),
             enrichment_source = COALESCE(?, enrichment_source),
+            is_known = 1,
             updated_at = datetime('now')
         WHERE id = ?"#,
     )

--- a/server/src/mdns.rs
+++ b/server/src/mdns.rs
@@ -183,12 +183,14 @@ pub async fn upsert_mdns_info(
 
     // Update hostname if device doesn't have one yet
     if current_hostname.is_none() && !hostname.is_empty() {
-        let result =
-            sqlx::query(r#"UPDATE devices SET hostname = ? WHERE id = ? AND hostname IS NULL"#)
-                .bind(hostname)
-                .bind(&device_id)
-                .execute(pool)
-                .await?;
+        let result = sqlx::query(
+            r#"UPDATE devices SET hostname = ?, name = COALESCE(name, ?), is_known = 1 WHERE id = ? AND hostname IS NULL"#,
+        )
+        .bind(hostname)
+        .bind(hostname)
+        .bind(&device_id)
+        .execute(pool)
+        .await?;
         if result.rows_affected() > 0 {
             info!("mDNS: set hostname '{hostname}' for device {device_id} (IP: {ip})");
             changed = true;

--- a/server/src/scanner/device_identify.rs
+++ b/server/src/scanner/device_identify.rs
@@ -202,12 +202,13 @@ pub async fn identify_from_external_sources(db: &SqlitePool, device_macs: &[(Str
             None => continue,
         };
 
-        // Priority 1: MikroTik DHCP hostname → sets `hostname` column.
+        // Priority 1: MikroTik DHCP hostname → sets `hostname` + `name` + marks known.
         if current_hostname.is_none() || current_hostname.as_deref() == Some("") {
             if let Some(dhcp_hostname) = mikrotik_hostnames.get(&mac_lower) {
                 if let Err(e) = sqlx::query(
-                    "UPDATE devices SET hostname = ?, updated_at = datetime('now') WHERE id = ? AND (hostname IS NULL OR hostname = '')",
+                    "UPDATE devices SET hostname = ?, name = COALESCE(name, ?), is_known = 1, updated_at = datetime('now') WHERE id = ? AND (hostname IS NULL OR hostname = '')",
                 )
+                .bind(dhcp_hostname)
                 .bind(dhcp_hostname)
                 .bind(device_id)
                 .execute(db)
@@ -222,12 +223,13 @@ pub async fn identify_from_external_sources(db: &SqlitePool, device_macs: &[(Str
             }
         }
 
-        // Priority 2: Xiaomi device name → sets `hostname` column (since `name` is user-assigned).
+        // Priority 2: Xiaomi device name → sets `hostname` + `name` + marks known.
         if current_hostname.is_none() || current_hostname.as_deref() == Some("") {
             if let Some(xiaomi_name) = xiaomi_names.get(&mac_lower) {
                 if let Err(e) = sqlx::query(
-                    "UPDATE devices SET hostname = ?, updated_at = datetime('now') WHERE id = ? AND (hostname IS NULL OR hostname = '')",
+                    "UPDATE devices SET hostname = ?, name = COALESCE(name, ?), is_known = 1, updated_at = datetime('now') WHERE id = ? AND (hostname IS NULL OR hostname = '')",
                 )
+                .bind(xiaomi_name)
                 .bind(xiaomi_name)
                 .bind(device_id)
                 .execute(db)

--- a/server/src/scanner/mod.rs
+++ b/server/src/scanner/mod.rs
@@ -156,8 +156,9 @@ async fn update_hostname(
     match hostname {
         Some(hostname) => {
             if let Err(e) = sqlx::query(
-                "UPDATE devices SET hostname = ?, updated_at = ? WHERE id = ? AND (hostname IS NULL OR hostname != ?)",
+                "UPDATE devices SET hostname = ?, name = COALESCE(name, ?), is_known = 1, updated_at = ? WHERE id = ? AND (hostname IS NULL OR hostname != ?)",
             )
+            .bind(hostname)
             .bind(hostname)
             .bind(now)
             .bind(device_id)

--- a/server/src/ssdp.rs
+++ b/server/src/ssdp.rs
@@ -230,6 +230,7 @@ pub async fn enrich_from_ssdp(pool: &SqlitePool) {
                         CASE WHEN ? IS NOT NULL OR ? IS NOT NULL THEN 'ssdp' ELSE NULL END,
                         enrichment_source
                     ),
+                    is_known = 1,
                     updated_at = datetime('now')
                 WHERE id = ? AND enrichment_corrected != 1"#,
             )


### PR DESCRIPTION
Closes #426

## Summary
- Auto-set `is_known = 1` when **any** identification source succeeds (reverse DNS, MikroTik DHCP, Xiaomi, mDNS, VyOS DHCP, SSDP, enrichment)
- Also set `name = COALESCE(name, hostname)` when setting hostname from any source, so devices get a proper display name
- This removes the misleading "NEW" badge and "Unknown Device" display for devices that have been identified

## Root Cause
The `is_known` column (default 0) was **never automatically updated** by any identification pipeline. All discovery sources (DNS, DHCP, mDNS, SSDP, enrichment) would resolve hostnames, vendor info, and device types, but left `is_known = 0`. The frontend shows a "NEW" badge when `!device.is_known`, so all auto-discovered devices appeared as new/unknown regardless of identification success.

Additionally, several hostname sources only set the `hostname` column without also setting the `name` column. The frontend display chain is `custom_name ?? name ?? hostname ?? "Unknown Device"` — while `hostname` is a fallback, not setting `name` meant inconsistent behavior between the automatic scan cycle and the manual resolve API.

## Changes (7 files)
- **`scanner/device_identify.rs`** — MikroTik DHCP / Xiaomi: set `name` + `is_known = 1`
- **`scanner/mod.rs`** — Reverse DNS: set `name` + `is_known = 1`
- **`enrichment.rs`** — Enrichment engine: set `is_known = 1` when persisting device type/brand/OS
- **`mdns.rs`** — mDNS discovery: set `name` + `is_known = 1`
- **`dhcp.rs`** — VyOS DHCP enrichment: set `name` + `is_known = 1`
- **`ssdp.rs`** — SSDP/UPnP discovery: set `is_known = 1`
- **`device_resolver.rs`** — Manual resolve API: set `is_known = 1`

## Smoke Test
- `cargo check` passes with no errors
- All 303 lib tests pass (including enrichment, scanner, mDNS, DHCP, SSDP tests)
- SQL changes are additive columns in UPDATE statements — backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX issue where devices remained marked as "NEW" even after being successfully identified through various discovery sources (DNS, DHCP, mDNS, SSDP, enrichment).

## Key Changes
- **Automatic `is_known` marking**: All identification pipelines now set `is_known = 1` when they successfully identify a device
- **Display name consistency**: Sources that set `hostname` now also set `name = COALESCE(name, hostname)` to ensure consistent frontend display
- **Coverage**: Changes span 7 files covering all identification sources (reverse DNS, MikroTik DHCP, Xiaomi, mDNS, VyOS DHCP, SSDP, enrichment)

## Technical Review
- All SQL parameter bindings are correct and match query placeholders
- Changes are backward compatible (additive UPDATE columns only)
- Implementation pattern is consistent across all files
- No security issues or logic errors detected
- The fix addresses the root cause described in the PR (frontend shows "NEW" badge when `!device.is_known`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Perfect score due to: (1) consistent implementation pattern across all 7 files, (2) all SQL parameter bindings are correct, (3) changes are backward compatible and additive only, (4) addresses a clear UX issue without introducing side effects, (5) all 303 tests pass, and (6) no security concerns or logic errors detected
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/device_resolver.rs | Added `is_known = 1` and `name = COALESCE(name, ?)` when resolving devices via MikroTik/Xiaomi APIs. SQL bindings are correct. |
| server/src/dhcp.rs | Added `is_known = 1` and `name = COALESCE(name, ?)` when setting hostname from VyOS DHCP. Parameter bindings are correct. |
| server/src/enrichment.rs | Added `is_known = 1` when persisting enrichment data. Clean additive change with no parameter binding changes needed. |
| server/src/mdns.rs | Added `is_known = 1` and `name = COALESCE(name, ?)` when setting hostname from mDNS discovery. Bindings are correct. |
| server/src/scanner/device_identify.rs | Added `is_known = 1` and `name = COALESCE(name, ?)` for both MikroTik DHCP and Xiaomi identification sources. All bindings are correct. |
| server/src/scanner/mod.rs | Added `is_known = 1` and `name = COALESCE(name, ?)` when setting hostname via reverse DNS. Triple binding of hostname is correct (2x for SET, 1x for WHERE). |
| server/src/ssdp.rs | Added `is_known = 1` when enriching from SSDP/UPnP discovery. Parameter bindings for CASE statement are correct. |

</details>



<sub>Last reviewed commit: fbbe3db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->