### PR TITLE
fix: uniform grid for MikroTik System tab info cards (#480)

### DIFF
--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -204,97 +204,93 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
       : null;
 
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-pink-500/10">
-              <Monitor className="h-4.5 w-4.5 text-pink-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">Version</p>
-              <p className="truncate text-sm font-medium text-white">
-                {status.version ?? "\u2014"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-pink-500/10">
+            <Monitor className="h-4.5 w-4.5 text-pink-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Version</p>
+            <p className="truncate text-sm font-medium text-white">
+              {status.version ?? "\u2014"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
-              <Clock className="h-4.5 w-4.5 text-emerald-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">Uptime</p>
-              <p className="truncate text-sm font-medium text-white">
-                {status.uptime ?? "\u2014"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
+            <Clock className="h-4.5 w-4.5 text-emerald-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Uptime</p>
+            <p className="truncate text-sm font-medium text-white">
+              {status.uptime ?? "\u2014"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10">
-              <Cpu className="h-4.5 w-4.5 text-amber-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">CPU Load</p>
-              <p className="text-sm font-medium text-white">
-                {status.cpu_load ? `${status.cpu_load}%` : "\u2014"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10">
+            <Cpu className="h-4.5 w-4.5 text-amber-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">CPU Load</p>
+            <p className="text-sm font-medium text-white">
+              {status.cpu_load ? `${status.cpu_load}%` : "\u2014"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
-              <MemoryStick className="h-4.5 w-4.5 text-purple-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">Memory</p>
-              <p className="text-sm font-medium text-white">
-                {memUsed
-                  ? `${formatMemory(memUsed)} / ${formatMemory(status.total_memory)}`
-                  : "\u2014"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
+            <MemoryStick className="h-4.5 w-4.5 text-purple-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Memory</p>
+            <p className="text-sm font-medium text-white">
+              {memUsed
+                ? `${formatMemory(memUsed)} / ${formatMemory(status.total_memory)}`
+                : "\u2014"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-cyan-500/10">
-              <HardDrive className="h-4.5 w-4.5 text-cyan-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">Platform</p>
-              <p className="truncate text-sm font-medium text-white">
-                {status.platform ?? "\u2014"}{" "}
-                {status.architecture ? `(${status.architecture})` : ""}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-cyan-500/10">
+            <HardDrive className="h-4.5 w-4.5 text-cyan-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Platform</p>
+            <p className="truncate text-sm font-medium text-white">
+              {status.platform ?? "\u2014"}{" "}
+              {status.architecture ? `(${status.architecture})` : ""}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardContent className="flex items-center gap-3 py-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-              <Server className="h-4.5 w-4.5 text-blue-400" />
-            </div>
-            <div className="min-w-0">
-              <p className="text-xs text-slate-500">Board</p>
-              <p className="truncate text-sm font-medium text-white">
-                {status.board_name ?? "\u2014"}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <Card className="col-span-1 border-slate-800 bg-slate-900">
+        <CardContent className="flex h-16 items-center gap-3 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+            <Server className="h-4.5 w-4.5 text-blue-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Board</p>
+            <p className="truncate text-sm font-medium text-white">
+              {status.board_name ?? "\u2014"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/tests/e2e/router.spec.ts
+++ b/web/tests/e2e/router.spec.ts
@@ -148,6 +148,66 @@ test.describe("Router Page — MikroTik", () => {
     });
   });
 
+  test("System tab info cards have uniform widths (#480)", async ({ page }) => {
+    test.setTimeout(60_000);
+    // Enable MikroTik so System tab may render (if router is reachable)
+    await page.goto("/settings/router/");
+    await expect(page.locator("#mt-url")).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState("load");
+
+    const toggle = page.locator("#mt-enabled");
+    await expect(toggle).toBeVisible();
+    const checked = await toggle.getAttribute("aria-checked");
+    if (checked !== "true") {
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+    }
+    await page.locator("#mt-url").fill("http://10.10.0.125");
+    await page.locator("#mt-user").fill("admin");
+    await page.locator("#mt-password").fill("admin");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByText("MikroTik settings saved."),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.goto("/router/mikrotik/");
+
+    // Wait for the page to resolve — either System tab (connected) or unreachable msg
+    const systemTab = page.getByRole("tab", { name: "System" });
+    const fallback = page.getByText(/unreachable|Unreachable|Not Configured/);
+    await expect(systemTab.or(fallback)).toBeVisible({ timeout: 25000 });
+
+    // If System tab is visible, verify info card widths are uniform
+    if (await systemTab.isVisible()) {
+      await systemTab.click();
+
+      // All info cards (Version, Uptime, CPU Load, Memory, Platform, Board)
+      // are inside a single grid with col-span-1 — their widths should match.
+      const cards = page.locator('[class*="col-span-1"][class*="border-slate-800"]');
+      const cardCount = await cards.count();
+      expect(cardCount).toBeGreaterThanOrEqual(4);
+
+      const widths: number[] = [];
+      for (let i = 0; i < cardCount; i++) {
+        const box = await cards.nth(i).boundingBox();
+        expect(box).toBeTruthy();
+        widths.push(box!.width);
+      }
+
+      // All cards in the same row should have equal width (within 2px tolerance)
+      // Cards wrap at breakpoints, so compare cards in groups that share a row
+      const firstWidth = widths[0];
+      for (const w of widths) {
+        expect(Math.abs(w - firstWidth)).toBeLessThanOrEqual(2);
+      }
+    }
+
+    await page.screenshot({
+      path: "tests/screenshots/router-mikrotik-card-widths.png",
+      fullPage: true,
+    });
+  });
+
   test("MikroTik page mobile layout does not overflow (#416)", async ({
     page,
   }) => {


### PR DESCRIPTION
Closes #480

## Summary
- Merged the two separate grids (4-card row + 2-card row) into a single uniform `grid-cols-2 md:grid-cols-3 lg:grid-cols-4` grid
- All six info cards (Version, Uptime, CPU Load, Memory, Platform, Board) now have equal `col-span-1` widths
- Added fixed `h-16` height to `CardContent` for consistent card sizing across all cards

## What changed
- `web/src/components/MikrotikRouter.tsx` — `SystemTab` function: replaced two separate grids with one uniform grid
- `web/tests/e2e/router.spec.ts` — added E2E test for card width uniformity

## Smoke Test
- Verified `bun run build` passes with the changes
- Confirmed the grid classes are correct: `grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4`
- All 6 cards use `col-span-1` ensuring equal column widths at every breakpoint
- Before: 2 separate grids caused Platform/Board cards to be wider than Version/Uptime/CPU/Memory cards
- After: single grid, all cards same width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Merged two separate grids into a single uniform grid for the MikroTik System tab, ensuring all six info cards (Version, Uptime, CPU Load, Memory, Platform, Board) have equal widths at all breakpoints.

- Replaced `space-y-4` container with two nested grids with single `grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4` layout
- All cards now use explicit `col-span-1` for uniform column widths
- Added fixed `h-16` height to `CardContent` for consistent card sizing
- Included comprehensive E2E test verifying card width uniformity (within 2px tolerance)
- Test properly follows CLAUDE.md requirements: uses Playwright, asserts visible UI state, includes screenshot

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Clean layout fix with proper E2E test coverage. The change is minimal, focused, and well-tested. Grid classes are correct, breakpoints are appropriate, and the test properly verifies the fix
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/MikrotikRouter.tsx | Replaced two separate grids with a single uniform grid using `grid-cols-2 md:grid-cols-3 lg:grid-cols-4`, ensuring all six info cards have equal widths with `col-span-1` and consistent `h-16` height |
| web/tests/e2e/router.spec.ts | Added E2E test verifying System tab info cards have uniform widths by measuring card bounding boxes and asserting they match within 2px tolerance |

</details>



<sub>Last reviewed commit: 1946217</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->