### PR TITLE
fix: GET /api/v1/devices/:id/scan returns 200 with null instead of 404 (#535)

### DIFF
--- a/server/src/api/devices.rs
+++ b/server/src/api/devices.rs
@@ -1154,10 +1154,11 @@ pub async fn trigger_scan(
 }
 
 /// GET /api/v1/devices/:id/scan — get the latest cached port scan result.
+/// Returns `null` (200 OK) when no scan has been performed yet.
 pub async fn get_scan(
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<PortScanResult>, StatusCode> {
+) -> Result<Json<Option<PortScanResult>>, StatusCode> {
     let row = sqlx::query(
         r#"SELECT scanned_at, result_json FROM port_scans WHERE device_id = ? ORDER BY scanned_at DESC LIMIT 1"#,
     )
@@ -1175,13 +1176,13 @@ pub async fn get_scan(
             let result_json: String = row.try_get("result_json").unwrap_or_default();
             let ports: Vec<PortEntry> = serde_json::from_str(&result_json).unwrap_or_default();
 
-            Ok(Json(PortScanResult {
+            Ok(Json(Some(PortScanResult {
                 device_id: id,
                 scanned_at,
                 ports,
-            }))
+            })))
         }
-        None => Err(StatusCode::NOT_FOUND),
+        None => Ok(Json(None)),
     }
 }
 

--- a/web/src/app/(app)/assets/detail/content.tsx
+++ b/web/src/app/(app)/assets/detail/content.tsx
@@ -99,7 +99,7 @@ export default function AssetDetailContent() {
         }
       }
 
-      // Load cached port scan results
+      // Load cached port scan results (null means no scan yet)
       try {
         const scan = await fetchPortScan(id);
         setPortScan(scan);

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -1857,7 +1857,7 @@ function DevicePortsTab({ deviceId }: { deviceId: string }) {
         const result = await fetchPortScan(deviceId);
         if (!cancelled) setScanResult(result);
       } catch {
-        // 404 means no scan yet — that's fine
+        // ignore fetch errors
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -290,8 +290,8 @@ export function triggerPortScan(id: string): Promise<PortScanResult> {
   return apiPost<PortScanResult>(`/api/v1/devices/${id}/scan`);
 }
 
-export function fetchPortScan(id: string): Promise<PortScanResult> {
-  return apiGet<PortScanResult>(`/api/v1/devices/${id}/scan`);
+export function fetchPortScan(id: string): Promise<PortScanResult | null> {
+  return apiGet<PortScanResult | null>(`/api/v1/devices/${id}/scan`);
 }
 
 export interface EnrichmentCorrection {

--- a/web/tests/e2e/device-scan-no-404.spec.ts
+++ b/web/tests/e2e/device-scan-no-404.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, login } from '../../e2e/fixtures';
+
+test.describe('Device scan endpoint — no 404 for unscanned devices', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('GET /devices/:id/scan returns 200 (not 404) when no scan exists', async ({ page }) => {
+    // Collect scan API responses
+    const scanResponses: { url: string; status: number }[] = [];
+    page.on('response', (resp) => {
+      if (resp.url().includes('/api/v1/devices/') && resp.url().endsWith('/scan')) {
+        scanResponses.push({ url: resp.url(), status: resp.status() });
+      }
+    });
+
+    await page.goto('/devices/');
+    await expect(page.getByRole('heading', { name: 'Devices', level: 1 })).toBeVisible({ timeout: 15000 });
+
+    // Wait for devices to load
+    await page.waitForTimeout(3000);
+    const pageText = await page.textContent('body') ?? '';
+    const hasDevices = /\d+\.\d+\.\d+\.\d+/.test(pageText);
+    if (!hasDevices) {
+      test.skip();
+      return;
+    }
+
+    // Open the first device drawer
+    const deviceRow = page.locator('[data-device-row]').first();
+    if (await deviceRow.isVisible()) {
+      await deviceRow.click();
+    } else {
+      const tableRow = page.locator('tr').filter({ hasText: /\d+\.\d+\.\d+\.\d+/ }).first();
+      if (await tableRow.isVisible()) {
+        await tableRow.click();
+      } else {
+        test.skip();
+        return;
+      }
+    }
+
+    // Wait for drawer to open
+    await page.waitForTimeout(1000);
+    const sheetContent = page.locator('[role="dialog"]');
+    await expect(sheetContent).toBeVisible({ timeout: 5000 });
+
+    // Click the Ports tab to trigger the scan fetch
+    const portsTab = page.getByRole('tab', { name: /Ports/i });
+    if (!(await portsTab.isVisible({ timeout: 3000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await portsTab.click();
+    await page.waitForTimeout(2000);
+
+    // Verify no 404 responses were received from scan endpoint
+    for (const resp of scanResponses) {
+      expect(resp.status, `Scan endpoint ${resp.url} should not return 404`).not.toBe(404);
+    }
+
+    // If we got scan responses, they should all be 200
+    if (scanResponses.length > 0) {
+      for (const resp of scanResponses) {
+        expect(resp.status).toBe(200);
+      }
+    }
+
+    await page.screenshot({ path: 'tests/screenshots/device-scan-no-404.png' });
+  });
+
+  test('Ports tab shows "No port scan results yet" for unscanned device', async ({ page }) => {
+    await page.goto('/devices/');
+    await expect(page.getByRole('heading', { name: 'Devices', level: 1 })).toBeVisible({ timeout: 15000 });
+
+    // Wait for devices to load
+    await page.waitForTimeout(3000);
+    const pageText = await page.textContent('body') ?? '';
+    const hasDevices = /\d+\.\d+\.\d+\.\d+/.test(pageText);
+    if (!hasDevices) {
+      test.skip();
+      return;
+    }
+
+    // Open the first device drawer
+    const deviceRow = page.locator('[data-device-row]').first();
+    if (await deviceRow.isVisible()) {
+      await deviceRow.click();
+    } else {
+      const tableRow = page.locator('tr').filter({ hasText: /\d+\.\d+\.\d+\.\d+/ }).first();
+      if (await tableRow.isVisible()) {
+        await tableRow.click();
+      } else {
+        test.skip();
+        return;
+      }
+    }
+
+    // Wait for drawer
+    await page.waitForTimeout(1000);
+    const sheetContent = page.locator('[role="dialog"]');
+    await expect(sheetContent).toBeVisible({ timeout: 5000 });
+
+    // Click Ports tab
+    const portsTab = page.getByRole('tab', { name: /Ports/i });
+    if (!(await portsTab.isVisible({ timeout: 3000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await portsTab.click();
+    await page.waitForTimeout(2000);
+
+    // The Ports tab should either show scan results or "No port scan results yet"
+    // It should NOT show an error state
+    const tabContent = await sheetContent.textContent() ?? '';
+    const hasValidState =
+      tabContent.includes('No port scan results yet') ||
+      tabContent.includes('Scan Ports') ||
+      tabContent.includes('Last scanned') ||
+      tabContent.includes('No open ports found');
+    expect(hasValidState, 'Ports tab should show a valid state (not an error)').toBeTruthy();
+
+    await page.screenshot({ path: 'tests/screenshots/device-scan-ports-tab.png' });
+  });
+});


### PR DESCRIPTION
Closes #535

## Summary

- **Backend**: `GET /api/v1/devices/:id/scan` now returns `200 OK` with `null` body when no scan exists, instead of `404 Not Found`
- **Frontend**: `fetchPortScan()` return type updated to `PortScanResult | null` — both callers already handle `null` gracefully
- **UX**: Device detail Ports tab shows "No port scan results yet. Click Scan Ports to start." without error noise

## Changes

| File | Change |
|------|--------|
| `server/src/api/devices.rs` | `get_scan` returns `Json<Option<PortScanResult>>` — `None` → `Ok(Json(None))` instead of `Err(NOT_FOUND)` |
| `web/src/lib/api.ts` | `fetchPortScan` typed as `Promise<PortScanResult \| null>` |
| `web/src/app/(app)/devices/page.tsx` | Updated catch comment (no longer 404-specific) |
| `web/src/app/(app)/assets/detail/content.tsx` | Updated comment to clarify null semantics |

## Smoke Test

- `cargo check` — passes
- `cargo test` — all 18 tests pass
- `bun run build` — frontend builds cleanly
- Backend change is minimal: the `None` case in `match row` now returns `Ok(Json(None))` serialized as JSON `null` with HTTP 200

## E2E Test

- `web/tests/e2e/device-scan-no-404.spec.ts` — verifies:
  1. No 404 responses from `/api/v1/devices/:id/scan` when opening device drawer
  2. Ports tab shows valid UI state ("No port scan results yet" or scan results)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves API semantics by returning `200 OK` with `null` instead of `404 Not Found` when no port scan exists for a device. The change is well-implemented across the stack:

- **Backend**: Uses idiomatic Rust pattern with `Option<PortScanResult>` — wraps result in `Some()` when found, returns `None` when not found
- **Frontend**: Type updated to `PortScanResult | null` — both callers already handle `null` gracefully with appropriate UI messages
- **E2E Test**: Comprehensive Playwright test verifies no 404 responses and proper UI state, includes screenshots per project guidelines

The change improves UX by eliminating error noise in the UI when devices haven't been scanned yet. All callers were already prepared to handle the "no scan" case through error handling, so the transition is seamless.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The change is minimal, well-tested, and improves API semantics. Backend change uses idiomatic Rust pattern, frontend types are correctly updated, both callers already handle null gracefully, and comprehensive E2E test validates the behavior. PR includes smoke test results showing all tests pass.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/devices.rs | Changed `get_scan` to return 200 with null instead of 404 when no scan exists — idiomatic Rust pattern using Option |
| web/src/lib/api.ts | Updated `fetchPortScan` return type to match backend change — now returns `PortScanResult | null` |
| web/src/app/(app)/devices/page.tsx | Updated comment to reflect new behavior — catch block still handles actual network errors |
| web/src/app/(app)/assets/detail/content.tsx | Updated comment to clarify null semantics — existing null handling already correct |
| web/tests/e2e/device-scan-no-404.spec.ts | Comprehensive E2E test verifying no 404 responses and proper UI state — includes screenshots per project guidelines |

</details>



<sub>Last reviewed commit: 6e50e61</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->