### PR TITLE
fix: Xiaomi BE3600 mesh topology shows 0 nodes (#473)

### DIFF
--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -250,6 +250,15 @@ pub async fn status(
     }
 }
 
+/// Parse `online`/`onlines` which may be a JSON number or string.
+fn parse_online_value(v: &serde_json::Value) -> Option<i32> {
+    match v {
+        serde_json::Value::Number(n) => n.as_i64().map(|v| v as i32),
+        serde_json::Value::String(s) => s.trim().parse::<i32>().ok(),
+        _ => None,
+    }
+}
+
 /// GET /xiaomi/topology — mesh topology graph (no auth required).
 pub async fn topology(
     State(state): State<AppState>,
@@ -266,22 +275,72 @@ pub async fn topology(
                 .unwrap_or_else(|| crate::xiaomi::types::TopoGraphInner {
                     nodes: vec![],
                     leafs: vec![],
+                    ip: None,
+                    name: None,
+                    locale: None,
+                    hardware: None,
+                    online: None,
                 });
-            Ok(Json(XiaomiTopoResponse {
-                nodes: graph
-                    .nodes
-                    .into_iter()
-                    .map(|n| XiaomiTopoNodeResponse {
-                        mac: n.mac,
-                        name: n.name,
-                        locale: n.locale,
-                        ip: n.ip,
-                        online: n.online,
-                        hardware: n.hardware,
-                        model: n.model,
-                    })
-                    .collect(),
-                leafs: graph
+
+            let mut nodes: Vec<XiaomiTopoNodeResponse> = graph
+                .nodes
+                .into_iter()
+                .map(|n| XiaomiTopoNodeResponse {
+                    mac: n.mac,
+                    name: n.name,
+                    locale: n.locale,
+                    ip: n.ip,
+                    online: n.online,
+                    hardware: n.hardware,
+                    model: n.model,
+                })
+                .collect();
+
+            let mut leafs_out = Vec::new();
+
+            // BE3600 (RD15) puts satellite mesh routers in `leafs` with
+            // `link_type` and `onlines` instead of using `nodes`.
+            // When `nodes` is empty, promote satellite leafs into nodes
+            // and add the graph root as the main router node.
+            if nodes.is_empty() && !graph.leafs.is_empty() {
+                // Add the graph root (main router) as the first node.
+                if graph.ip.is_some() {
+                    let main_online = graph.online.as_ref().and_then(parse_online_value);
+                    nodes.push(XiaomiTopoNodeResponse {
+                        mac: None,
+                        name: graph.name,
+                        locale: graph.locale,
+                        ip: graph.ip,
+                        online: main_online,
+                        hardware: graph.hardware,
+                        model: None,
+                    });
+                }
+
+                // Promote satellite leafs (those with link_type) to nodes.
+                for leaf in graph.leafs {
+                    if leaf.link_type.is_some() {
+                        nodes.push(XiaomiTopoNodeResponse {
+                            mac: leaf.mac,
+                            name: leaf.name,
+                            locale: leaf.locale,
+                            ip: leaf.ip,
+                            online: leaf.online,
+                            hardware: leaf.hardware,
+                            model: None,
+                        });
+                    } else {
+                        leafs_out.push(XiaomiTopoLeafResponse {
+                            mac: leaf.mac,
+                            ip: leaf.ip,
+                            name: leaf.name,
+                            online: leaf.online,
+                            parent_id: leaf.parent_id,
+                        });
+                    }
+                }
+            } else {
+                leafs_out = graph
                     .leafs
                     .into_iter()
                     .map(|l| XiaomiTopoLeafResponse {
@@ -291,7 +350,12 @@ pub async fn topology(
                         online: l.online,
                         parent_id: l.parent_id,
                     })
-                    .collect(),
+                    .collect();
+            }
+
+            Ok(Json(XiaomiTopoResponse {
+                nodes,
+                leafs: leafs_out,
             }))
         }
         Err(e) => {

--- a/server/src/xiaomi/types.rs
+++ b/server/src/xiaomi/types.rs
@@ -96,10 +96,20 @@ pub struct TopoLeaf {
     pub ip: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
-    #[serde(default)]
+    /// Number of online devices. The BE3600 (RD15) sends `"onlines"` while
+    /// other models send `"online"`.
+    #[serde(default, alias = "onlines")]
     pub online: Option<i32>,
     #[serde(default, rename = "parentId")]
     pub parent_id: Option<String>,
+    /// Connection type for satellite nodes (e.g. "wired", "wireless").
+    /// Only present on leafs that represent satellite mesh routers (BE3600).
+    #[serde(default)]
+    pub link_type: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -114,6 +124,20 @@ pub struct TopoGraphInner {
     pub nodes: Vec<TopoNode>,
     #[serde(default)]
     pub leafs: Vec<TopoLeaf>,
+    /// Root node fields — represent the main router.
+    /// These are present in the BE3600 response where the graph object itself
+    /// acts as the main router node.
+    #[serde(default)]
+    pub ip: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub locale: Option<String>,
+    #[serde(default)]
+    pub hardware: Option<String>,
+    /// Number of online devices on the main router. May be a string or number.
+    #[serde(default, alias = "onlines")]
+    pub online: Option<serde_json::Value>,
 }
 
 // ── System status ───────────────────────────────────────────
@@ -445,5 +469,91 @@ mod tests {
         assert_eq!(parsed.list.len(), 1);
         assert_eq!(parsed.list[0].online, Some("1".to_string()));
         assert_eq!(parsed.list[0].ip[0].online, Some("400346".to_string()));
+    }
+
+    #[test]
+    fn topo_graph_parses_be3600_rd15_satellite_leafs() {
+        // BE3600 (RD15) sends satellite routers in `leafs` with `onlines`
+        // instead of `nodes`. The graph root IS the main router.
+        let payload = serde_json::json!({
+            "code": 0,
+            "graph": {
+                "ip": "10.10.0.199",
+                "name": "OK Home",
+                "mode": 2,
+                "onlines": 8,
+                "leafs": [
+                    {
+                        "ip": "10.10.0.52",
+                        "name": "Basement",
+                        "link_type": "wired",
+                        "onlines": 5
+                    },
+                    {
+                        "ip": "10.10.0.54",
+                        "name": "Network Enclosure",
+                        "link_type": "wired",
+                        "onlines": 4
+                    },
+                    {
+                        "ip": "10.10.0.53",
+                        "name": "Floor 2",
+                        "link_type": "wired",
+                        "onlines": 8
+                    }
+                ]
+            }
+        });
+
+        let parsed: MiWiFiResponse<TopoGraph> =
+            serde_json::from_value(payload).expect("BE3600 topo_graph should parse");
+        assert_eq!(parsed.code, 0);
+
+        let graph = parsed.data.graph.expect("graph should be present");
+
+        // No nodes in BE3600 response
+        assert!(graph.nodes.is_empty());
+
+        // Graph root fields represent the main router
+        assert_eq!(graph.ip.as_deref(), Some("10.10.0.199"));
+        assert_eq!(graph.name.as_deref(), Some("OK Home"));
+
+        // Satellite leafs with `onlines` field parsed via alias
+        assert_eq!(graph.leafs.len(), 3);
+        assert_eq!(graph.leafs[0].name.as_deref(), Some("Basement"));
+        assert_eq!(graph.leafs[0].online, Some(5));
+        assert_eq!(graph.leafs[0].link_type.as_deref(), Some("wired"));
+        assert_eq!(graph.leafs[1].online, Some(4));
+        assert_eq!(graph.leafs[2].online, Some(8));
+
+        // Total online devices = 5 + 4 + 8 = 17
+        let total: i32 = graph.leafs.iter().filter_map(|l| l.online).sum();
+        assert_eq!(total, 17);
+    }
+
+    #[test]
+    fn topo_leaf_accepts_both_online_and_onlines() {
+        // `online` (standard models)
+        let leaf_online = serde_json::json!({
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "ip": "192.168.1.100",
+            "online": 1,
+            "parentId": "11:22:33:44:55:66"
+        });
+        let parsed: TopoLeaf =
+            serde_json::from_value(leaf_online).expect("leaf with online should parse");
+        assert_eq!(parsed.online, Some(1));
+
+        // `onlines` (BE3600)
+        let leaf_onlines = serde_json::json!({
+            "ip": "10.10.0.52",
+            "name": "Basement",
+            "link_type": "wired",
+            "onlines": 5
+        });
+        let parsed: TopoLeaf =
+            serde_json::from_value(leaf_onlines).expect("leaf with onlines should parse");
+        assert_eq!(parsed.online, Some(5));
+        assert_eq!(parsed.link_type.as_deref(), Some("wired"));
     }
 }

--- a/web/tests/e2e/mesh.spec.ts
+++ b/web/tests/e2e/mesh.spec.ts
@@ -224,6 +224,112 @@ test.describe("Mesh Page", () => {
   });
 });
 
+// ── Xiaomi Mesh Topology Page (/xiaomi) ─────────────────────
+//
+// The /xiaomi page displays mesh nodes from the /api/v1/xiaomi/topology
+// endpoint. The BE3600 (RD15) sends satellite routers in `leafs` with
+// `link_type` and `onlines`. The backend normalizes these into `nodes`.
+
+/** Mock data simulating BE3600 response after backend normalization. */
+const MOCK_XIAOMI_TOPOLOGY_BE3600 = {
+  nodes: [
+    {
+      mac: null,
+      name: "OK Home",
+      locale: null,
+      ip: "10.10.0.199",
+      online: 8,
+      hardware: "RD15",
+      model: null,
+    },
+    {
+      mac: null,
+      name: "Basement",
+      locale: null,
+      ip: "10.10.0.52",
+      online: 5,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: null,
+      name: "Network Enclosure",
+      locale: null,
+      ip: "10.10.0.54",
+      online: 4,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: null,
+      name: "Floor 2",
+      locale: null,
+      ip: "10.10.0.53",
+      online: 8,
+      hardware: null,
+      model: null,
+    },
+  ],
+  leafs: [],
+};
+
+async function mockXiaomiTopology(page: Page, data: unknown) {
+  await page.route("**/api/v1/xiaomi/topology", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(data),
+    }),
+  );
+}
+
+test.describe("Xiaomi Topology Page — BE3600 satellite nodes (#473)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("shows correct mesh node count for BE3600 with leafs promoted to nodes", async ({
+    page,
+  }) => {
+    await mockXiaomiTopology(page, MOCK_XIAOMI_TOPOLOGY_BE3600);
+    await page.goto("/xiaomi/");
+
+    // "Mesh Nodes" stat card should show 4 (1 main + 3 satellites)
+    const meshNodesCard = page.locator("text=Mesh Nodes").locator("..");
+    await expect(meshNodesCard).toBeVisible({ timeout: 15000 });
+    await expect(meshNodesCard.getByText("4")).toBeVisible();
+
+    // "Online Devices" stat card should show 25 (8+5+4+8)
+    const onlineDevicesCard = page.locator("text=Online Devices").locator("..");
+    await expect(onlineDevicesCard).toBeVisible();
+    await expect(onlineDevicesCard.getByText("25")).toBeVisible();
+
+    // All node names should be visible as cards
+    await expect(page.getByText("OK Home")).toBeVisible();
+    await expect(page.getByText("Basement")).toBeVisible();
+    await expect(page.getByText("Network Enclosure")).toBeVisible();
+    await expect(page.getByText("Floor 2")).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/xiaomi-be3600-mesh-nodes.png",
+    });
+  });
+
+  test("empty state when no mesh nodes or leafs", async ({ page }) => {
+    await mockXiaomiTopology(page, { nodes: [], leafs: [] });
+    await page.goto("/xiaomi/");
+
+    // Should show empty state message
+    await expect(
+      page.getByText("No mesh nodes found"),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/xiaomi-empty-state.png",
+    });
+  });
+});
+
 // ── Settings Page: IP + Password Autofill Tests ──────────────
 
 test.describe("Xiaomi Mesh Settings — IP and Password autofill", () => {


### PR DESCRIPTION
Closes #473

## Summary

- The Xiaomi BE3600 (RD15) uses `graph.leafs` with `onlines` for satellite mesh routers instead of `graph.nodes` with `online`, causing the `/xiaomi` page to show "Mesh Nodes: 0" and "Online Devices: 0"
- Added `#[serde(alias = "onlines")]` to `TopoLeaf.online` so both `online` and `onlines` field names are accepted
- Extended `TopoLeaf` with `link_type`, `locale`, `hardware` fields for satellite router data
- Extended `TopoGraphInner` with root node fields (`ip`, `name`, `hardware`, etc.) to capture main router info
- In the `/xiaomi/topology` handler: when `nodes` is empty, the graph root becomes the main node and satellite leafs (those with `link_type`) are promoted to nodes

## Smoke Test

- `cargo check` passes with no errors
- `cargo test` passes all 434 unit tests including 2 new BE3600-specific tests:
  - `topo_graph_parses_be3600_rd15_satellite_leafs` — verifies the BE3600 response structure is parsed correctly with `onlines` mapped via alias, `link_type` captured, and graph root fields preserved
  - `topo_leaf_accepts_both_online_and_onlines` — verifies the `online`/`onlines` alias works for both standard and BE3600 leaf formats

## Test plan

- [x] Backend unit tests for BE3600 topo_graph parsing
- [x] Backend unit test for `online`/`onlines` field alias
- [x] E2E test: Xiaomi page shows correct node count with BE3600 mock data
- [x] E2E test: Xiaomi page empty state with no nodes
- [x] `cargo fmt --all` clean
- [x] `cargo check` clean
- [x] All existing tests still pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Xiaomi BE3600 mesh topology display issue where the page showed "Mesh Nodes: 0" and "Online Devices: 0". The BE3600 uses a different JSON structure (`graph.leafs` with `onlines` field) compared to other Xiaomi routers (`graph.nodes` with `online` field). The fix adds serde field aliases and backend logic to normalize BE3600's response structure into the expected format.

**Key changes:**
- Added `#[serde(alias = "onlines")]` to accept both field naming conventions
- Extended data structures to capture BE3600-specific fields (`link_type`, root node information)
- Added normalization logic to promote satellite leafs to nodes when the BE3600 structure is detected
- Includes comprehensive unit tests (2) and E2E tests (2) that verify the fix works correctly
- Backward compatible - standard routers continue to work as before

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no significant risks
- Score reflects well-tested fix with comprehensive unit and E2E tests, clean implementation using serde aliases for field compatibility, backward compatible changes that don't affect existing router models, and proper edge case handling. All tests pass including 434 unit tests.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/xiaomi/types.rs | Added serde alias for online/onlines field compatibility, extended TopoLeaf and TopoGraphInner with BE3600 fields, includes comprehensive unit tests |
| server/src/api/xiaomi.rs | Added parse_online_value helper and BE3600-specific logic to promote satellite leafs to nodes when nodes array is empty, maintains backward compatibility |
| web/tests/e2e/mesh.spec.ts | Added E2E tests for BE3600 mesh topology display and empty state, includes proper mocking and screenshot verification |

</details>



<sub>Last reviewed commit: 8a51043</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->