### PR TITLE
feat: Caddy page — domain name should be clickable link to https://<domain> (#436)

### DIFF
--- a/web/src/app/(app)/caddy/page.tsx
+++ b/web/src/app/(app)/caddy/page.tsx
@@ -365,8 +365,15 @@ export default function CaddyPage() {
                       key={host.id}
                       className="border-slate-800 hover:bg-slate-800/30"
                     >
-                      <TableCell className="font-medium text-white">
-                        {host.domain}
+                      <TableCell className="font-medium">
+                        <a
+                          href={`https://${host.domain}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-400 hover:underline"
+                        >
+                          {host.domain}
+                        </a>
                       </TableCell>
                       <TableCell className="text-slate-400">
                         {host.forward_scheme}://{host.forward_host}:


### PR DESCRIPTION
Closes #436

## Summary
- Domain names in the Caddy proxy hosts table are now clickable links (`<a href="https://<domain>" target="_blank">`)
- Links open in a new tab with `rel="noopener noreferrer"` for security
- Styled with `text-blue-400 hover:underline` to be visually distinct as links while fitting the dark theme

## Smoke Test
- Verified TypeScript compiles cleanly (`tsc --noEmit` passes with no errors)
- The change is purely presentational — wraps `{host.domain}` in an `<a>` tag with `https://` prefix
- `target="_blank"` ensures new tab, `rel="noopener noreferrer"` follows security best practices

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes domain names in the Caddy proxy hosts table clickable by wrapping them in `<a>` tags. The change is small and self-contained, but the hardcoded `https://` scheme is incorrect for hosts where `tls_enabled` is `false` — those domains are served over plain HTTP and the resulting links will fail. Additionally, wildcard domain values (e.g. `*.example.com`) produce non-navigable URLs.

- **Protocol mismatch**: `href` always uses `https://` regardless of `host.tls_enabled`. The scheme should be derived from the flag to match how the TLS badge already distinguishes HTTP vs HTTPS in the same row.
- **Wildcard domains**: If a stored domain begins with `*.`, the generated URL (`https://*.example.com`) is invalid. Plain text fallback should be rendered for wildcard entries.
- **Positive**: Security attributes (`rel="noopener noreferrer"`) and new-tab behaviour (`target="_blank"`) are correctly applied.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the hardcoded `https://` scheme for non-TLS hosts.
- The change is purely presentational and isolated to one file, but the hardcoded `https://` will produce broken links for any proxy host configured without TLS, which is a real functional regression for those rows.
- web/src/app/(app)/caddy/page.tsx — line 370: `href` scheme must be conditioned on `host.tls_enabled`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/caddy/page.tsx | Domain column now renders a clickable `https://` link, but the scheme is hardcoded regardless of `tls_enabled`, which will produce broken links for HTTP-only hosts. Wildcard domains also generate invalid URLs. |

</details>



<sub>Last reviewed commit: 7ef6c94</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->