### PR TITLE
fix: Xiaomi settings IP field shows 'admin' — browser autofill ignores autocomplete=off (#435)

### DIFF
--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -255,7 +255,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="text"
                 value={ip}
                 onChange={(e) => setIp(e.target.value)}
-                autoComplete="off"
+                autoComplete="one-time-code"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="10.10.0.199"
               />
@@ -282,7 +282,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                autoComplete="off"
+                autoComplete="new-password"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder={
                   passwordSet


### PR DESCRIPTION
Closes #435

## Summary
- Changed IP field `autocomplete` from `"off"` to `"one-time-code"` — browsers don't associate this value with credential autofill, so the loaded IP value is preserved
- Changed password field `autocomplete` from `"off"` to `"new-password"` — tells browsers this is for setting a new password, not for filling saved credentials

## Why
Browsers ignore `autocomplete="off"` for fields they classify as credential inputs (username/password). The IP field was being autofilled with the saved username `"admin"` because the browser detected a nearby password field and treated the text input as a username field.

## Smoke Test
- Verified the correct `autoComplete` values are present in the source code via grep
- `next build` passes cleanly with the changes
- Only the target file (`web/src/app/(app)/settings/xiaomi-mesh/page.tsx`) was modified — 2 lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a browser autofill issue (#435) where the IP address field in the Xiaomi Mesh settings page was being filled with the saved username `"admin"` by the browser's credential manager, because `autocomplete="off"` is widely ignored by modern browsers for fields adjacent to a password input.

- **IP field**: Changed to `autoComplete="one-time-code"` — prevents credential autofill on desktop, but this value triggers iOS/Safari's native SMS OTP suggestion UI, which is semantically unexpected for an IP address field. A neutral alternative like `"url"` or `"address-level1"` would avoid both credential autofill and OTP suggestions.
- **Password field**: Changed to `autoComplete="new-password"` — this is the correct, W3C-recommended value for "set a new password" forms; it prevents browsers from filling saved login credentials, and no other settings pages were found to have the same `autocomplete="off"` pattern.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix correctly resolves the autofill bug; the only concern is a minor mobile UX side-effect on the IP field.
- The two-line change is minimal and targeted, `new-password` is the standard correct value for the password field, and no regressions are introduced. A small caveat is that `one-time-code` on the IP field may display an unexpected OTP suggestion on iOS Safari, which warrants consideration but is not a blocker.
- No files require special attention beyond the minor `autoComplete` value choice on line 258.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | Two-line fix changing `autoComplete="off"` to `"one-time-code"` (IP field) and `"new-password"` (password field). `new-password` is the correct standard value; `one-time-code` solves the desktop autofill issue but may trigger SMS OTP suggestion UI on iOS/Safari. |

</details>



<sub>Last reviewed commit: 9a80e21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->