### PR TITLE
fix: layout/grid problems across UI — card overflow, misalignment, clipping (#524)

### DIFF
--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -484,7 +484,7 @@ export default function CloudflareTunnelPage() {
                   <TableBody>
                     {routes.map((route) => (
                       <TableRow key={route.hostname} className="border-slate-800">
-                        <TableCell className="font-medium text-slate-200">
+                        <TableCell className="max-w-[200px] font-medium text-slate-200">
                           {route.service.startsWith("http") ? (
                             <TooltipProvider>
                               <Tooltip>
@@ -493,7 +493,7 @@ export default function CloudflareTunnelPage() {
                                     href={`https://${route.hostname}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex max-w-[260px] items-center gap-1.5 text-blue-400 hover:text-blue-300 hover:underline"
+                                    className="inline-flex max-w-full items-center gap-1.5 text-blue-400 hover:text-blue-300 hover:underline"
                                   >
                                     <span className="truncate">
                                       {route.hostname}
@@ -507,11 +507,11 @@ export default function CloudflareTunnelPage() {
                               </Tooltip>
                             </TooltipProvider>
                           ) : (
-                            route.hostname
+                            <span className="block truncate">{route.hostname}</span>
                           )}
                         </TableCell>
-                        <TableCell className="font-mono text-sm text-slate-300">
-                          {route.service}
+                        <TableCell className="max-w-[250px] font-mono text-sm text-slate-300">
+                          <span className="block truncate">{route.service}</span>
                         </TableCell>
                         <TableCell className="text-slate-400">
                           {route.path || "/"}

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -179,8 +179,8 @@ function StatCard({
         </div>
       </CardHeader>
       <CardContent>
-        <p className="text-2xl font-bold tabular-nums text-white">{value}</p>
-        <p className="mt-1 text-xs text-slate-500">{subtitle}</p>
+        <p className="truncate text-2xl font-bold tabular-nums text-white">{value}</p>
+        <p className="mt-1 truncate text-xs text-slate-500">{subtitle}</p>
       </CardContent>
     </Card>
   );
@@ -389,7 +389,7 @@ export default function DashboardPage() {
         </Card></StaggerItem>
 
         {/* ── Stat Cards Row ───────────────────────────── */}
-        <StaggerItem className="h-full lg:col-span-4"><div className="grid h-full grid-cols-2 gap-4 lg:grid-cols-4">
+        <StaggerItem className="h-full lg:col-span-4"><div className="grid h-full grid-cols-2 gap-3 lg:grid-cols-4">
           {statsError ? (
             <>
               <StatCard
@@ -659,16 +659,16 @@ export default function DashboardPage() {
             ) : deviceBreakdown.length === 0 ? (
               <p className="text-sm text-slate-600">No devices found.</p>
             ) : (
-              <div className="grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
                 {deviceBreakdown.map((item) => {
                   const Icon = getDeviceIcon(item.type, null, null).icon;
                   return (
                     <div key={item.type} className="flex items-center gap-3">
                       <Icon className="h-4 w-4 shrink-0 text-slate-400" />
-                      <span className="w-16 shrink-0 text-sm text-slate-300">
+                      <span className="w-24 shrink-0 truncate text-sm text-slate-300">
                         {item.label}
                       </span>
-                      <div className="flex flex-1 items-center gap-2">
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
                         <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-800">
                           <div
                             className={`h-full rounded-full ${TYPE_COLORS[item.type] ?? "bg-slate-500"} transition-all duration-500`}

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -759,8 +759,8 @@ function DeviceCard({
 
         {/* Technical info */}
         <div className="mt-3 space-y-1">
-          <p className="font-mono tabular-nums text-sm text-slate-400">{primaryIp}</p>
-          <p className="font-mono tabular-nums text-xs text-slate-600">{device.mac}</p>
+          <p className="truncate font-mono tabular-nums text-sm text-slate-400">{primaryIp}</p>
+          <p className="truncate font-mono tabular-nums text-xs text-slate-600">{device.mac}</p>
         </div>
 
         {/* 24-hour status sparkline */}
@@ -954,13 +954,13 @@ function DevicesTable({
                 <TableCell className="tabular-nums font-mono text-sm text-slate-300">
                   {primaryIp}
                 </TableCell>
-                <TableCell>
-                  <div>
-                    <span className="text-sm text-slate-300">
+                <TableCell className="max-w-[200px]">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="truncate text-sm text-slate-300">
                       {device.hostname ?? "—"}
                     </span>
                     {device.agent?.is_online && (
-                      <span className="ml-2 rounded border border-blue-500/30 bg-blue-500/20 px-1.5 py-0.5 text-xs text-blue-400">
+                      <span className="shrink-0 rounded border border-blue-500/30 bg-blue-500/20 px-1.5 py-0.5 text-xs text-blue-400">
                         Agent
                       </span>
                     )}

--- a/web/src/app/(app)/mesh/page.tsx
+++ b/web/src/app/(app)/mesh/page.tsx
@@ -262,7 +262,7 @@ function InfoRow({
         {label}
       </span>
       <span
-        className={`text-sm text-slate-300 ${mono ? 'font-mono tabular-nums' : ''}`}
+        className={`min-w-0 truncate text-sm text-slate-300 ${mono ? 'font-mono tabular-nums' : ''}`}
       >
         {value}
       </span>

--- a/web/src/app/(app)/services/page.tsx
+++ b/web/src/app/(app)/services/page.tsx
@@ -397,17 +397,19 @@ export default function ServicesPage() {
                     key={host.id}
                     className="border-slate-800 hover:bg-slate-800/50"
                   >
-                    <TableCell>
-                      <div className="flex items-center gap-2">
-                        <Globe className="h-4 w-4 text-slate-500" />
-                        <span className="font-medium text-white">
+                    <TableCell className="max-w-[250px]">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Globe className="h-4 w-4 shrink-0 text-slate-500" />
+                        <span className="truncate font-medium text-white">
                           {host.domain}
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell className="text-slate-300">
-                      {host.forward_scheme}://{host.forward_host}:
-                      {host.forward_port}
+                    <TableCell className="max-w-[200px] text-slate-300">
+                      <span className="block truncate">
+                        {host.forward_scheme}://{host.forward_host}:
+                        {host.forward_port}
+                      </span>
                     </TableCell>
                     <TableCell>
                       {host.tls_enabled ? (

--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -617,15 +617,15 @@ function InfoRow({
         {label}
       </span>
       <span
-        className={`flex items-center gap-1 text-sm text-slate-300 ${
+        className={`flex min-w-0 items-center gap-1 text-sm text-slate-300 ${
           mono ? 'font-mono tabular-nums' : ''
         }`}
       >
-        {value}
+        <span className="truncate">{value}</span>
         {onCopy && (
           <button
             onClick={onCopy}
-            className="ml-1 text-slate-600 transition-colors hover:text-slate-400"
+            className="ml-1 shrink-0 text-slate-600 transition-colors hover:text-slate-400"
           >
             {copied ? (
               <Check className="h-3 w-3 text-emerald-400" />

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -436,13 +436,15 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
                       </span>
                     )}
                   </TableCell>
-                  <TableCell className="font-mono text-xs text-slate-400">
-                    {peer.endpoint ?? "—"}
+                  <TableCell className="max-w-[180px] font-mono text-xs text-slate-400">
+                    <span className="block truncate">{peer.endpoint ?? "—"}</span>
                   </TableCell>
-                  <TableCell className="font-mono text-xs text-slate-400">
-                    {peer.allowed_ips.length > 0
-                      ? peer.allowed_ips.join(", ")
-                      : "—"}
+                  <TableCell className="max-w-[200px] font-mono text-xs text-slate-400">
+                    <span className="block truncate">
+                      {peer.allowed_ips.length > 0
+                        ? peer.allowed_ips.join(", ")
+                        : "—"}
+                    </span>
                   </TableCell>
                   <TableCell className="text-slate-400">
                     {timeAgo(peer.last_handshake)}

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -204,13 +204,13 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
       : null;
 
   return (
-    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-pink-500/10">
             <Monitor className="h-4.5 w-4.5 text-pink-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">Version</p>
             <p className="truncate text-sm font-medium text-white">
               {status.version ?? "\u2014"}
@@ -219,12 +219,12 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
         </CardContent>
       </Card>
 
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
             <Clock className="h-4.5 w-4.5 text-emerald-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">Uptime</p>
             <p className="truncate text-sm font-medium text-white">
               {status.uptime ?? "\u2014"}
@@ -233,12 +233,12 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
         </CardContent>
       </Card>
 
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/10">
             <Cpu className="h-4.5 w-4.5 text-amber-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">CPU Load</p>
             <p className="text-sm font-medium text-white">
               {status.cpu_load ? `${status.cpu_load}%` : "\u2014"}
@@ -247,14 +247,14 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
         </CardContent>
       </Card>
 
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
             <MemoryStick className="h-4.5 w-4.5 text-purple-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">Memory</p>
-            <p className="text-sm font-medium text-white">
+            <p className="truncate text-sm font-medium text-white">
               {memUsed
                 ? `${formatMemory(memUsed)} / ${formatMemory(status.total_memory)}`
                 : "\u2014"}
@@ -263,12 +263,12 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
         </CardContent>
       </Card>
 
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-cyan-500/10">
             <HardDrive className="h-4.5 w-4.5 text-cyan-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">Platform</p>
             <p className="truncate text-sm font-medium text-white">
               {status.platform ?? "\u2014"}{" "}
@@ -278,12 +278,12 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
         </CardContent>
       </Card>
 
-      <Card className="col-span-1 border-slate-800 bg-slate-900">
-        <CardContent className="flex h-16 items-center gap-3 py-4">
+      <Card className="border-slate-800 bg-slate-900">
+        <CardContent className="flex min-h-[4rem] items-center gap-3 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
             <Server className="h-4.5 w-4.5 text-blue-400" />
           </div>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-slate-500">Board</p>
             <p className="truncate text-sm font-medium text-white">
               {status.board_name ?? "\u2014"}

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -279,14 +279,14 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                                 : "bg-slate-500"
                             }`}
                           />
-                          <span className="font-mono tabular-nums text-white">
+                          <span className="min-w-0 truncate font-mono tabular-nums text-white">
                             {d.name || d.ip_address || d.mac_address}
                           </span>
                           {d.hostname && (
-                            <span className="text-slate-500">({d.hostname})</span>
+                            <span className="min-w-0 truncate text-slate-500">({d.hostname})</span>
                           )}
                           {d.vendor && (
-                            <span className="ml-auto text-xs text-slate-600">{d.vendor}</span>
+                            <span className="ml-auto shrink-0 truncate text-xs text-slate-600 max-w-[120px]">{d.vendor}</span>
                           )}
                         </button>
                       );
@@ -319,9 +319,9 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                                 : "bg-slate-500"
                             }`}
                           />
-                          <span className="text-white">{a.name || a.id}</span>
+                          <span className="min-w-0 truncate text-white">{a.name || a.id}</span>
                           {a.hostname && (
-                            <span className="text-slate-500">({a.hostname})</span>
+                            <span className="min-w-0 truncate text-slate-500">({a.hostname})</span>
                           )}
                         </button>
                       );
@@ -354,8 +354,8 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                                 : "bg-slate-500"
                             }`}
                           />
-                          <span className="text-white">{st.name}</span>
-                          <span className="text-slate-500 font-mono text-xs">
+                          <span className="min-w-0 truncate text-white">{st.name}</span>
+                          <span className="min-w-0 truncate text-slate-500 font-mono text-xs">
                             {st.username}@{st.host}
                           </span>
                         </button>
@@ -382,10 +382,10 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                           onMouseEnter={() => setActiveIndex(idx)}
                         >
                           <Package className="h-4 w-4 shrink-0 text-slate-400" />
-                          <span className="text-white">{asset.name}</span>
-                          <span className="text-slate-500 text-xs">{asset.asset_type}</span>
+                          <span className="min-w-0 truncate text-white">{asset.name}</span>
+                          <span className="shrink-0 text-slate-500 text-xs">{asset.asset_type}</span>
                           {asset.location && (
-                            <span className="ml-auto text-xs text-slate-600">{asset.location}</span>
+                            <span className="ml-auto shrink-0 truncate text-xs text-slate-600 max-w-[120px]">{asset.location}</span>
                           )}
                         </button>
                       );
@@ -494,7 +494,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                           {timeAgo(alert.created_at)}
                         </span>
                       </div>
-                      <span className="text-sm text-slate-300 truncate">
+                      <span className="block text-sm text-slate-300 truncate">
                         {alert.message}
                       </span>
                     </button>

--- a/web/tests/e2e/layout-grid.spec.ts
+++ b/web/tests/e2e/layout-grid.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, login } from '../../e2e/fixtures';
+
+test.describe('Layout & Grid — no overflow or clipping (#524)', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('dashboard cards do not overflow viewport at 1280px', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // Wait for stat cards to resolve
+    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
+
+    // No horizontal scrollbar — body should not be wider than viewport
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1); // +1 for sub-pixel rounding
+
+    await page.screenshot({ path: 'tests/screenshots/layout-dashboard-1280.png', fullPage: true });
+  });
+
+  test('dashboard cards do not overflow at 768px tablet width', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+
+    await page.screenshot({ path: 'tests/screenshots/layout-dashboard-768.png', fullPage: true });
+  });
+
+  test('device breakdown labels are not clipped', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByText('Device Breakdown')).toBeVisible({ timeout: 10000 });
+
+    // Wait for device breakdown section to populate (or show "No devices found")
+    const breakdownSection = page.getByText('Device Breakdown').locator('xpath=ancestor::div[contains(@class,"border-slate-800")]').first();
+    await expect(breakdownSection).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: 'tests/screenshots/layout-device-breakdown.png', fullPage: true });
+  });
+
+  test('stat card values use truncate to prevent overflow', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
+
+    // Verify that the stat card value elements have truncate class
+    // This is a structural check — the "truncate" class on value <p> elements
+    // ensures long text won't break the card layout.
+    const statValues = page.locator('.tabular-nums.truncate');
+    const count = await statValues.count();
+    // At least one stat card value should have the truncate class
+    expect(count).toBeGreaterThan(0);
+
+    await page.screenshot({ path: 'tests/screenshots/layout-stat-card-truncate.png', fullPage: true });
+  });
+
+  test('devices page grid cards do not overflow at 1024px', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto('/devices');
+    await expect(page.getByRole('heading', { name: 'Devices', level: 1 })).toBeVisible();
+
+    // Wait for either device cards or empty state
+    await page.waitForTimeout(3000);
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+
+    await page.screenshot({ path: 'tests/screenshots/layout-devices-1024.png', fullPage: true });
+  });
+
+  test('services page table cells handle long domains', async ({ page }) => {
+    await page.goto('/services');
+    await expect(page.getByRole('heading', { name: 'Services', level: 1 })).toBeVisible();
+
+    // Verify the table container has overflow handling
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+
+    await page.screenshot({ path: 'tests/screenshots/layout-services.png', fullPage: true });
+  });
+
+  test('TopBar search dropdown truncates long results', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // The search input should be present in the top bar
+    const searchInput = page.locator('input[placeholder*="Search"]');
+    await expect(searchInput).toBeVisible();
+
+    await page.screenshot({ path: 'tests/screenshots/layout-topbar.png' });
+  });
+
+  test('no horizontal scroll on any major page at 1280px', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    const pages = ['/dashboard', '/devices', '/services'];
+
+    for (const url of pages) {
+      await page.goto(url);
+      await page.waitForTimeout(2000);
+
+      const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+      const viewportWidth = await page.evaluate(() => window.innerWidth);
+      expect(bodyWidth, `Page ${url} overflows horizontally`).toBeLessThanOrEqual(viewportWidth + 1);
+    }
+
+    await page.screenshot({ path: 'tests/screenshots/layout-no-scroll.png', fullPage: true });
+  });
+});


### PR DESCRIPTION
Closes #524

## Summary

- **Dashboard**: Widen device breakdown labels (`w-16` → `w-24` + `truncate`), add `truncate` to stat card values/subtitles, tighten grid gaps
- **TopBar**: Add `min-w-0 truncate` to all search result text spans (device name, hostname, vendor, agent, SSH targets, assets); add `max-w` + `shrink-0` on vendor/location tags
- **Devices**: Add `truncate` to device card IP/MAC text; add `max-w-[200px]` + `truncate` to hostname column in table view
- **Services**: Add `max-w` + `truncate` to domain and upstream columns in services table
- **MikroTik Router**: Replace fixed `h-16` with `min-h-[4rem]` on system stat cards; add `flex-1` to text containers so long values don't clip
- **Cloudflare Tunnel**: Add `max-w` + `block truncate` to hostname and service columns in routes table
- **VPN Status**: Add `max-w` + `block truncate` to endpoint and allowed IPs columns in peer table
- **Topology**: Add `min-w-0` + `truncate` to InfoRow value spans and copy button `shrink-0`
- **Mesh**: Add `min-w-0 truncate` to InfoRow value spans in node detail panel

## Design decisions

- Used `truncate` (single-line overflow with ellipsis) as the standard pattern for all constrained text — consistent with existing patterns in the codebase
- Used `min-w-0` on flex children containing truncated text to allow flex items to shrink below their content size (required for `truncate` to work in flex contexts)
- Used `max-w-[Npx]` on table cells to cap column widths for long URLs, domains, and IP lists
- Replaced fixed `h-16` with `min-h-[4rem]` to prevent clipping while maintaining visual consistency

## Smoke Test

- `bun run build` passes with no errors
- `cargo check` passes
- All 49 pages compile successfully
- No bundle size regression (changes are class name additions only)

## Test plan

- [ ] Dashboard: stat cards don't overflow at 1280px and 768px
- [ ] Dashboard: device breakdown labels visible without clipping
- [ ] Devices: grid cards don't overflow at 1024px  
- [ ] Services: table cells truncate long domains
- [ ] TopBar: search results truncate long names/vendors
- [ ] MikroTik: system stat cards don't clip long values
- [ ] No horizontal scrollbar on any major page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR systematically fixes layout and grid overflow issues across the UI by applying consistent Tailwind CSS utility patterns.

**Key changes:**
- Applied `truncate` class to prevent text overflow with ellipsis across stat cards, device info, table cells, and search results
- Used `min-w-0` on flex containers to enable proper text truncation in flexbox contexts
- Applied `max-w-[Npx]` constraints to table columns for long URLs, domains, and IP lists
- Replaced fixed `h-16` with `min-h-[4rem]` on MikroTik stat cards to prevent value clipping
- Added comprehensive E2E tests covering multiple viewports (768px, 1024px, 1280px) and pages

**Impact:**
- All changes are purely CSS utility class additions/modifications
- No logic changes, no security implications
- Follows existing codebase patterns and Tailwind conventions
- Build and tests pass successfully

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are CSS-only modifications using Tailwind utility classes with no logic, security, or breaking changes. The approach is consistent, well-documented, and includes comprehensive E2E test coverage. Build passes successfully.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dashboard/page.tsx | Added `truncate` to stat card values/subtitles, widened device breakdown labels, tightened grid gaps — clean CSS changes |
| web/src/components/layout/TopBar.tsx | Added `min-w-0 truncate` to search result text spans, applied `max-w` + `shrink-0` to vendor/location tags — consistent overflow handling |
| web/src/app/(app)/devices/page.tsx | Added `truncate` to device card IP/MAC text, constrained hostname column width in table — prevents text overflow |
| web/src/components/MikrotikRouter.tsx | Replaced fixed `h-16` with `min-h-[4rem]`, added `flex-1` to text containers — prevents value clipping while maintaining visual consistency |
| web/tests/e2e/layout-grid.spec.ts | New comprehensive test suite for layout overflow — covers multiple viewports and pages (note: hardcoded timeouts already flagged) |

</details>



<sub>Last reviewed commit: 6664cfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->