### PR TITLE
fix: VyOS dashboard widget shows Router Offline when VyOS is not active (#475)

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -110,11 +110,13 @@ async fn active_router(state: &AppState) -> (&'static str, Option<bool>) {
         return ("mikrotik", check_mikrotik(state).await);
     }
 
-    // Fall back to VyOS if it has a URL configured.
-    let vyos_url = get_setting(state, "vyos_url").await;
-    let has_vyos = vyos_url.is_some() || state.config.vyos.url.is_some();
+    // Fall back to VyOS only when explicitly enabled.
+    let vyos_enabled = get_setting(state, "vyos_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
-    if has_vyos {
+    if vyos_enabled {
         return ("vyos", check_vyos(state).await);
     }
 

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -12,6 +12,7 @@ pub struct SettingsResponse {
     pub vyos_url: Option<String>,
     /// Masked API key — never return the full key to the frontend.
     pub vyos_api_key_set: bool,
+    pub vyos_enabled: bool,
     // --- Network Scanner ---
     pub scan_interval_seconds: Option<u64>,
     pub scan_subnets: Option<String>,
@@ -61,6 +62,7 @@ pub struct UpdateSettingsRequest {
     pub webhook_url: Option<String>,
     pub vyos_url: Option<String>,
     pub vyos_api_key: Option<String>,
+    pub vyos_enabled: Option<bool>,
     // --- Network Scanner ---
     pub scan_interval_seconds: Option<u64>,
     pub scan_subnets: Option<String>,
@@ -138,6 +140,11 @@ pub async fn get_settings(
                 .filter(|v| !v.trim().is_empty())
         })
         .is_some();
+
+    let vyos_enabled = get_setting(&state, "vyos_enabled")
+        .await
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
 
     // Network Scanner settings (fall back to config defaults).
     let scan_interval_seconds = get_setting(&state, "scan_interval_seconds")
@@ -229,6 +236,7 @@ pub async fn get_settings(
         webhook_url,
         vyos_url,
         vyos_api_key_set,
+        vyos_enabled,
         scan_interval_seconds,
         scan_subnets,
         ping_sweep_enabled,
@@ -283,6 +291,11 @@ pub async fn update_settings(
         // is added in the future.
         upsert_setting(&state, "vyos_api_key", key).await?;
         info!("VyOS API key updated");
+    }
+
+    if let Some(enabled) = body.vyos_enabled {
+        upsert_setting(&state, "vyos_enabled", if enabled { "1" } else { "0" }).await?;
+        info!(vyos_enabled = enabled, "VyOS enabled toggle updated");
     }
 
     // --- Network Scanner settings ---

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -38,6 +38,8 @@ function VyosPanel() {
   const [savedUrl, setSavedUrl] = useState<string | null>(null);
   const [apiKey, setApiKey] = useState("");
   const [apiKeySet, setApiKeySet] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [savedEnabled, setSavedEnabled] = useState(false);
   const [saveStatus, setSaveStatus] = useState<Status>("idle");
   const [saveMsg, setSaveMsg] = useState("");
   const [testStatus, setTestStatus] = useState<Status>("idle");
@@ -49,26 +51,29 @@ function VyosPanel() {
     fetch("/api/v1/settings", { credentials: "include" })
       .then((res) => res.json())
       .then(
-        (data: { vyos_url: string | null; vyos_api_key_set: boolean }) => {
+        (data: { vyos_url: string | null; vyos_api_key_set: boolean; vyos_enabled: boolean }) => {
           if (loadToken !== loadTokenRef.current) return;
           setUrl(data.vyos_url ?? "");
           setSavedUrl(data.vyos_url ?? null);
           setApiKeySet(data.vyos_api_key_set);
+          setEnabled(data.vyos_enabled);
+          setSavedEnabled(data.vyos_enabled);
         }
       )
       .catch(() => {});
   }, []);
 
-  const dirty = url !== (savedUrl ?? "") || apiKey.length > 0;
+  const dirty = url !== (savedUrl ?? "") || apiKey.length > 0 || enabled !== savedEnabled;
 
   async function handleSave() {
     loadTokenRef.current++;
     setSaveStatus("loading");
     setSaveMsg("");
     try {
-      const body: Record<string, string> = {};
+      const body: Record<string, string | boolean> = {};
       if (url !== (savedUrl ?? "")) body.vyos_url = url;
       if (apiKey.length > 0) body.vyos_api_key = apiKey;
+      if (enabled !== savedEnabled) body.vyos_enabled = enabled;
 
       const res = await fetch("/api/v1/settings", {
         method: "PATCH",
@@ -77,11 +82,13 @@ function VyosPanel() {
         credentials: "include",
       });
       if (res.ok) {
-        const data: { vyos_url: string | null; vyos_api_key_set: boolean } =
+        const data: { vyos_url: string | null; vyos_api_key_set: boolean; vyos_enabled: boolean } =
           await res.json();
         setSavedUrl(data.vyos_url ?? null);
         setUrl(data.vyos_url ?? "");
         setApiKeySet(data.vyos_api_key_set);
+        setEnabled(data.vyos_enabled);
+        setSavedEnabled(data.vyos_enabled);
         setApiKey("");
         setSaveStatus("success");
         setSaveMsg("VyOS settings saved.");
@@ -122,6 +129,17 @@ function VyosPanel() {
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Label htmlFor="vyos-enabled" className="text-xs text-slate-400">
+          Enable VyOS integration
+        </Label>
+        <Switch
+          id="vyos-enabled"
+          checked={enabled}
+          onCheckedChange={setEnabled}
+        />
+      </div>
+
       <div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
         <AlertTriangle className="h-4 w-4 shrink-0 text-amber-400" />
         <p className="text-xs text-amber-400">

--- a/web/tests/e2e/settings-router.spec.ts
+++ b/web/tests/e2e/settings-router.spec.ts
@@ -91,6 +91,28 @@ test.describe("Router Settings — VyOS", () => {
     await page.waitForLoadState("networkidle");
   });
 
+  test("toggle enabled persists after reload", async ({ page }) => {
+    const toggle = page.locator("#vyos-enabled");
+    const before = await toggle.getAttribute("aria-checked");
+    const expected = before === "true" ? "false" : "true";
+
+    await toggle.click();
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("VyOS settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await page.getByRole("tab", { name: /VyOS/ }).click();
+    await expect(toggle).toBeVisible({ timeout: 15000 });
+    await expect(toggle).toHaveAttribute("aria-checked", expected);
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-vyos-toggle-persisted.png",
+    });
+  });
+
   test("save and reload persists URL and API key", async ({ page }) => {
     const testUrl = "https://10.10.0.50";
 


### PR DESCRIPTION
Closes #475

## Summary

- Added `vyos_enabled` boolean setting (matching the existing `mikrotik_enabled` pattern)
- Dashboard `active_router()` now checks `vyos_enabled` instead of just checking if `vyos_url` exists in the DB
- VyOS settings panel now has an explicit Enable/Disable toggle (same as MikroTik)
- VyOS defaults to disabled (`false`), so stale `vyos_url` entries no longer trigger the "Router Offline" widget

## Changes

| File | Change |
|------|--------|
| `server/src/api/settings.rs` | Add `vyos_enabled` to response/request structs, get/set logic |
| `server/src/api/dashboard.rs` | `active_router()` checks `vyos_enabled` flag instead of URL presence |
| `web/src/app/(app)/settings/router/page.tsx` | Add Enable toggle to VyOS panel |
| `web/tests/e2e/settings-router.spec.ts` | E2E test for VyOS toggle persistence |

## Smoke Test

- `cargo check` — passes
- `cargo test` — all 21 tests pass
- `bun run build` — frontend builds clean
- Verified `vyos_enabled` defaults to `false`, so existing setups with stale `vyos_url` will no longer show the VyOS widget on the dashboard

## Test plan

- [ ] VyOS toggle on settings page persists after save + reload (covered by E2E test)
- [ ] Dashboard does not show "Router Offline" for VyOS when `vyos_enabled=false`
- [ ] MikroTik toggle behavior unchanged
- [ ] Enabling VyOS toggle + saving shows VyOS status on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the stale-VyOS-URL bug (#475) by replacing the implicit "URL present → widget active" heuristic with an explicit `vyos_enabled` boolean flag, mirroring the existing MikroTik pattern end-to-end across the backend API, dashboard logic, settings UI, and E2E tests. The implementation is clean and internally consistent.

- `server/src/api/settings.rs` — `vyos_enabled` added to `SettingsResponse` and `UpdateSettingsRequest`; stored as `"1"`/`"0"` with a `false` default, exactly matching the MikroTik pattern.
- `server/src/api/dashboard.rs` — `active_router()` now gates the VyOS path on the DB flag rather than URL presence; `check_vyos()` still correctly falls back to TOML config for credentials once enabled.
- `web/…/settings/router/page.tsx` — Enable toggle added to `VyosPanel` with proper `enabled`/`savedEnabled` state, dirty tracking, and round-trip on save.
- `web/tests/e2e/settings-router.spec.ts` — New VyOS toggle persistence test is missing a `waitForLoadState("networkidle")` after the in-test page reload, making it susceptible to a race condition where the assertion reads React's initial `false` state before the settings API responds.
- **Migration concern** — Existing users who configured VyOS via `panoptikon.toml` (not the DB) will have their dashboard widget silently disabled after upgrade since `vyos_enabled` defaults to `false` and no DB row is auto-seeded. Consider checking `state.config.vyos.url` at startup/migration to seed `vyos_enabled = "1"` for those users.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-up recommended for the test race condition and TOML-user migration path.
- The core logic is correct, well-tested against DB-based configurations, and mirrors an already-proven pattern. Two non-blocking issues prevent a 5: the E2E test has a potential race after reload, and users who had VyOS configured only in TOML will silently lose their dashboard widget after upgrading until they manually enable the toggle.
- `web/tests/e2e/settings-router.spec.ts` and `server/src/api/dashboard.rs` (migration path for TOML-configured VyOS users).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Replaces URL-presence check with an explicit `vyos_enabled` flag in `active_router()`; logic is correct and mirrors the existing MikroTik pattern, though TOML-configured users will silently lose their dashboard widget after upgrade until they toggle VyOS on in settings. |
| server/src/api/settings.rs | Adds `vyos_enabled` to both the response and request structs, with correct get/upsert logic defaulting to `false`; cleanly follows the MikroTik pattern already in place. |
| web/src/app/(app)/settings/router/page.tsx | Adds `enabled`/`savedEnabled` state, wires up the VyOS Enable toggle, and correctly tracks dirty state and round-trips the value through save — consistent with the MikroTik panel implementation. |
| web/tests/e2e/settings-router.spec.ts | New VyOS toggle persistence test is structured correctly but is missing a `waitForLoadState("networkidle")` call after the in-test reload, creating a race condition where the assertion may read the React default state (`false`) before the settings API responds. |

</details>



<sub>Last reviewed commit: 501835a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->