### PR TITLE
fix: use specific autocomplete values to prevent browser autofill on Xiaomi Mesh inputs (#435)

### DIFF
--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -255,7 +255,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="text"
                 value={ip}
                 onChange={(e) => setIp(e.target.value)}
-                autoComplete="off"
+                autoComplete="one-time-code"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="10.10.0.199"
               />
@@ -282,7 +282,7 @@ export default function XiaomiMeshSettingsPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                autoComplete="off"
+                autoComplete="new-password"
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder={
                   passwordSet


### PR DESCRIPTION
Closes #435

## Summary
- Changed IP field `autocomplete="off"` → `autocomplete="one-time-code"` so browsers don't treat it as a username/credential field
- Changed password field `autocomplete="off"` → `autocomplete="new-password"` which browsers respect for password managers

## Root Cause
Browsers ignore `autocomplete="off"` for fields they detect as credential inputs. The IP field was being autofilled with `admin` from saved login credentials because the browser treated it as a username field (text input near a password input).

## Smoke Test
- Verified the fix compiles: `bun run build` passes
- Grep confirms the correct autocomplete values are set on lines 258 and 285 of `page.tsx`
- `autocomplete="one-time-code"` is a well-known workaround — browsers will not autofill credential data into fields with this attribute
- `autocomplete="new-password"` tells browsers this is for setting a new password, not for autofilling existing credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed autocomplete attributes on Xiaomi Mesh settings inputs to prevent unwanted browser autofill behavior. The IP field now uses `autocomplete="one-time-code"` (a well-known workaround to prevent credential autofill) and the password field uses `autocomplete="new-password"` (semantically correct for setting/updating passwords). These changes address the issue where browsers were autofilling the IP field with saved username credentials like "admin".

- Replaced `autocomplete="off"` with `autocomplete="one-time-code"` on IP input (line 258)
- Replaced `autocomplete="off"` with `autocomplete="new-password"` on password input (line 285)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal (only two autocomplete attribute values), well-tested, and use standard browser-respected values to solve a legitimate UX issue. No logic changes, no security concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | Changed autocomplete attributes to prevent browser autofill: IP field now uses `one-time-code` and password field uses `new-password` |

</details>



<sub>Last reviewed commit: 56d4fa2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->