### PR TITLE
fix: show actual server version in UI instead of hardcoded v0.5.0 (#479)

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -5,9 +5,9 @@ use axum::extract::State;
 use axum::http::{header, Method};
 use axum::{
     middleware::{self, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::{delete, get, patch, post, put},
-    Router,
+    Json, Router,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -126,6 +126,7 @@ pub fn router(state: AppState) -> Router {
     // Public routes — no auth required.
     let public_routes = Router::new()
         .route("/health", get(health))
+        .route("/version", get(server_version))
         .route("/auth/login", post(auth::login))
         .route("/auth/logout", post(auth::logout))
         .route("/auth/status", get(auth::status))
@@ -699,4 +700,9 @@ async fn vyos_cache_invalidation(
 /// Simple health check endpoint.
 async fn health() -> &'static str {
     "ok"
+}
+
+/// Returns the server binary version from Cargo.toml.
+async fn server_version() -> impl IntoResponse {
+    Json(serde_json::json!({ "version": env!("CARGO_PKG_VERSION") }))
 }

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChevronDown, Menu, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { navGroups, useGroupCollapse } from "./Sidebar";
+import { navGroups, useGroupCollapse, useServerVersion } from "./Sidebar";
 import {
   Sheet,
   SheetContent,
@@ -17,6 +17,7 @@ export function MobileSidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const wsConnected = useWsConnected();
+  const serverVersion = useServerVersion();
   const { collapsed: groupCollapsed, toggle: toggleGroup } = useGroupCollapse(
     navGroups,
     pathname,
@@ -144,7 +145,7 @@ export function MobileSidebar() {
                 {wsConnected ? "Live" : "Disconnected"}
               </span>
               <p className="ml-auto text-[10px] text-slate-700">
-                Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.5.0"}
+                Panoptikon {serverVersion ?? "..."}
               </p>
             </div>
           </div>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -184,6 +184,22 @@ export function useGroupCollapse(groups: NavGroup[], pathname: string | null) {
   return { collapsed, toggle };
 }
 
+/** Fetches the server binary version from the backend. */
+export function useServerVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/v1/version", { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.version) setVersion(`v${data.version}`);
+      })
+      .catch(() => {});
+  }, []);
+
+  return version;
+}
+
 /** NPM connectivity state: null = not configured, true = reachable, false = unreachable. */
 function useNpmStatus(): null | boolean {
   const [status, setStatus] = useState<null | boolean>(null);
@@ -222,6 +238,7 @@ export function Sidebar() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const wsConnected = useWsConnected();
   const npmStatus = useNpmStatus();
+  const serverVersion = useServerVersion();
   const { collapsed: groupCollapsed, toggle: toggleGroup } = useGroupCollapse(
     navGroups,
     pathname,
@@ -403,7 +420,7 @@ export function Sidebar() {
                 </Tooltip>
               )}
               <p className="text-[10px] text-slate-700">
-                Panoptikon {process.env.NEXT_PUBLIC_VERSION || "v0.5.0"}
+                Panoptikon {serverVersion ?? "..."}
               </p>
             </div>
           ) : (

--- a/web/tests/e2e/version.spec.ts
+++ b/web/tests/e2e/version.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E test for the version display in the sidebar.
+ * Verifies the UI fetches the version from the backend API
+ * instead of showing a hardcoded value from package.json.
+ */
+test.describe("Version display", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("sidebar shows server version from /api/v1/version", async ({ page }) => {
+    // First, fetch the version from the API directly to know what to expect
+    const response = await page.request.get("/api/v1/version");
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+    expect(data.version).toBeTruthy();
+
+    const expectedVersion = `v${data.version}`;
+
+    // Navigate to dashboard where sidebar is visible
+    await page.goto("/dashboard/");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The sidebar version text should contain the server version
+    const versionText = page.locator("text=Panoptikon v");
+    await expect(versionText).toBeVisible({ timeout: 10000 });
+    await expect(versionText).toContainText(`Panoptikon ${expectedVersion}`);
+
+    // Ensure the old hardcoded "v0.5.0" is NOT displayed
+    await expect(page.locator("text=v0.5.0")).not.toBeVisible();
+
+    await page.screenshot({ path: "tests/screenshots/version-sidebar.png" });
+  });
+});


### PR DESCRIPTION
## Summary

- Added `GET /api/v1/version` public endpoint that returns `{"version": "X.Y.Z"}` from the Cargo binary version (`CARGO_PKG_VERSION`)
- Replaced hardcoded `process.env.NEXT_PUBLIC_VERSION || "v0.5.0"` in both `Sidebar.tsx` and `MobileSidebar.tsx` with a `useServerVersion()` hook that fetches the version from the backend API
- The UI now always shows the actual deployed server version instead of the stale package.json value

## Smoke Test

- `cargo check` passes with no errors
- `cargo test` — all 21 tests pass
- `bun run build` — frontend compiles successfully
- The `/api/v1/version` endpoint returns `{"version":"0.6.24"}` matching `CARGO_PKG_VERSION`
- Sidebar displays `Panoptikon v0.6.24` (fetched from backend) instead of `v0.5.0`

## Test Plan

- [x] E2E test `web/tests/e2e/version.spec.ts` verifies:
  - The `/api/v1/version` API returns a version string
  - The sidebar displays the version from the API
  - The old hardcoded `v0.5.0` is no longer shown

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hardcoded version string `v0.5.0` in the UI with the actual server version fetched from a new backend API endpoint.

- Added `GET /api/v1/version` public endpoint that returns `{"version": "X.Y.Z"}` from `CARGO_PKG_VERSION`
- Created `useServerVersion()` hook that fetches the version from the API on component mount
- Updated both `Sidebar.tsx` and `MobileSidebar.tsx` to use the hook instead of `process.env.NEXT_PUBLIC_VERSION`
- Includes comprehensive E2E test that verifies the API and UI display
- The implementation is clean, focused, and follows existing patterns in the codebase

The PR meets the mandatory E2E test requirement per `CLAUDE.md` and all smoke tests pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are simple, focused, and well-tested. The new endpoint is lightweight and public (no sensitive data exposed). The frontend hook follows existing patterns and handles errors gracefully. Comprehensive E2E test coverage ensures the feature works end-to-end. All smoke tests pass.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Added public `/version` endpoint that returns server version from `CARGO_PKG_VERSION` |
| web/src/components/layout/Sidebar.tsx | Added `useServerVersion()` hook to fetch version from API; replaced hardcoded version with dynamic version display |
| web/src/components/layout/MobileSidebar.tsx | Updated to use `useServerVersion()` hook instead of hardcoded version |
| web/tests/e2e/version.spec.ts | Added E2E test verifying version API and UI display; ensures old hardcoded value not shown |

</details>



<sub>Last reviewed commit: ea7a07d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->