### PR TITLE
feat: enforce E2E test coverage — PRs without tests for new features must be rejected (#428)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,16 @@ on:
 
 jobs:
   deploy:
-    name: Build & Deploy to LXC 115
+    name: Build, Deploy & Smoke Test LXC 115
     runs-on: self-hosted
     steps:
-      - name: Run deploy script
+      - name: Run deploy script (includes smoke test)
         run: /home/shtrudel/src/panoptikon/scripts/deploy-lxc.sh
+        env:
+          REPO_ROOT: /home/shtrudel/src/panoptikon
+
+      - name: Notify on smoke test failure
+        if: failure()
+        run: |
+          echo "::error::Deploy smoke tests FAILED — Panoptikon may not be fully functional on LXC 115"
+          echo "Oleg: check http://10.10.0.22:8080 manually"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Panoptikon — Claude Code Guidelines
+
+## E2E Test Requirement (Mandatory)
+
+Every PR that implements a **feature** or **bug fix** MUST include:
+
+1. **A Playwright E2E test** that verifies the feature actually works end-to-end
+   - Test must be in `web/tests/e2e/`
+   - Test must exercise the real UI (not just unit-test a function)
+   - Test must fail before the fix and pass after
+2. **Save→reload roundtrip** — if the PR touches a settings page, include a test that:
+   - Fills the form with values
+   - Clicks Save
+   - Reloads the page
+   - Asserts the values persisted
+3. **No test = explicit justification** — if a test is genuinely impossible (e.g., hardware-only integration), the PR description must explain why under a `## Why No E2E Test` section
+
+### What counts as a valid E2E test
+
+- Uses Playwright (`web/tests/e2e/*.spec.ts`)
+- Imports fixtures from `../../e2e/fixtures`
+- Logs in via `login(page)` or uses `authenticatedPage` fixture
+- Asserts visible UI state (not just API responses)
+- Includes a screenshot on key assertions (`page.screenshot(...)`)
+
+### Examples of PRs that MUST have tests
+
+- New settings page → save/reload roundtrip test
+- New dashboard widget → page loads, widget visible, data renders
+- Bug fix for persisting a value → test that value persists after reload
+- New API endpoint with UI → navigate to page, interact, verify result
+- Layout fix → screenshot comparison or element visibility check
+
+### Examples where tests may be skipped (with justification)
+
+- Pure CI/CD configuration changes
+- Documentation-only changes
+- Dependency bumps with no behavior change
+- Infrastructure scripts that require hardware (e.g., MikroTik physical router)
+
+## Project Structure
+
+- `server/` — Rust backend (axum, SQLite)
+- `web/` — Next.js frontend (TypeScript, shadcn/ui)
+- `web/tests/e2e/` — Playwright E2E tests
+- `web/e2e/fixtures.ts` — Shared test fixtures (login, setup)
+- `scripts/` — Build and deploy scripts
+
+## Build & Test Commands
+
+```bash
+# Rust
+cargo fmt --all              # Format (required before every commit)
+cargo check                  # Type check
+cargo clippy                 # Lint
+cargo test                   # Run backend tests
+
+# Frontend (use bun, never npm/yarn)
+cd web && bun install && bun run build
+cd web && bunx playwright test            # Run all E2E tests
+cd web && bunx playwright test smoke      # Run smoke tests only
+
+# Deploy smoke test
+scripts/smoke-test.sh        # Run post-deploy health + smoke checks
+```
+
+## Code Conventions
+
+- Use `bun` for all JavaScript operations (never npm/yarn)
+- `cargo fmt --all` before every commit
+- Dark theme — slate color palette for UI
+- shadcn/ui components — no window.alert/confirm/prompt
+- Loading states use skeleton components, not spinners

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-prod dev clean deploy
+.PHONY: build build-prod dev clean deploy smoke-test
 
 # Default build: web + Rust binary (correct order for rust-embed)
 build: ## Build production binary with embedded frontend
@@ -19,3 +19,8 @@ deploy: build ## Build and deploy to LXC 115 (10.10.0.22)
 	scp target/release/panoptikon-server root@10.10.0.22:/usr/local/bin/panoptikon-server.new
 	ssh root@10.10.0.22 "systemctl stop panoptikon.service && mv /usr/local/bin/panoptikon-server.new /usr/local/bin/panoptikon-server && chmod 755 /usr/local/bin/panoptikon-server && systemctl start panoptikon.service"
 	@echo "✅ Deployed to 10.10.0.22:8080"
+	@echo "Running smoke tests..."
+	scripts/smoke-test.sh http://10.10.0.22:8080
+
+smoke-test: ## Run post-deploy smoke tests against LXC 115
+	scripts/smoke-test.sh http://10.10.0.22:8080

--- a/scripts/deploy-lxc.sh
+++ b/scripts/deploy-lxc.sh
@@ -32,9 +32,27 @@ cd "$REPO_ROOT"
 echo "=== Step 3/4: Building Rust server ==="
 "$CARGO" build --release -p panoptikon-server
 
-echo "=== Step 4/4: Deploying to LXC $LXC_ID ==="
+echo "=== Step 4/5: Deploying to LXC $LXC_ID ==="
 scp target/release/panoptikon-server "$DEVBOX":/tmp/panoptikon-server
 ssh "$DEVBOX" "pct exec $LXC_ID -- systemctl stop panoptikon; pct push $LXC_ID /tmp/panoptikon-server /usr/local/bin/panoptikon-server; pct exec $LXC_ID -- systemctl start panoptikon"
 
 echo ""
-echo "Deploy complete — panoptikon is running on LXC $LXC_ID"
+echo "=== Step 5/5: Running smoke tests ==="
+if "$REPO_ROOT/scripts/smoke-test.sh" "http://10.10.0.22:8080"; then
+  echo ""
+  echo "Deploy complete — panoptikon is running on LXC $LXC_ID (smoke tests passed)"
+else
+  SMOKE_EXIT=$?
+  echo ""
+  echo "DEPLOY WARNING: Smoke tests FAILED (exit code $SMOKE_EXIT)"
+  echo "Server is running but may not be fully functional."
+  echo "Alerting Oleg..."
+  # Send webhook/notification if configured
+  if command -v curl &> /dev/null; then
+    curl -sf "http://10.10.0.22:8080/api/v1/webhooks/notify" \
+      -H 'Content-Type: application/json' \
+      -d "{\"event\":\"deploy_smoke_failed\",\"message\":\"Smoke tests failed after deploy to LXC $LXC_ID (exit $SMOKE_EXIT)\"}" \
+      2>/dev/null || true
+  fi
+  exit 1
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# smoke-test.sh — Post-deploy smoke test for Panoptikon.
+#
+# Runs:
+#   1. curl health check (server responds on /login)
+#   2. Playwright smoke suite (key pages load, no crashes)
+#
+# Usage:
+#   scripts/smoke-test.sh [URL]
+#
+# Arguments:
+#   URL — base URL of the Panoptikon instance (default: http://10.10.0.22:8080)
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — health check failed (server not responding)
+#   2 — Playwright smoke tests failed
+#
+set -euo pipefail
+
+PANOPTIKON_URL="${1:-http://10.10.0.22:8080}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+BUN="${BUN:-$HOME/.bun/bin/bun}"
+
+echo "=== Smoke Test: $PANOPTIKON_URL ==="
+
+# ── Step 1: Health check ──────────────────────────────────────────────
+echo ""
+echo "--- Step 1/2: Health check (curl) ---"
+
+HEALTH_OK=false
+for i in $(seq 1 10); do
+  if curl -sf "${PANOPTIKON_URL}/login" > /dev/null 2>&1; then
+    echo "Health check passed after ${i}s"
+    HEALTH_OK=true
+    break
+  fi
+  echo "  Waiting for server... (${i}/10)"
+  sleep 2
+done
+
+if [ "$HEALTH_OK" = false ]; then
+  echo ""
+  echo "SMOKE TEST FAILED: Server not responding at ${PANOPTIKON_URL}/login"
+  echo "Deploy should NOT be marked as success."
+  exit 1
+fi
+
+# ── Step 2: Playwright smoke suite ────────────────────────────────────
+echo ""
+echo "--- Step 2/2: Playwright smoke suite ---"
+
+cd "$REPO_ROOT/web"
+
+# Install browsers if not present (CI may need this)
+"$BUN" x playwright install chromium --with-deps 2>/dev/null || true
+
+if PANOPTIKON_URL="$PANOPTIKON_URL" "$BUN" x playwright test smoke; then
+  echo ""
+  echo "ALL SMOKE TESTS PASSED"
+  exit 0
+else
+  echo ""
+  echo "SMOKE TEST FAILED: Playwright smoke suite had failures."
+  echo "Deploy should NOT be marked as success."
+  exit 2
+fi

--- a/web/tests/e2e/settings-xiaomi.spec.ts
+++ b/web/tests/e2e/settings-xiaomi.spec.ts
@@ -78,4 +78,61 @@ test.describe("Xiaomi Mesh Settings", () => {
       path: "tests/screenshots/settings-xiaomi-enabled.png",
     });
   });
+
+  test("password persists after save and reload (shows saved badge)", async ({
+    page,
+  }) => {
+    // Enable integration so password field is relevant
+    const toggle = page.locator("#xiaomi-enabled");
+    const currentState = await toggle.getAttribute("aria-checked");
+    if (currentState !== "true") {
+      await toggle.click();
+    }
+
+    // Fill and save password
+    await page.locator("#xiaomi-password").fill("e2e-password-roundtrip");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Xiaomi Mesh settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Reload and verify password was stored
+    await page.reload();
+    await expect(page.locator("#xiaomi-password")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // The "(saved)" badge next to the password label confirms it was stored
+    await expect(
+      page.locator('label[for="xiaomi-password"]'),
+    ).toContainText("(saved)");
+
+    // Password field should be empty (not echoed back) with a placeholder hint
+    await expect(page.locator("#xiaomi-password")).toHaveValue("");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-xiaomi-password-saved.png",
+    });
+  });
+
+  test("poll interval persists after save and reload", async ({ page }) => {
+    await page.locator("#xiaomi-poll-interval").fill("120");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("Xiaomi Mesh settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await expect(page.locator("#xiaomi-poll-interval")).toBeVisible({
+      timeout: 15000,
+    });
+
+    await expect(page.locator("#xiaomi-poll-interval")).toHaveValue("120");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-xiaomi-poll-interval.png",
+    });
+  });
 });

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * Smoke test suite — runs after every deploy to verify key pages load
+ * and no crashes occur. Lightweight and fast by design.
+ *
+ * Run with: bunx playwright test smoke
+ */
+test.describe("Smoke Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("dashboard loads without errors", async ({ page }) => {
+    await page.goto("/dashboard/");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "tests/screenshots/smoke-dashboard.png" });
+  });
+
+  test("devices page loads without errors", async ({ page }) => {
+    await page.goto("/devices/");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "tests/screenshots/smoke-devices.png" });
+  });
+
+  test("agents page loads without errors", async ({ page }) => {
+    await page.goto("/agents/");
+    await expect(
+      page.getByRole("heading", { name: "Agents", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "tests/screenshots/smoke-agents.png" });
+  });
+
+  test("alerts page loads without errors", async ({ page }) => {
+    await page.goto("/alerts/");
+    await expect(
+      page.getByRole("heading", { name: "Alerts", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "tests/screenshots/smoke-alerts.png" });
+  });
+
+  test("settings page loads without errors", async ({ page }) => {
+    await page.goto("/settings/");
+    await expect(
+      page.getByRole("heading", { name: "Settings", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "tests/screenshots/smoke-settings.png" });
+  });
+
+  test("settings router page loads without errors", async ({ page }) => {
+    await page.goto("/settings/router/");
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+    await page.screenshot({
+      path: "tests/screenshots/smoke-settings-router.png",
+    });
+  });
+
+  test("settings xiaomi-mesh page loads without errors", async ({ page }) => {
+    await page.goto("/settings/xiaomi-mesh/");
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+    await page.screenshot({
+      path: "tests/screenshots/smoke-settings-xiaomi.png",
+    });
+  });
+
+  test("no console errors on dashboard", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/dashboard/");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Allow network errors (external services may be down) but no JS crashes
+    const jsErrors = errors.filter(
+      (e) => !e.includes("NetworkError") && !e.includes("fetch"),
+    );
+    expect(jsErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #428

## Summary

- **CLAUDE.md** — Added worker prompt rules enforcing that every feature/fix PR must include Playwright E2E tests (or explicit justification). Defines what counts as a valid test and provides examples.
- **Smoke test suite** (`web/tests/e2e/smoke.spec.ts`) — Lightweight Playwright tests that verify all key pages load without errors: dashboard, devices, agents, alerts, settings, router settings, Xiaomi mesh settings. Also checks for JS console errors.
- **Post-deploy smoke script** (`scripts/smoke-test.sh`) — Runs after every deploy: curl health check (10 retries), then Playwright smoke suite. Exits non-zero on failure so deploy is not marked as success.
- **Deploy integration** — Updated `scripts/deploy-lxc.sh` (step 5/5: smoke test) and `.github/workflows/deploy.yml` to run smoke tests automatically after every deploy. Failure alerts Oleg and blocks deploy success status.
- **Makefile** — Added `make smoke-test` target for manual runs.
- **Enhanced Xiaomi settings tests** — Added password persistence roundtrip test (save → reload → verify "(saved)" badge) and poll interval roundtrip test.

## What changed

| File | Change |
|------|--------|
| `CLAUDE.md` | New — E2E test enforcement rules for worker agents |
| `web/tests/e2e/smoke.spec.ts` | New — 8 smoke tests for key pages |
| `scripts/smoke-test.sh` | New — Post-deploy health + smoke script |
| `scripts/deploy-lxc.sh` | Added smoke test step after deploy |
| `.github/workflows/deploy.yml` | Added smoke test + failure notification |
| `Makefile` | Added `smoke-test` target |
| `web/tests/e2e/settings-xiaomi.spec.ts` | Added password + poll interval roundtrip tests |

## Smoke Test

Verified locally:
- All new test files have valid TypeScript syntax
- Smoke test script is executable and has correct exit codes
- Deploy script correctly chains smoke test after deploy step
- Existing settings tests remain intact with new tests appended

## Test plan

- [ ] CI passes (Rust build, frontend build, E2E tests)
- [ ] Smoke tests run as part of E2E suite in CI
- [ ] New Xiaomi password + poll interval tests pass
- [ ] Deploy workflow runs smoke test after deploy to LXC 115
- [ ] CLAUDE.md is picked up by Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes mandatory E2E test coverage requirements through `CLAUDE.md` guidelines and implements a comprehensive smoke test suite that runs automatically after every deploy.

- Added 8 Playwright smoke tests covering all key pages (dashboard, devices, agents, alerts, settings)
- Created post-deploy smoke test script with health checks and proper exit codes
- Integrated smoke tests into deploy pipeline (`deploy-lxc.sh`, GitHub Actions workflow, Makefile)
- Enhanced Xiaomi settings tests with save→reload roundtrip validation for password and poll interval persistence
- All tests follow documented patterns with proper authentication, screenshots, and error handling

Minor style improvements recommended for step numbering consistency and timing message clarity in deployment scripts.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style improvements recommended
- Well-structured implementation with proper error handling, exit codes, and test patterns. Only minor inconsistencies in messaging (step numbering, timing) that don't affect functionality.
- scripts/deploy-lxc.sh and scripts/smoke-test.sh have minor style inconsistencies but are functionally correct

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | New file establishing E2E test requirements for PRs. Clear guidelines with examples. |
| web/tests/e2e/smoke.spec.ts | New smoke test suite covering 8 key pages. Proper imports, good error handling. |
| scripts/smoke-test.sh | Post-deploy health check + Playwright runner. Misleading timing message in health check loop. |
| scripts/deploy-lxc.sh | Added smoke test step after deploy. Inconsistent step numbering (1-3 say /4, should be /5). |

</details>



<sub>Last reviewed commit: 61dd39f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->