### PR TITLE
feat: Tunnel Routes hostnames should be clickable links (#525)

### DIFF
--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Cloud,
+  ExternalLink,
   Pencil,
   Plus,
   RefreshCw,
@@ -48,6 +49,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { PageTransition } from "@/components/PageTransition";
 import {
   fetchCloudflareTunnelStatus,
@@ -478,7 +485,30 @@ export default function CloudflareTunnelPage() {
                     {routes.map((route) => (
                       <TableRow key={route.hostname} className="border-slate-800">
                         <TableCell className="font-medium text-slate-200">
-                          {route.hostname}
+                          {route.service.startsWith("http") ? (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <a
+                                    href={`https://${route.hostname}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex max-w-[260px] items-center gap-1.5 text-blue-400 hover:text-blue-300 hover:underline"
+                                  >
+                                    <span className="truncate">
+                                      {route.hostname}
+                                    </span>
+                                    <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                                  </a>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  <p>{route.hostname}</p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          ) : (
+                            route.hostname
+                          )}
                         </TableCell>
                         <TableCell className="font-mono text-sm text-slate-300">
                           {route.service}

--- a/web/tests/e2e/cloudflare-tunnel-hostname-links.spec.ts
+++ b/web/tests/e2e/cloudflare-tunnel-hostname-links.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Cloudflare Tunnel Routes — Hostname links", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto("/cloudflare-tunnel/");
+    await expect(
+      page.getByRole("heading", { name: "Cloudflare Tunnel", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("hostnames with HTTP services render as clickable links with external-link icon", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Tunnel Routes")).toBeVisible({
+      timeout: 15000,
+    });
+
+    const rows = page.locator("table tbody tr");
+    const rowCount = await rows.count();
+
+    if (rowCount > 0) {
+      const firstRow = rows.first();
+      const hostnameCell = firstRow.locator("td").nth(0);
+
+      // Check if the hostname is rendered as a link
+      const link = hostnameCell.locator("a");
+      const linkCount = await link.count();
+
+      if (linkCount > 0) {
+        // Verify the link has correct attributes
+        const href = await link.getAttribute("href");
+        expect(href).toMatch(/^https:\/\/.+/);
+
+        await expect(link).toHaveAttribute("target", "_blank");
+        await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+
+        // Verify external link icon is present
+        const externalIcon = link.locator("svg.lucide-external-link");
+        await expect(externalIcon).toBeVisible();
+
+        // Verify the hostname text is visible inside the link
+        const hostnameText = await link.locator("span").first().textContent();
+        expect(hostnameText?.trim()).toBeTruthy();
+
+        // Verify the href matches the hostname text
+        expect(href).toBe(`https://${hostnameText?.trim()}`);
+      }
+      // If no link, the service is non-HTTP — hostname rendered as plain text (safe fallback)
+
+      await page.screenshot({
+        path: "tests/screenshots/cloudflare-tunnel-hostname-links.png",
+      });
+    }
+  });
+
+  test("hostname link text matches value used in edit dialog", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Tunnel Routes")).toBeVisible({
+      timeout: 15000,
+    });
+
+    const rows = page.locator("table tbody tr");
+    const rowCount = await rows.count();
+
+    if (rowCount > 0) {
+      const firstRow = rows.first();
+      const hostnameCell = firstRow.locator("td").nth(0);
+      const link = hostnameCell.locator("a");
+      const linkCount = await link.count();
+
+      // Get the hostname from the cell (either from link or plain text)
+      let hostname: string;
+      if (linkCount > 0) {
+        hostname = (await link.locator("span").first().textContent()) || "";
+      } else {
+        hostname = (await hostnameCell.textContent()) || "";
+      }
+      hostname = hostname.trim();
+
+      // Open the edit dialog and check hostname matches
+      const editButton = firstRow.locator("button").filter({
+        has: page.locator("svg.lucide-pencil"),
+      });
+      await editButton.click();
+
+      const dialog = page.locator('[role="dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 3000 });
+
+      await expect(page.locator("#edit-hostname")).toHaveValue(hostname);
+
+      await page.screenshot({
+        path: "tests/screenshots/cloudflare-tunnel-hostname-link-edit-match.png",
+      });
+
+      // Close dialog
+      await dialog.getByRole("button", { name: "Cancel" }).click();
+      await expect(dialog).not.toBeVisible({ timeout: 3000 });
+    }
+  });
+});


### PR DESCRIPTION
Closes #525

## Summary
- Hostnames in the Cloudflare Tunnel Routes table are now rendered as clickable `<a>` links opening `https://<hostname>` in a new tab
- Added external-link icon (lucide `ExternalLink`) next to each hostname for visual affordance
- Long hostnames truncate with `max-w-[260px]` and a tooltip shows the full hostname on hover
- Safe fallback: non-HTTP service hostnames (e.g. `ssh://`, `tcp://`) render as plain text

## UX Details
- `target="_blank"` + `rel="noopener noreferrer"` on all hostname links
- Blue link color (`text-blue-400`) with hover underline, consistent with existing link styles
- Tooltip via shadcn/ui `Tooltip` component

## Smoke Test
- Verified `bun run build` (Next.js) passes with no errors
- Verified `cargo check` passes with no errors
- The service field is checked with `route.service.startsWith("http")` to determine if the hostname should be a link

## Test Plan
- [x] E2E test `cloudflare-tunnel-hostname-links.spec.ts` verifies:
  - Hostname links have correct `href` (`https://<hostname>`), `target="_blank"`, and `rel="noopener noreferrer"`
  - External link icon (`svg.lucide-external-link`) is visible
  - Hostname text in the link matches the value pre-filled in the edit dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the Cloudflare Tunnel Routes table by making HTTP/HTTPS service hostnames clickable links that open in a new tab. The implementation follows existing patterns in the codebase (similar to the Caddy page) and includes good UX improvements: external link icon, hostname truncation with tooltip, and proper security attributes (`target="_blank"` with `rel="noopener noreferrer"`).

**Key changes:**
- Hostnames for routes with HTTP/HTTPS services render as blue clickable links opening `https://<hostname>`
- Non-HTTP services (ssh, tcp, etc.) safely fall back to plain text rendering
- Added `ExternalLink` icon from lucide-react for visual affordance
- Long hostnames truncate at 260px with tooltip showing full hostname
- Comprehensive E2E test coverage following project guidelines

**Minor optimization opportunity:**
- Nested `TooltipProvider` instances are redundant since the app layout already provides one globally

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with no functional issues
- Implementation is solid and follows established patterns; E2E tests are comprehensive; security best practices are followed; only minor style optimization identified (redundant TooltipProvider)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/cloudflare-tunnel/page.tsx | Added clickable hostname links with external link icon and tooltip for HTTP services; contains redundant TooltipProvider instances |
| web/tests/e2e/cloudflare-tunnel-hostname-links.spec.ts | Comprehensive E2E test verifying hostname link attributes, external link icon visibility, and consistency with edit dialog |

</details>



<sub>Last reviewed commit: 7f9bd68</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->