### PR TITLE
feat: Cloudflare Tunnel settings — add inline help/guide (#510)

### DIFF
--- a/web/src/app/(app)/settings/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/settings/cloudflare-tunnel/page.tsx
@@ -151,6 +151,15 @@ export default function CloudflareTunnelSettingsPage() {
                     : "Enter Cloudflare API token"
                 }
               />
+              <p className="text-[10px] text-slate-600">
+                Create at: dash.cloudflare.com → My Profile → API Tokens →
+                Create Token. Required permissions:{" "}
+                <code className="text-slate-500">
+                  Account:Cloudflare Tunnel:Edit
+                </code>
+                ,{" "}
+                <code className="text-slate-500">Zone:DNS:Edit</code>
+              </p>
             </div>
 
             <div className="space-y-1.5">
@@ -165,6 +174,10 @@ export default function CloudflareTunnelSettingsPage() {
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="e.g. 1a2b3c4d5e6f..."
               />
+              <p className="text-[10px] text-slate-600">
+                Found at: dash.cloudflare.com → any domain → right sidebar →
+                Account ID. Format: 32-character hex string.
+              </p>
             </div>
 
             <div className="space-y-1.5">
@@ -179,6 +192,10 @@ export default function CloudflareTunnelSettingsPage() {
                 className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
                 placeholder="e.g. a1b2c3d4-e5f6-..."
               />
+              <p className="text-[10px] text-slate-600">
+                Found at: dash.cloudflare.com → Zero Trust → Networks →
+                Tunnels → your tunnel → Overview. Format: UUID.
+              </p>
             </div>
 
             {status === "success" && msg && (

--- a/web/tests/e2e/settings-cloudflare.spec.ts
+++ b/web/tests/e2e/settings-cloudflare.spec.ts
@@ -48,6 +48,34 @@ test.describe("Cloudflare Tunnel Settings", () => {
     });
   });
 
+  test("inline help text is visible for all three fields", async ({ page }) => {
+    // API Token help text
+    const apiTokenHelp = page.locator(
+      'text=Create at: dash.cloudflare.com → My Profile → API Tokens → Create Token',
+    );
+    await expect(apiTokenHelp).toBeVisible();
+    await expect(apiTokenHelp).toContainText("Account:Cloudflare Tunnel:Edit");
+    await expect(apiTokenHelp).toContainText("Zone:DNS:Edit");
+
+    // Account ID help text
+    const accountIdHelp = page.locator(
+      'text=Found at: dash.cloudflare.com → any domain → right sidebar → Account ID',
+    );
+    await expect(accountIdHelp).toBeVisible();
+    await expect(accountIdHelp).toContainText("32-character hex string");
+
+    // Tunnel ID help text
+    const tunnelIdHelp = page.locator(
+      'text=Found at: dash.cloudflare.com → Zero Trust → Networks → Tunnels',
+    );
+    await expect(tunnelIdHelp).toBeVisible();
+    await expect(tunnelIdHelp).toContainText("UUID");
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-cloudflare-tunnel-help-text.png",
+    });
+  });
+
   test("settings index shows Cloudflare Tunnel card under Integrations", async ({
     page,
   }) => {


### PR DESCRIPTION
Closes #510

## Summary

- Added inline helper text below each Cloudflare Tunnel settings field (API Token, Account ID, Tunnel ID)
- Each field now shows where to find the value in the Cloudflare dashboard and the expected format
- Uses the existing `text-[10px] text-slate-600` pattern consistent with other settings pages (e.g. speedtest)

## Changes

- `web/src/app/(app)/settings/cloudflare-tunnel/page.tsx` — added `<p>` helper text under each input field
- `web/tests/e2e/settings-cloudflare.spec.ts` — added E2E test verifying all three help texts are visible

## Help text content

| Field | Help text |
|-------|-----------|
| API Token | Create at: dash.cloudflare.com → My Profile → API Tokens → Create Token. Required permissions: `Account:Cloudflare Tunnel:Edit`, `Zone:DNS:Edit` |
| Account ID | Found at: dash.cloudflare.com → any domain → right sidebar → Account ID. Format: 32-character hex string. |
| Tunnel ID | Found at: dash.cloudflare.com → Zero Trust → Networks → Tunnels → your tunnel → Overview. Format: UUID. |

## Smoke Test

- Verified frontend builds successfully (`next build` exits 0)
- Helper text uses same pattern as speedtest settings page (`text-[10px] text-slate-600`)
- No backend changes required

## Test plan

- [x] E2E test: `inline help text is visible for all three fields` — verifies each help paragraph is visible and contains expected content
- [x] Screenshot captured at `tests/screenshots/settings-cloudflare-tunnel-help-text.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inline help text beneath each of the three Cloudflare Tunnel settings fields (API Token, Account ID, Tunnel ID), guiding users to the exact location in the Cloudflare dashboard and describing the expected value format. The change is purely presentational — no backend or state-management code is touched — and correctly follows the `text-[10px] text-slate-600` pattern already used on the speedtest settings page.

**Key points:**
- The help-text `<p>` elements are not linked to their inputs via `aria-describedby`, so screen readers won't announce the hints when a field is focused.
- The new E2E test uses the older `text=` CSS selector engine rather than `page.getByText()`. Because `text=` matches ancestor elements that also contain the substring, all three locators may resolve to multiple elements and trigger a Playwright strict-mode violation.
- No backend changes are required; the implementation is simple and low-risk.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; changes are purely UI/cosmetic with no backend impact.
- The production code change is trivial and carries no functional risk. The score is not a full 5 because the new E2E test uses `text=` locators that may resolve to multiple elements and fail under Playwright's strict mode, meaning CI could report a false failure without any actual regression in the UI.
- web/tests/e2e/settings-cloudflare.spec.ts — the `text=` locators should be replaced with `page.getByText()` to avoid potential strict-mode violations.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/cloudflare-tunnel/page.tsx | Adds three `<p>` help-text blocks (one per settings field) using the existing `text-[10px] text-slate-600` pattern; no logic changes. Minor accessibility improvement possible by linking paragraphs to inputs via `aria-describedby`. |
| web/tests/e2e/settings-cloudflare.spec.ts | New E2E test verifies all three help paragraphs are visible; however, the three `text=` locators can match multiple ancestor elements and may trigger a Playwright strict-mode violation at runtime. |

</details>



<sub>Last reviewed commit: 9d8235b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->