### PR TITLE
fix: hide MikroTik VPN tab when no WireGuard interfaces configured (#476)

### DIFF
--- a/server/src/api/vpn_status.rs
+++ b/server/src/api/vpn_status.rs
@@ -103,7 +103,8 @@ pub async fn vpn_status(
     let vyos = vyos_client(&state).await;
     let mikrotik = mikrotik_client(&state).await;
     let vyos_available = vyos.is_some();
-    let mikrotik_available = mikrotik.is_some();
+    // mikrotik_available is determined after we check for WireGuard interfaces
+    let mut mikrotik_available = false;
 
     let now = chrono::Utc::now().timestamp();
     // 3 minutes = 180 seconds threshold for "online"
@@ -183,6 +184,8 @@ pub async fn vpn_status(
     // ── MikroTik WireGuard ──
     if let Some(client) = mikrotik {
         let wg_ifaces = client.wireguard_interfaces().await.unwrap_or_default();
+        // Only mark MikroTik as available if it has WireGuard interfaces
+        mikrotik_available = !wg_ifaces.is_empty();
         let wg_peers = client.wireguard_peers().await.unwrap_or_default();
 
         fn is_true(val: &Option<String>) -> bool {

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -96,7 +96,10 @@ export default function VpnStatusPage() {
     if (!vyosVisible && activeTab === "vyos") {
       setActiveTab("overview");
     }
-  }, [activeTab, vyosVisible]);
+    if (!data?.mikrotik_available && activeTab === "mikrotik") {
+      setActiveTab("overview");
+    }
+  }, [activeTab, vyosVisible, data?.mikrotik_available]);
 
   // Default to MikroTik tab when available (once, on first data load)
   useEffect(() => {

--- a/web/tests/e2e/vpn-status.spec.ts
+++ b/web/tests/e2e/vpn-status.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * E2E tests for VPN Status page (/vpn-status).
+ *
+ * Validates that the MikroTik tab is only shown when the router
+ * actually has WireGuard interfaces configured (#476).
+ */
+
+// ── Mock data ────────────────────────────────────────────────
+
+/** VPN status response with no MikroTik WireGuard interfaces. */
+const MOCK_VPN_NO_MIKROTIK_WG = {
+  vyos_available: false,
+  mikrotik_available: false,
+  interfaces: [],
+  total_peers: 0,
+  online_peers: 0,
+  total_rx_bytes: 0,
+  total_tx_bytes: 0,
+};
+
+/** VPN status response with MikroTik WireGuard interfaces. */
+const MOCK_VPN_WITH_MIKROTIK_WG = {
+  vyos_available: false,
+  mikrotik_available: true,
+  interfaces: [
+    {
+      name: "wireguard1",
+      address: null,
+      port: 13231,
+      public_key: "ABCDEF1234567890ABCDEF1234567890ABCDEFGH=",
+      status: "up",
+      peers: [
+        {
+          name: "peer-1",
+          public_key: "PEER1KEY1234567890ABCDEF1234567890ABCDE=",
+          endpoint: "203.0.113.1:51820",
+          allowed_ips: ["10.0.0.2/32"],
+          last_handshake: Math.floor(Date.now() / 1000) - 30,
+          rx_bytes: 1048576,
+          tx_bytes: 524288,
+          connectivity: "online",
+        },
+      ],
+      peers_online: 1,
+      peers_total: 1,
+      source: "mikrotik",
+    },
+  ],
+  total_peers: 1,
+  online_peers: 1,
+  total_rx_bytes: 1048576,
+  total_tx_bytes: 524288,
+};
+
+// ── Helpers ──────────────────────────────────────────────────
+
+async function mockVpnStatus(page: Page, data: unknown) {
+  await page.route("**/api/v1/vpn-status", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(data),
+    }),
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+test.describe("VPN Status Page — MikroTik tab visibility (#476)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("hides MikroTik tab when no WireGuard interfaces exist", async ({
+    page,
+  }) => {
+    await mockVpnStatus(page, MOCK_VPN_NO_MIKROTIK_WG);
+    await page.goto("/vpn-status/");
+
+    // Wait for page to load — heading should be visible
+    await expect(
+      page.getByRole("heading", { name: "VPN Status", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Overview tab should be visible
+    await expect(
+      page.getByRole("tab", { name: "Overview" }),
+    ).toBeVisible();
+
+    // MikroTik tab should NOT be visible
+    await expect(
+      page.getByRole("tab", { name: "MikroTik" }),
+    ).not.toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/vpn-status-no-mikrotik-tab.png",
+    });
+  });
+
+  test("shows MikroTik tab when WireGuard interfaces exist", async ({
+    page,
+  }) => {
+    await mockVpnStatus(page, MOCK_VPN_WITH_MIKROTIK_WG);
+    await page.goto("/vpn-status/");
+
+    // Wait for page to load
+    await expect(
+      page.getByRole("heading", { name: "VPN Status", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // MikroTik tab should be visible
+    await expect(
+      page.getByRole("tab", { name: "MikroTik" }),
+    ).toBeVisible();
+
+    // Click MikroTik tab and verify interface data is shown
+    await page.getByRole("tab", { name: "MikroTik" }).click();
+    await expect(page.getByText("wireguard1")).toBeVisible();
+    await expect(page.getByText("peer-1")).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/vpn-status-with-mikrotik-tab.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #476

## Summary
- **Backend**: Changed `mikrotik_available` in the VPN status endpoint to only be `true` when the MikroTik router actually has WireGuard interfaces (not just when the router is configured)
- **Frontend**: Added a guard to switch away from the MikroTik tab if `mikrotik_available` becomes `false` (e.g., after data refresh)

## What changed

### `server/src/api/vpn_status.rs`
- `mikrotik_available` now starts as `false` and is only set to `true` after successfully fetching WireGuard interfaces and finding at least one

### `web/src/app/(app)/vpn-status/page.tsx`
- Added guard to redirect from MikroTik tab to Overview when `mikrotik_available` is `false`

## Smoke Test
- Verified `cargo check`, `cargo fmt`, and `cargo test` all pass (21 tests)
- Verified `bun run build` passes
- E2E tests confirm: MikroTik tab is hidden when no WireGuard interfaces, shown when interfaces exist

## Test plan
- [x] E2E test: MikroTik tab hidden when `mikrotik_available: false`
- [x] E2E test: MikroTik tab visible and functional when `mikrotik_available: true` with interfaces
- [x] All 21 existing Rust tests pass
- [x] Frontend builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly implements the fix to hide the MikroTik VPN tab when no WireGuard interfaces are configured. The backend now only sets `mikrotik_available` to true when actual WireGuard interfaces exist (not just when the router client is configured), and the frontend adds a guard to switch away from the MikroTik tab if it becomes unavailable.

- Backend change cleanly modifies the availability check from client existence to interface presence
- Frontend guard follows the existing VyOS pattern consistently
- E2E tests cover both scenarios (tab hidden/shown) with proper mocking and assertions
- All changes align with CLAUDE.md E2E test requirements

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects clean implementation that follows existing patterns, comprehensive E2E tests that verify the fix works, and simple logic changes with no security implications
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/vpn_status.rs | Changed mikrotik_available logic to check for actual WireGuard interfaces instead of just client existence |
| web/src/app/(app)/vpn-status/page.tsx | Added guard to switch away from MikroTik tab when mikrotik_available becomes false |
| web/tests/e2e/vpn-status.spec.ts | Added E2E tests covering both scenarios: tab hidden when no interfaces, shown when interfaces exist |

</details>



<sub>Last reviewed commit: c10f258</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->