### PR TITLE
test: add E2E tests for Caddy/reverse-proxy page (#463)

### DIFF
--- a/web/tests/e2e/caddy.spec.ts
+++ b/web/tests/e2e/caddy.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * Helper: create a proxy host via the Add Host dialog.
+ * Waits for the dialog to close (up to 20s, since sync_to_caddy can
+ * block ~10s when Caddy is unreachable).
+ */
+async function createHost(
+  page: import("@playwright/test").Page,
+  domain: string,
+  host: string,
+  port: string,
+) {
+  await page.getByRole("button", { name: "Add Host" }).click();
+  await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3000 });
+  await page.locator("#domain").fill(domain);
+  await page.locator("#forward-host").fill(host);
+  await page.locator("#forward-port").fill(port);
+  await page.getByRole("button", { name: "Create" }).click();
+  // sync_to_caddy may block ~10s when Caddy is unreachable
+  await expect(page.locator('[role="dialog"]')).not.toBeVisible({
+    timeout: 20000,
+  });
+}
+
+test.describe("Caddy Reverse Proxy page", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/caddy/");
+    await expect(
+      page.getByRole("heading", { name: "Caddy Reverse Proxy", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("page loads with heading and key UI elements", async ({ page }) => {
+    // Admin URL card
+    await expect(page.locator("#admin-url")).toBeVisible();
+
+    // Action buttons
+    await expect(
+      page.getByRole("button", { name: "Test Connection" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sync to Caddy" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Host" }),
+    ).toBeVisible();
+
+    // Search input
+    await expect(
+      page.getByPlaceholder("Filter by domain or upstream..."),
+    ).toBeVisible();
+
+    // Table headers
+    await expect(
+      page.getByRole("columnheader", { name: "Domain" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Upstream" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "TLS" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Status" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Actions" }),
+    ).toBeVisible();
+
+    await page.screenshot({ path: "tests/screenshots/caddy-page.png" });
+  });
+
+  test("domain list renders after adding a host", async ({ page }) => {
+    const domain = `e2e-${Date.now()}.example.com`;
+
+    await createHost(page, domain, "10.0.0.5", "8080");
+
+    // Domain should appear as a link in the table
+    const link = page.getByRole("link", { name: domain });
+    await expect(link).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-domain-list.png",
+      fullPage: true,
+    });
+  });
+
+  test("add domain form validates required fields", async ({ page }) => {
+    // Open Add Host dialog
+    await page.getByRole("button", { name: "Add Host" }).click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible({
+      timeout: 3000,
+    });
+
+    // Submit with empty domain
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByText("Domain is required")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-validation-domain.png",
+    });
+
+    // Fill domain but leave forward host empty
+    await page.locator("#domain").fill("test.example.com");
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByText("Forward host is required")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-validation-host.png",
+    });
+  });
+
+  test("domain link is clickable with correct href (#436/#442)", async ({
+    page,
+  }) => {
+    const domain = `link-test-${Date.now()}.example.com`;
+
+    await createHost(page, domain, "10.0.0.99", "443");
+
+    // Verify the domain is rendered as a clickable <a> tag
+    const link = page.getByRole("link", { name: domain });
+    await expect(link).toBeVisible({ timeout: 10000 });
+    await expect(link).toHaveAttribute("href", `https://${domain}`);
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", /noopener/);
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-domain-link.png",
+    });
+  });
+
+  test("admin URL save and reload roundtrip", async ({ page }) => {
+    // Wait for settings to load (admin URL gets populated from API)
+    await expect(page.locator("#admin-url")).toBeVisible({ timeout: 15000 });
+
+    const testUrl = "http://192.168.1.100:2019";
+    await page.locator("#admin-url").fill(testUrl);
+
+    const saveBtn = page.getByRole("button", { name: "Save", exact: true });
+    await expect(saveBtn).toBeEnabled({ timeout: 3000 });
+    await saveBtn.click();
+
+    await expect(page.getByText("Caddy admin URL saved")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Reload and verify persistence — settings fetch may take a moment
+    await page.reload();
+    await expect(page.locator("#admin-url")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator("#admin-url")).toHaveValue(testUrl, {
+      timeout: 15000,
+    });
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-admin-url-persisted.png",
+    });
+
+    // Restore default to avoid interfering with other tests
+    await page.locator("#admin-url").fill("http://localhost:2019");
+    await expect(saveBtn).toBeEnabled({ timeout: 3000 });
+    await saveBtn.click();
+    await expect(page.getByText("Caddy admin URL saved")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("search filters domain list", async ({ page }) => {
+    const uniqueTag = Date.now();
+    const domain1 = `search-alpha-${uniqueTag}.example.com`;
+    const domain2 = `search-bravo-${uniqueTag}.example.com`;
+
+    // Create two hosts (each create can take ~10s due to Caddy sync timeout)
+    await createHost(page, domain1, "10.0.0.1", "80");
+    await expect(page.getByRole("link", { name: domain1 })).toBeVisible({
+      timeout: 10000,
+    });
+
+    await createHost(page, domain2, "10.0.0.2", "80");
+    await expect(page.getByRole("link", { name: domain2 })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Filter for alpha — only domain1 should be visible
+    await page
+      .getByPlaceholder("Filter by domain or upstream...")
+      .fill("alpha");
+    await expect(page.getByRole("link", { name: domain1 })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: domain2 }),
+    ).not.toBeVisible();
+
+    // Filter for bravo — only domain2 should be visible
+    await page
+      .getByPlaceholder("Filter by domain or upstream...")
+      .fill("bravo");
+    await expect(page.getByRole("link", { name: domain2 })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: domain1 }),
+    ).not.toBeVisible();
+
+    // Non-matching filter
+    await page
+      .getByPlaceholder("Filter by domain or upstream...")
+      .fill("zzzznonexistent");
+    await expect(
+      page.getByText("No hosts match your filter."),
+    ).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/caddy-search-filter.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #463

## Summary
- Add comprehensive Playwright E2E tests for the Caddy reverse-proxy management page
- Tests cover: page load, domain list rendering, form validation, clickable domain links (#436/#442 regression), admin URL save/reload roundtrip, and search filtering
- Uses existing test fixtures and follows established patterns from other E2E tests

## Tests Added (`web/tests/e2e/caddy.spec.ts`)

| Test | What it verifies |
|------|-----------------|
| page loads with heading and key UI elements | Heading, buttons, search input, table headers all visible |
| domain list renders after adding a host | Create host via dialog → domain appears as link in table |
| add domain form validates required fields | Empty domain → error, empty host → error |
| domain link is clickable with correct href | `<a href="https://domain" target="_blank">` regression for #436/#442 |
| admin URL save and reload roundtrip | Fill URL → Save → reload → value persists |
| search filters domain list | Create 2 hosts → filter shows/hides correctly |

## Smoke Test
All 6 tests pass consistently (ran twice):
```
6 passed (27.7s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added comprehensive Playwright E2E test suite for the Caddy reverse-proxy management page. The tests verify all major functionality including page load, domain CRUD operations, form validation, clickable domain links (regression for #436/#442), admin URL save/reload roundtrip (per CLAUDE.md requirement), and search filtering.

- Uses existing test fixtures and follows established patterns from other E2E tests
- Includes appropriate timeouts to handle Caddy sync delays (~10-20s when Caddy is unreachable)
- Helper function `createHost` properly waits for dialog to close after sync operations
- Admin URL test includes cleanup to restore default value and avoid test interference
- All tests include screenshots on key assertions as required
- Satisfies the mandatory E2E test requirement from CLAUDE.md for settings pages

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only adds new E2E tests without modifying production code
- Score reflects that this PR introduces only test code following established patterns, satisfies mandatory E2E test requirements from CLAUDE.md, includes proper cleanup and timeouts, and has been verified to pass consistently (6 passed tests in 27.7s per PR description)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/tests/e2e/caddy.spec.ts | Comprehensive E2E test suite for Caddy page covering UI elements, domain CRUD operations, form validation, link regression test, admin URL persistence, and search filtering |

</details>



<sub>Last reviewed commit: fe549e1</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->