### PR TITLE
fix: dashboard stats no longer blocks 3-5s due to VyOS timeout (#494)

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -71,7 +71,7 @@ async fn check_mikrotik(state: &AppState) -> Option<bool> {
     }
 }
 
-/// Check VyOS router connectivity with a 5-second timeout.
+/// Check VyOS router connectivity with a 500ms timeout.
 async fn check_vyos(state: &AppState) -> Option<bool> {
     let db_url = get_setting(state, "vyos_url").await;
     let db_key = get_setting(state, "vyos_api_key").await;
@@ -82,8 +82,11 @@ async fn check_vyos(state: &AppState) -> Option<bool> {
     match (url, key) {
         (Some(u), Some(k)) if !u.is_empty() && !k.is_empty() => {
             let client = crate::vyos::client::VyosClient::new(&u, &k);
-            match tokio::time::timeout(Duration::from_secs(5), client.show(&["system", "uptime"]))
-                .await
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                client.show(&["system", "uptime"]),
+            )
+            .await
             {
                 Ok(Ok(_)) => Some(true), // connected
                 _ => Some(false),        // configured but unreachable

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -95,6 +95,29 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-card-heights.png', fullPage: true });
   });
 
+  test('dashboard stats API responds within 2 seconds (#494)', async ({ page }) => {
+    // Bug #494: /api/v1/dashboard/stats used to block 3-5s because check_vyos()
+    // always ran with a 5s timeout even when MikroTik was the active router.
+    // After the fix, the endpoint should respond in <2s.
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    const start = Date.now();
+    const response = await page.request.get('/api/v1/dashboard/stats');
+    const elapsed = Date.now() - start;
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body).toHaveProperty('router_status');
+    expect(body).toHaveProperty('devices_online');
+    expect(body).toHaveProperty('devices_total');
+    expect(body).toHaveProperty('alerts_unread');
+
+    // Must respond in under 2 seconds (was 3-5s before fix)
+    expect(elapsed).toBeLessThan(2000);
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-stats-perf.png', fullPage: true });
+  });
+
   test('dashboard displays loading state or content', async ({ page }) => {
     // Dashboard should either show content or be in loading state
     // Check that we're on the dashboard and it's responsive


### PR DESCRIPTION
Closes #494

## Summary
- **Root cause**: `/api/v1/dashboard/stats` always ran `check_vyos()` in parallel with `check_mikrotik()`. When VyOS is offline, the 5-second timeout blocked every dashboard load for 3-5 seconds.
- **Fix (proper)**: Only check the **active** router — if `mikrotik_enabled=1`, skip VyOS check entirely
- **Fix (immediate)**: Reduced VyOS timeout from 5s to 500ms as a safety net for when VyOS _is_ the active router

## Changes
- `server/src/api/dashboard.rs`: Check `mikrotik_enabled` setting before deciding which router to check. If MikroTik is enabled, only `check_mikrotik()` runs. Otherwise, only `check_vyos()` runs (with 500ms timeout instead of 5s).
- `web/tests/e2e/dashboard.spec.ts`: Added E2E test that verifies the `/api/v1/dashboard/stats` API responds within 2 seconds.

## Smoke Test
- `cargo check` passes with no errors
- `cargo test` — all 21 tests pass
- `cargo fmt --all` — no formatting issues

## Test plan
- [ ] Dashboard loads in <2s with MikroTik as active router (VyOS offline)
- [ ] Dashboard still shows correct router status when only VyOS is configured
- [ ] E2E test `dashboard stats API responds within 2 seconds` passes
- [ ] Stat cards still resolve correctly (Online/Offline/Unconfigured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a significant performance issue where the dashboard stats API blocked for 3-5 seconds due to VyOS timeout, even when MikroTik was the active router.

**Key Changes:**
- Refactored router checking logic to only ping the **active** router (MikroTik takes priority if enabled, otherwise VyOS)
- Reduced VyOS timeout from 5s to 500ms as a safety net when VyOS is the active router
- Added E2E test to verify the API responds within 2 seconds

**Notes:**
- The duplicate `mikrotik_enabled` DB query at `dashboard.rs:104` and inside `check_mikrotik()` at line 50 was already noted in previous comments
- The 500ms VyOS timeout is aggressive but appears to be an intentional trade-off prioritizing dashboard responsiveness over connection check accuracy
- Test correctly validates the performance fix using direct API requests

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one known performance optimization opportunity
- The fix correctly addresses the performance issue by checking only the active router. The duplicate `mikrotik_enabled` DB query (already noted) is a performance optimization opportunity but not a correctness issue. The aggressive 500ms VyOS timeout is an intentional trade-off.
- No files require special attention beyond the duplicate DB query already noted in previous comments

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Refactored to skip VyOS check when MikroTik active, reduced VyOS timeout to 500ms; duplicate `mikrotik_enabled` check already noted |
| web/tests/e2e/dashboard.spec.ts | Added E2E test verifying dashboard stats API responds within 2 seconds; test structure is correct |

</details>



<sub>Last reviewed commit: 6cee505</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->