### PR TITLE
feat: onboarding / help system — tooltips, first-run guide, documentation links (#438)

### DIFF
--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -42,6 +42,7 @@ import type { Agent, AgentCreateResponse, AgentReport } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 import { useWsEvent } from "@/lib/ws";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
 import { copyToClipboard } from "@/lib/utils";
 
 export default function AgentsPage() {
@@ -120,7 +121,10 @@ export default function AgentsPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold text-white">Agents</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold text-white">Agents</h1>
+          <HelpTooltip text="Lightweight agents installed on your machines that report system info (CPU, memory, disk, OS) back to Panoptikon." />
+        </div>
         <AddAgentDialog
           onCreated={() => {
             fetchAgents().then(setAgents).catch(() => {});

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -52,6 +52,12 @@ import { timeAgo } from "@/lib/format";
 import { downloadExport } from "@/lib/export";
 import { toast } from "sonner";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function alertIcon(type: Alert["type"]) {
   switch (type) {
@@ -265,6 +271,7 @@ export default function AlertsPage() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-semibold text-white">Alerts</h1>
+          <HelpTooltip text="Notifications about network events — new devices, devices going offline, and security alerts. Configure rules in Settings → Alert Rules." />
           {activeCount > 0 && (
             <Badge variant="secondary" className="gap-1">
               <Bell className="h-3 w-3" />
@@ -316,25 +323,39 @@ export default function AlertsPage() {
               </DropdownMenuContent>
             </DropdownMenu>
             {(alerts ?? []).some((a) => !a.is_read) && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
-                onClick={handleMarkAllRead}
-              >
-                <CheckCheck className="h-3.5 w-3.5" />
-                Mark all read
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-gray-700 text-slate-400 hover:text-gray-200 gap-1.5"
+                    onClick={handleMarkAllRead}
+                  >
+                    <CheckCheck className="h-3.5 w-3.5" />
+                    Mark all read
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                  Mark every unread alert as read
+                </TooltipContent>
+              </Tooltip>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-gray-700 text-slate-400 hover:text-rose-400 gap-1.5"
-              onClick={() => setClearAllDialogOpen(true)}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Clear all
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-gray-700 text-slate-400 hover:text-rose-400 gap-1.5"
+                  onClick={() => setClearAllDialogOpen(true)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Clear all
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Permanently delete all alerts
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>
@@ -401,8 +422,11 @@ export default function AlertsPage() {
       ) : alerts.length === 0 ? (
         <Card className="border-slate-800 bg-slate-900">
           <CardContent className="flex flex-col items-center gap-3 py-16">
-            <BellOff className="h-10 w-10 text-slate-600" />
-            <p className="text-sm text-slate-500">No alerts yet — all quiet.</p>
+            <BellOff className="h-12 w-12 text-slate-600" />
+            <p className="text-lg font-medium text-slate-400">No alerts yet — all quiet</p>
+            <p className="max-w-sm text-sm text-slate-600">
+              Alerts appear here when new devices join the network, devices go offline, or configured rules are triggered. Set up rules in Settings → Alert Rules.
+            </p>
           </CardContent>
         </Card>
       ) : (

--- a/web/src/app/(app)/caddy/page.tsx
+++ b/web/src/app/(app)/caddy/page.tsx
@@ -51,6 +51,13 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import { EmptyState } from "@/components/EmptyState";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   fetchCaddyStatus,
   fetchCaddyProxyHosts,
@@ -203,6 +210,7 @@ export default function CaddyPage() {
             <h1 className="text-2xl font-semibold text-white">
               Caddy Reverse Proxy
             </h1>
+            <HelpTooltip text="Manage reverse-proxy hosts that Caddy serves. Add domains, point them to internal services, and enable automatic HTTPS." />
           </div>
           <div className="flex items-center gap-2">
             {caddyStatus && (
@@ -222,34 +230,48 @@ export default function CaddyPage() {
                 {caddyStatus.reachable ? "Connected" : "Unreachable"}
               </Badge>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleTestConnection}
-              disabled={testing}
-              className="border-slate-800 text-slate-300 hover:bg-slate-800"
-            >
-              {testing ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Zap className="mr-1.5 h-3.5 w-3.5" />
-              )}
-              Test Connection
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleSync}
-              disabled={syncing}
-              className="border-slate-800 text-slate-300 hover:bg-slate-800"
-            >
-              {syncing ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-              )}
-              Sync to Caddy
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleTestConnection}
+                  disabled={testing}
+                  className="border-slate-800 text-slate-300 hover:bg-slate-800"
+                >
+                  {testing ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Zap className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  Test Connection
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Verify that Panoptikon can reach the Caddy admin API
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleSync}
+                  disabled={syncing}
+                  className="border-slate-800 text-slate-300 hover:bg-slate-800"
+                >
+                  {syncing ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  Sync to Caddy
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Push current proxy host configuration to the Caddy reverse proxy
+              </TooltipContent>
+            </Tooltip>
             <Button
               size="sm"
               onClick={() => setShowAdd(true)}
@@ -352,11 +374,17 @@ export default function CaddyPage() {
                   <TableRow className="border-slate-800 hover:bg-transparent">
                     <TableCell
                       colSpan={5}
-                      className="py-12 text-center text-slate-500"
+                      className="py-12 text-center"
                     >
-                      {search
-                        ? "No hosts match your filter."
-                        : "No proxy hosts configured yet."}
+                      {search ? (
+                        <span className="text-slate-500">No hosts match your filter.</span>
+                      ) : (
+                        <EmptyState
+                          icon={Globe}
+                          title="No proxy hosts configured yet"
+                          description="Click &quot;Add Host&quot; to create your first reverse-proxy entry. Make sure the Caddy admin URL is set above."
+                        />
+                      )}
                     </TableCell>
                   </TableRow>
                 ) : (

--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -61,6 +61,12 @@ import {
   deleteNpmCertificate,
 } from "@/lib/api";
 import type { NpmCertificate, NpmConnectionStatus } from "@/lib/types";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ─── Status badge helpers ──────────────────────────────────
 
@@ -297,30 +303,47 @@ export default function CertificatesPage() {
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold text-white">
-            SSL Certificates
-          </h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-semibold text-white">
+              SSL Certificates
+            </h1>
+            <HelpTooltip text="View and manage SSL/TLS certificates provisioned through Nginx Proxy Manager. Request free Let's Encrypt certs or upload your own." />
+          </div>
           <p className="text-sm text-slate-400">
             Manage SSL certificates via Nginx Proxy Manager
           </p>
         </div>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={() => setLeDialogOpen(true)}
-            className="border-slate-700 text-slate-300 hover:bg-slate-800"
-          >
-            <Plus className="mr-1.5 h-3.5 w-3.5" />
-            Let&apos;s Encrypt
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => setCustomDialogOpen(true)}
-            className="border-slate-700 text-slate-300 hover:bg-slate-800"
-          >
-            <Upload className="mr-1.5 h-3.5 w-3.5" />
-            Upload Custom
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                onClick={() => setLeDialogOpen(true)}
+                className="border-slate-700 text-slate-300 hover:bg-slate-800"
+              >
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Let&apos;s Encrypt
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Request a free SSL certificate from Let&apos;s Encrypt via DNS challenge
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                onClick={() => setCustomDialogOpen(true)}
+                className="border-slate-700 text-slate-300 hover:bg-slate-800"
+              >
+                <Upload className="mr-1.5 h-3.5 w-3.5" />
+                Upload Custom
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Upload your own SSL certificate and private key
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -354,9 +377,13 @@ export default function CertificatesPage() {
         </CardHeader>
         <CardContent>
           {certs.length === 0 ? (
-            <p className="py-8 text-center text-sm text-slate-500">
-              No certificates found. Create one using the buttons above.
-            </p>
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <Shield className="mb-4 h-12 w-12 text-slate-600" />
+              <p className="text-lg font-medium text-slate-400">No certificates yet</p>
+              <p className="mt-1 max-w-sm text-sm text-slate-600">
+                Request a free Let&apos;s Encrypt certificate or upload your own using the buttons above. Make sure NPM is configured in Settings first.
+              </p>
+            </div>
           ) : (
             <div className="overflow-x-auto">
               <Table>

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -50,6 +50,12 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
 import { MotionCard } from "@/components/MotionCard";
 import { DeviceTrafficChart } from "@/components/DeviceTrafficChart";
@@ -299,102 +305,133 @@ export default function DevicesPage() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold text-white">Devices</h1>
         <div className="flex items-center gap-2">
-          <Button
-            variant="secondary"
-            onClick={() => setAddAssetOpen(true)}
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Add Asset
-          </Button>
-          <Button
-            variant="secondary"
-            disabled={identifying}
-            onClick={async () => {
-              setIdentifying(true);
-              try {
-                const result = await identifyDevices();
-                toast.success(`Checked ${result.devices_checked} devices`);
-                await load();
-              } catch {
-                toast.error("Device identification failed");
-              } finally {
-                setIdentifying(false);
-              }
-            }}
-          >
-            {identifying ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Identifying…
-              </>
-            ) : (
-              <>
-                <Search className="mr-2 h-4 w-4" />
-                Re-identify
-              </>
-            )}
-          </Button>
-          <Button
-            disabled={scanningNetwork}
-            onClick={async () => {
-              setScanningNetwork(true);
-              try {
-                await fetch("/api/v1/scanner/trigger", { method: "POST", credentials: "include" });
-                toast.success("Network scan complete");
-                await load();
-              } catch {
-                toast.error("Network scan failed");
-              } finally {
-                setTimeout(() => setScanningNetwork(false), 5000);
-              }
-            }}
-          >
-            {scanningNetwork ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Scanning…
-              </>
-            ) : (
-              <>
-                <Radar className="mr-2 h-4 w-4" />
-                Scan Now
-              </>
-            )}
-          </Button>
-          <Button
-            variant="secondary"
-            disabled={resolving}
-            onClick={async () => {
-              setResolving(true);
-              try {
-                const result = await resolveDevices();
-                if (result.resolved > 0) {
-                  toast.success(`Resolved ${result.resolved} device${result.resolved === 1 ? "" : "s"}`);
-                  await load();
-                } else {
-                  toast.info("No new hostnames found");
-                }
-              } catch {
-                toast.error("Device resolution failed");
-              } finally {
-                setResolving(false);
-              }
-            }}
-          >
-            {resolving ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Resolving…
-              </>
-            ) : (
-              <>
-                <Search className="mr-2 h-4 w-4" />
-                Resolve Names
-              </>
-            )}
-          </Button>
+          <h1 className="text-2xl font-semibold text-white">Devices</h1>
+          <HelpTooltip text="All devices discovered on your network. Use Scan Now to discover new devices, Re-identify to fingerprint them, and Resolve Names to look up hostnames via DNS." />
+        </div>
+        <div className="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                onClick={() => setAddAssetOpen(true)}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Add Asset
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Manually register a device or service as a tracked asset
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                disabled={identifying}
+                onClick={async () => {
+                  setIdentifying(true);
+                  try {
+                    const result = await identifyDevices();
+                    toast.success(`Checked ${result.devices_checked} devices`);
+                    await load();
+                  } catch {
+                    toast.error("Device identification failed");
+                  } finally {
+                    setIdentifying(false);
+                  }
+                }}
+              >
+                {identifying ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Identifying…
+                  </>
+                ) : (
+                  <>
+                    <Search className="mr-2 h-4 w-4" />
+                    Re-identify
+                  </>
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Re-run device fingerprinting to detect device type, manufacturer, and OS
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                disabled={scanningNetwork}
+                onClick={async () => {
+                  setScanningNetwork(true);
+                  try {
+                    await fetch("/api/v1/scanner/trigger", { method: "POST", credentials: "include" });
+                    toast.success("Network scan complete");
+                    await load();
+                  } catch {
+                    toast.error("Network scan failed");
+                  } finally {
+                    setTimeout(() => setScanningNetwork(false), 5000);
+                  }
+                }}
+              >
+                {scanningNetwork ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Scanning…
+                  </>
+                ) : (
+                  <>
+                    <Radar className="mr-2 h-4 w-4" />
+                    Scan Now
+                  </>
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Trigger an immediate network scan to discover new devices
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="secondary"
+                disabled={resolving}
+                onClick={async () => {
+                  setResolving(true);
+                  try {
+                    const result = await resolveDevices();
+                    if (result.resolved > 0) {
+                      toast.success(`Resolved ${result.resolved} device${result.resolved === 1 ? "" : "s"}`);
+                      await load();
+                    } else {
+                      toast.info("No new hostnames found");
+                    }
+                  } catch {
+                    toast.error("Device resolution failed");
+                  } finally {
+                    setResolving(false);
+                  }
+                }}
+              >
+                {resolving ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Resolving…
+                  </>
+                ) : (
+                  <>
+                    <Search className="mr-2 h-4 w-4" />
+                    Resolve Names
+                  </>
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Look up hostnames via reverse DNS for all discovered devices
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -548,9 +585,19 @@ export default function DevicesPage() {
         </div>
         )
       ) : sorted.length === 0 ? (
-        <p className="py-10 text-center text-slate-500">
-          No devices match your filters.
-        </p>
+        filter === "all" && !search.trim() ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Monitor className="mb-4 h-12 w-12 text-slate-600" />
+            <p className="text-lg font-medium text-slate-400">No devices found yet</p>
+            <p className="mt-1 max-w-sm text-sm text-slate-600">
+              Make sure your router is configured in Settings, then click &quot;Scan Now&quot; to discover devices on your network.
+            </p>
+          </div>
+        ) : (
+          <p className="py-10 text-center text-slate-500">
+            No devices match your filters.
+          </p>
+        )
       ) : view === "grid" ? (
         <StaggerContainer className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
           {sorted.map((device) => (

--- a/web/src/app/(app)/dns-logs/page.tsx
+++ b/web/src/app/(app)/dns-logs/page.tsx
@@ -39,6 +39,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { fetchDnsQueryLog, fetchDnsStats, purgeDnsLogs } from "@/lib/api";
 import type {
   DnsQueryLogEntry,
@@ -142,18 +148,28 @@ export default function DnsLogsPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">
-              DNS Query Log
-            </h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight">
+                DNS Query Log
+              </h1>
+              <HelpTooltip text="Shows DNS queries made by devices on your network. Useful for spotting suspicious domains and debugging connectivity. Data is kept for 7 days." />
+            </div>
             <p className="text-muted-foreground">
               Per-device DNS query history and statistics (7-day retention)
             </p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleRefresh}>
-              <RefreshCw className="mr-2 h-4 w-4" />
-              Refresh
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={handleRefresh}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Refresh
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Reload the query log with the latest entries
+              </TooltipContent>
+            </Tooltip>
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button variant="destructive" size="sm">

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { MobileSidebar } from "@/components/layout/MobileSidebar";
 import { CommandPalette } from "@/components/CommandPalette";
 import { WebSocketProvider } from "@/components/providers/WebSocketProvider";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 /**
  * Authenticated app layout with sidebar + topbar.
@@ -14,14 +15,16 @@ import { WebSocketProvider } from "@/components/providers/WebSocketProvider";
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <WebSocketProvider>
-      <div className="flex h-screen overflow-hidden">
-        <Sidebar />
-        <div className="flex flex-1 flex-col overflow-hidden">
-          <TopBar mobileMenu={<MobileSidebar />} />
-          <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 md:p-6">{children}</main>
+      <TooltipProvider delayDuration={300}>
+        <div className="flex h-screen overflow-hidden">
+          <Sidebar />
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <TopBar mobileMenu={<MobileSidebar />} />
+            <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden p-3 md:p-6">{children}</main>
+          </div>
         </div>
-      </div>
-      <CommandPalette />
+        <CommandPalette />
+      </TooltipProvider>
     </WebSocketProvider>
   );
 }

--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -50,6 +50,12 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   fetchSettings,
   fetchNatSummary,
@@ -222,20 +228,28 @@ export default function NatPage() {
             <h1 className="text-2xl font-semibold text-white">
               NAT / Port Forwarding
             </h1>
+            <HelpTooltip text="View and manage DNAT (port forwarding) rules on your router. Supports VyOS and MikroTik." />
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              load();
-              if (activeTab === "vyos") loadVyos();
-              if (activeTab === "mikrotik") loadMt();
-            }}
-            className="border-slate-800 text-slate-300 hover:bg-slate-800"
-          >
-            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-            Refresh
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  load();
+                  if (activeTab === "vyos") loadVyos();
+                  if (activeTab === "mikrotik") loadMt();
+                }}
+                className="border-slate-800 text-slate-300 hover:bg-slate-800"
+              >
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                Refresh
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+              Reload NAT rules from the router
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Summary Cards */}

--- a/web/src/app/(app)/services/page.tsx
+++ b/web/src/app/(app)/services/page.tsx
@@ -40,6 +40,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   addService,
   removeService,
@@ -483,25 +489,42 @@ export default function ServicesPage() {
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-bold text-white">Services</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-white">Services</h1>
+              <HelpTooltip text="One-click service deployment — creates an NPM reverse proxy entry, firewall rule, and DNAT port forward in a single step." />
+            </div>
             <p className="mt-1 text-sm text-slate-400">
               Deploy or remove services end-to-end — NPM reverse proxy,
               firewall, and DNAT in one flow.
             </p>
           </div>
           <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={openRemoveDialog}
-              className="border-slate-700 text-slate-300 hover:bg-slate-800"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Remove Service
-            </Button>
-            <Button onClick={openWizard}>
-              <Plus className="mr-2 h-4 w-4" />
-              Add Service
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  onClick={openRemoveDialog}
+                  className="border-slate-700 text-slate-300 hover:bg-slate-800"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Remove Service
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Remove a deployed service and clean up its proxy, firewall, and NAT entries
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={openWizard}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add Service
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
+                Launch the service wizard to create proxy, firewall, and NAT entries together
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
 
@@ -564,9 +587,12 @@ export default function ServicesPage() {
               Loading...
             </div>
           ) : proxyHosts.length === 0 ? (
-            <div className="py-12 text-center text-sm text-slate-500">
-              No proxy hosts configured yet. Click &quot;Add Service&quot; to
-              create one.
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <Globe className="mb-4 h-12 w-12 text-slate-600" />
+              <p className="text-lg font-medium text-slate-400">No services deployed yet</p>
+              <p className="mt-1 max-w-sm text-sm text-slate-600">
+                Click &quot;Add Service&quot; to create your first service. The wizard will set up reverse proxy, firewall, and NAT entries automatically.
+              </p>
             </div>
           ) : (
             <div className="overflow-x-auto">

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageTransition } from "@/components/PageTransition";
+import { HelpTooltip } from "@/components/HelpTooltip";
 import { downloadExport } from "@/lib/export";
 import { DeviceTrafficChart } from "@/components/DeviceTrafficChart";
 
@@ -80,7 +81,10 @@ export default function TrafficPage() {
     <PageTransition>
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-white">Traffic</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold text-white">Traffic</h1>
+          <HelpTooltip text="Network bandwidth usage over time. Requires NetFlow/sFlow export from your router to be configured in Settings." />
+        </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="secondary" size="sm">

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * Reusable empty-state placeholder shown when a section has no data.
+ * Displays an icon, a heading, and a helpful hint pointing users
+ * toward the next action they should take.
+ */
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <Icon className="mb-4 h-12 w-12 text-slate-600" />
+      <p className="text-lg font-medium text-slate-400">{title}</p>
+      <p className="mt-1 max-w-sm text-sm text-slate-600">{description}</p>
+    </div>
+  );
+}

--- a/web/src/components/HelpTooltip.tsx
+++ b/web/src/components/HelpTooltip.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { HelpCircle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * Small (?) icon that shows a tooltip on hover.
+ * Used next to section titles to explain what a section does.
+ */
+export function HelpTooltip({ text }: { text: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full text-slate-500 hover:text-slate-300 transition-colors"
+          aria-label="Help"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="right"
+        className="max-w-xs border-slate-700 bg-slate-800 text-slate-200"
+      >
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
Closes #438

## Summary

- **TooltipProvider at app layout level** — tooltips now work on every page, not just the sidebar
- **HelpTooltip component** — reusable `(?)` icon that shows an explanation on hover, placed next to section titles
- **EmptyState component** — reusable first-run guidance with icon, heading, and actionable description
- **Button tooltips** — action buttons across 7 pages now show what they do on hover
- **"Sync to Caddy"** tooltip specifically explains: *"Push current proxy host configuration to the Caddy reverse proxy"*
- **Improved empty states** — Caddy, Devices, Alerts, Certificates, and Services pages now show helpful guidance when no data exists

### Pages updated
| Page | Tooltips | Help icon | Empty state |
|------|----------|-----------|-------------|
| Caddy | Sync to Caddy, Test Connection | ✓ | ✓ |
| Devices | Add Asset, Re-identify, Scan Now, Resolve Names | ✓ | ✓ |
| Alerts | Mark all read, Clear all | ✓ | ✓ |
| Certificates | Let's Encrypt, Upload Custom | ✓ | ✓ |
| Services | Add Service, Remove Service | ✓ | ✓ |
| DNS Logs | Refresh | ✓ | — |
| NAT | Refresh | ✓ | — |
| Traffic | — | ✓ | — |
| Agents | — | ✓ | — |

### New components
- `web/src/components/HelpTooltip.tsx` — small `(?)` icon with tooltip
- `web/src/components/EmptyState.tsx` — icon + title + description for empty sections

## Smoke Test
- TypeScript compiles clean (`tsc --noEmit` passes)
- Next.js build succeeds (all pages compile)
- Rust backend unaffected (`cargo check` passes)
- Verified tooltip imports and EmptyState usage compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a comprehensive onboarding and help system across the application, adding tooltips, contextual help icons, and improved empty states to guide users through first-time setup and usage.

**Key improvements:**
- `TooltipProvider` wrapped around the entire app layout enables tooltips on every page
- Two new reusable components (`HelpTooltip` and `EmptyState`) provide consistent UI patterns
- Help tooltips added to 9 pages explaining what each section does
- Action button tooltips clarify what clicking each button will do (e.g., "Sync to Caddy" explains it pushes config to Caddy)
- Empty states now show helpful guidance instead of just "No data" messages

**Implementation quality:**
- Clean, consistent component API and styling
- Follows existing dark theme patterns
- TypeScript types are properly defined
- No breaking changes to existing functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The changes are purely additive UX improvements with no logic changes, TypeScript compilation passes, and the implementation follows existing patterns consistently across all files
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/EmptyState.tsx | New reusable component for displaying empty states with icon, title, and description |
| web/src/components/HelpTooltip.tsx | New reusable help tooltip component showing (?) icon with explanation on hover |
| web/src/app/(app)/layout.tsx | Wrapped app content in TooltipProvider to enable tooltips throughout the application |
| web/src/app/(app)/caddy/page.tsx | Added HelpTooltip, button tooltips for actions, and EmptyState for no proxy hosts |
| web/src/app/(app)/devices/page.tsx | Added HelpTooltip and tooltips on Add Asset, Re-identify, Scan Now, and Resolve Names buttons |
| web/src/app/(app)/alerts/page.tsx | Added HelpTooltip, tooltips on Mark all read and Clear all buttons, improved empty state with better guidance |

</details>



<sub>Last reviewed commit: c169b52</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->