### PR TITLE
fix: show user-friendly error when Xiaomi mesh router is unreachable (#429)

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -4,10 +4,11 @@
 //! endpoint which requires **no authentication**. The router IP is read from the
 //! `xiaomi_mesh_ip` setting (defaults to `10.10.0.199`).
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+use super::error::AppError;
 use super::AppState;
 
 // ── Settings helper ─────────────────────────────────────────
@@ -108,7 +109,7 @@ pub struct MeshTopologyResponse {
 /// GET /api/v1/mesh/topology
 pub async fn topology(
     State(state): State<AppState>,
-) -> Result<Json<MeshTopologyResponse>, StatusCode> {
+) -> Result<Json<MeshTopologyResponse>, AppError> {
     let router_ip = mesh_router_ip(&state).await;
     let url = format!("http://{router_ip}/cgi-bin/luci/api/misystem/topo_graph");
 
@@ -117,12 +118,14 @@ pub async fn topology(
         .build()
         .map_err(|e| {
             warn!("failed to build HTTP client for mesh: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
+            AppError::Internal("Failed to initialize HTTP client".to_string())
         })?;
 
     let resp = client.get(&url).send().await.map_err(|e| {
         warn!("failed to fetch mesh topology from {url}: {e}");
-        StatusCode::BAD_GATEWAY
+        AppError::BadGateway(format!(
+            "Could not reach Xiaomi mesh router at {router_ip}. Check the router IP in Settings \u{2192} Xiaomi Mesh."
+        ))
     })?;
 
     if !resp.status().is_success() {
@@ -130,17 +133,24 @@ pub async fn topology(
             "mesh topology endpoint returned HTTP {}",
             resp.status().as_u16()
         );
-        return Err(StatusCode::BAD_GATEWAY);
+        return Err(AppError::BadGateway(format!(
+            "Xiaomi mesh router at {router_ip} returned an error. Verify the router is a Xiaomi mesh device."
+        )));
     }
 
     let raw: XiaomiTopoResponse = resp.json().await.map_err(|e| {
         warn!("failed to parse mesh topology response: {e}");
-        StatusCode::BAD_GATEWAY
+        AppError::BadGateway(format!(
+            "Invalid response from Xiaomi mesh router at {router_ip}. The device may not be a supported Xiaomi mesh router."
+        ))
     })?;
 
     if raw.code != 0 {
         warn!("mesh topology returned error code {}", raw.code);
-        return Err(StatusCode::BAD_GATEWAY);
+        return Err(AppError::BadGateway(format!(
+            "Xiaomi mesh router at {router_ip} returned error code {}.",
+            raw.code
+        )));
     }
 
     let topo_nodes = raw.graph.map(|g| g.nodes).unwrap_or_default();

--- a/web/src/app/(app)/mesh/page.tsx
+++ b/web/src/app/(app)/mesh/page.tsx
@@ -24,7 +24,10 @@ import {
   Cable,
   MonitorSmartphone,
   Crown,
+  WifiOff,
+  Settings,
 } from 'lucide-react'
+import Link from 'next/link'
 import { fetchMeshTopology } from '@/lib/api'
 import type { MeshNode, MeshTopologyResponse } from '@/lib/types'
 import { PageTransition } from '@/components/PageTransition'
@@ -401,17 +404,39 @@ export default function MeshPage() {
     return (
       <PageTransition>
         <div className="flex h-[calc(100vh-64px)] items-center justify-center">
-          <div className="text-center">
-            <p className="text-sm text-rose-400">{error}</p>
-            <button
-              onClick={() => {
-                setLoading(true)
-                buildGraph(true)
-              }}
-              className="mt-3 text-xs text-blue-400 hover:underline"
-            >
-              Retry
-            </button>
+          <div className="mx-4 flex max-w-md flex-col items-center gap-4 rounded-xl border border-slate-800 bg-slate-900/80 p-8 text-center shadow-lg">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-rose-500/10">
+              <WifiOff className="h-6 w-6 text-rose-400" />
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-base font-semibold text-white">
+                Mesh router unreachable
+              </h2>
+              <p className="text-sm leading-relaxed text-slate-400">
+                Could not connect to the Xiaomi mesh router. Make sure the
+                router IP is correct and the device is reachable on your
+                network.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <Link
+                href="/settings/xiaomi-mesh"
+                className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-500"
+              >
+                <Settings className="h-3.5 w-3.5" />
+                Xiaomi Mesh Settings
+              </Link>
+              <button
+                onClick={() => {
+                  setLoading(true)
+                  buildGraph(true)
+                }}
+                className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-300 transition-colors hover:bg-slate-800"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retry
+              </button>
+            </div>
           </div>
         </div>
       </PageTransition>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -136,6 +136,7 @@ async function request<T>(
       try {
         const body = await res.json();
         if (body?.error) detail = body.error;
+        else if (body?.message) detail = body.message;
       } catch {
         // body wasn't JSON — keep statusText
       }


### PR DESCRIPTION
## Summary
- **Backend**: Replace bare `StatusCode::BAD_GATEWAY` returns in `mesh.rs` with `AppError::BadGateway(...)` containing descriptive messages (e.g. "Could not reach Xiaomi mesh router at {ip}. Check the router IP in Settings → Xiaomi Mesh.")
- **Frontend API client**: Update `request()` in `api.ts` to also extract `body.message` from error responses (the `ApiErrorBody` struct uses `message`, not `error`)
- **Frontend mesh page**: Replace raw red error text with a styled error card showing a WifiOff icon, helpful explanation, a link to Xiaomi Mesh Settings, and a Retry button

## Smoke Test
- `cargo check` passes with no errors
- `cargo test` — all 21 tests pass
- `next build` — frontend builds successfully
- Verified that the backend now returns JSON `{"code":"bad_gateway","message":"Could not reach Xiaomi mesh router at ..."}` instead of a bare 502 status
- Verified the frontend extracts the `message` field from the structured error body

Closes #429

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces bare HTTP status codes with structured error responses containing helpful, user-friendly messages when the Xiaomi mesh router is unreachable. The backend now returns detailed error messages with the router IP and troubleshooting guidance, while the frontend displays a polished error card with actionable buttons.

**Key improvements:**
- Backend returns `AppError::BadGateway` with context-specific messages instead of bare 502 status codes
- API client properly extracts `message` field from `ApiErrorBody` structure
- Frontend shows styled error card with icon, helpful text, link to settings, and retry button
- All smoke tests pass (cargo check, cargo test, next build)

**Minor consideration:**
- The frontend error card displays a generic message rather than the specific backend error messages, which could reduce the helpfulness of backend's context-specific errors (e.g., showing the actual router IP)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor UX consideration
- The changes are well-implemented and all tests pass. The backend properly returns structured errors, the API client correctly extracts error messages, and the frontend displays a polished error UI. The only consideration is that the frontend shows a generic message instead of the specific backend errors, which slightly reduces the value of the backend's detailed error messages.
- Pay attention to `web/src/app/(app)/mesh/page.tsx` - consider displaying the specific error message from the backend since it includes helpful context like the router IP address

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mesh.rs | Replaced bare status codes with structured `AppError::BadGateway` containing helpful error messages with router IP and troubleshooting guidance |
| web/src/lib/api.ts | Added extraction of `message` field from error responses to properly handle `ApiErrorBody` structure |
| web/src/app/(app)/mesh/page.tsx | Replaced plain error text with styled card including icon, description, settings link, and retry button. Generic message doesn't display specific backend errors |

</details>



<sub>Last reviewed commit: a7ec5e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->