### PR TITLE
fix: prevent browser autofill on Xiaomi Mesh IP/password inputs (#435)

### DIFF
--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -255,7 +255,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="text"
                 value={ip}
                 onChange={(e) => setIp(e.target.value)}
-                autoComplete="off"
+                autoComplete="one-time-code"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="10.10.0.199"
               />
@@ -282,7 +282,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                autoComplete="off"
+                autoComplete="new-password"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder={
                   passwordSet


### PR DESCRIPTION
Closes #435

## Summary
- Changed IP field `autocomplete` from `"off"` to `"one-time-code"` — browsers don't associate this with credential fields, so they won't autofill usernames into it
- Changed password field `autocomplete` from `"off"` to `"new-password"` — tells browsers this is for setting a new password, not for filling saved credentials

## Why
Browsers ignore `autocomplete="off"` for fields they detect as credential inputs. The IP field was being filled with `"admin"` from saved credentials because browsers matched the nearby password field and treated the text input above it as a username field. Using more specific autocomplete values prevents this behavior.

## Smoke Test
- Verified the diff only touches the two `autoComplete` attributes in `web/src/app/(app)/settings/xiaomi-mesh/page.tsx`
- No functional logic changed — the fix is purely about HTML autocomplete hints
- DB value (`xiaomi_mesh_ip = '10.10.0.199'`) was already confirmed correct; this is a browser-side rendering fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the browser autofill prevention fix for Xiaomi Mesh settings. The previous attempt using `autocomplete="off"` failed because modern browsers ignore it on credential fields. This implementation uses specific autocomplete values: `"one-time-code"` for the IP field prevents browsers from treating it as a username field, and `"new-password"` for the password field signals this is for setting a new password rather than filling saved credentials.

- Changed IP field autocomplete from `"off"` to `"one-time-code"` to prevent username association
- Changed password field autocomplete from `"off"` to `"new-password"` to prevent saved credential autofill
- No functional logic changes, purely HTML attribute updates

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal risk, HTML-only change with no functional impact
- Two-line change updating HTML autocomplete attributes with valid values, no logic modifications, addresses known browser behavior issue
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | Changed autocomplete attributes from "off" to specific values ("one-time-code" for IP, "new-password" for password) to prevent browser autofill |

</details>



<sub>Last reviewed commit: 2510191</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->