### PR TITLE
feat: enforce E2E test coverage — PRs without tests for new features must be rejected (#428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,59 @@ jobs:
       - name: Build
         run: bun run build
 
+  e2e-check:
+    name: E2E Test Coverage Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for E2E test changes or justification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get list of changed files in this PR
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Check if any source files changed (not just docs/config)
+          HAS_SRC_CHANGES=false
+          for f in $CHANGED; do
+            case "$f" in
+              server/src/*|web/src/*) HAS_SRC_CHANGES=true; break ;;
+            esac
+          done
+
+          if [ "$HAS_SRC_CHANGES" = "false" ]; then
+            echo "No source changes detected — E2E test not required"
+            exit 0
+          fi
+
+          # Check if E2E tests were added or modified
+          HAS_E2E=false
+          for f in $CHANGED; do
+            case "$f" in
+              web/tests/e2e/*|web/e2e/*) HAS_E2E=true; break ;;
+            esac
+          done
+
+          if [ "$HAS_E2E" = "true" ]; then
+            echo "E2E test changes detected — check passed"
+            exit 0
+          fi
+
+          # Check PR body for justification
+          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body -q .body 2>/dev/null || echo "")
+          if echo "$PR_BODY" | grep -qi "why no e2e test"; then
+            echo "PR contains 'Why no E2E test' justification — check passed"
+            exit 0
+          fi
+
+          echo "::error::This PR changes source code but does not include E2E tests."
+          echo "::error::Either add Playwright tests in web/tests/e2e/ or add a '## Why no E2E test' section to the PR description."
+          exit 1
+
   e2e:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,5 +9,11 @@ jobs:
     name: Build & Deploy to LXC 115
     runs-on: self-hosted
     steps:
-      - name: Run deploy script
+      - name: Run deploy script (includes smoke test)
         run: /home/shtrudel/src/panoptikon/scripts/deploy-lxc.sh
+
+      - name: Alert on failure
+        if: failure()
+        run: |
+          echo "::error::Deploy or smoke test failed — panoptikon on LXC 115 may be unhealthy"
+          wall "PANOPTIKON: Deploy failed smoke test — check GitHub Actions" 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Panoptikon — Development Guidelines
+
+## E2E Test Requirement (Mandatory)
+
+Every PR that implements a feature or bug fix **MUST** include a Playwright E2E test that verifies the change actually works.
+
+### Rules
+
+1. **Test must exist** — Add or update a test in `web/tests/e2e/` that exercises the feature end-to-end.
+2. **Test must fail before, pass after** — The test should demonstrate the fix/feature works. If modifying an existing test, the old behavior should fail and the new behavior should pass.
+3. **No test = explicit justification** — If the change is genuinely untestable (e.g., pure CI config, docs-only), the PR description must include a section:
+   ```
+   ## Why no E2E test
+   <explanation>
+   ```
+4. **Settings changes need roundtrip tests** — Any change to a settings page must include a save → reload → verify test (see existing patterns in `settings-xiaomi.spec.ts` and `settings-router.spec.ts`).
+5. **UI changes need visual coverage** — Layout changes, new pages, or component changes should have screenshot assertions or at minimum verify elements are visible and correctly positioned.
+
+### Test patterns
+
+- Test files go in `web/tests/e2e/<feature>.spec.ts`
+- Use shared fixtures from `web/e2e/fixtures.ts` (`login`, `setupIfNeeded`, `test`, `expect`)
+- Follow existing test structure: `test.describe` → `test.beforeEach` (login + navigate) → individual `test()` cases
+- Run tests locally: `cd web && bunx playwright test`
+- Run a specific test: `cd web && bunx playwright test tests/e2e/<file>.spec.ts`
+
+### Smoke tests
+
+After deploy, a smoke test suite runs automatically to verify the deployment is healthy. Tests tagged with `@smoke` in `web/tests/e2e/smoke.spec.ts` cover:
+
+- Health endpoint responds
+- Login page loads
+- Dashboard loads after authentication
+- Key pages (Devices, Settings) are accessible
+- No JavaScript errors or crashes
+
+## Project Structure
+
+```
+panoptikon/
+├── server/                 # Rust backend (axum, SQLite)
+│   └── src/
+│       ├── api/mod.rs      # Route registration
+│       ├── api/<feature>.rs # Handlers
+│       └── db/             # Database models
+└── web/                    # Next.js frontend (TypeScript)
+    └── src/
+        ├── app/(app)/      # Pages
+        ├── components/     # Shared components (shadcn/ui)
+        └── lib/
+            ├── api.ts      # API client functions
+            └── types.ts    # TypeScript types
+```
+
+## Build & Test Commands
+
+- **Rust format**: `cargo fmt --all`
+- **Rust check**: `cargo check -p panoptikon-server`
+- **Rust test**: `cd server && cargo test`
+- **Frontend build**: `cd web && bun install && bun run build`
+- **E2E tests**: `cd web && bunx playwright test`
+- **Smoke tests**: `cd web && bunx playwright test tests/e2e/smoke.spec.ts`
+
+## Code Quality
+
+- Run `cargo fmt --all` before every commit
+- Run `cargo check` before pushing
+- Follow existing code patterns — look at similar files before writing
+- Use shadcn/ui components, dark theme with slate palette
+- No `window.alert/confirm/prompt` — use AlertDialog instead

--- a/scripts/deploy-lxc.sh
+++ b/scripts/deploy-lxc.sh
@@ -14,27 +14,44 @@ set -euo pipefail
 REPO_ROOT="${REPO_ROOT:-/home/shtrudel/src/panoptikon}"
 DEVBOX="root@10.10.0.11"
 LXC_ID="115"
+LXC_IP="10.10.0.22"
+LXC_PORT="8080"
 BUN="${BUN:-$HOME/.bun/bin/bun}"
 CARGO="${CARGO:-$HOME/.cargo/bin/cargo}"
+ALERT_USER="${ALERT_USER:-shtrudel}"
 
 cd "$REPO_ROOT"
 
-echo "=== Step 1/4: Pulling latest main ==="
+echo "=== Step 1/5: Pulling latest main ==="
 git checkout main
 git pull origin main
 
-echo "=== Step 2/4: Building web frontend ==="
+echo "=== Step 2/5: Building web frontend ==="
 cd web
 "$BUN" install --frozen-lockfile
 "$BUN" run build
 cd "$REPO_ROOT"
 
-echo "=== Step 3/4: Building Rust server ==="
+echo "=== Step 3/5: Building Rust server ==="
 "$CARGO" build --release -p panoptikon-server
 
-echo "=== Step 4/4: Deploying to LXC $LXC_ID ==="
+echo "=== Step 4/5: Deploying to LXC $LXC_ID ==="
 scp target/release/panoptikon-server "$DEVBOX":/tmp/panoptikon-server
 ssh "$DEVBOX" "pct exec $LXC_ID -- systemctl stop panoptikon; pct push $LXC_ID /tmp/panoptikon-server /usr/local/bin/panoptikon-server; pct exec $LXC_ID -- systemctl start panoptikon"
 
 echo ""
-echo "Deploy complete — panoptikon is running on LXC $LXC_ID"
+echo "=== Step 5/5: Post-deploy smoke test ==="
+
+SMOKE_URL="http://${LXC_IP}:${LXC_PORT}"
+
+if "$REPO_ROOT/scripts/smoke-test.sh" "$SMOKE_URL"; then
+  echo ""
+  echo "Deploy complete — panoptikon is running and healthy on LXC $LXC_ID"
+else
+  echo ""
+  echo "DEPLOY WARNING: Smoke test FAILED on LXC $LXC_ID"
+  echo "Alerting $ALERT_USER — deploy is NOT healthy."
+  # Send wall message to alert logged-in users
+  wall "PANOPTIKON DEPLOY FAILED SMOKE TEST on LXC $LXC_ID — check logs" 2>/dev/null || true
+  exit 1
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# smoke-test.sh — Post-deploy smoke test for panoptikon.
+#
+# Runs:
+#   1. curl health check against the target server
+#   2. Playwright smoke suite (key pages load, no crashes)
+#
+# Usage:
+#   scripts/smoke-test.sh [URL]
+#
+# Arguments:
+#   URL   Base URL to test (default: http://10.10.0.22:8080)
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — health check or smoke tests failed
+#
+set -euo pipefail
+
+PANOPTIKON_URL="${1:-http://10.10.0.22:8080}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUN="${BUN:-bun}"
+
+echo "=== Smoke Test: $PANOPTIKON_URL ==="
+echo ""
+
+# -------------------------------------------------------------------
+# Step 1: Health check via curl
+# -------------------------------------------------------------------
+echo "--- Step 1/2: Health check ---"
+
+HEALTH_OK=false
+for i in $(seq 1 30); do
+  if curl -sf "${PANOPTIKON_URL}/api/v1/auth/status" > /dev/null 2>&1; then
+    echo "Health check passed after ${i}s"
+    HEALTH_OK=true
+    break
+  fi
+  sleep 1
+done
+
+if [ "$HEALTH_OK" != "true" ]; then
+  echo "FAIL: Server at $PANOPTIKON_URL did not respond within 30 seconds"
+  exit 1
+fi
+
+# -------------------------------------------------------------------
+# Step 2: Playwright smoke suite
+# -------------------------------------------------------------------
+echo ""
+echo "--- Step 2/2: Playwright smoke tests ---"
+
+cd "$REPO_ROOT/web"
+
+# Install deps if needed (CI may already have them)
+if [ ! -d "node_modules" ]; then
+  "$BUN" install
+fi
+
+# Run only smoke tests against the target URL
+PANOPTIKON_URL="$PANOPTIKON_URL" "$BUN"x playwright test tests/e2e/smoke.spec.ts 2>&1
+RESULT=$?
+
+echo ""
+if [ $RESULT -eq 0 ]; then
+  echo "=== SMOKE TEST PASSED ==="
+else
+  echo "=== SMOKE TEST FAILED ==="
+fi
+
+exit $RESULT

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Smoke tests — run after every deploy to verify the app is healthy.
+ *
+ * These are fast, lightweight checks that confirm key pages load and
+ * the server is responsive. If any of these fail, the deploy should
+ * be considered broken.
+ *
+ * Run manually: cd web && bunx playwright test tests/e2e/smoke.spec.ts
+ * Run via script: scripts/smoke-test.sh
+ */
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Smoke tests @smoke", () => {
+  test("health endpoint responds", async ({ page }) => {
+    const response = await page.request.get("/api/v1/auth/status");
+    expect(response.status()).toBeLessThan(500);
+  });
+
+  test("login page loads without errors", async ({ page }) => {
+    await page.goto("/login");
+
+    // Page should render the login form
+    await expect(
+      page.getByText("Sign in to your network dashboard"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // No uncaught JS errors
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+    await page.waitForTimeout(1000);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("dashboard loads after authentication", async ({ page }) => {
+    await login(page);
+    await page.goto("/dashboard/");
+
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Stat cards should be present
+    await expect(page.locator('[class*="card"]').first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("devices page loads", async ({ page }) => {
+    await login(page);
+    await page.goto("/devices/");
+
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("settings page loads", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings/");
+
+    await expect(
+      page.getByRole("heading", { name: "Settings", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("agents page loads", async ({ page }) => {
+    await login(page);
+    await page.goto("/agents/");
+
+    await expect(
+      page.getByRole("heading", { name: "Agents", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("no JavaScript errors on key pages", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await login(page);
+
+    // Visit key pages
+    for (const path of ["/dashboard/", "/devices/", "/agents/", "/settings/"]) {
+      await page.goto(path);
+      await page.waitForLoadState("networkidle");
+    }
+
+    expect(errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #428

## Summary

- **CLAUDE.md worker prompt** — Every PR implementing a feature/fix must include a Playwright E2E test. No test = PR description must include a "Why no E2E test" section explaining why.
- **CI enforcement** — New `e2e-check` job in CI that fails PRs with source changes but no E2E test modifications and no justification in the PR body.
- **Post-deploy smoke tests** — Playwright smoke suite (`web/tests/e2e/smoke.spec.ts`) verifying: health endpoint, login page, dashboard, devices, settings, agents pages load without JS errors.
- **Deploy integration** — `deploy-lxc.sh` now runs smoke tests as step 5/5 after deploying to LXC 115. If smoke fails → deploy exits with error, alert is sent, deploy is NOT marked as success.
- **Settings roundtrip tests** — Already existed: `settings-xiaomi.spec.ts` (IP/password/toggle persist), `settings-router.spec.ts` (MikroTik URL/user/password persist, VyOS URL/key persist).

## Files changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New — worker prompt with E2E test requirement rules |
| `.github/workflows/ci.yml` | Added `e2e-check` job for PR enforcement |
| `.github/workflows/deploy.yml` | Added failure alert step |
| `scripts/deploy-lxc.sh` | Added step 5/5: post-deploy smoke test |
| `scripts/smoke-test.sh` | New — curl health check + Playwright smoke suite |
| `web/tests/e2e/smoke.spec.ts` | New — 7 smoke tests for key pages |

## Why no E2E test

This PR adds CI/deploy configuration and test infrastructure — the smoke tests themselves serve as the E2E test for this change. The smoke suite will be validated when CI runs the Playwright tests.

## Smoke Test

The smoke test suite (`smoke.spec.ts`) covers:
1. Health endpoint responds (< 500 status)
2. Login page loads without JS errors
3. Dashboard loads after authentication
4. Devices page loads
5. Settings page loads
6. Agents page loads
7. No JavaScript errors across key pages

These run both in CI (via existing Playwright job) and after every deploy to LXC 115 (via `smoke-test.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements comprehensive E2E test coverage enforcement through CI validation, post-deploy smoke tests, and developer guidelines. The implementation includes a new `e2e-check` job that blocks PRs without tests or justification, and automatic smoke testing after deployments to catch regressions.

**Key changes:**
- CI enforcement job validates that source changes include E2E tests or explicit "Why no E2E test" justification
- Post-deploy smoke suite verifies health endpoint, authentication flow, and key pages load without errors
- `CLAUDE.md` worker prompt establishes mandatory E2E test requirements for all feature/fix PRs
- Deploy script integration runs smoke tests as final validation step, failing deployment if tests fail

**Issues found:**
- Shell variable concatenation bug in `smoke-test.sh` that breaks if `BUN` is set to a path
- Error listener timing issue in smoke tests that won't catch errors during initial page load

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the two logic bugs - no breaking changes to existing functionality
- Strong implementation of E2E coverage enforcement with clear documentation. Two logic bugs need fixing: BUN variable concatenation and error listener timing. The CI validation logic is sound but could be more robust with SHA-based git diff.
- Pay attention to `scripts/smoke-test.sh` line 62 and `web/tests/e2e/smoke.spec.ts` lines 19-31 - both have logic bugs that need fixing

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds e2e-check job to enforce E2E test coverage for PRs; logic checks source changes and requires tests or justification |
| scripts/smoke-test.sh | New smoke test script with health check and Playwright suite; has BUN variable concatenation issue |
| web/tests/e2e/smoke.spec.ts | New smoke test suite covering health endpoint and key pages; error listener timing issue in login test |

</details>



<sub>Last reviewed commit: 69c8f02</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->