### PR TITLE
fix: dashboard skeleton cards never resolve — missing MikroTik support in stats endpoint (#478)

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -1,4 +1,5 @@
 use crate::api::AppState;
+use crate::mikrotik::client::MikrotikClient;
 use axum::{
     extract::{Query, State},
     Json,
@@ -32,6 +33,65 @@ pub struct LimitQuery {
     pub limit: Option<i64>,
 }
 
+/// Read a single setting value from the DB.
+async fn get_setting(state: &AppState, key: &str) -> Option<String> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM settings WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|v| !v.is_empty())
+}
+
+/// Check MikroTik router connectivity with a 5-second timeout.
+async fn check_mikrotik(state: &AppState) -> Option<bool> {
+    let enabled = get_setting(state, "mikrotik_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return None; // not configured
+    }
+
+    let url = get_setting(state, "mikrotik_url").await?;
+    let user = get_setting(state, "mikrotik_user")
+        .await
+        .unwrap_or_else(|| "admin".to_string());
+    let password = get_setting(state, "mikrotik_password")
+        .await
+        .unwrap_or_default();
+
+    let client = MikrotikClient::with_http(&url, &user, &password, state.mikrotik_http.clone());
+    match tokio::time::timeout(Duration::from_secs(5), client.system_resource()).await {
+        Ok(Ok(_)) => Some(true),   // connected
+        Ok(Err(_)) => Some(false), // configured but unreachable
+        Err(_) => Some(false),     // timeout
+    }
+}
+
+/// Check VyOS router connectivity with a 5-second timeout.
+async fn check_vyos(state: &AppState) -> Option<bool> {
+    let db_url = get_setting(state, "vyos_url").await;
+    let db_key = get_setting(state, "vyos_api_key").await;
+
+    let url = db_url.or_else(|| state.config.vyos.url.clone());
+    let key = db_key.or_else(|| state.config.vyos.api_key.clone());
+
+    match (url, key) {
+        (Some(u), Some(k)) if !u.is_empty() && !k.is_empty() => {
+            let client = crate::vyos::client::VyosClient::new(&u, &k);
+            match tokio::time::timeout(Duration::from_secs(5), client.show(&["system", "uptime"]))
+                .await
+            {
+                Ok(Ok(_)) => Some(true), // connected
+                _ => Some(false),        // configured but unreachable
+            }
+        }
+        _ => None, // not configured
+    }
+}
+
 /// GET /api/v1/dashboard/stats
 pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
     let devices_online: i64 =
@@ -50,50 +110,23 @@ pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
         .await
         .unwrap_or(0);
 
-    // Check VyOS connectivity — read settings from DB first, fall back to config.
-    let router_status = {
-        let db_url: Option<String> =
-            sqlx::query_scalar(r#"SELECT value FROM settings WHERE key = 'vyos_url'"#)
-                .fetch_optional(&state.db)
-                .await
-                .ok()
-                .flatten();
-        let db_key: Option<String> =
-            sqlx::query_scalar(r#"SELECT value FROM settings WHERE key = 'vyos_api_key'"#)
-                .fetch_optional(&state.db)
-                .await
-                .ok()
-                .flatten();
+    // Check both MikroTik and VyOS router connectivity in parallel.
+    let (mikrotik_result, vyos_result) = tokio::join!(check_mikrotik(&state), check_vyos(&state));
 
-        let url = db_url
-            .filter(|s| !s.is_empty())
-            .or_else(|| state.config.vyos.url.clone());
-        let key = db_key
-            .filter(|s| !s.is_empty())
-            .or_else(|| state.config.vyos.api_key.clone());
-
-        match (url, key) {
-            (Some(u), Some(k)) if !u.is_empty() && !k.is_empty() => {
-                let client = crate::vyos::client::VyosClient::new(&u, &k);
-                match tokio::time::timeout(
-                    Duration::from_secs(5),
-                    client.show(&["system", "uptime"]),
-                )
-                .await
-                {
-                    Ok(Ok(_)) => "connected".to_string(),
-                    _ => "disconnected".to_string(),
-                }
-            }
-            _ => "unconfigured".to_string(),
-        }
+    let router_status = match (mikrotik_result, vyos_result) {
+        // Either router is connected → "connected"
+        (Some(true), _) | (_, Some(true)) => "connected".to_string(),
+        // At least one is configured but not reachable → "disconnected"
+        (Some(false), _) | (_, Some(false)) => "disconnected".to_string(),
+        // Neither is configured
+        _ => "unconfigured".to_string(),
     };
 
-    // Latest WAN traffic from traffic_samples (source = 'vyos'), most recent entry
+    // Latest WAN traffic — check all sources (mikrotik, netflow, agent),
+    // not just 'vyos' which is never inserted.
     let (wan_rx_bps, wan_tx_bps): (i64, i64) = sqlx::query_as(
         "SELECT COALESCE(rx_bps, 0), COALESCE(tx_bps, 0)
          FROM traffic_samples
-         WHERE source = 'vyos'
          ORDER BY sampled_at DESC LIMIT 1",
     )
     .fetch_optional(&state.db)

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -7,19 +7,66 @@ test.describe('Dashboard', () => {
 
   test('dashboard page loads with stat cards', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
-    
+
     // Should have stat cards (4 of them)
     await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Active Devices')).toBeVisible();
     await expect(page.getByText('WAN Bandwidth')).toBeVisible();
     await expect(page.getByText('Unread Alerts')).toBeVisible();
-    
+
     await page.screenshot({ path: 'tests/screenshots/dashboard-stats.png', fullPage: true });
+  });
+
+  test('stat cards resolve from skeleton to real values', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // The stat cards should resolve within 10s — the /api/v1/dashboard/stats
+    // endpoint must return valid JSON. If the skeleton never resolves, these
+    // assertions will time out (the bug this test catches).
+    //
+    // "Router Status" card shows one of: Online, Offline, Unconfigured
+    const routerCard = page.getByText('Router Status');
+    await expect(routerCard).toBeVisible({ timeout: 10000 });
+
+    // After stat cards load, at least one value should be visible.
+    // With no router configured, we expect "Unconfigured".
+    // With a router configured, we expect "Online" or "Offline".
+    const routerValue = page.getByText(/^(Online|Offline|Unconfigured|Unreachable)$/);
+    await expect(routerValue.first()).toBeVisible({ timeout: 10000 });
+
+    // "Active Devices" card shows a number
+    await expect(page.getByText('Active Devices')).toBeVisible();
+    // The value is a number (could be 0)
+    const devicesCard = page.locator('text=Active Devices').locator('..').locator('..');
+    await expect(devicesCard.getByText(/total known/)).toBeVisible({ timeout: 10000 });
+
+    // "Unread Alerts" card shows a value
+    await expect(page.getByText('Unread Alerts')).toBeVisible();
+    const alertsCard = page.locator('text=Unread Alerts').locator('..').locator('..');
+    await expect(alertsCard.getByText(/All clear|Needs attention/)).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-stat-values.png', fullPage: true });
+  });
+
+  test('system health ring loads', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // System Health card should show the health ring (percentage text)
+    await expect(page.getByText('System Health')).toBeVisible({ timeout: 10000 });
+    // The ring shows "X%" and "N/N online" — wait for the percentage
+    await expect(page.getByText(/\d+%/)).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-health-ring.png', fullPage: true });
   });
 
   test('dashboard has Recent Alerts section', async ({ page }) => {
     await expect(page.getByText('Recent Alerts')).toBeVisible({ timeout: 10000 });
     await page.screenshot({ path: 'tests/screenshots/dashboard-alerts.png', fullPage: true });
+  });
+
+  test('dashboard has Device Breakdown section', async ({ page }) => {
+    await expect(page.getByText('Device Breakdown')).toBeVisible({ timeout: 10000 });
+    await page.screenshot({ path: 'tests/screenshots/dashboard-devices.png', fullPage: true });
   });
 
   test('dashboard displays loading state or content', async ({ page }) => {


### PR DESCRIPTION
## Summary
- **Fixed dashboard stats endpoint** (`/api/v1/dashboard/stats`) which only checked VyOS for router connectivity and queried traffic with `source='vyos'` — a source value that is never actually inserted by any traffic poller
- **Added MikroTik router status check** in parallel with VyOS (both with 5-second timeouts), so MikroTik-only setups correctly report router connectivity
- **Removed stale `source='vyos'` filter** from WAN traffic query — now returns the latest traffic sample from any source (mikrotik, netflow, agent)

## Root Cause
The `dashboard::stats` handler had two bugs:
1. **Router status only checked VyOS** — MikroTik users always saw "Unconfigured" even with a working router
2. **WAN traffic filtered by `WHERE source = 'vyos'`** — but no code in the entire codebase ever inserts traffic samples with `source = 'vyos'`. MikroTik traffic uses `source = 'mikrotik'`, NetFlow uses `source = 'netflow'`, and agents use `source = 'agent'`. This meant WAN bandwidth always showed 0 bps.

## Changes
- `server/src/api/dashboard.rs`: Refactored router status check to test both MikroTik and VyOS in parallel; removed broken `source='vyos'` filter from WAN traffic query
- `web/tests/e2e/dashboard.spec.ts`: Added E2E tests verifying stat cards resolve from skeleton to actual values (catches this exact regression)

## Smoke Test
- `cargo check` passes with no errors
- `cargo test` — all 21 tests pass
- `cargo fmt --all` — no formatting changes needed
- Frontend builds successfully with `bun run build`

## Test plan
- [ ] Verify dashboard loads and stat cards resolve from skeleton to values
- [ ] Verify router status shows correctly for MikroTik-only setups
- [ ] Verify WAN bandwidth displays non-zero values when traffic data exists
- [ ] Run E2E test suite: `bunx playwright test dashboard`

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two critical bugs in the dashboard stats endpoint that prevented stat cards from resolving:

- **Router status bug**: Only checked VyOS for connectivity, causing MikroTik-only setups to always show "Unconfigured" even with a working router
- **WAN traffic bug**: Filtered by `WHERE source = 'vyos'`, but no code in the codebase ever inserts traffic with that source value — MikroTik uses `source = 'mikrotik'`, NetFlow uses `source = 'netflow'`, and agents use `source = 'agent'`

The fix adds parallel MikroTik and VyOS connectivity checks using `tokio::join!` and removes the broken source filter from the WAN traffic query. Comprehensive E2E tests were added that would have caught this regression (required per CLAUDE.md).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- Perfect score because: (1) root cause is well-documented and verified by codebase analysis, (2) fix directly addresses both bugs without introducing new issues, (3) clean implementation with proper async/await patterns and parallel execution, (4) comprehensive E2E tests added that catch the exact regression, (5) follows project E2E test requirements from CLAUDE.md, (6) smoke tests confirm no breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Added parallel MikroTik + VyOS router checks, removed broken `source='vyos'` filter from WAN traffic query |
| web/tests/e2e/dashboard.spec.ts | Added comprehensive E2E tests that verify stat cards resolve from skeleton to actual values |

</details>



<sub>Last reviewed commit: b0a5e4c</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->