### PR TITLE
fix: replace Nginx Proxy Manager references with Caddy in SSL Certificates page (#516)

### DIFF
--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -271,11 +271,11 @@ export default function CertificatesPage() {
       <div className="flex flex-col items-center justify-center gap-4 py-20">
         <Shield className="h-12 w-12 text-slate-600" />
         <h2 className="text-lg font-medium text-white">
-          NPM Not Configured
+          Caddy Not Configured
         </h2>
         <p className="max-w-md text-center text-sm text-slate-400">
-          Configure your Nginx Proxy Manager connection in Settings to manage
-          SSL certificates.
+          Configure your Caddy connection in Settings to manage SSL
+          certificates.
         </p>
       </div>
     );
@@ -285,10 +285,10 @@ export default function CertificatesPage() {
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-20">
         <AlertTriangle className="h-12 w-12 text-amber-500" />
-        <h2 className="text-lg font-medium text-white">NPM Unreachable</h2>
+        <h2 className="text-lg font-medium text-white">Caddy Unreachable</h2>
         <p className="max-w-md text-center text-sm text-slate-400">
-          Could not connect to your Nginx Proxy Manager instance. Check your
-          settings and ensure the service is running.
+          Could not connect to your Caddy instance. Check your settings and
+          ensure the service is running.
         </p>
       </div>
     );
@@ -307,10 +307,10 @@ export default function CertificatesPage() {
             <h1 className="text-xl font-semibold text-white">
               SSL Certificates
             </h1>
-            <HelpTooltip text="View and manage SSL/TLS certificates provisioned through Nginx Proxy Manager. Request free Let's Encrypt certs or upload your own." />
+            <HelpTooltip text="View and manage SSL/TLS certificates provisioned through Caddy. Request free Let's Encrypt certs or upload your own." />
           </div>
           <p className="text-sm text-slate-400">
-            Manage SSL certificates via Nginx Proxy Manager
+            Manage SSL certificates via Caddy
           </p>
         </div>
         <div className="flex gap-2">
@@ -370,7 +370,7 @@ export default function CertificatesPage() {
                 Certificates ({certs.length})
               </CardTitle>
               <CardDescription className="text-xs text-slate-500">
-                All SSL certificates managed by NPM
+                All SSL certificates managed by Caddy
               </CardDescription>
             </div>
           </div>
@@ -381,7 +381,7 @@ export default function CertificatesPage() {
               <Shield className="mb-4 h-12 w-12 text-slate-600" />
               <p className="text-lg font-medium text-slate-400">No certificates yet</p>
               <p className="mt-1 max-w-sm text-sm text-slate-600">
-                Request a free Let&apos;s Encrypt certificate or upload your own using the buttons above. Make sure NPM is configured in Settings first.
+                Request a free Let&apos;s Encrypt certificate or upload your own using the buttons above. Make sure Caddy is configured in Settings first.
               </p>
             </div>
           ) : (

--- a/web/tests/e2e/certificates.spec.ts
+++ b/web/tests/e2e/certificates.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("SSL Certificates page", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/certificates/");
+    // Wait for the page to finish loading (skeleton or real content)
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("does not reference Nginx Proxy Manager", async ({ page }) => {
+    const pageContent = await page.textContent("body");
+    expect(pageContent).not.toContain("Nginx Proxy Manager");
+
+    await page.screenshot({
+      path: "tests/screenshots/certificates-no-npm.png",
+      fullPage: true,
+    });
+  });
+
+  test("references Caddy instead of NPM in headings and descriptions", async ({
+    page,
+  }) => {
+    const pageContent = await page.textContent("body");
+
+    // The page should reference Caddy (either in configured state messages
+    // or in the subtitle/tooltip when connected)
+    // Check that NPM-specific branding is gone
+    expect(pageContent).not.toContain("NPM Not Configured");
+    expect(pageContent).not.toContain("NPM Unreachable");
+    expect(pageContent).not.toContain("managed by NPM");
+
+    // If the "not configured" state is shown, verify it says Caddy
+    const notConfiguredHeading = page.getByText("Caddy Not Configured");
+    const sslHeading = page.getByText("SSL Certificates");
+
+    // One of these should be visible depending on connection state
+    await Promise.race([
+      notConfiguredHeading.waitFor({ state: "visible", timeout: 10000 }),
+      sslHeading.waitFor({ state: "visible", timeout: 10000 }),
+    ]);
+
+    await page.screenshot({
+      path: "tests/screenshots/certificates-caddy-branding.png",
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #516

## Summary

- Updated all user-facing text in the SSL Certificates page (`web/src/app/(app)/certificates/page.tsx`) that still referenced "Nginx Proxy Manager" / "NPM" to reference "Caddy" instead
- Changed 6 strings: page subtitle, help tooltip, "not configured" heading + message, "unreachable" heading + message, card description, and empty-state hint

## Changes

| Location | Before | After |
|---|---|---|
| Page subtitle | "Manage SSL certificates via Nginx Proxy Manager" | "Manage SSL certificates via Caddy" |
| Help tooltip | "...provisioned through Nginx Proxy Manager..." | "...provisioned through Caddy..." |
| Not configured heading | "NPM Not Configured" | "Caddy Not Configured" |
| Not configured message | "Configure your Nginx Proxy Manager connection..." | "Configure your Caddy connection..." |
| Unreachable heading | "NPM Unreachable" | "Caddy Unreachable" |
| Unreachable message | "Could not connect to your Nginx Proxy Manager instance..." | "Could not connect to your Caddy instance..." |
| Card description | "All SSL certificates managed by NPM" | "All SSL certificates managed by Caddy" |
| Empty state hint | "Make sure NPM is configured..." | "Make sure Caddy is configured..." |

## Smoke Test

- Verified no "Nginx Proxy Manager" text remains in `certificates/page.tsx` via grep
- Verified all 8 updated strings now reference "Caddy"
- Next.js production build passes cleanly
- Rust `cargo check` passes cleanly

## E2E Test

Added `web/tests/e2e/certificates.spec.ts` that:
- Navigates to `/certificates/`
- Asserts page body does NOT contain "Nginx Proxy Manager"
- Asserts NPM-specific headings ("NPM Not Configured", "NPM Unreachable", "managed by NPM") are absent
- Verifies either "Caddy Not Configured" or "SSL Certificates" heading is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the user-facing text migration from Nginx Proxy Manager to Caddy in the SSL Certificates page. All 8 user-facing strings have been correctly updated to reference "Caddy" instead of "NPM"/"Nginx Proxy Manager".

**Changes:**
- Updated page subtitle, help tooltip, error state headings/messages, card description, and empty-state hint
- Added comprehensive E2E test to prevent regression and ensure Caddy branding is present
- All text changes are straightforward substitutions with no logic modifications

**Note:** Internal code still uses NPM naming conventions (`fetchNpmCertificates`, `NpmCertificate`, etc.), which is expected as the backend API hasn't been renamed yet. This PR appropriately focuses only on user-facing text.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are simple string replacements in user-facing text with no logic modifications. The E2E test provides good coverage to prevent regression. The changes align with the broader Caddy migration effort already in progress.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/certificates/page.tsx | Updated 8 user-facing strings from "Nginx Proxy Manager"/"NPM" to "Caddy" in headings, tooltips, and messages |
| web/tests/e2e/certificates.spec.ts | Added E2E test to verify NPM references are removed and Caddy branding is present on certificates page |

</details>



<sub>Last reviewed commit: 5776a87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->