### PR TITLE
fix: update Xiaomi mesh topo_graph parsing for RD15 firmware (#446)

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -27,52 +27,77 @@ async fn mesh_router_ip(state: &AppState) -> String {
 }
 
 // ── Raw Xiaomi topo_graph response shapes ───────────────────
+//
+// On RD15 firmware (BE3600) the `api/misystem/topo_graph` endpoint returns
+// the main router info *directly* in the `graph` object (no separate `nodes`
+// array), with satellite mesh nodes listed under `graph.leafs`.
 
-/// Inner graph object containing nodes (and optionally leafs).
-#[derive(Debug, Deserialize)]
-struct XiaomiTopoGraph {
-    #[serde(default)]
-    nodes: Vec<XiaomiTopoNode>,
+/// Deserialize an `i32` from either a JSON number or a JSON string.
+/// Returns 0 for any other type.
+fn de_i32_from_string_or_number<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match &value {
+        serde_json::Value::Number(n) => Ok(n.as_i64().unwrap_or(0) as i32),
+        serde_json::Value::String(s) => Ok(s.trim().parse::<i32>().unwrap_or(0)),
+        _ => Ok(0),
+    }
 }
 
 /// Root response from `api/misystem/topo_graph`.
-///
-/// The actual Xiaomi response nests the node list inside `graph.nodes`,
-/// **not** at the top-level `list` key.
 #[derive(Debug, Deserialize)]
 struct XiaomiTopoResponse {
     code: i32,
     #[serde(default)]
-    graph: Option<XiaomiTopoGraph>,
+    graph: Option<XiaomiTopoGraphRoot>,
 }
 
-/// A single node in the Xiaomi mesh topology.
+/// The `graph` object from `api/misystem/topo_graph`.
+///
+/// On RD15 firmware this object contains the main router's own fields
+/// (ip, name, hardware, etc.) and a `leafs` array of satellite nodes.
 #[derive(Debug, Deserialize)]
-struct XiaomiTopoNode {
+struct XiaomiTopoGraphRoot {
     #[serde(default)]
     ip: String,
     #[serde(default)]
-    mac: String,
-    #[serde(default)]
     name: String,
-    #[serde(default)]
-    model: String,
     #[serde(default)]
     hardware: String,
     #[serde(default)]
     locale: String,
-    /// 1 = main/CAP node, 0 = satellite
+    /// Network mode: 2 = AP (main node), 1 = satellite repeater.
     #[serde(default)]
-    is_ap: i32,
-    /// Number of online devices connected to this node.
+    mode: i32,
+    /// Number of online devices (may be a number or a string).
+    #[serde(default, deserialize_with = "de_i32_from_string_or_number")]
+    onlines: i32,
+    /// Satellite mesh nodes.
     #[serde(default)]
-    online: i32,
-    /// Connection type: "wire" or "wifi", etc.
-    #[serde(default, rename = "type")]
-    connection_type: String,
-    /// Parent node MAC address (empty for the main/CAP node).
+    leafs: Vec<XiaomiTopoLeaf>,
+}
+
+/// A satellite mesh node in the `graph.leafs` array.
+#[derive(Debug, Deserialize)]
+struct XiaomiTopoLeaf {
     #[serde(default)]
-    parent_mac: String,
+    ip: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    hardware: String,
+    #[serde(default)]
+    locale: String,
+    #[serde(default)]
+    mode: i32,
+    /// Number of online devices connected to this satellite.
+    #[serde(default)]
+    onlines: i32,
+    /// Connection type: "wired" or "wifi".
+    #[serde(default)]
+    link_type: String,
     /// Signal strength (for wireless backhaul, otherwise 0).
     #[serde(default)]
     signal: i32,
@@ -154,39 +179,67 @@ pub async fn topology(
         )));
     }
 
-    let topo_nodes = raw.graph.map(|g| g.nodes).unwrap_or_default();
+    let graph = match raw.graph {
+        Some(g) => g,
+        None => {
+            return Ok(Json(MeshTopologyResponse {
+                main_ip: router_ip,
+                total_devices: 0,
+                nodes: vec![],
+            }));
+        }
+    };
 
-    let mut total_devices = 0i32;
-    let nodes: Vec<MeshNode> = topo_nodes
-        .into_iter()
-        .map(|n| {
-            total_devices += n.online;
-            let backhaul_type = if n.is_ap == 1 {
-                "main".to_string()
-            } else if n.connection_type == "wire" {
-                "wired".to_string()
+    let mut total_devices = graph.onlines;
+    let mut nodes = Vec::with_capacity(1 + graph.leafs.len());
+
+    // Main router node (the graph root itself).
+    nodes.push(MeshNode {
+        ip: graph.ip,
+        mac: String::new(),
+        name: if graph.name.is_empty() {
+            graph.locale.clone()
+        } else {
+            graph.name
+        },
+        model: String::new(),
+        hardware: graph.hardware,
+        is_main: true,
+        online_devices: graph.onlines,
+        backhaul_type: "main".to_string(),
+        parent_mac: String::new(),
+        signal: 0,
+        is_online: true,
+    });
+
+    // Satellite mesh nodes from leafs.
+    for leaf in graph.leafs {
+        total_devices += leaf.onlines;
+        let backhaul_type = if leaf.link_type == "wired" || leaf.link_type == "wire" {
+            "wired".to_string()
+        } else if leaf.link_type.is_empty() {
+            "unknown".to_string()
+        } else {
+            leaf.link_type
+        };
+        nodes.push(MeshNode {
+            ip: leaf.ip.clone(),
+            mac: String::new(),
+            name: if leaf.name.is_empty() {
+                leaf.locale.clone()
             } else {
-                n.connection_type.clone()
-            };
-            MeshNode {
-                ip: n.ip.clone(),
-                mac: n.mac,
-                name: if n.name.is_empty() {
-                    n.locale.clone()
-                } else {
-                    n.name
-                },
-                model: n.model,
-                hardware: n.hardware,
-                is_main: n.is_ap == 1,
-                online_devices: n.online,
-                backhaul_type,
-                parent_mac: n.parent_mac,
-                signal: n.signal,
-                is_online: !n.ip.is_empty(),
-            }
-        })
-        .collect();
+                leaf.name
+            },
+            model: String::new(),
+            hardware: leaf.hardware,
+            is_main: false,
+            online_devices: leaf.onlines,
+            backhaul_type,
+            parent_mac: String::new(),
+            signal: leaf.signal,
+            is_online: !leaf.ip.is_empty(),
+        });
+    }
 
     Ok(Json(MeshTopologyResponse {
         main_ip: router_ip,

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -62,28 +62,20 @@ pub struct XiaomiStatusResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct XiaomiTopoNodeResponse {
-    pub mac: Option<String>,
+    pub ip: Option<String>,
     pub name: Option<String>,
     pub locale: Option<String>,
-    pub ip: Option<String>,
-    pub online: Option<i32>,
     pub hardware: Option<String>,
-    pub model: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct XiaomiTopoLeafResponse {
-    pub mac: Option<String>,
-    pub ip: Option<String>,
-    pub name: Option<String>,
+    pub mode: Option<i32>,
     pub online: Option<i32>,
-    pub parent_id: Option<String>,
+    pub link_type: Option<String>,
+    pub signal: Option<i32>,
+    pub is_main: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct XiaomiTopoResponse {
     pub nodes: Vec<XiaomiTopoNodeResponse>,
-    pub leafs: Vec<XiaomiTopoLeafResponse>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -255,38 +247,44 @@ pub async fn topology(
 
     match client.topo_graph().await {
         Ok(topo) => {
-            let graph = topo
-                .graph
-                .unwrap_or_else(|| crate::xiaomi::types::TopoGraphInner {
-                    nodes: vec![],
-                    leafs: vec![],
+            let graph = match topo.graph {
+                Some(g) => g,
+                None => {
+                    return Ok(Json(XiaomiTopoResponse { nodes: vec![] }));
+                }
+            };
+
+            let mut nodes = Vec::with_capacity(1 + graph.leafs.len());
+
+            // Main router node (the graph root itself).
+            nodes.push(XiaomiTopoNodeResponse {
+                ip: graph.ip,
+                name: graph.name,
+                locale: graph.locale,
+                hardware: graph.hardware,
+                mode: graph.mode,
+                online: graph.onlines,
+                link_type: None,
+                signal: None,
+                is_main: true,
+            });
+
+            // Satellite mesh nodes from leafs.
+            for leaf in graph.leafs {
+                nodes.push(XiaomiTopoNodeResponse {
+                    ip: leaf.ip,
+                    name: leaf.name,
+                    locale: leaf.locale,
+                    hardware: leaf.hardware,
+                    mode: leaf.mode,
+                    online: leaf.onlines,
+                    link_type: leaf.link_type,
+                    signal: leaf.signal,
+                    is_main: false,
                 });
-            Ok(Json(XiaomiTopoResponse {
-                nodes: graph
-                    .nodes
-                    .into_iter()
-                    .map(|n| XiaomiTopoNodeResponse {
-                        mac: n.mac,
-                        name: n.name,
-                        locale: n.locale,
-                        ip: n.ip,
-                        online: n.online,
-                        hardware: n.hardware,
-                        model: n.model,
-                    })
-                    .collect(),
-                leafs: graph
-                    .leafs
-                    .into_iter()
-                    .map(|l| XiaomiTopoLeafResponse {
-                        mac: l.mac,
-                        ip: l.ip,
-                        name: l.name,
-                        online: l.online,
-                        parent_id: l.parent_id,
-                    })
-                    .collect(),
-            }))
+            }
+
+            Ok(Json(XiaomiTopoResponse { nodes }))
         }
         Err(e) => {
             tracing::error!(error = %e, "MiWiFi topology request failed");

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -69,37 +69,29 @@ pub struct LoginResponse {
 }
 
 // ── Topology (topo_graph) ───────────────────────────────────
+//
+// On RD15 firmware (BE3600) the `api/misystem/topo_graph` response has the
+// main router info directly in the `graph` object, with satellite mesh nodes
+// in `graph.leafs`. There is no separate `nodes` array.
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TopoNode {
+pub struct TopoLeaf {
     #[serde(default)]
-    pub mac: Option<String>,
+    pub ip: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
     pub locale: Option<String>,
     #[serde(default)]
-    pub ip: Option<String>,
-    #[serde(default)]
-    pub online: Option<i32>,
-    #[serde(default)]
     pub hardware: Option<String>,
     #[serde(default)]
-    pub model: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TopoLeaf {
+    pub mode: Option<i32>,
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
+    pub onlines: Option<i32>,
     #[serde(default)]
-    pub mac: Option<String>,
+    pub link_type: Option<String>,
     #[serde(default)]
-    pub ip: Option<String>,
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub online: Option<i32>,
-    #[serde(default, rename = "parentId")]
-    pub parent_id: Option<String>,
+    pub signal: Option<i32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -108,10 +100,22 @@ pub struct TopoGraph {
     pub graph: Option<TopoGraphInner>,
 }
 
+/// The `graph` object — on RD15 firmware this contains the main router's own
+/// fields (ip, name, hardware, etc.) and a `leafs` array of satellite nodes.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TopoGraphInner {
     #[serde(default)]
-    pub nodes: Vec<TopoNode>,
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    #[serde(default)]
+    pub mode: Option<i32>,
+    #[serde(default, deserialize_with = "de_opt_i32_from_any")]
+    pub onlines: Option<i32>,
     #[serde(default)]
     pub leafs: Vec<TopoLeaf>,
 }

--- a/web/src/app/(app)/xiaomi/page.tsx
+++ b/web/src/app/(app)/xiaomi/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Cable,
   Crown,
-  Loader2,
   MonitorSmartphone,
   RefreshCw,
   Router,
@@ -21,40 +20,12 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageTransition } from "@/components/PageTransition";
 import { fetchXiaomiTopology } from "@/lib/api";
-import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types";
-
-// ─── Helpers ─────────────────────────────────────────────
-
-/** Count leafs attached to a given node MAC. */
-function leafCountForNode(
-  nodeMac: string | null,
-  leafs: XiaomiTopoLeaf[],
-): number {
-  if (!nodeMac) return 0;
-  return leafs.filter((l) => l.parent_id === nodeMac).length;
-}
-
-/** Get leafs attached to a given node MAC. */
-function leafsForNode(
-  nodeMac: string | null,
-  leafs: XiaomiTopoLeaf[],
-): XiaomiTopoLeaf[] {
-  if (!nodeMac) return [];
-  return leafs.filter((l) => l.parent_id === nodeMac);
-}
+import type { XiaomiTopology, XiaomiTopoNode } from "@/lib/types";
 
 // ─── Node Card ───────────────────────────────────────────
 
-function NodeCard({
-  node,
-  leafs,
-  isMain,
-}: {
-  node: XiaomiTopoNode;
-  leafs: XiaomiTopoLeaf[];
-  isMain: boolean;
-}) {
-  const connectedLeafs = leafsForNode(node.mac, leafs);
+function NodeCard({ node }: { node: XiaomiTopoNode }) {
+  const isMain = node.is_main;
   const onlineDevices = node.online ?? 0;
 
   return (
@@ -80,7 +51,7 @@ function NodeCard({
           </div>
           <div className="min-w-0 flex-1">
             <CardTitle className="truncate text-sm font-semibold text-white">
-              {node.locale || node.name || "Mesh Node"}
+              {node.name || node.locale || "Mesh Node"}
             </CardTitle>
             <p className="truncate font-mono text-xs text-slate-400">
               {node.ip || "No IP"}
@@ -102,25 +73,27 @@ function NodeCard({
             <MonitorSmartphone className="h-3.5 w-3.5" />
             {onlineDevices} device{onlineDevices !== 1 ? "s" : ""} online
           </span>
-          {connectedLeafs.length > 0 && (
+          {node.link_type && (
+            <span className="flex items-center gap-1.5">
+              {node.link_type === "wired" ? (
+                <Cable className="h-3.5 w-3.5" />
+              ) : (
+                <Wifi className="h-3.5 w-3.5" />
+              )}
+              {node.link_type}
+            </span>
+          )}
+          {node.signal != null && node.signal > 0 && (
             <span className="flex items-center gap-1.5">
               <Wifi className="h-3.5 w-3.5" />
-              {connectedLeafs.length} connected
+              Signal: {node.signal}
             </span>
           )}
         </div>
 
         {/* Badges */}
         <div className="flex flex-wrap items-center gap-1.5">
-          {node.model && (
-            <Badge
-              variant="outline"
-              className="border-slate-700 text-[10px] text-slate-500"
-            >
-              {node.model}
-            </Badge>
-          )}
-          {node.hardware && node.hardware !== node.model && (
+          {node.hardware && (
             <Badge
               variant="outline"
               className="border-slate-700 text-[10px] text-slate-500"
@@ -134,37 +107,6 @@ function NodeCard({
             </Badge>
           )}
         </div>
-
-        {/* MAC address */}
-        {node.mac && (
-          <p className="font-mono text-[10px] text-slate-600">
-            MAC: {node.mac}
-          </p>
-        )}
-
-        {/* Connected devices list */}
-        {connectedLeafs.length > 0 && (
-          <div className="mt-2 space-y-1 border-t border-slate-800 pt-2">
-            <p className="text-[10px] font-medium uppercase tracking-wider text-slate-500">
-              Connected Devices
-            </p>
-            <div className="max-h-32 space-y-0.5 overflow-y-auto">
-              {connectedLeafs.map((leaf) => (
-                <div
-                  key={leaf.mac || leaf.ip}
-                  className="flex items-center justify-between rounded px-1.5 py-0.5 text-[11px] hover:bg-slate-800/50"
-                >
-                  <span className="truncate text-slate-300">
-                    {leaf.name || leaf.mac || "Unknown"}
-                  </span>
-                  <span className="shrink-0 font-mono text-slate-500">
-                    {leaf.ip || "—"}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
       </CardContent>
     </Card>
   );
@@ -229,24 +171,19 @@ export default function XiaomiMeshPage() {
     return () => clearInterval(interval);
   }, [load]);
 
-  // Determine which node is "main" (first node, typically the primary router)
-  const { sortedNodes, mainMac } = useMemo(() => {
-    if (!data) return { sortedNodes: [], mainMac: null };
-    // The first node in the list is usually the main router
-    const main = data.nodes[0] ?? null;
-    const mainMac = main?.mac ?? null;
-    // Sort: main first, then by online device count descending
-    const sorted = [...data.nodes].sort((a, b) => {
-      if (a.mac === mainMac) return -1;
-      if (b.mac === mainMac) return 1;
+  // Sort: main node first, then by online device count descending
+  const sortedNodes = useMemo(() => {
+    if (!data) return [];
+    return [...data.nodes].sort((a, b) => {
+      if (a.is_main && !b.is_main) return -1;
+      if (!a.is_main && b.is_main) return 1;
       return (b.online ?? 0) - (a.online ?? 0);
     });
-    return { sortedNodes: sorted, mainMac };
   }, [data]);
 
   // Stats
   const stats = useMemo(() => {
-    if (!data) return { nodeCount: 0, totalDevices: 0, totalLeafs: 0 };
+    if (!data) return { nodeCount: 0, totalDevices: 0 };
     const totalDevices = data.nodes.reduce(
       (sum, n) => sum + (n.online ?? 0),
       0,
@@ -254,7 +191,6 @@ export default function XiaomiMeshPage() {
     return {
       nodeCount: data.nodes.length,
       totalDevices,
-      totalLeafs: data.leafs.length,
     };
   }, [data]);
 
@@ -291,7 +227,7 @@ export default function XiaomiMeshPage() {
 
         {/* Summary stats */}
         {!loading && data && (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Card className="border-slate-800 bg-slate-900/50">
               <CardContent className="flex items-center gap-3 p-4">
                 <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/20">
@@ -315,19 +251,6 @@ export default function XiaomiMeshPage() {
                     {stats.totalDevices}
                   </p>
                   <p className="text-xs text-slate-400">Online Devices</p>
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="border-slate-800 bg-slate-900/50">
-              <CardContent className="flex items-center gap-3 p-4">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/20">
-                  <Wifi className="h-4.5 w-4.5 text-purple-400" />
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-white">
-                    {stats.totalLeafs}
-                  </p>
-                  <p className="text-xs text-slate-400">Connected Clients</p>
                 </div>
               </CardContent>
             </Card>
@@ -365,12 +288,7 @@ export default function XiaomiMeshPage() {
         {!loading && data && sortedNodes.length > 0 && (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             {sortedNodes.map((node) => (
-              <NodeCard
-                key={node.mac || node.ip}
-                node={node}
-                leafs={data.leafs}
-                isMain={node.mac === mainMac}
-              />
+              <NodeCard key={node.ip || node.name} node={node} />
             ))}
           </div>
         )}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1870,26 +1870,19 @@ export interface XiaomiStatus {
 }
 
 export interface XiaomiTopoNode {
-  mac: string | null;
+  ip: string | null;
   name: string | null;
   locale: string | null;
-  ip: string | null;
-  online: number | null;
   hardware: string | null;
-  model: string | null;
-}
-
-export interface XiaomiTopoLeaf {
-  mac: string | null;
-  ip: string | null;
-  name: string | null;
+  mode: number | null;
   online: number | null;
-  parent_id: string | null;
+  link_type: string | null;
+  signal: number | null;
+  is_main: boolean;
 }
 
 export interface XiaomiTopology {
   nodes: XiaomiTopoNode[];
-  leafs: XiaomiTopoLeaf[];
 }
 
 export interface XiaomiDevice {


### PR DESCRIPTION
## Summary
- Fix Xiaomi mesh topology page showing 0 nodes on RD15 firmware (BE3600)
- The `api/misystem/topo_graph` endpoint returns a different response format on RD15: the main router info is directly in the `graph` object with satellite nodes in `graph.leafs`, rather than a separate `graph.nodes` array
- Updated deserialization structs in `mesh.rs`, `xiaomi/types.rs`, and `api/xiaomi.rs` to match the actual response format
- Updated frontend `XiaomiTopology` types and the Xiaomi mesh page to use a flat node list with `is_main` flag

## Changes
- **server/src/api/mesh.rs** — Replaced `XiaomiTopoGraph.nodes` parsing with `XiaomiTopoGraphRoot` that reads main router from graph root and satellites from `graph.leafs`. Handles `onlines` (string or number), `link_type`, and `mode` fields.
- **server/src/xiaomi/types.rs** — Updated `TopoGraphInner` to match actual response: main router fields at graph level + `leafs` array with correct field names
- **server/src/api/xiaomi.rs** — Updated topology handler to construct flat node list from graph root + leafs, with `is_main` flag
- **web/src/lib/types.ts** — Updated `XiaomiTopoNode` to match new backend response, removed `XiaomiTopoLeaf`
- **web/src/app/(app)/xiaomi/page.tsx** — Simplified page to use flat node list with `is_main` instead of separate nodes/leafs matching by MAC

## Smoke Test
Confirmed that the `api/misystem/topo_graph` endpoint returns data from the router at 10.10.0.199:
```json
{
  "graph": {
    "ip": "10.10.0.199",
    "name": "OK Home",
    "hardware": "RD15",
    "mode": 2,
    "leafs": [
      {"ip": "10.10.0.52", "name": "Basement", "hardware": "RD15", "link_type": "wired", "onlines": 10},
      {"ip": "10.10.0.54", "name": "Network Enclosure", "hardware": "RD15", "link_type": "wired", "onlines": 1},
      {"ip": "10.10.0.53", "name": "Floor 2", "hardware": "RD15", "link_type": "wired", "onlines": 4}
    ],
    "onlines": "7"
  },
  "code": 0
}
```
All 303 unit tests + 21 integration tests pass. TypeScript compiles cleanly.

Closes #446

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the Xiaomi mesh topology parsing to handle the new RD15 firmware response format where the main router info is embedded directly in the `graph` object with satellite nodes in `graph.leafs`, replacing the old `graph.nodes` array structure.

**Key Changes:**
- Added custom deserializer `de_i32_from_string_or_number` to handle `onlines` field that can be either string or number in RD15 firmware
- Restructured backend types (`XiaomiTopoGraphRoot`, `TopoGraphInner`) to match actual API response structure
- Unified node representation with `is_main` flag instead of separate nodes/leafs arrays
- Updated frontend to display satellite connection type (`link_type`) and signal strength
- Removed obsolete MAC-based leaf matching logic that was based on old firmware format

**Code Quality:**
- All 303 unit tests + 21 integration tests pass
- Proper null/Option handling throughout
- Smoke test confirms correct deserialization of actual RD15 router response
- Clean removal of deprecated code without backwards-compatibility cruft

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks identified
- The changes are well-structured with comprehensive test coverage (303 unit + 21 integration tests passing), properly handle edge cases with Option types and custom deserializers, and include smoke test validation against real RD15 firmware response. The refactoring cleanly removes obsolete code while maintaining backward compatibility for the mesh endpoint.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mesh.rs | Updated topology parsing to read main router from graph root and satellites from `graph.leafs`, added custom deserializer for `onlines` field |
| server/src/xiaomi/types.rs | Restructured `TopoGraphInner` to include main router fields directly, updated `TopoLeaf` to match RD15 firmware response format |
| server/src/api/xiaomi.rs | Merged node and leaf responses into unified `XiaomiTopoNodeResponse` with `is_main` flag, constructs flat node list from graph root and leafs |
| web/src/lib/types.ts | Updated `XiaomiTopoNode` interface to match new backend response, removed deprecated `XiaomiTopoLeaf` type |
| web/src/app/(app)/xiaomi/page.tsx | Simplified UI to use flat node list with `is_main` flag, removed legacy MAC-based leaf matching logic, added `link_type` and `signal` display for satellites |

</details>



<sub>Last reviewed commit: b5b0896</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->