### PR TITLE
fix: app-wide layout regressions follow-up (#536)

### DIFF
--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -263,7 +263,7 @@ export default function AgentsPage() {
                             </button>
                           </span>
                           {agent.cpu_name && (
-                            <span className="text-xs text-slate-500 font-normal truncate max-w-[200px]" title={agent.cpu_name}>
+                            <span className="w-full min-w-0 truncate text-xs font-normal text-slate-500" title={agent.cpu_name}>
                               {agent.cpu_name}
                             </span>
                           )}

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -474,18 +474,19 @@ export default function AlertsPage() {
                     )}
                   </div>
                   <p
-                    className={`mt-0.5 text-sm ${
+                    className={`mt-0.5 line-clamp-2 text-sm ${
                       alert.acknowledged_at
                         ? "text-slate-500"
                         : !alert.is_read
                           ? "text-gray-200"
                           : "text-slate-400"
                     }`}
+                    title={alert.message}
                   >
                     {alert.message}
                   </p>
                   {alert.acknowledged_by && (
-                    <p className="mt-0.5 text-xs text-slate-600 italic">
+                    <p className="mt-0.5 truncate text-xs italic text-slate-600" title={alert.acknowledged_by}>
                       Note: {alert.acknowledged_by}
                     </p>
                   )}

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -663,11 +663,7 @@ function DeviceCard({
   const displayName = device.custom_name ?? device.hostname ?? device.name ?? device.vendor ?? device.mac;
   const effectiveType = device.custom_type ?? device.device_type;
   const { icon: DevIcon } = getDeviceIcon(device.custom_vendor ?? device.vendor, device.hostname, device.mdns_services, effectiveType);
-  const vendorDisplay = (device.custom_vendor ?? device.vendor)
-    ? (device.custom_vendor ?? device.vendor)!.length > 20
-      ? (device.custom_vendor ?? device.vendor)!.slice(0, 20) + "…"
-      : (device.custom_vendor ?? device.vendor)
-    : null;
+  const vendorDisplay = device.custom_vendor ?? device.vendor ?? null;
 
   const canWake = !device.is_online && device.mac && !device.is_randomized_mac;
 
@@ -706,7 +702,7 @@ function DeviceCard({
           </div>
 
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <span
                 className={`h-2 w-2 shrink-0 rounded-full ${
                   device.is_online
@@ -714,23 +710,23 @@ function DeviceCard({
                     : "bg-slate-500"
                 }`}
               />
-              <span className="truncate font-medium text-white">{displayName}</span>
+              <span className="min-w-0 flex-1 truncate font-medium text-white">{displayName}</span>
               {device.is_critical && (
                 <Pin className="h-3 w-3 shrink-0 text-amber-400" />
               )}
               {device.agent?.is_online && (
-                <span className="ml-auto shrink-0 rounded border border-blue-500/30 bg-blue-500/20 px-1.5 py-0.5 text-xs text-blue-400">
+                <span className="shrink-0 rounded border border-blue-500/30 bg-blue-500/20 px-1.5 py-0.5 text-xs text-blue-400">
                   Agent
                 </span>
               )}
               {!device.is_known && (
-                <Badge variant="outline" className="ml-auto shrink-0 border-amber-500/50 text-amber-400 text-[10px]">
+                <Badge variant="outline" className="shrink-0 border-amber-500/50 text-amber-400 text-[10px]">
                   NEW
                 </Badge>
               )}
             </div>
             {vendorDisplay && (
-              <p className="mt-0.5 text-xs text-slate-400">{vendorDisplay}</p>
+              <p className="mt-0.5 truncate text-xs text-slate-400" title={vendorDisplay}>{vendorDisplay}</p>
             )}
           </div>
         </div>
@@ -909,11 +905,7 @@ function DevicesTable({
           {devices.map((device, index) => {
             const primaryIp = (device.ips ?? [])[0] ?? "—";
             const { icon: RowIcon } = getDeviceIcon(device.vendor, device.hostname, device.mdns_services, device.device_type);
-            const vendorDisplay = device.vendor
-              ? device.vendor.length > 20
-                ? device.vendor.slice(0, 20) + "…"
-                : device.vendor
-              : "—";
+            const vendorDisplay = device.vendor ?? "—";
             const canWake = !device.is_online && device.mac && !device.is_randomized_mac;
 
             return (
@@ -969,8 +961,8 @@ function DevicesTable({
                 <TableCell className="tabular-nums font-mono text-xs text-slate-500">
                   {device.mac}
                 </TableCell>
-                <TableCell className="text-xs text-slate-400">
-                  {vendorDisplay}
+                <TableCell className="max-w-[160px] text-xs text-slate-400">
+                  <span className="block truncate" title={vendorDisplay}>{vendorDisplay}</span>
                 </TableCell>
                 <TableCell className="text-xs text-slate-400">
                   {device.agent && device.agent.cpu_percent != null && device.agent.memory_percent != null
@@ -1066,11 +1058,7 @@ function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => vo
     device.mdns_services,
     effectiveType
   );
-  const vendorDisplay = (device.custom_vendor ?? device.vendor)
-    ? (device.custom_vendor ?? device.vendor)!.length > 20
-      ? (device.custom_vendor ?? device.vendor)!.slice(0, 20) + "…"
-      : (device.custom_vendor ?? device.vendor)
-    : null;
+  const vendorDisplay = device.custom_vendor ?? device.vendor ?? null;
 
   const handleWake = async () => {
     setWaking(true);
@@ -1111,14 +1099,14 @@ function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => vo
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               {device.custom_name && device.hostname && (
-                <span className="text-xs text-slate-500">{device.hostname}</span>
+                <span className="truncate text-xs text-slate-500" title={device.hostname}>{device.hostname}</span>
               )}
               {vendorDisplay && (
-                <span className="text-xs text-slate-400">{vendorDisplay}</span>
+                <span className="truncate text-xs text-slate-400" title={vendorDisplay}>{vendorDisplay}</span>
               )}
-              <span className="text-xs text-slate-500">{deviceTypeLabel}</span>
+              <span className="shrink-0 text-xs text-slate-500">{deviceTypeLabel}</span>
             </div>
           </div>
         </div>
@@ -1288,10 +1276,10 @@ function DeviceInfoTab({
         <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">
           MAC Address
         </span>
-        <span className="flex items-center gap-1.5 font-mono tabular-nums text-sm text-slate-300">
-          {device.mac}
+        <span className="flex min-w-0 items-center gap-1.5 font-mono tabular-nums text-sm text-slate-300">
+          <span className="truncate">{device.mac}</span>
           {device.is_randomized_mac && (
-            <span className="rounded bg-amber-500/20 px-1 py-0.5 text-[10px] font-medium text-amber-400">
+            <span className="shrink-0 rounded bg-amber-500/20 px-1 py-0.5 text-[10px] font-medium text-amber-400">
               Random
             </span>
           )}
@@ -1314,8 +1302,8 @@ function DeviceInfoTab({
           {osDisplayString && (
             <div className="flex items-baseline justify-between gap-4">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">OS</span>
-              <span className="flex items-center text-sm text-slate-300">
-                {osDisplayString}
+              <span className="flex min-w-0 items-center gap-1 text-sm text-slate-300">
+                <span className="truncate" title={osDisplayString}>{osDisplayString}</span>
                 {device.custom_os ? <CustomBadge /> : (device.os_family || sysinfo?.os_name) ? <DetectedBadge /> : null}
               </span>
             </div>
@@ -1323,8 +1311,8 @@ function DeviceInfoTab({
           {effectiveType && (
             <div className="flex items-baseline justify-between gap-4">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">Type</span>
-              <span className="flex items-center text-sm text-slate-300">
-                {effectiveType}
+              <span className="flex min-w-0 items-center gap-1 text-sm text-slate-300">
+                <span className="truncate" title={effectiveType}>{effectiveType}</span>
                 {device.custom_type ? <CustomBadge /> : device.device_type ? <DetectedBadge /> : null}
               </span>
             </div>
@@ -1332,8 +1320,8 @@ function DeviceInfoTab({
           {effectiveVendor && (
             <div className="flex items-baseline justify-between gap-4">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">Brand</span>
-              <span className="flex items-center text-sm text-slate-300">
-                {effectiveVendor}
+              <span className="flex min-w-0 items-center gap-1 text-sm text-slate-300">
+                <span className="truncate" title={effectiveVendor}>{effectiveVendor}</span>
                 {device.custom_vendor ? <CustomBadge /> : (device.device_brand || device.vendor) ? <DetectedBadge /> : null}
               </span>
             </div>
@@ -1341,8 +1329,8 @@ function DeviceInfoTab({
           {effectiveModel && (
             <div className="flex items-baseline justify-between gap-4">
               <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-slate-500">Model</span>
-              <span className="flex items-center text-sm text-slate-300">
-                {effectiveModel}
+              <span className="flex min-w-0 items-center gap-1 text-sm text-slate-300">
+                <span className="truncate" title={effectiveModel}>{effectiveModel}</span>
                 {device.custom_model ? <CustomBadge /> : device.device_model ? <DetectedBadge /> : null}
               </span>
             </div>
@@ -2810,7 +2798,8 @@ function InfoRow({
         {label}
       </span>
       <span
-        className={`text-sm text-slate-300 ${mono ? "font-mono tabular-nums" : ""}`}
+        className={`min-w-0 truncate text-right text-sm text-slate-300 ${mono ? "font-mono tabular-nums" : ""}`}
+        title={value}
       >
         {value}
       </span>


### PR DESCRIPTION
## Summary

Closes #536

Follow-up to #524 — addresses remaining layout regressions not caught in the initial pass, app-wide where shared card/grid patterns are used.

**Scope:** devices page (card + table + drawer), agents page, alerts page.
**Drawer/Save visibility:** untouched (scoped out per issue comments).

---

## Before / After

### `InfoRow` in device drawer
**Before:** Value `span` had no `min-w-0` or `truncate` — long values (vendor names, hostnames, locations, model strings) would silently overflow the drawer width.

**After:** `min-w-0 truncate text-right` + `title` tooltip added, matching the already-fixed `mesh/page.tsx` and `topology/page.tsx` patterns.

### `DeviceCard` name row
**Before:** `span.truncate` sat inside `div.flex.gap-2` (no `min-w-0`) — truncation silently failed whenever Agent/NEW badges were present alongside a long device name.

**After:** Added `min-w-0` to the flex row and `min-w-0 flex-1` to the name span. Also removed duplicate `ml-auto` that caused both badges to push simultaneously (layout conflict when `is_online=true` + `is_known=false`).

### Vendor display (JS truncation → CSS)
**Before:** Three separate JS `slice(0, 20) + "…"` calls in `DeviceCard`, `DevicesTable`, and `DeviceDetail` replaced text content at a hardcoded 20-char limit regardless of available space.

**After:** Raw vendor string passed through; CSS `truncate` + `title` tooltip handles clipping adaptively at actual container width.

### DeviceDetail identity rows (OS / Type / Brand / Model)
**Before:** Inline `flex items-center` value spans had no `min-w-0` — long OS strings or model names could overflow the drawer.

**After:** Value container is `flex min-w-0 items-center gap-1` with inner `truncate` span; badge siblings stay `shrink-0`.

### Alerts card rhythm
**Before:** Alert messages of arbitrary length caused variable card heights, breaking vertical grid rhythm.

**After:** `line-clamp-2` on message body with `title` tooltip; acknowledged-by note gains `truncate`.

### Agents page cpu_name
**Before:** `max-w-[200px]` was a hardcoded pixel cap that could clip or under-clip depending on font/zoom.

**After:** `w-full min-w-0 truncate` — clips relative to the actual table cell width.

---

## Files Changed

| File | What changed |
|------|-------------|
| `web/src/app/(app)/devices/page.tsx` | `InfoRow`, `DeviceCard`, `DevicesTable`, `DeviceDetail` header and identity rows, MAC row |
| `web/src/app/(app)/agents/page.tsx` | cpu_name truncation strategy |
| `web/src/app/(app)/alerts/page.tsx` | Alert message line-clamp, acknowledged-by truncation |

Build: ✅ clean (`bun run build`, zero TypeScript errors)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up PR replaces JS-side 20-char vendor slicing with CSS `truncate`+`title` tooltips app-wide, and adds the missing `min-w-0` scaffolding to several flex rows in the devices drawer, device cards, and table — a solid approach that matches the patterns already established in `mesh/page.tsx` and `topology/page.tsx`. The alerts change (`line-clamp-2` + tooltip) and `InfoRow` fix are clean and correct.

Two places where the `min-w-0` scaffolding is incomplete:

- **`agents/page.tsx` — `cpu_name` span:** `w-full min-w-0 truncate` is applied to the span, but the parent `span.flex.flex-col` has no `min-w-0`. Because the column is unconstrained in its flex-row parent, `w-full` resolves to the intrinsic text width and ellipsis never fires. This effectively removes the previous `max-w-[200px]` hard cap without a working CSS replacement.
- **`devices/page.tsx` — `DeviceDetail` header sub-row:** The hostname and `vendorDisplay` spans receive `truncate` but not `min-w-0`. Flex children default to `min-width: auto`; combined with `white-space: nowrap` (from `truncate`), neither span will shrink below its full text width, leaving truncation dead code in that row.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; all changes are presentational with no data or logic impact, and the two incomplete truncation fixes are minor layout regressions rather than functional errors.
- The vast majority of changes are correct and well-structured CSS layout fixes. The two flagged issues (agents cpu_name parent missing min-w-0, DeviceDetail header spans missing min-w-0) are cosmetic layout imprecisions — they won't cause crashes or data loss, but may mean truncation silently doesn't fire in those two spots.
- web/src/app/(app)/agents/page.tsx (cpu_name parent flex-col needs min-w-0) and web/src/app/(app)/devices/page.tsx (DeviceDetail header hostname/vendor spans need min-w-0)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Largest changeset: removes JS 20-char vendor truncation in DeviceCard/DevicesTable/DeviceDetail in favour of CSS truncate+title; adds min-w-0 to flex rows for DeviceCard name, MAC row, and identity rows (OS/Type/Brand/Model); fixes InfoRow value span with min-w-0+truncate+title; DeviceDetail header hostname/vendor spans gain truncate but are missing min-w-0, which may leave truncation ineffective in that row. |
| web/src/app/(app)/agents/page.tsx | Replaces max-w-[200px] on cpu_name span with w-full min-w-0 truncate; however the parent span.flex.flex-col lacks min-w-0, so the flex column is unconstrained and w-full resolves to the intrinsic text width — truncation likely never fires, regressing from the previous hard pixel cap. |
| web/src/app/(app)/alerts/page.tsx | Adds line-clamp-2 + title tooltip to alert message paragraph for consistent card height, and truncate + title to the acknowledged-by note; changes are self-contained and correct. |

</details>



<sub>Last reviewed commit: 4e9ca51</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->