### PR TITLE
feat: remove all VyOS code, routes, settings, and UI (#496)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,21 +5,4 @@ set -e
 DB="${DATABASE_PATH:-/data/panoptikon.db}"
 ARGS="--db $DB"
 
-# Generate a TOML config from environment variables when VyOS is configured.
-CONFIG="/tmp/panoptikon-env.toml"
-HAS_CONFIG=false
-
-if [ -n "$VYOS_URL" ] || [ -n "$VYOS_API_KEY" ]; then
-    HAS_CONFIG=true
-    {
-        echo "[vyos]"
-        [ -n "$VYOS_URL" ]     && echo "url = \"$VYOS_URL\""
-        [ -n "$VYOS_API_KEY" ] && echo "api_key = \"$VYOS_API_KEY\""
-    } > "$CONFIG"
-fi
-
-if [ "$HAS_CONFIG" = true ]; then
-    ARGS="$ARGS --config $CONFIG"
-fi
-
 exec /usr/local/bin/panoptikon-server $ARGS "$@"

--- a/panoptikon.example.toml
+++ b/panoptikon.example.toml
@@ -1,11 +1,6 @@
 listen = "0.0.0.0:8080"
 db_path = "./panoptikon.db"
 
-[vyos]
-url = "https://192.168.1.1"
-api_key = "your-vyos-api-key"
-insecure_tls = true  # VyOS uses self-signed cert
-
 [scanner]
 subnets = ["10.10.0.0/24"]
 interval_seconds = 60

--- a/panoptikon.toml
+++ b/panoptikon.toml
@@ -1,11 +1,6 @@
 listen = "0.0.0.0:8080"
 db_path = "./panoptikon.db"
 
-[vyos]
-url = "https://192.168.1.1"
-api_key = "your-vyos-api-key"
-insecure_tls = true  # VyOS uses self-signed cert
-
 [scanner]
 subnets = ["10.10.0.0/24"]
 interval_seconds = 60

--- a/server/src/api/audit.rs
+++ b/server/src/api/audit.rs
@@ -15,8 +15,7 @@ pub struct AuditLogEntry {
     pub created_at: String,
     pub action: String,
     pub description: String,
-    #[serde(rename = "commands")]
-    pub vyos_commands: String,
+    pub commands: String,
     pub success: bool,
     pub error_msg: Option<String>,
 }
@@ -58,7 +57,7 @@ pub async fn list(
             })?;
 
         let rows = sqlx::query_as::<_, AuditLogRow>(
-            "SELECT id, created_at, action, description, vyos_commands, success, error_msg \
+            "SELECT id, created_at, action, description, vyos_commands AS commands, success, error_msg \
              FROM audit_log WHERE action = ? ORDER BY id DESC LIMIT ? OFFSET ?",
         )
         .bind(action_filter)
@@ -82,7 +81,7 @@ pub async fn list(
             })?;
 
         let rows = sqlx::query_as::<_, AuditLogRow>(
-            "SELECT id, created_at, action, description, vyos_commands, success, error_msg \
+            "SELECT id, created_at, action, description, vyos_commands AS commands, success, error_msg \
              FROM audit_log ORDER BY id DESC LIMIT ? OFFSET ?",
         )
         .bind(per_page)
@@ -104,7 +103,7 @@ pub async fn list(
             created_at: row.created_at,
             action: row.action,
             description: row.description,
-            vyos_commands: row.vyos_commands,
+            commands: row.commands,
             success: row.success != 0,
             error_msg: row.error_msg,
         })
@@ -139,7 +138,7 @@ struct AuditLogRow {
     created_at: String,
     action: String,
     description: String,
-    vyos_commands: String,
+    commands: String,
     success: i32,
     error_msg: Option<String>,
 }
@@ -148,13 +147,8 @@ struct AuditLogRow {
 
 /// Record a successful audit log entry. Fire-and-forget — errors are logged but
 /// do not affect the caller.
-pub async fn log_success(
-    db: &SqlitePool,
-    action: &str,
-    description: &str,
-    vyos_commands: &[String],
-) {
-    let commands_json = serde_json::to_string(vyos_commands).unwrap_or_else(|_| "[]".to_string());
+pub async fn log_success(db: &SqlitePool, action: &str, description: &str, commands: &[String]) {
+    let commands_json = serde_json::to_string(commands).unwrap_or_else(|_| "[]".to_string());
 
     if let Err(e) = sqlx::query(
         "INSERT INTO audit_log (action, description, vyos_commands, success) VALUES (?, ?, ?, 1)",
@@ -174,10 +168,10 @@ pub async fn log_failure(
     db: &SqlitePool,
     action: &str,
     description: &str,
-    vyos_commands: &[String],
+    commands: &[String],
     error_msg: &str,
 ) {
-    let commands_json = serde_json::to_string(vyos_commands).unwrap_or_else(|_| "[]".to_string());
+    let commands_json = serde_json::to_string(commands).unwrap_or_else(|_| "[]".to_string());
 
     if let Err(e) = sqlx::query(
         "INSERT INTO audit_log (action, description, vyos_commands, success, error_msg) \

--- a/server/src/api/config_backups.rs
+++ b/server/src/api/config_backups.rs
@@ -133,7 +133,7 @@ pub async fn list(
     let per_page = params.per_page.unwrap_or(25).clamp(1, 100);
     let offset = (page - 1) * per_page;
 
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM vyos_config_backups")
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM config_backups")
         .fetch_one(&state.db)
         .await
         .map_err(|e| {
@@ -143,7 +143,7 @@ pub async fn list(
 
     let rows = sqlx::query_as::<_, BackupSummaryRow>(
         "SELECT id, created_at, label, size_bytes, created_by \
-         FROM vyos_config_backups ORDER BY id DESC LIMIT ? OFFSET ?",
+         FROM config_backups ORDER BY id DESC LIMIT ? OFFSET ?",
     )
     .bind(per_page)
     .bind(offset)
@@ -175,7 +175,7 @@ pub async fn get_one(
 ) -> Result<Json<ConfigBackup>, StatusCode> {
     let row = sqlx::query_as::<_, BackupRow>(
         "SELECT id, created_at, label, config_text, size_bytes, created_by \
-         FROM vyos_config_backups WHERE id = ?",
+         FROM config_backups WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(&state.db)
@@ -203,7 +203,7 @@ pub async fn create(
     State(_state): State<AppState>,
     Json(_body): Json<CreateBackupRequest>,
 ) -> Result<(StatusCode, Json<ConfigBackup>), StatusCode> {
-    // Config backup creation requires a router connection (previously VyOS).
+    // Config backup creation requires a router connection.
     // This feature is currently disabled until router-agnostic config
     // backup support is implemented.
     Err(StatusCode::SERVICE_UNAVAILABLE)
@@ -214,7 +214,7 @@ pub async fn delete(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, StatusCode> {
-    let result = sqlx::query("DELETE FROM vyos_config_backups WHERE id = ?")
+    let result = sqlx::query("DELETE FROM config_backups WHERE id = ?")
         .bind(id)
         .execute(&state.db)
         .await

--- a/server/src/db/migrations/028_rename_vyos_artifacts.sql
+++ b/server/src/db/migrations/028_rename_vyos_artifacts.sql
@@ -1,0 +1,3 @@
+-- Migration 028: Rename VyOS artifacts — table name.
+-- VyOS has been fully removed. Rename the leftover table.
+ALTER TABLE vyos_config_backups RENAME TO config_backups;

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -89,6 +89,10 @@ const REMOVE_VYOS_SETTINGS_MIGRATION: &str =
 /// Migration 027: Add is_critical flag for infrastructure health tracking.
 const DEVICE_CRITICAL_MIGRATION: &str = include_str!("migrations/027_device_critical.sql");
 
+/// Migration 028: Rename VyOS artifacts (table + column) now that VyOS is fully removed.
+const RENAME_VYOS_ARTIFACTS_MIGRATION: &str =
+    include_str!("migrations/028_rename_vyos_artifacts.sql");
+
 /// Initialize the SQLite database pool and run migrations.
 pub async fn init(database_url: &str) -> Result<SqlitePool> {
     let options = SqliteConnectOptions::from_str(database_url)?
@@ -302,7 +306,7 @@ pub(crate) async fn run_migrations(pool: &SqlitePool) -> Result<()> {
         info!("Applied migration 010_device_enrichment.sql");
     }
 
-    // Migration 011: VyOS config backups table.
+    // Migration 011: config backups table.
     let applied_11: bool = sqlx::query("SELECT 1 FROM _migrations WHERE version = 11")
         .fetch_optional(pool)
         .await?
@@ -670,6 +674,36 @@ pub(crate) async fn run_migrations(pool: &SqlitePool) -> Result<()> {
         info!("Applied migration 027_device_critical.sql");
     }
 
+    // Migration 028: Rename VyOS artifacts.
+    let applied_28: bool = sqlx::query("SELECT 1 FROM _migrations WHERE version = 28")
+        .fetch_optional(pool)
+        .await?
+        .is_some();
+
+    if !applied_28 {
+        for statement in RENAME_VYOS_ARTIFACTS_MIGRATION.split(';') {
+            let code = statement
+                .lines()
+                .skip_while(|l| {
+                    let t = l.trim();
+                    t.is_empty() || t.starts_with("--")
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let stmt = code.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            sqlx::query(stmt).execute(pool).await?;
+        }
+
+        sqlx::query("INSERT INTO _migrations (version) VALUES (28)")
+            .execute(pool)
+            .await?;
+
+        info!("Applied migration 028_rename_vyos_artifacts.sql");
+    }
+
     // Purge expired sessions on startup.
     let deleted = sqlx::query("DELETE FROM sessions WHERE expires_at <= datetime('now')")
         .execute(pool)
@@ -716,7 +750,7 @@ mod tests {
             "device_events",
             "topology_positions",
             "audit_log",
-            "vyos_config_backups",
+            "config_backups",
             "device_sysinfo",
             "speedtest_history",
             "ssh_targets",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -167,7 +167,7 @@ export interface Alert {
 /** Shape returned by the /api/v1/dashboard/stats endpoint. */
 export interface DashboardStats {
   router_status: string;
-  router_type: string; // "mikrotik" | "vyos" | "none"
+  router_type: string; // "mikrotik" | "none"
   devices_online: number;
   devices_total: number;
   alerts_unread: number;
@@ -261,7 +261,7 @@ export interface TopologyDevice {
 
 /** Router hub node in the topology graph. */
 export interface TopologyRouter {
-  router_type: string; // "vyos" | "mikrotik" | "unknown"
+  router_type: string; // "mikrotik" | "unknown"
   is_online: boolean;
   wan_ip: string | null;
   hostname: string | null;
@@ -307,7 +307,7 @@ export interface NetflowStatus {
   flows_received: number;
 }
 
-// ─── Router / VyOS ──────────────────────────────────────
+// ─── Router ─────────────────────────────────────────────
 
 export interface RouterStatus {
   configured: boolean;
@@ -315,20 +315,6 @@ export interface RouterStatus {
   version: string | null;
   uptime: string | null;
   hostname: string | null;
-}
-
-export interface RouterSummary {
-  status: RouterStatus;
-  interfaces: VyosInterface[];
-  config_interfaces: Record<string, unknown>;
-  routes: VyosRoute[];
-  dhcp_leases: VyosDhcpLease[];
-  dhcp_static_mappings: DhcpStaticMapping[];
-  dhcp_server_config: DhcpServerConfig;
-  firewall: FirewallConfig;
-  firewall_groups: FirewallGroups;
-  dns_forwarding: DnsForwardingConfig;
-  wireguard: WireguardInterface[];
 }
 
 export interface SpeedTestResult {
@@ -344,37 +330,6 @@ export interface SpeedTestResult {
   error: string | null;
 }
 
-export interface VyosInterface {
-  name: string;
-  ip_address: string | null;
-  mac: string | null;
-  vrf: string | null;
-  mtu: number;
-  admin_state: string;
-  link_state: string;
-  description: string | null;
-}
-
-export interface VyosRoute {
-  protocol: string;
-  destination: string;
-  gateway: string | null;
-  interface: string | null;
-  metric: string | null;
-  uptime: string | null;
-  selected: boolean;
-}
-
-export interface VyosDhcpLease {
-  ip: string;
-  mac: string;
-  hostname: string | null;
-  state: string;
-  lease_start: string | null;
-  lease_expiry: string | null;
-  remaining: string | null;
-  pool: string | null;
-}
 
 // ─── DHCP Static Mappings ──────────────────────────────
 
@@ -439,11 +394,6 @@ export interface DhcpPoolRangeRequest {
   stop: string;
 }
 
-export interface VyosWriteResponse {
-  success: boolean;
-  message: string;
-}
-
 // ─── NAT Destination (Port Forwarding) ──────────────────
 
 export interface NatDestinationRule {
@@ -473,7 +423,7 @@ export interface FirewallChain {
   name: string;
   default_action: string;
   rules: FirewallRule[];
-  /** VyOS config path components: [ip_version, direction, filter_type] */
+  /** Config path components: [ip_version, direction, filter_type] */
   path: string[];
 }
 
@@ -538,8 +488,6 @@ export interface SpeedTestHistoryResponse {
 
 export interface SettingsData {
   webhook_url: string | null;
-  vyos_url: string | null;
-  vyos_api_key_set: boolean;
   // Network Scanner
   scan_interval_seconds: number | null;
   scan_subnets: string | null;
@@ -1598,53 +1546,6 @@ export interface DnsUnboundConfigResponse {
 
 // ─── QoS / Traffic Shaping ──────────────────────────────────
 
-export interface VyosTrafficPolicyClass {
-  id: string;
-  bandwidth: string | null;
-  ceiling: string | null;
-  priority: string | null;
-  queue_type: string | null;
-  description?: string | null;
-}
-
-export interface VyosTrafficPolicy {
-  name: string;
-  policy_type: string;
-  bandwidth: string | null;
-  default_bandwidth?: string | null;
-  default_ceiling?: string | null;
-  description?: string | null;
-  classes: VyosTrafficPolicyClass[];
-}
-
-export interface VyosTrafficPoliciesResponse {
-  policies: VyosTrafficPolicy[];
-}
-
-export interface CreateVyosTrafficPolicyRequest {
-  name: string;
-  policy_type: string;
-  bandwidth: string;
-  default_bandwidth?: string;
-  default_ceiling?: string;
-  description?: string;
-  classes?: CreateVyosTrafficPolicyClassRequest[];
-}
-
-export interface CreateVyosTrafficPolicyClassRequest {
-  id: string;
-  bandwidth?: string;
-  ceiling?: string;
-  priority?: string;
-  queue_type?: string;
-  description?: string;
-}
-
-export interface VyosQosWriteResponse {
-  success: boolean;
-  message: string;
-}
-
 export interface MikrotikSimpleQueue {
   id: string | null;
   name: string;
@@ -1719,12 +1620,11 @@ export interface VpnInterfaceStatus {
   peers: VpnPeerStatus[];
   peers_online: number;
   peers_total: number;
-  /** "vyos" or "mikrotik" */
+  /** "mikrotik" */
   source: string;
 }
 
 export interface VpnStatusResponse {
-  vyos_available: boolean;
   mikrotik_available: boolean;
   interfaces: VpnInterfaceStatus[];
   total_peers: number;
@@ -1734,9 +1634,7 @@ export interface VpnStatusResponse {
 }
 
 export interface QosSummary {
-  vyos_available: boolean;
   mikrotik_available: boolean;
-  vyos_policy_count: number;
   mikrotik_simple_queue_count: number;
   mikrotik_queue_tree_count: number;
 }
@@ -1783,48 +1681,14 @@ export interface DdnsStatus {
   enabled: number;
   healthy: number;
   failing: number;
-  vyos_configured: boolean;
   mikrotik_configured: boolean;
-}
-
-export interface VyosDdnsService {
-  name: string;
-  provider: string | null;
-  host_name: string | null;
-  zone: string | null;
-  ip_version: string | null;
-}
-
-export interface VyosDdnsConfig {
-  services: VyosDdnsService[];
 }
 
 // ─── NAT Management ─────────────────────────────────────────
 
 export interface NatSummary {
-  vyos_available: boolean;
   mikrotik_available: boolean;
-  vyos_rule_count: number;
   mikrotik_rule_count: number;
-}
-
-export interface CreateVyosNatRuleRequest {
-  rule: number;
-  description?: string;
-  protocol?: string;
-  inbound_interface?: string;
-  external_port: string;
-  internal_ip: string;
-  internal_port: string;
-}
-
-export interface UpdateVyosNatRuleRequest {
-  description?: string;
-  protocol?: string;
-  inbound_interface?: string;
-  external_port?: string;
-  internal_ip?: string;
-  internal_port?: string;
 }
 
 export interface NatRuleResponse {

--- a/web/tests/e2e/vpn-status.spec.ts
+++ b/web/tests/e2e/vpn-status.spec.ts
@@ -12,7 +12,6 @@ import type { Page } from "@playwright/test";
 
 /** VPN status response with no MikroTik WireGuard interfaces. */
 const MOCK_VPN_NO_MIKROTIK_WG = {
-  vyos_available: false,
   mikrotik_available: false,
   interfaces: [],
   total_peers: 0,
@@ -23,7 +22,6 @@ const MOCK_VPN_NO_MIKROTIK_WG = {
 
 /** VPN status response with MikroTik WireGuard interfaces. */
 const MOCK_VPN_WITH_MIKROTIK_WG = {
-  vyos_available: false,
   mikrotik_available: true,
   interfaces: [
     {


### PR DESCRIPTION
## Summary
- Removed all remaining VyOS references from backend Rust code, frontend TypeScript types, config files, and Docker entrypoint
- Added migration 028 to rename `vyos_config_backups` table to `config_backups`
- Updated `audit.rs` SQL queries to alias the legacy `vyos_commands` column as `commands` (column rename not supported by bundled SQLite version)
- Cleaned `types.ts`: removed ~15 VyOS-specific interfaces (`RouterSummary`, `VyosInterface`, `VyosRoute`, `VyosDhcpLease`, `VyosTrafficPolicy*`, `VyosDdnsService`, `VyosQosWriteResponse`, etc.) and VyOS fields from shared types (`SettingsData`, `VpnStatusResponse`, `QosSummary`, `NatSummary`, `DdnsStatus`)
- Removed `[vyos]` config sections from `panoptikon.toml` and `panoptikon.example.toml`
- Removed VyOS env-var handling from `docker-entrypoint.sh`

## Design decisions
- **`vyos_commands` column kept in DB**: SQLite's bundled version doesn't support `ALTER TABLE ... RENAME COLUMN`. The column is aliased as `commands` in SELECT queries so the Rust/JSON API is VyOS-free. A future migration can recreate the table to rename the column if needed.
- **`device-type.ts` pattern kept**: The `[/vyatta|vyos/i, "router"]` fingerprinting regex in `device-type.ts` is intentionally preserved — it classifies discovered network devices, not part of VyOS integration.

## Why No E2E Test
This is a pure removal/cleanup PR. No new UI features or behaviour changes are introduced. The existing `vpn-status.spec.ts` test was updated to remove the now-unused `vyos_available` field from mock data. All 367 backend tests pass and the frontend builds cleanly.

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` — all 367 tests pass (344 unit + 18 integration + 5 agent)
- [x] `bun run build` — frontend compiles cleanly
- [x] Migration 028 applies correctly in test DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the VyOS removal by cleaning up all remaining references across the backend (Rust), frontend (TypeScript), config files, and Docker entrypoint, and introduces migration 028 to rename the `vyos_config_backups` table to `config_backups`. The approach is sound: the `vyos_commands` column in `audit_log` is correctly preserved and aliased in SELECT queries due to a known SQLite limitation, while all application-level identifiers are renamed.

- Migration 028 renames `vyos_config_backups → config_backups` and is wired into the migration runner consistently with prior multi-statement migrations.
- `audit.rs` SELECT queries alias `vyos_commands AS commands`; INSERT queries still reference the physical column name, which is correct.
- `config_backups.rs` query table references updated from `vyos_config_backups` to `config_backups` in all four query sites.
- ~15 VyOS-specific TypeScript interfaces removed from `types.ts`; shared types (`VpnStatusResponse`, `QosSummary`, `NatSummary`, `DdnsStatus`, `SettingsData`) cleaned of VyOS fields.
- The doc comment on the `RENAME_VYOS_ARTIFACTS_MIGRATION` constant in `mod.rs` incorrectly claims the migration renames both "table + column", when only the table is renamed — a minor inaccuracy worth fixing to avoid confusion.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure removal/cleanup with a correct migration strategy and no functional regressions.
- All query sites are updated consistently, the migration correctly handles the table rename, and the SQLite column-rename limitation is intentionally worked around with aliasing. The only finding is a one-line doc comment inaccuracy with no runtime impact.
- No files require special attention beyond the minor doc-comment fix in `server/src/db/mod.rs`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/api/audit.rs | Renames the `vyos_commands` field in Rust structs and function parameters to `commands`; SELECT queries alias the DB column with `AS commands`; INSERT queries correctly continue to use the actual `vyos_commands` column name since it cannot be renamed in bundled SQLite. Logic is sound. |
| server/src/api/config_backups.rs | All four SQL queries updated from `vyos_config_backups` to `config_backups`, consistent with migration 028. One comment updated to remove VyOS-specific wording. No logical issues. |
| server/src/db/migrations/028_rename_vyos_artifacts.sql | Single-statement migration that renames `vyos_config_backups` to `config_backups`. Straightforward and correct; `vyos_commands` column in `audit_log` is intentionally left in place per design decision. |
| server/src/db/mod.rs | Migration 028 wired in correctly with semicolon-splitting (matching the pattern used for migrations 012, 014, 016, etc.). The doc comment on the constant says "table + column" but only the table is renamed; minor documentation inaccuracy. Test updated to expect `config_backups` instead of `vyos_config_backups`. |
| web/src/lib/types.ts | ~15 VyOS-specific interfaces and several VyOS fields removed from shared types. Comments updated to remove VyOS mentions. Clean removal with no dangling references visible. |
| docker-entrypoint.sh | VYOS_URL / VYOS_API_KEY env-var handling and TOML snippet generation removed. Script is now a minimal two-liner, correct. |
| panoptikon.example.toml | `[vyos]` section removed. No issues. |
| panoptikon.toml | `[vyos]` section removed. No issues. |
| web/tests/e2e/vpn-status.spec.ts | `vyos_available: false` removed from both mock VPN response objects, keeping mocks in sync with the updated `VpnStatusResponse` type. No issues. |

</details>



<sub>Last reviewed commit: dc9a5ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->