### PR TITLE
fix: remove sticky positioning from tab/filter bars (#482)

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -361,8 +361,8 @@ export default function AlertsPage() {
       </div>
 
       {/* Filter tabs */}
-      <div className="space-y-2">
-        <div className="flex gap-2">
+      <div className="static space-y-2">
+        <div className="static flex gap-2">
           {(["all", "active", "acknowledged"] as StatusFilter[]).map((f) => (
             <Button
               key={f}
@@ -381,7 +381,7 @@ export default function AlertsPage() {
         </div>
 
         {/* Type filter */}
-        <div className="flex gap-2 flex-wrap">
+        <div className="static flex gap-2 flex-wrap">
           {ALERT_TYPES.map((t) => (
             <Button
               key={t.value}

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -436,7 +436,7 @@ export default function DevicesPage() {
       </div>
 
       {/* Filter bar */}
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="static flex flex-wrap items-center gap-3">
         {(["all", "online", "offline", "unknown"] as Filter[]).map((f) => (
           <Button
             key={f}

--- a/web/src/app/(app)/dns-logs/page.tsx
+++ b/web/src/app/(app)/dns-logs/page.tsx
@@ -293,7 +293,7 @@ export default function DnsLogsPage() {
                 }}
                 className="w-48"
               />
-              <div className="flex gap-1">
+              <div className="static flex gap-1">
                 <Button
                   variant={blockedFilter === undefined ? "default" : "outline"}
                   size="sm"

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -15,7 +15,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground max-w-full overflow-x-auto scrollbar-hide",
+      "static inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground max-w-full overflow-x-auto scrollbar-hide",
       className
     )}
     {...props}

--- a/web/tests/e2e/no-sticky-bars.spec.ts
+++ b/web/tests/e2e/no-sticky-bars.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * Verify that tab/filter bars on inner pages use static positioning
+ * and do not stick to the top of the viewport on scroll.
+ *
+ * Regression test for #482 — same class of bug as #452 (Settings headers).
+ */
+test.describe("No sticky tab/filter bars (#482)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("alerts filter bar has static positioning", async ({ page }) => {
+    await page.goto("/alerts/");
+    await expect(
+      page.getByRole("heading", { name: "Alerts", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The filter wrapper div contains the status and type filter buttons
+    const filterSection = page.locator("text=All Types").locator("..");
+    await expect(filterSection).toBeVisible();
+
+    const position = await filterSection.evaluate(
+      (el) => window.getComputedStyle(el).position,
+    );
+    expect(position).toBe("static");
+
+    await page.screenshot({
+      path: "tests/screenshots/no-sticky-alerts-filter.png",
+    });
+  });
+
+  test("devices filter bar has static positioning", async ({ page }) => {
+    await page.goto("/devices/");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The filter bar contains All/Online/Offline/Unknown buttons
+    const filterBar = page.getByRole("button", { name: "All" }).locator("..");
+    await expect(filterBar).toBeVisible();
+
+    const position = await filterBar.evaluate(
+      (el) => window.getComputedStyle(el).position,
+    );
+    expect(position).toBe("static");
+
+    await page.screenshot({
+      path: "tests/screenshots/no-sticky-devices-filter.png",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add explicit `position: static` to the `TabsList` component default classes, preventing all tab bars from sticking to the viewport on scroll
- Add `static` class to filter bar wrapper divs on the Alerts page (status + type filter rows)
- Add `static` class to filter bar on the Devices page (All/Online/Offline/Unknown)
- Add `static` class to filter buttons on the DNS Logs page (All/Allowed/Blocked)

Same fix pattern as #458 (Settings section headers), now applied to all remaining pages with horizontal tab/filter bars.

## Pages Audited

| Page | Element | Fixed |
|------|---------|-------|
| Alerts | Status filter bar (All/Active/Acknowledged) | `static` added |
| Alerts | Type filter bar (All Types/New Device/Online/...) | `static` added |
| Devices | Filter bar (All/Online/Offline/Unknown) | `static` added |
| DNS Logs | Filter buttons (All/Allowed/Blocked) | `static` added |
| Router (MikroTik) | TabsList (System/Interfaces/VLANs/...) | Fixed via TabsList component |
| All other tab pages | TabsList component | Fixed via TabsList component |
| Settings | Section headers | Already fixed in #458 |

## Smoke Test

- Verified `next build` passes with all changes
- Grepped all source files — no `sticky` or `top-0` classes remain on inner-page navigation elements
- The `static` class in Tailwind maps to `position: static`, which is the CSS default and explicitly prevents sticky behavior

## Test Plan

- [x] E2E test `no-sticky-bars.spec.ts` verifies computed `position: static` on Alerts and Devices filter bars
- [x] Build passes (`next build`)

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies an explicit `position: static` fix (via Tailwind's `static` utility) to all remaining tab and filter bars that were unintentionally sticking to the viewport on scroll — mirroring the pattern already established in #458 for Settings section headers.

- **`web/src/components/ui/tabs.tsx`**: `static` added to the default `TabsList` class string. Because `cn()` delegates to `tailwind-merge`, callers can still intentionally override positioning via the `className` prop.
- **`web/src/app/(app)/alerts/page.tsx`**: `static` applied to all three filter wrapper divs (outer container, status row, type row).
- **`web/src/app/(app)/devices/page.tsx`**: `static` applied to the single All/Online/Offline/Unknown filter bar wrapper.
- **`web/src/app/(app)/dns-logs/page.tsx`**: `static` applied to the All/Allowed/Blocked button group wrapper.
- **`web/tests/e2e/no-sticky-bars.spec.ts`**: New regression E2E test verifying computed `position: static` on the Alerts and Devices filter bars. Import path (`../../e2e/fixtures`) correctly resolves to `web/e2e/fixtures.ts` and screenshot output path points to the existing `web/tests/screenshots/` directory. Minor: the JSDoc comment cites `#452` instead of the correct `#458`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are additive, low-risk CSS utility additions with correct `tailwind-merge` conflict resolution and a passing build.
- All changes add only `position: static` (the CSS default) to elements that were incorrectly sticking. The `cn()`/`tailwind-merge` setup ensures intentional overrides via `className` still work. The only issue found is a wrong issue number in a test comment (#452 vs #458), which has no functional impact.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/ui/tabs.tsx | Adds `static` to the default `TabsList` className. Since `cn()` uses `tailwind-merge`, a caller can still override this with `sticky` via the `className` prop if intentionally needed. |
| web/src/app/(app)/alerts/page.tsx | Adds `static` to all three filter wrapper divs (outer spacing div, status row, type row), correctly applying the position override at every relevant level. |
| web/src/app/(app)/devices/page.tsx | Adds `static` to the single filter bar wrapper div. Straightforward single-line change; no issues found. |
| web/src/app/(app)/dns-logs/page.tsx | Adds `static` to the All/Allowed/Blocked filter button group wrapper. Straightforward single-line change; no issues found. |
| web/tests/e2e/no-sticky-bars.spec.ts | New regression E2E test for the sticky-positioning bug. Import path correctly resolves to `web/e2e/fixtures.ts`. Minor issue: the JSDoc comment references #452 instead of the correct #458. |

</details>



<sub>Last reviewed commit: bd83800</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->