### PR TITLE
feat: enforce E2E test coverage — PRs without tests must be rejected (#428)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,3 +11,25 @@ jobs:
     steps:
       - name: Run deploy script
         run: /home/shtrudel/src/panoptikon/scripts/deploy-lxc.sh
+
+  smoke-test:
+    name: Post-Deploy Smoke Test
+    runs-on: self-hosted
+    needs: [deploy]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Playwright browsers
+        working-directory: web
+        run: ~/.bun/bin/bun x playwright install chromium --with-deps
+
+      - name: Run smoke tests against LXC 115
+        run: REPO_ROOT="$GITHUB_WORKSPACE" scripts/smoke-test.sh http://10.10.0.22:8080
+
+      - name: Alert on failure
+        if: failure()
+        run: |
+          echo "::error::Smoke test failed after deploy to LXC 115. Deploy is NOT verified."
+          gh issue comment 428 --repo "$GITHUB_REPOSITORY" --body "Smoke test failed after deploy. Manual verification needed." || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Panoptikon — Claude Code Guidelines
+
+## E2E Test Requirement
+
+Every PR that implements a feature or bug fix **MUST** include a Playwright E2E test that verifies the change actually works.
+
+### Rules
+
+1. **Test must exist**: Add or update a Playwright test in `web/tests/e2e/` that exercises the new behavior.
+2. **Test must be meaningful**: The test should fail before the fix/feature and pass after. A test that always passes is not a real test.
+3. **Test must cover the user flow**: If you changed a settings page, test save → reload → verify persisted. If you added UI, test that it renders and responds to interaction.
+4. **No test = justification required**: If the change is genuinely untestable (e.g., documentation-only, CI config, dependency bump), the PR description must explain why under a `## Why No E2E Test` section.
+
+### What to test
+
+| Change type | Required test |
+|---|---|
+| New settings field | Save value → reload → assert value persists |
+| New page / route | Navigate to page → assert key elements render |
+| Bug fix | Reproduce the bug scenario → assert it no longer occurs |
+| API endpoint | Call endpoint → assert response (can use Playwright `request` context) |
+| Layout change | Load page → screenshot → assert no visual regression |
+
+### Test patterns
+
+- Tests live in `web/tests/e2e/*.spec.ts`
+- Use fixtures from `web/e2e/fixtures.ts` (`login`, `setupIfNeeded`, `expect`)
+- Follow existing test patterns (see `settings-router.spec.ts`, `devices.spec.ts`)
+- Take screenshots for visual verification: `page.screenshot({ path: 'tests/screenshots/<name>.png' })`
+
+### Smoke tests
+
+After every deploy to LXC 115, the smoke test suite runs automatically:
+- Health check: `curl -sf http://10.10.0.22:8080/api/health`
+- Playwright smoke suite: `bunx playwright test --grep @smoke`
+- If smoke fails, the deploy is NOT marked as successful and Oleg is alerted.
+
+## Build & Format
+
+- Run `cargo fmt --all` before every commit
+- Run `cargo check` before pushing — don't open PRs with compile errors
+- Use `bun` for all JS operations (never npm/yarn)
+
+## Project Structure
+
+```
+server/           — Rust backend (axum, SQLite)
+web/              — Next.js frontend (TypeScript)
+web/tests/e2e/    — Playwright E2E tests
+web/e2e/          — Playwright fixtures
+scripts/          — Deploy and utility scripts
+```

--- a/scripts/deploy-lxc.sh
+++ b/scripts/deploy-lxc.sh
@@ -19,22 +19,37 @@ CARGO="${CARGO:-$HOME/.cargo/bin/cargo}"
 
 cd "$REPO_ROOT"
 
-echo "=== Step 1/4: Pulling latest main ==="
+echo "=== Step 1/5: Pulling latest main ==="
 git checkout main
 git pull origin main
 
-echo "=== Step 2/4: Building web frontend ==="
+echo "=== Step 2/5: Building web frontend ==="
 cd web
 "$BUN" install --frozen-lockfile
 "$BUN" run build
 cd "$REPO_ROOT"
 
-echo "=== Step 3/4: Building Rust server ==="
+echo "=== Step 3/5: Building Rust server ==="
 "$CARGO" build --release -p panoptikon-server
 
-echo "=== Step 4/4: Deploying to LXC $LXC_ID ==="
+echo "=== Step 4/5: Deploying to LXC $LXC_ID ==="
 scp target/release/panoptikon-server "$DEVBOX":/tmp/panoptikon-server
 ssh "$DEVBOX" "pct exec $LXC_ID -- systemctl stop panoptikon; pct push $LXC_ID /tmp/panoptikon-server /usr/local/bin/panoptikon-server; pct exec $LXC_ID -- systemctl start panoptikon"
 
 echo ""
 echo "Deploy complete — panoptikon is running on LXC $LXC_ID"
+
+echo ""
+echo "=== Step 5/5: Post-deploy smoke test ==="
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if REPO_ROOT="$REPO_ROOT" "$SCRIPT_DIR/smoke-test.sh" "http://10.10.0.22:8080"; then
+  echo "Smoke test passed — deploy is verified."
+else
+  echo "SMOKE TEST FAILED — deploy is NOT verified."
+  echo "Alerting Oleg..."
+  # Send alert via GitHub issue comment if gh is available
+  if command -v gh &>/dev/null; then
+    gh issue comment 428 --repo BeFeast/panoptikon --body "Smoke test failed after deploy to LXC $LXC_ID. Manual verification needed." 2>/dev/null || true
+  fi
+  exit 1
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# smoke-test.sh — Post-deploy smoke test for panoptikon on LXC 115.
+#
+# Runs:
+#   1. curl health check against the deployed instance
+#   2. Playwright smoke suite (key pages load, no crashes)
+#
+# If any check fails, exits non-zero so the caller can alert.
+#
+# Usage:
+#   scripts/smoke-test.sh [URL]
+#   Default URL: http://10.10.0.22:8080
+#
+set -euo pipefail
+
+PANOPTIKON_URL="${1:-http://10.10.0.22:8080}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+BUN="${BUN:-$HOME/.bun/bin/bun}"
+
+echo "=== Smoke Test: $PANOPTIKON_URL ==="
+
+# --- Step 1: Health check ---
+echo ""
+echo "--- Step 1/2: Health check ---"
+HEALTH_RESPONSE=$(curl -sf --max-time 10 "$PANOPTIKON_URL/health" 2>&1) || {
+  echo "FAIL: Health check failed — server at $PANOPTIKON_URL is not responding."
+  echo "Response: $HEALTH_RESPONSE"
+  exit 1
+}
+
+if [ "$HEALTH_RESPONSE" != "ok" ]; then
+  echo "FAIL: Health check returned unexpected response: $HEALTH_RESPONSE"
+  exit 1
+fi
+echo "PASS: Health check returned 'ok'"
+
+# --- Step 2: Playwright smoke suite ---
+echo ""
+echo "--- Step 2/2: Playwright smoke suite ---"
+cd "$REPO_ROOT/web"
+
+# Install deps if needed (CI may have them cached)
+if [ ! -d "node_modules" ]; then
+  "$BUN" install --frozen-lockfile
+fi
+
+# Run only smoke-tagged tests
+PANOPTIKON_URL="$PANOPTIKON_URL" "$BUN" x playwright test --grep @smoke 2>&1 || {
+  echo ""
+  echo "FAIL: Playwright smoke tests failed against $PANOPTIKON_URL"
+  echo "Deploy should NOT be marked as successful."
+  exit 1
+}
+
+echo ""
+echo "=== All smoke tests passed ==="

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * Smoke tests — tagged @smoke.
+ * Run after every deploy to verify key pages load without crashes.
+ *
+ * Usage: bunx playwright test --grep @smoke
+ */
+
+test.describe("Smoke Tests @smoke", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("health endpoint returns ok @smoke", async ({ request }) => {
+    const response = await request.get("/health");
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toBe("ok");
+  });
+
+  test("dashboard loads without errors @smoke", async ({ page }) => {
+    await page.goto("/dashboard/");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("devices page loads without errors @smoke", async ({ page }) => {
+    await page.goto("/devices/");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("agents page loads without errors @smoke", async ({ page }) => {
+    await page.goto("/agents/");
+    await expect(
+      page.getByRole("heading", { name: "Agents", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("settings page loads without errors @smoke", async ({ page }) => {
+    await page.goto("/settings/");
+    await expect(
+      page.getByRole("heading", { name: "Settings", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("router settings loads without errors @smoke", async ({ page }) => {
+    await page.goto("/settings/router/");
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("xiaomi settings loads without errors @smoke", async ({ page }) => {
+    await page.goto("/settings/xiaomi-mesh/");
+    await expect(page.locator("#xiaomi-ip")).toBeVisible({ timeout: 15000 });
+  });
+});


### PR DESCRIPTION
Closes #428

## Summary

- **CLAUDE.md** — Worker prompt enforcing that every feature/fix PR must include a Playwright E2E test (or justify why not)
- **Smoke test suite** (`web/tests/e2e/smoke.spec.ts`) — Tagged `@smoke`, verifies all key pages load without crashes (dashboard, devices, agents, settings, router settings, xiaomi settings, health endpoint)
- **Post-deploy smoke script** (`scripts/smoke-test.sh`) — Runs health check + Playwright smoke suite against the deployed instance; exits non-zero on failure
- **Deploy script updated** (`scripts/deploy-lxc.sh`) — Now runs smoke test as step 5/5 after deploy; alerts via GitHub issue comment on failure
- **Deploy workflow updated** (`.github/workflows/deploy.yml`) — Separate `smoke-test` job runs after deploy; alerts on failure

## What already existed

Settings roundtrip tests were already in place:
- `web/tests/e2e/settings-xiaomi.spec.ts` — Xiaomi Mesh IP, password, enabled toggle persist
- `web/tests/e2e/settings-router.spec.ts` — MikroTik URL/user/password, VyOS URL/API key persist

## Design decisions

- Smoke tests are tagged `@smoke` in the test description, filtered via `--grep @smoke`
- The smoke test script is reusable: `scripts/smoke-test.sh [URL]` defaults to LXC 115
- Deploy workflow runs smoke test as a separate job (not inline in deploy-lxc.sh for CI) so it has its own pass/fail status
- On smoke failure, the deploy is marked as failed and a GitHub issue comment alerts the team

## Smoke Test

Verified locally:
- `CLAUDE.md` contains complete E2E test enforcement rules
- `smoke.spec.ts` follows existing test patterns (fixtures, login, assertions)
- `smoke-test.sh` is executable and follows existing deploy script conventions
- `deploy-lxc.sh` step numbering updated correctly (5 steps)
- `deploy.yml` smoke-test job depends on deploy job completing first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements comprehensive E2E test enforcement with post-deploy smoke testing. Adds `CLAUDE.md` guidelines requiring Playwright tests for all feature/fix PRs, creates a smoke test suite tagged with `@smoke` covering all key pages, and integrates smoke tests into the deployment pipeline.

- New `CLAUDE.md` establishes clear E2E test requirements with examples and patterns
- Smoke test suite (`smoke.spec.ts`) verifies health endpoint and all major pages load correctly
- Post-deploy smoke script (`smoke-test.sh`) runs health check + Playwright suite against deployed instance
- Deploy pipeline updated to run smoke tests as final verification step

**Critical issue**: Both `deploy-lxc.sh` and `deploy.yml` hardcode issue #428 for failure alerts. Once this PR closes #428, all future deployment failures will comment on a closed issue instead of creating new alerts.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing hardcoded issue number
- Implementation is solid with well-structured tests and scripts following existing patterns. Score reduced due to hardcoded issue #428 in alert mechanism which will cause operational issues after merge.
- `scripts/deploy-lxc.sh` and `.github/workflows/deploy.yml` — both hardcode issue #428 for alerts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/tests/e2e/smoke.spec.ts | Well-structured smoke tests following existing test patterns with proper `@smoke` tagging |
| scripts/deploy-lxc.sh | Deploy script updated with smoke test step, but hardcodes issue #428 for alerts |
| .github/workflows/deploy.yml | Smoke test job added correctly, but also hardcodes issue #428 for failure alerts |

</details>



<sub>Last reviewed commit: b460589</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->