### PR TITLE
fix: dashboard top cards have inconsistent heights (#495)

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -75,7 +75,7 @@ function HealthRing({ online, total }: { online: number; total: number }) {
 
   return (
     <div className="flex flex-col items-center justify-center gap-1">
-      <div className="relative h-28 w-28">
+      <div className="relative aspect-square w-full max-w-[7rem]">
         <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
           <circle
             cx="50"
@@ -143,7 +143,7 @@ function StatCard({
   href?: string;
 }) {
   const inner = (
-    <Card className="border-slate-800 bg-slate-900 transition-all hover:border-blue-500/50 hover:bg-slate-800/60 hover:shadow-lg hover:shadow-blue-500/5">
+    <Card className="h-full border-slate-800 bg-slate-900 transition-all hover:border-blue-500/50 hover:bg-slate-800/60 hover:shadow-lg hover:shadow-blue-500/5">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-sm font-medium text-slate-400">
           {title}
@@ -172,7 +172,7 @@ function StatCard({
 
 function StatCardSkeleton() {
   return (
-    <Card className="border-slate-800 bg-slate-900">
+    <Card className="h-full border-slate-800 bg-slate-900">
       <CardHeader className="pb-2">
         <Skeleton className="h-4 w-24" />
       </CardHeader>
@@ -344,9 +344,9 @@ export default function DashboardPage() {
       <h1 className="text-2xl font-semibold text-white">Dashboard</h1>
 
       {/* ── Bento Grid ─────────────────────────────────── */}
-      <StaggerContainer className="grid grid-cols-1 gap-4 lg:grid-cols-5">
+      <StaggerContainer className="grid grid-cols-1 gap-4 lg:grid-cols-5 items-stretch">
         {/* ── Health Score Ring ─────────────────────────── */}
-        <StaggerItem><Card className="border-slate-800 bg-slate-900 lg:col-span-1">
+        <StaggerItem className="h-full"><Card className="h-full border-slate-800 bg-slate-900 lg:col-span-1">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-slate-400">
               System Health
@@ -358,13 +358,13 @@ export default function DashboardPage() {
             ) : stats ? (
               <HealthRing online={stats.devices_online} total={stats.devices_total} />
             ) : (
-              <Skeleton className="h-28 w-28 rounded-full" />
+              <Skeleton className="aspect-square w-full max-w-[7rem] rounded-full" />
             )}
           </CardContent>
         </Card></StaggerItem>
 
         {/* ── Stat Cards Row ───────────────────────────── */}
-        <StaggerItem className="lg:col-span-4"><div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StaggerItem className="h-full lg:col-span-4"><div className="grid h-full grid-cols-2 gap-4 lg:grid-cols-4">
           {statsError ? (
             <>
               <StatCard

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -69,6 +69,32 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-devices.png', fullPage: true });
   });
 
+  test('top row cards have consistent heights', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // Wait for stat cards to resolve so we measure final rendered heights
+    await expect(page.getByText('System Health')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
+
+    // The System Health card and the stat-cards wrapper are direct children
+    // of the top bento grid. Grab all top-level grid children and compare heights.
+    const systemHealthCard = page.getByText('System Health').locator('xpath=ancestor::div[contains(@class,"border-slate-800")]').first();
+    const routerStatusCard = page.getByText('Router Status').locator('xpath=ancestor::div[contains(@class,"border-slate-800")]').first();
+
+    const healthBox = await systemHealthCard.boundingBox();
+    const routerBox = await routerStatusCard.boundingBox();
+
+    expect(healthBox).toBeTruthy();
+    expect(routerBox).toBeTruthy();
+
+    // Both cards should have h-full, so the stat cards should stretch to match
+    // the System Health card. Allow a small tolerance (5px) for sub-pixel rounding.
+    const heightDiff = Math.abs(healthBox!.height - routerBox!.height);
+    expect(heightDiff).toBeLessThanOrEqual(5);
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-card-heights.png', fullPage: true });
+  });
+
   test('dashboard displays loading state or content', async ({ page }) => {
     // Dashboard should either show content or be in loading state
     // Check that we're on the dashboard and it's responsive


### PR DESCRIPTION
Closes #495

## Summary

- Added `items-stretch` to the dashboard bento grid so all top-row items stretch to equal height
- Added `h-full` to System Health card, StatCard, and StatCardSkeleton components
- Made the health ring SVG use `aspect-square w-full max-w-[7rem]` instead of fixed `h-28 w-28`, so it scales to fit the available space rather than forcing the card taller
- Added `h-full` to the stat cards wrapper `<div>` and its parent `StaggerItem`

## Smoke Test

- `bun run build` passes with no errors
- Verified the `items-stretch` class is applied to the grid container
- Verified `h-full` is present on all 5 top-row cards (System Health + 4 stat cards)
- Health ring uses responsive `aspect-square` sizing instead of fixed dimensions

## Test plan

- [x] E2E test added: `top row cards have consistent heights` — measures bounding box heights of System Health and Router Status cards, asserts they match within 5px tolerance
- [x] Screenshot captured at `tests/screenshots/dashboard-card-heights.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes inconsistent dashboard card heights by applying flexbox stretch properties. The implementation adds `items-stretch` to the top-level grid container and propagates `h-full` through the component hierarchy (StaggerItems, Cards, and wrapper divs). The health ring was also made responsive by switching from fixed dimensions to `aspect-square w-full max-w-[7rem]`.

- Clean, minimal changes focused solely on the layout issue
- Proper E2E test included that verifies card heights match within 5px tolerance
- All changes align with Tailwind CSS best practices for flexbox/grid layouts
- No logical issues or regressions identified

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Changes are minimal, well-tested, and only affect CSS layout classes. No logic changes, no breaking changes, and includes proper E2E test coverage.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dashboard/page.tsx | Added flexbox stretch and h-full classes to ensure consistent card heights; made health ring responsive |
| web/tests/e2e/dashboard.spec.ts | Added E2E test verifying top row cards have consistent heights within 5px tolerance |

</details>



<sub>Last reviewed commit: 1c58706</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->