### PR TITLE
fix: handle integer online field in Xiaomi device list response (#453)

### DIFF
--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -188,7 +188,7 @@ pub struct MiWiFiDevice {
     pub name: Option<String>,
     #[serde(default, rename = "type")]
     pub device_type: Option<i32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_string_from_any")]
     pub online: Option<String>,
     #[serde(default)]
     pub authority: Option<serde_json::Value>,
@@ -427,5 +427,23 @@ mod tests {
         let payload = serde_json::json!({ "upTime": 123 });
         let parsed: UptimeResponse = serde_json::from_value(payload).expect("uptime should parse");
         assert_eq!(parsed.uptime, Some("123".to_string()));
+    }
+
+    #[test]
+    fn device_list_deserializes_online_as_integer() {
+        let payload = serde_json::json!({
+            "list": [{
+                "mac": "BC:24:11:BF:35:FB",
+                "online": 1,
+                "name": "BC:24:11:BF:35:FB",
+                "ip": [{"online": "400346", "ip": "192.168.1.100"}]
+            }]
+        });
+
+        let parsed: DeviceListResponse =
+            serde_json::from_value(payload).expect("device list should parse");
+        assert_eq!(parsed.list.len(), 1);
+        assert_eq!(parsed.list[0].online, Some("1".to_string()));
+        assert_eq!(parsed.list[0].ip[0].online, Some("400346".to_string()));
     }
 }


### PR DESCRIPTION
Closes #453

## Summary
- The Xiaomi API returns `"online": 1` (integer) at the device level, but `MiWiFiDevice.online` was typed as `Option<String>`, causing serde to fail parsing the entire device list.
- Added `deserialize_with = "de_opt_string_from_any"` to `MiWiFiDevice.online`, which converts integers to strings automatically. This matches the existing pattern used throughout `types.rs` for other mixed-type fields.
- `MiWiFiDeviceIp.online` is left unchanged — it receives a string (seconds elapsed) from the API.

## Smoke Test
- Added a unit test `device_list_deserializes_online_as_integer` that reproduces the exact failure scenario from the issue (integer `online` at device level, string `online` in nested `ip[]`).
- All 3 tests in `xiaomi::types` pass.

## Test plan
- [x] `cargo test -p panoptikon-server --lib xiaomi::types` — all 3 tests pass
- [x] `cargo fmt --all` — formatted
- [x] Existing behavior preserved: downstream code (`d.online.as_deref() == Some("1")`) works identically since the integer `1` is converted to string `"1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Xiaomi device list deserialization by adding `deserialize_with = "de_opt_string_from_any"` to `MiWiFiDevice.online`, converting integer values to strings. This follows the existing pattern used extensively in the codebase and preserves backward compatibility since downstream code checks `d.online.as_deref() == Some("1")`.

The unit test comprehensively covers the fix and directly reproduces the failure scenario. However, per `CLAUDE.md`, the PR should include a "## Why No E2E Test" section explaining that this hardware integration fix cannot be tested end-to-end without physical Xiaomi router hardware (similar to the documented MikroTik example).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - the fix is correct, well-tested, and preserves backward compatibility.
- The code change follows an established pattern used throughout the codebase, the unit test directly reproduces and verifies the fix, and downstream usage is preserved (integer `1` converts to string `"1"`). The only note is a process requirement: the PR should document why an E2E test isn't included.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added `deserialize_with` attribute to handle integer `online` field, following existing codebase patterns. Includes comprehensive unit test. |

</details>



<sub>Last reviewed commit: 8e1ecf9</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->