### PR TITLE
feat: Infrastructure Health card — show which critical devices are counted (#528)

### DIFF
--- a/server/src/api/dashboard.rs
+++ b/server/src/api/dashboard.rs
@@ -101,45 +101,6 @@ async fn active_router(state: &AppState) -> (&'static str, Option<bool>) {
 /// by a slow or offline router.  DB queries and router connectivity check
 /// run in parallel via `tokio::join!`.
 pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
-    // SQL condition for auto-detected infrastructure devices (when is_critical IS NULL).
-    // Matches routers, switches, APs, servers, NAS by device_type or vendor/hostname patterns.
-    const AUTO_INFRA_CONDITION: &str = r#"
-        (is_critical = 1)
-        OR (
-            is_critical IS NULL
-            AND (
-                -- By device_type (from enrichment or custom_type)
-                COALESCE(custom_type, device_type) IN ('router', 'switch', 'access_point', 'server', 'nas', 'ups', 'workstation')
-                -- By vendor pattern (infrastructure vendors)
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*synology*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*qnap*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*supermicro*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*ubiquiti*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*unifi*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*mikrotik*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*cisco*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*juniper*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*aruba*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*fortinet*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*truenas*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*freenas*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*ixsystems*'
-                OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*asustor*'
-                -- By hostname pattern (common infra names)
-                OR LOWER(COALESCE(hostname, '')) GLOB '*server*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*nas*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*proxmox*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*pve*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*truenas*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*docker*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*router*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*gateway*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*switch*'
-                OR LOWER(COALESCE(hostname, '')) GLOB '*firewall*'
-            )
-        )
-    "#;
-
     // Phase 1: run DB counts and the router check concurrently.
     let (
         devices_online,
@@ -228,6 +189,122 @@ pub async fn stats(State(state): State<AppState>) -> Json<DashboardStats> {
         critical_online,
         critical_total,
     })
+}
+
+/// A single critical device returned by the critical-devices endpoint.
+#[derive(Serialize)]
+pub struct CriticalDevice {
+    pub id: String,
+    pub name: Option<String>,
+    pub hostname: Option<String>,
+    pub ip: Option<String>,
+    pub vendor: Option<String>,
+    pub device_type: Option<String>,
+    pub is_online: bool,
+    pub last_seen_at: Option<String>,
+    /// How the device was classified: "pinned" or "auto".
+    pub classification: String,
+}
+
+/// SQL condition for auto-detected infrastructure devices (when is_critical IS NULL).
+const AUTO_INFRA_CONDITION: &str = r#"
+    (is_critical = 1)
+    OR (
+        is_critical IS NULL
+        AND (
+            COALESCE(custom_type, device_type) IN ('router', 'switch', 'access_point', 'server', 'nas', 'ups', 'workstation')
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*synology*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*qnap*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*supermicro*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*ubiquiti*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*unifi*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*mikrotik*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*cisco*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*juniper*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*aruba*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*fortinet*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*truenas*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*freenas*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*ixsystems*'
+            OR LOWER(COALESCE(custom_vendor, vendor, '')) GLOB '*asustor*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*server*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*nas*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*proxmox*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*pve*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*truenas*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*docker*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*router*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*gateway*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*switch*'
+            OR LOWER(COALESCE(hostname, '')) GLOB '*firewall*'
+        )
+    )
+"#;
+
+/// GET /api/v1/dashboard/critical-devices
+///
+/// Returns the list of devices that make up the Infrastructure Health metric.
+pub async fn critical_devices(State(state): State<AppState>) -> Json<Vec<CriticalDevice>> {
+    let q = format!(
+        "SELECT d.id, d.name, d.hostname, di.ip,
+                COALESCE(d.custom_vendor, d.vendor) as vendor,
+                COALESCE(d.custom_type, d.device_type) as device_type,
+                d.is_online, d.last_seen_at, d.is_critical
+         FROM devices d
+         LEFT JOIN device_ips di ON di.device_id = d.id AND di.is_current = 1
+         WHERE ({AUTO_INFRA_CONDITION})
+         ORDER BY d.is_online DESC, COALESCE(d.name, d.hostname, '') ASC"
+    );
+
+    #[allow(clippy::type_complexity)]
+    let rows: Vec<(
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        bool,
+        Option<String>,
+        Option<i32>,
+    )> = sqlx::query_as(&q)
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    Json(
+        rows.into_iter()
+            .map(
+                |(
+                    id,
+                    name,
+                    hostname,
+                    ip,
+                    vendor,
+                    device_type,
+                    is_online,
+                    last_seen_at,
+                    is_critical,
+                )| {
+                    CriticalDevice {
+                        id,
+                        name,
+                        hostname,
+                        ip,
+                        vendor,
+                        device_type,
+                        is_online,
+                        last_seen_at,
+                        classification: if is_critical == Some(1) {
+                            "pinned".to_string()
+                        } else {
+                            "auto".to_string()
+                        },
+                    }
+                },
+            )
+            .collect(),
+    )
 }
 
 /// GET /api/v1/dashboard/top-devices?limit=5

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -161,6 +161,10 @@ pub fn router(state: AppState) -> Router {
         .route("/agents/bulk-delete", post(agents::bulk_delete))
         // Dashboard
         .route("/dashboard/stats", get(dashboard::stats))
+        .route(
+            "/dashboard/critical-devices",
+            get(dashboard::critical_devices),
+        )
         .route("/dashboard/top-devices", get(dashboard::top_devices))
         // Alerts
         .route("/alerts", get(alerts::list))

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -5,7 +5,9 @@ import {
   Activity,
   AlertTriangle,
   ArrowRight,
+  ExternalLink,
   MonitorSmartphone,
+  Pin,
   Router,
   WifiOff,
 } from "lucide-react";
@@ -18,12 +20,20 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
   fetchDashboardStats,
   fetchRecentAlerts,
   fetchTrafficHistory,
   fetchDevices,
+  fetchCriticalDevices,
 } from "@/lib/api";
-import type { Alert, DashboardStats, TrafficHistoryPoint, Device } from "@/lib/types";
+import type { Alert, CriticalDevice, DashboardStats, TrafficHistoryPoint, Device } from "@/lib/types";
 import { formatBps, timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
@@ -54,6 +64,107 @@ function severityDotColor(severity: Alert["severity"]): string {
     default:
       return "bg-blue-500";
   }
+}
+
+// ─── Critical Devices Dialog ──────────────────────────
+
+function CriticalDevicesDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [devices, setDevices] = useState<CriticalDevice[] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setDevices(null);
+    setError(false);
+    fetchCriticalDevices()
+      .then(setDevices)
+      .catch(() => setError(true));
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="border-slate-700 bg-slate-900 text-white sm:max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="text-white">Critical Devices</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Devices included in the Infrastructure Health metric.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="overflow-y-auto -mx-6 px-6">
+          {error ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-rose-400">
+              <WifiOff className="h-4 w-4 shrink-0" />
+              <span>Failed to load critical devices</span>
+            </div>
+          ) : devices === null ? (
+            <div className="space-y-3 py-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : devices.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-500">
+              No critical devices found.
+            </p>
+          ) : (
+            <div className="space-y-1 py-2">
+              {devices.map((dev) => (
+                <Link
+                  key={dev.id}
+                  href={`/devices?id=${dev.id}`}
+                  className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-slate-800 transition-colors group"
+                  onClick={() => onOpenChange(false)}
+                >
+                  <span
+                    className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+                      dev.is_online
+                        ? "bg-emerald-400 ring-2 ring-emerald-400/30"
+                        : "bg-rose-400 ring-2 ring-rose-400/30"
+                    }`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="truncate text-sm font-medium text-slate-200">
+                        {dev.name || dev.hostname || dev.ip || "Unknown"}
+                      </span>
+                      {dev.classification === "pinned" && (
+                        <Pin className="h-3 w-3 shrink-0 text-amber-400" />
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-slate-500">
+                      {dev.device_type && (
+                        <span className="capitalize">{dev.device_type.replace(/_/g, " ")}</span>
+                      )}
+                      {dev.ip && <span>{dev.ip}</span>}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <span
+                      className={`text-xs font-medium ${
+                        dev.is_online ? "text-emerald-400" : "text-rose-400"
+                      }`}
+                    >
+                      {dev.is_online ? "Online" : "Offline"}
+                    </span>
+                    {dev.last_seen_at && (
+                      <p className="text-xs text-slate-600">{timeAgo(dev.last_seen_at)}</p>
+                    )}
+                  </div>
+                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-slate-600 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 // ─── Health Ring SVG ───────────────────────────────────
@@ -266,6 +377,7 @@ export default function DashboardPage() {
 
   const [devices, setDevices] = useState<Device[] | null>(null);
   const [devicesError, setDevicesError] = useState(false);
+  const [criticalDialogOpen, setCriticalDialogOpen] = useState(false);
 
   // ── Independent loaders — each resolves on its own ────
 
@@ -371,7 +483,11 @@ export default function DashboardPage() {
       {/* ── Bento Grid ─────────────────────────────────── */}
       <StaggerContainer className="grid grid-cols-1 gap-4 lg:grid-cols-5 items-stretch">
         {/* ── Health Score Ring ─────────────────────────── */}
-        <StaggerItem className="h-full"><Card className="h-full border-slate-800 bg-slate-900 lg:col-span-1">
+        <StaggerItem className="h-full"><Card
+          className="h-full border-slate-800 bg-slate-900 lg:col-span-1 cursor-pointer transition-all hover:border-blue-500/50 hover:bg-slate-800/60 hover:shadow-lg hover:shadow-blue-500/5"
+          onClick={() => stats && stats.critical_total > 0 && setCriticalDialogOpen(true)}
+          data-testid="infra-health-card"
+        >
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-slate-400">
               Infrastructure Health
@@ -381,12 +497,25 @@ export default function DashboardPage() {
             {statsError ? (
               <SectionError message="Failed to load" />
             ) : stats ? (
-              <HealthRing online={stats.critical_online} total={stats.critical_total} />
+              <>
+                <HealthRing online={stats.critical_online} total={stats.critical_total} />
+              </>
             ) : (
               <Skeleton className="aspect-square w-full max-w-[7rem] rounded-full" />
             )}
           </CardContent>
+          {stats && stats.critical_total > 0 && (
+            <div className="px-6 pb-3 -mt-2">
+              <p className="text-center text-[10px] text-slate-600">
+                Click for details
+              </p>
+            </div>
+          )}
         </Card></StaggerItem>
+        <CriticalDevicesDialog
+          open={criticalDialogOpen}
+          onOpenChange={setCriticalDialogOpen}
+        />
 
         {/* ── Stat Cards Row ───────────────────────────── */}
         <StaggerItem className="h-full lg:col-span-4"><div className="grid h-full grid-cols-2 gap-4 lg:grid-cols-4">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -184,6 +184,12 @@ export function fetchRecentAlerts(limit = 5): Promise<Alert[]> {
   });
 }
 
+export function fetchCriticalDevices(): Promise<import("./types").CriticalDevice[]> {
+  return apiGet<import("./types").CriticalDevice[]>("/api/v1/dashboard/critical-devices", {
+    timeoutMs: DASHBOARD_TIMEOUT_MS,
+  });
+}
+
 export function fetchTopDevices(limit = 5): Promise<TopDevice[]> {
   return apiGet<TopDevice[]>(`/api/v1/dashboard/top-devices?limit=${limit}`, {
     timeoutMs: DASHBOARD_TIMEOUT_MS,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -179,6 +179,20 @@ export interface DashboardStats {
   critical_total: number;
 }
 
+/** A single critical device returned by /api/v1/dashboard/critical-devices. */
+export interface CriticalDevice {
+  id: string;
+  name: string | null;
+  hostname: string | null;
+  ip: string | null;
+  vendor: string | null;
+  device_type: string | null;
+  is_online: boolean;
+  last_seen_at: string | null;
+  /** "pinned" or "auto" */
+  classification: string;
+}
+
 export interface TopDevice {
   id: string;
   name: string | null;

--- a/web/tests/e2e/critical-devices-dialog.spec.ts
+++ b/web/tests/e2e/critical-devices-dialog.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, login } from '../../e2e/fixtures';
+
+test.describe('Critical Devices Dialog (#528)', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('critical-devices API returns list with expected fields', async ({ page }) => {
+    // Create a test device that will be auto-detected as critical
+    const createResp = await page.request.post('/api/v1/devices', {
+      data: {
+        mac: 'CC:DD:EE:FF:00:28',
+        is_manual: true,
+        custom_name: 'Critical Dialog Test Server',
+        custom_type: 'server',
+      },
+    });
+    expect(createResp.ok()).toBeTruthy();
+
+    // Fetch critical devices list
+    const response = await page.request.get('/api/v1/dashboard/critical-devices');
+    expect(response.ok()).toBeTruthy();
+    const devices = await response.json();
+
+    expect(Array.isArray(devices)).toBeTruthy();
+    expect(devices.length).toBeGreaterThanOrEqual(1);
+
+    // Verify structure of the first device
+    const dev = devices[0];
+    expect(dev).toHaveProperty('id');
+    expect(dev).toHaveProperty('is_online');
+    expect(dev).toHaveProperty('classification');
+    expect(['pinned', 'auto']).toContain(dev.classification);
+
+    await page.screenshot({ path: 'tests/screenshots/critical-devices-api.png' });
+  });
+
+  test('clicking Infrastructure Health card opens critical devices dialog', async ({ page }) => {
+    // Create a test device that qualifies as critical
+    await page.request.post('/api/v1/devices', {
+      data: {
+        mac: 'CC:DD:EE:FF:01:28',
+        is_manual: true,
+        custom_name: 'Dialog Click Test NAS',
+        custom_type: 'nas',
+      },
+    });
+
+    // Navigate to dashboard
+    await page.goto('/dashboard');
+    await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 10000 });
+
+    // Wait for stats to load (health ring should show a percentage or N/A)
+    await expect(page.getByText(/\d+%|No critical devices|N\/A/).first()).toBeVisible({ timeout: 10000 });
+
+    // Click the health card
+    const healthCard = page.locator('[data-testid="infra-health-card"]');
+    await expect(healthCard).toBeVisible();
+    await healthCard.click();
+
+    // Dialog should appear with "Critical Devices" title
+    await expect(page.getByRole('heading', { name: 'Critical Devices' })).toBeVisible({ timeout: 5000 });
+
+    // Should show at least our test device
+    await expect(page.getByText('Dialog Click Test NAS')).toBeVisible({ timeout: 5000 });
+
+    // Each device should show online/offline status
+    await expect(page.getByText(/Online|Offline/).first()).toBeVisible();
+
+    await page.screenshot({ path: 'tests/screenshots/critical-devices-dialog.png' });
+  });
+
+  test('dialog shows device classification (pinned vs auto)', async ({ page }) => {
+    // Create a device and pin it as critical
+    const createResp = await page.request.post('/api/v1/devices', {
+      data: {
+        mac: 'CC:DD:EE:FF:02:28',
+        is_manual: true,
+        custom_name: 'Pinned Critical Device',
+        custom_type: 'phone', // Not auto-infra type
+      },
+    });
+    const created = await createResp.json();
+
+    // Pin as critical
+    await page.request.patch(`/api/v1/devices/${created.id}`, {
+      data: { is_critical: true },
+    });
+
+    // Fetch critical devices and verify classification
+    const response = await page.request.get('/api/v1/dashboard/critical-devices');
+    const devices = await response.json();
+
+    const pinned = devices.find((d: { id: string }) => d.id === created.id);
+    expect(pinned).toBeDefined();
+    expect(pinned.classification).toBe('pinned');
+
+    // Navigate to dashboard and open dialog
+    await page.goto('/dashboard');
+    await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(2000); // Wait for stats to load
+
+    const healthCard = page.locator('[data-testid="infra-health-card"]');
+    await healthCard.click();
+
+    await expect(page.getByRole('heading', { name: 'Critical Devices' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Pinned Critical Device')).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({ path: 'tests/screenshots/critical-devices-pinned.png' });
+  });
+
+  test('dialog can be closed', async ({ page }) => {
+    // Ensure there's at least one critical device
+    await page.request.post('/api/v1/devices', {
+      data: {
+        mac: 'CC:DD:EE:FF:03:28',
+        is_manual: true,
+        custom_name: 'Close Dialog Test Router',
+        custom_type: 'router',
+      },
+    });
+
+    await page.goto('/dashboard');
+    await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Open dialog
+    const healthCard = page.locator('[data-testid="infra-health-card"]');
+    await healthCard.click();
+    await expect(page.getByRole('heading', { name: 'Critical Devices' })).toBeVisible({ timeout: 5000 });
+
+    // Close via the X button
+    await page.locator('button:has(.sr-only:text("Close"))').click();
+
+    // Dialog should be gone
+    await expect(page.getByRole('heading', { name: 'Critical Devices' })).not.toBeVisible({ timeout: 3000 });
+
+    await page.screenshot({ path: 'tests/screenshots/critical-devices-dialog-closed.png' });
+  });
+});


### PR DESCRIPTION
Closes #528

## Summary
- Added `GET /api/v1/dashboard/critical-devices` endpoint that returns the full list of devices included in the Infrastructure Health metric, with name, status, device type, IP, last seen time, and classification (pinned vs auto-detected)
- Made the Infrastructure Health card on the dashboard clickable — clicking it opens a dialog listing all critical devices
- Each device row shows online/offline status indicator, device name, type, IP, last seen time, and a pin icon for manually pinned devices
- Device names are clickable links to the device detail page

## Implementation Details
- Extracted the `AUTO_INFRA_CONDITION` SQL constant to module level so it's shared between the `stats` and `critical_devices` handlers (DRY)
- The dialog uses shadcn/ui `Dialog` component, consistent with the project's UI conventions
- Loading state uses skeleton components (not spinners), per project conventions
- Dialog fetches data on open, not on dashboard load, to avoid unnecessary API calls

## Smoke Test
- `cargo check` passes with no errors
- `cargo fmt --all` applied
- `bun run build` passes with no errors
- New API endpoint returns correct structure with `id`, `name`, `hostname`, `ip`, `vendor`, `device_type`, `is_online`, `last_seen_at`, `classification` fields

## E2E Tests
- `critical-devices API returns list with expected fields` — verifies the new endpoint
- `clicking Infrastructure Health card opens critical devices dialog` — verifies card click opens modal with device list
- `dialog shows device classification (pinned vs auto)` — verifies pinned devices get `classification: "pinned"`
- `dialog can be closed` — verifies the close button works

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a new `/api/v1/dashboard/critical-devices` endpoint that returns devices included in the Infrastructure Health metric, with classification ("pinned" vs "auto"). Made the Infrastructure Health card clickable to open a dialog showing all critical devices with their status, type, IP, and last seen time.

**Implementation highlights:**
- Properly extracted `AUTO_INFRA_CONDITION` to module level for DRY
- Dialog fetches data on-demand (only when opened) to avoid unnecessary API calls
- Uses skeleton components for loading states, consistent with project conventions
- Includes comprehensive E2E tests covering API structure, dialog interactions, and device classification

**Minor style improvements suggested:**
- Dialog component placement should follow the pattern used elsewhere (move outside grid container)
- E2E tests use `waitForTimeout` in two places where proper UI state waits would be better

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style improvements recommended
- Well-implemented feature with proper error handling, performance optimization, and comprehensive E2E tests. Only minor style issues around dialog placement and test timeouts that don't affect functionality.
- web/src/app/(app)/dashboard/page.tsx — consider moving dialog outside grid container for consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/dashboard.rs | Extracted AUTO_INFRA_CONDITION to module level, added critical_devices endpoint with proper error handling |
| web/src/app/(app)/dashboard/page.tsx | Added CriticalDevicesDialog component with click handler, uses skeleton loading states; dialog placement could be improved |
| web/tests/e2e/critical-devices-dialog.spec.ts | Comprehensive E2E tests covering API, UI interactions, and classification; uses waitForTimeout anti-pattern in places |

</details>



<sub>Last reviewed commit: b17348c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->