### PR TITLE
feat: enforce E2E test coverage — PRs without tests for new features must be rejected (#428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,57 @@ jobs:
       - name: Build
         run: bun run build
 
+  e2e-coverage-check:
+    name: E2E Test Coverage Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for E2E tests in feature/fix PRs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Only enforce on feat/fix PRs (not chore, docs, ci, refactor)
+          TITLE_LOWER=$(echo "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
+          if ! echo "$TITLE_LOWER" | grep -qE '^(feat|fix)'; then
+            echo "PR is not a feat/fix — skipping E2E test requirement"
+            exit 0
+          fi
+
+          echo "This is a feat/fix PR — checking for E2E test changes..."
+
+          # Check if PR body contains explicit justification for no tests
+          if echo "$PR_BODY" | grep -qiE '## Why no E2E test'; then
+            echo "PR body contains 'Why no E2E test' justification — OK"
+            exit 0
+          fi
+
+          # Check if any E2E test files were added or modified
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          E2E_CHANGES=$(echo "$CHANGED_FILES" | grep -E 'web/tests/e2e/.*\.spec\.ts$' || true)
+
+          if [ -z "$E2E_CHANGES" ]; then
+            echo "::error::Feature/fix PR must include Playwright E2E tests in web/tests/e2e/"
+            echo ""
+            echo "This PR changes feature code but does not add or modify any E2E tests."
+            echo "Either:"
+            echo "  1. Add a Playwright test in web/tests/e2e/ that verifies the feature works"
+            echo "  2. Add a '## Why no E2E test' section to the PR description explaining why"
+            echo ""
+            echo "See CLAUDE.md for test patterns and examples."
+            exit 1
+          fi
+
+          echo "Found E2E test changes:"
+          echo "$E2E_CHANGES"
+          echo "E2E coverage check passed!"
+
   e2e:
     name: E2E Tests (Playwright)
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,3 +11,36 @@ jobs:
     steps:
       - name: Run deploy script
         run: /home/shtrudel/src/panoptikon/scripts/deploy-lxc.sh
+
+  smoke-test:
+    name: Post-Deploy Smoke Test
+    runs-on: self-hosted
+    needs: [deploy]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: web
+        run: bun install
+
+      - name: Install Playwright browsers
+        working-directory: web
+        run: bunx playwright install chromium --with-deps
+
+      - name: Run smoke tests
+        env:
+          PANOPTIKON_URL: http://10.10.0.22:8080
+          PANOPTIKON_PASSWORD: ${{ secrets.PANOPTIKON_PASSWORD }}
+        run: ./scripts/smoke-test.sh
+
+      - name: Alert on failure
+        if: failure()
+        run: |
+          echo "::error::Smoke test FAILED after deploy to LXC 115. Panoptikon may not be working correctly."
+          echo "Deploy completed but the application is not responding correctly."
+          echo "Check http://10.10.0.22:8080 manually."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# Panoptikon — Developer Guidelines
+
+## E2E Test Requirement (Mandatory)
+
+Every PR that implements a feature or fixes a bug **MUST** include a Playwright E2E test that verifies the change actually works.
+
+### Rules
+
+1. **New feature PRs** must include at least one Playwright test in `web/tests/e2e/` that:
+   - Exercises the feature through the UI or API
+   - Asserts the expected behavior (not just "page loads")
+   - Would fail if the feature were removed
+
+2. **Bug fix PRs** must include a test that:
+   - Reproduces the bug (fails before the fix)
+   - Passes after the fix
+
+3. **If a test is genuinely impossible** (e.g., pure refactor with no behavior change, docs-only change, CI config change), the PR description must include a section:
+   ```
+   ## Why no E2E test
+   <explanation of why this change cannot be tested with Playwright>
+   ```
+
+4. **Settings changes** must include a save → reload roundtrip test (see existing patterns in `web/tests/e2e/settings-router.spec.ts` and `web/tests/e2e/settings-xiaomi.spec.ts`).
+
+5. **API endpoint changes** must include a test that calls the endpoint and verifies the response.
+
+### Test patterns
+
+- Test files go in `web/tests/e2e/<feature>.spec.ts`
+- Import fixtures from `../../e2e/fixtures` (provides `login`, `test`, `expect`)
+- Use `login(page)` in `beforeEach` for authenticated tests
+- Take screenshots at key points: `await page.screenshot({ path: 'tests/screenshots/<name>.png' })`
+- Use `{ timeout: 15000 }` for initial page load assertions
+
+### Running tests locally
+
+```bash
+cd web
+bunx playwright test                    # run all E2E tests
+bunx playwright test settings-router    # run specific test file
+bunx playwright test --headed           # run with browser visible
+```
+
+## Code Quality
+
+- Run `cargo fmt --all` before every commit
+- Run `cargo check` before pushing
+- Run `cargo test` to verify Rust tests pass
+- Follow existing code patterns — look at similar files before writing new code
+
+## Project Structure
+
+```
+server/          — Rust backend (axum, SQLite)
+web/             — Next.js frontend (TypeScript)
+web/tests/e2e/   — Playwright E2E tests
+web/e2e/         — Test fixtures (login, setup helpers)
+scripts/         — Build, deploy, and test scripts
+```

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# smoke-test.sh — Post-deploy smoke test for Panoptikon on LXC 115.
+#
+# Runs:
+#   1. curl health check (login page responds)
+#   2. Playwright smoke suite (key pages load, no crashes)
+#
+# Usage:
+#   ./scripts/smoke-test.sh [base_url]
+#
+# Defaults to http://10.10.0.22:8080 (LXC 115 IP).
+# Set PANOPTIKON_URL env var or pass as first argument to override.
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — health check or smoke tests failed
+#
+set -euo pipefail
+
+BASE_URL="${1:-${PANOPTIKON_URL:-http://10.10.0.22:8080}}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+ALERT_USER="${ALERT_USER:-shtrudel}"
+
+echo "=== Panoptikon Smoke Test ==="
+echo "Target: $BASE_URL"
+echo ""
+
+# --- Step 1: Health check (curl) ---
+echo "--- Step 1/2: Health check ---"
+HEALTH_OK=false
+for i in $(seq 1 10); do
+  if curl -sf "${BASE_URL}/login" > /dev/null 2>&1; then
+    echo "Health check passed (attempt $i)"
+    HEALTH_OK=true
+    break
+  fi
+  echo "Waiting for server... (attempt $i/10)"
+  sleep 3
+done
+
+if [ "$HEALTH_OK" = false ]; then
+  echo "FAIL: Server at $BASE_URL did not respond within 30 seconds"
+  echo ""
+  echo "ALERT: @${ALERT_USER} — Panoptikon deploy smoke test FAILED (health check)"
+  exit 1
+fi
+
+# --- Step 2: Playwright smoke suite ---
+echo ""
+echo "--- Step 2/2: Playwright smoke tests ---"
+cd "$REPO_ROOT/web"
+
+# Check if playwright and dependencies are available
+if ! command -v bunx &> /dev/null && ! command -v npx &> /dev/null; then
+  echo "WARN: Neither bunx nor npx available, skipping Playwright smoke tests"
+  echo "Health check passed — deploy is likely OK but not fully verified"
+  exit 0
+fi
+
+RUNNER="bunx"
+if ! command -v bunx &> /dev/null; then
+  RUNNER="npx"
+fi
+
+# Run only the smoke-tagged tests (or all tests if no smoke tag exists)
+PANOPTIKON_URL="$BASE_URL" $RUNNER playwright test --grep "@smoke" 2>&1 || {
+  # If no @smoke tests found, run the core page-load tests
+  echo "No @smoke-tagged tests found, running core page-load tests..."
+  PANOPTIKON_URL="$BASE_URL" $RUNNER playwright test dashboard navigation auth 2>&1 || {
+    echo ""
+    echo "FAIL: Playwright smoke tests failed"
+    echo "ALERT: @${ALERT_USER} — Panoptikon deploy smoke test FAILED (Playwright)"
+    exit 1
+  }
+}
+
+echo ""
+echo "=== All smoke tests passed ==="

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * Smoke tests — lightweight checks that key pages load without crashing.
+ * Run after every deploy to verify the application is functional.
+ *
+ * Tag: @smoke (used by scripts/smoke-test.sh --grep "@smoke")
+ */
+
+test.describe("@smoke Post-deploy smoke tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("@smoke login page loads", async ({ page }) => {
+    // Already logged in via beforeEach — verify we reached a valid page
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("@smoke dashboard loads with stat cards", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText("Router Status")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Active Devices")).toBeVisible();
+  });
+
+  test("@smoke devices page loads", async ({ page }) => {
+    await page.goto("/devices/");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("@smoke settings router page loads", async ({ page }) => {
+    await page.goto("/settings/router/");
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("@smoke settings xiaomi page loads", async ({ page }) => {
+    await page.goto("/settings/xiaomi-mesh/");
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("@smoke navigation sidebar renders", async ({ page }) => {
+    await page.goto("/");
+    // Sidebar should have key navigation items
+    await expect(page.getByRole("link", { name: /Dashboard/i })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("link", { name: /Devices/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #428

## Summary

- **CLAUDE.md** — Added project-level developer guidelines requiring every feat/fix PR to include Playwright E2E tests (or explicit justification)
- **CI: e2e-coverage-check job** — New GitHub Actions job that automatically rejects feat/fix PRs that don't include E2E test changes, unless the PR body contains a "## Why no E2E test" section
- **Post-deploy smoke tests** — `scripts/smoke-test.sh` runs a health check (curl) and Playwright smoke suite against LXC 115 after every deploy
- **Deploy workflow updated** — `deploy.yml` now runs the smoke test job after deploy completes; if smoke fails, deploy is not marked as success
- **Playwright smoke spec** — `web/tests/e2e/smoke.spec.ts` covers login, dashboard, devices, settings, and navigation page loads

## What already existed

Settings roundtrip tests for Xiaomi Mesh (`settings-xiaomi.spec.ts`), MikroTik (`settings-router.spec.ts`), and VyOS (`settings-router.spec.ts`) were already present and comprehensive. No changes needed.

## Design decisions

- The e2e-coverage-check only runs on PRs (not pushes to main) and only enforces on `feat:` or `fix:` prefixed titles — chore/docs/ci/refactor PRs are exempt
- Smoke tests use `@smoke` grep tag so they can be run independently from the full suite
- The smoke test script falls back gracefully if Playwright isn't installed (health check only)
- Alert on failure uses GitHub Actions `::error::` annotation; the deploy job itself still completes so the smoke failure is visible as a separate job

## Why no E2E test

This PR modifies CI configuration, deploy workflows, and adds developer documentation — all infrastructure changes that cannot be tested via Playwright. However, it does add a new smoke test spec (`smoke.spec.ts`) that will run in the existing E2E suite.

## Smoke Test

Verified manually:
- `CLAUDE.md` contains correct test patterns and file paths
- `scripts/smoke-test.sh` is executable and has correct shebang
- CI workflow YAML is valid (checked structure)
- Deploy workflow YAML is valid with proper job dependency chain
- Playwright smoke spec follows existing test patterns (imports from fixtures, uses login, proper timeouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added E2E test enforcement for feature/fix PRs and post-deploy smoke testing infrastructure.

- **CI enforcement**: New `e2e-coverage-check` job automatically rejects feat/fix PRs without E2E tests unless a "## Why no E2E test" justification is provided in the PR body
- **Developer guidelines**: `CLAUDE.md` documents mandatory E2E test requirements, patterns, and examples
- **Post-deploy validation**: New smoke test script and Playwright spec verify critical pages load after deployment to LXC 115
- **Workflow integration**: Deploy workflow now runs smoke tests after deployment completes, marking the workflow as failed if smoke tests don't pass

The implementation is solid overall, with one logic issue in the smoke test script's fallback behavior that won't affect normal operation since the PR includes proper `@smoke` tagged tests.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one non-critical logic issue in fallback behavior
- The implementation is well-designed and follows good practices. The e2e-coverage-check job correctly enforces test requirements, and the smoke test infrastructure is properly integrated into the deploy workflow. One logic flaw exists in `scripts/smoke-test.sh` where the fallback runs on test failure instead of only when no tests exist, but this won't affect normal operation since proper `@smoke` tests are included.
- Pay attention to `scripts/smoke-test.sh` — the fallback logic will run alternative tests if smoke tests fail rather than failing immediately

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Added e2e-coverage-check job that enforces E2E test requirements on feat/fix PRs, with proper escape hatch via PR body justification |
| .github/workflows/deploy.yml | Added post-deploy smoke test job with proper dependency chain and failure alerting |
| CLAUDE.md | Comprehensive developer guidelines documenting E2E test requirements, patterns, and project structure |
| scripts/smoke-test.sh | Implements health check and Playwright smoke tests, but has incorrect fallback logic that runs alternative tests when `@smoke` tests fail |
| web/tests/e2e/smoke.spec.ts | Implements `@smoke` tagged tests covering key pages (dashboard, devices, settings) following existing test patterns |

</details>



<sub>Last reviewed commit: 2bde600</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->