### PR TITLE
feat: Caddy page — domain name should be clickable link to https://<domain> (#436)

### DIFF
--- a/web/src/app/(app)/caddy/page.tsx
+++ b/web/src/app/(app)/caddy/page.tsx
@@ -366,7 +366,14 @@ export default function CaddyPage() {
                       className="border-slate-800 hover:bg-slate-800/30"
                     >
                       <TableCell className="font-medium text-white">
-                        {host.domain}
+                        <a
+                          href={`https://${host.domain}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline text-blue-400"
+                        >
+                          {host.domain}
+                        </a>
                       </TableCell>
                       <TableCell className="text-slate-400">
                         {host.forward_scheme}://{host.forward_host}:


### PR DESCRIPTION
Closes #436

## Summary
- Domain column in the Caddy proxy hosts table now renders as a clickable `<a>` link pointing to `https://<domain>`
- Opens in a new tab (`target="_blank"` with `rel="noopener noreferrer"`)
- Styled with blue text and underline on hover for clear link affordance

## Changes
- `web/src/app/(app)/caddy/page.tsx` — wrapped `host.domain` text in an anchor element

## Smoke Test
- Verified `bun run build` passes with no errors before and after the change
- The link is constructed as `https://${host.domain}` which matches the expected behavior from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made domain names in the Caddy proxy hosts table clickable links to the corresponding domains. The link opens in a new tab with proper security attributes (`rel="noopener noreferrer"`).

- Added clickable link to domain column that wraps `host.domain`
- Link protocol hardcoded to `https://` - should respect `host.tls_enabled` to use `http://` when TLS is disabled

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the protocol logic to respect TLS settings
- The change introduces a useful feature but has a logic bug where links always use https:// regardless of the TLS setting, which will cause broken links for HTTP-only hosts
- Pay attention to `web/src/app/(app)/caddy/page.tsx` - the link protocol needs to be fixed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/caddy/page.tsx | Made domain clickable with link to https://<domain>, but link protocol should respect TLS setting |

</details>



<sub>Last reviewed commit: 9bce0f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->