### PR TITLE
fix: deduplicate agent_offline alerts with 10-minute cooldown (#547)

### DIFF
--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -699,7 +699,9 @@ async fn handle_agent_ws(mut socket: WebSocket, state: AppState, api_key: Option
         None => false,
     };
 
-    if !device_muted {
+    if !device_muted
+        && !alerts::recent_agent_alert_exists(&state.db, &agent_id, "agent_offline", 600).await
+    {
         let alert_id = uuid::Uuid::new_v4().to_string();
         let severity = alerts::severity_for_alert_type("agent_offline");
         let _ = sqlx::query(

--- a/server/src/api/alerts.rs
+++ b/server/src/api/alerts.rs
@@ -341,6 +341,34 @@ where
     result.is_some()
 }
 
+/// Check if a recent alert of the same type already exists for an agent
+/// within the given cooldown window (in seconds). Used to deduplicate
+/// alerts from agent connection flapping (e.g. repeated connect/disconnect cycles).
+pub async fn recent_agent_alert_exists<'e, E>(
+    executor: E,
+    agent_id: &str,
+    alert_type: &str,
+    cooldown_secs: i64,
+) -> bool
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
+    let result: Option<i64> = sqlx::query_scalar(
+        r#"SELECT 1 FROM alerts
+           WHERE agent_id = ? AND type = ?
+             AND datetime(created_at) > datetime('now', '-' || ? || ' seconds')
+           LIMIT 1"#,
+    )
+    .bind(agent_id)
+    .bind(alert_type)
+    .bind(cooldown_secs)
+    .fetch_optional(executor)
+    .await
+    .unwrap_or(None);
+
+    result.is_some()
+}
+
 /// Determine the severity level for an alert type.
 pub fn severity_for_alert_type(alert_type: &str) -> &'static str {
     match alert_type {
@@ -643,6 +671,102 @@ mod tests {
             .unwrap();
 
         assert_eq!(rows.len(), 1, "Only one new_device alert should match");
+    }
+
+    /// Helper: insert a test agent and return its id.
+    async fn insert_test_agent(pool: &sqlx::SqlitePool, name: &str) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let key_hash = "$2b$12$dummyhashfortest000000000000000000000000000000000000";
+        sqlx::query(
+            r#"INSERT INTO agents (id, api_key_hash, name, created_at)
+               VALUES (?, ?, ?, datetime('now'))"#,
+        )
+        .bind(&id)
+        .bind(key_hash)
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_recent_agent_alert_exists_within_cooldown() {
+        let pool = test_db().await;
+        let agent_id = insert_test_agent(&pool, "mac-mini").await;
+
+        // Insert a recent agent_offline alert using RFC 3339 format (as the production
+        // code does via chrono::Utc::now().to_rfc3339()).
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"INSERT INTO alerts (id, type, agent_id, message, severity, created_at)
+               VALUES (?, 'agent_offline', ?, 'Test agent alert', 'WARNING', ?)"#,
+        )
+        .bind(&id)
+        .bind(&agent_id)
+        .bind(&now)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Should detect the recent alert within a 600-second cooldown.
+        let exists = recent_agent_alert_exists(&pool, &agent_id, "agent_offline", 600).await;
+        assert!(
+            exists,
+            "Should detect a recent agent_offline alert within the cooldown window"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recent_agent_alert_not_exists_outside_cooldown() {
+        let pool = test_db().await;
+        let agent_id = insert_test_agent(&pool, "mac-mini-2").await;
+
+        // Insert an old agent_offline alert (20 minutes ago) using SQLite datetime.
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO alerts (id, type, agent_id, message, severity, created_at)
+               VALUES (?, 'agent_offline', ?, 'Test agent alert', 'WARNING', datetime('now', '-1200 seconds'))"#,
+        )
+        .bind(&id)
+        .bind(&agent_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Should NOT detect it within a 600-second cooldown.
+        let exists = recent_agent_alert_exists(&pool, &agent_id, "agent_offline", 600).await;
+        assert!(
+            !exists,
+            "Should NOT detect an agent_offline alert outside the cooldown window"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recent_agent_alert_different_agent() {
+        let pool = test_db().await;
+        let agent_a = insert_test_agent(&pool, "agent-a").await;
+        let agent_b = insert_test_agent(&pool, "agent-b").await;
+
+        // Insert a recent alert for agent A using SQLite datetime.
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            r#"INSERT INTO alerts (id, type, agent_id, message, severity, created_at)
+               VALUES (?, 'agent_offline', ?, 'Test agent alert', 'WARNING', datetime('now'))"#,
+        )
+        .bind(&id)
+        .bind(&agent_a)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Should NOT find it when querying for agent B.
+        let exists = recent_agent_alert_exists(&pool, &agent_b, "agent_offline", 600).await;
+        assert!(
+            !exists,
+            "Alert for agent A should not affect dedup check for agent B"
+        );
     }
 
     #[tokio::test]

--- a/web/tests/e2e/alerts.spec.ts
+++ b/web/tests/e2e/alerts.spec.ts
@@ -11,6 +11,64 @@ test.describe('Alerts page', () => {
     await page.screenshot({ path: 'tests/screenshots/alerts-page.png', fullPage: true });
   });
 
+  test('no duplicate agent_offline alerts within cooldown window', async ({ page }) => {
+    // Navigate to alerts page.
+    await page.goto('/alerts/');
+    await expect(page.getByRole('heading', { name: 'Alerts', level: 1 })).toBeVisible({ timeout: 15000 });
+
+    // Fetch all agent_offline alerts via the API.
+    const resp = await page.request.get('/api/v1/alerts?limit=200&type=agent_offline');
+    expect(resp.ok()).toBeTruthy();
+    const alerts: Array<{
+      agent_id: string | null;
+      type: string;
+      message: string;
+      created_at: string;
+    }> = await resp.json();
+
+    // Group agent_offline alerts by agent_id and check that no two alerts
+    // for the same agent were created within the 10-minute cooldown window.
+    const byAgent = new Map<string, string[]>();
+    for (const a of alerts) {
+      if (a.agent_id) {
+        const times = byAgent.get(a.agent_id) ?? [];
+        times.push(a.created_at);
+        byAgent.set(a.agent_id, times);
+      }
+    }
+
+    for (const [agentId, times] of byAgent) {
+      const sorted = times.map(t => new Date(t).getTime()).sort((a, b) => a - b);
+      for (let i = 1; i < sorted.length; i++) {
+        const gap = sorted[i] - sorted[i - 1];
+        expect(gap).toBeGreaterThanOrEqual(600_000); // 10 minutes in ms
+      }
+    }
+
+    // Also check the UI: filter to Agent Offline type and verify no
+    // adjacent cards show the exact same message text.
+    await page.getByRole('button', { name: /Agent Offline/i }).click();
+    await page.waitForTimeout(500);
+
+    const cards = await page.locator('[class*="card"], [class*="Card"]').all();
+    const messages: string[] = [];
+    for (const card of cards) {
+      const text = await card.textContent();
+      if (text) messages.push(text.trim());
+    }
+
+    // Consecutive identical card text would indicate duplicates.
+    for (let i = 1; i < messages.length; i++) {
+      if (messages[i] === messages[i - 1]) {
+        // Allow if timestamps differ — same message with different times is OK.
+        // But exact duplicates (same card text) indicate a problem.
+        expect(messages[i]).not.toBe(messages[i - 1]);
+      }
+    }
+
+    await page.screenshot({ path: 'tests/screenshots/alerts-no-duplicates.png', fullPage: true });
+  });
+
   test('agent offline alert shows agent name not raw UUID', async ({ page }) => {
     const agentName = `e2e-alert-agent-${Date.now()}`;
 


### PR DESCRIPTION
Closes #547

## Summary

- Added `recent_agent_alert_exists()` function in `alerts.rs` — mirrors the existing `recent_alert_exists()` for device alerts but keyed on `agent_id`
- Gated the `agent_offline` alert INSERT in `handle_agent_ws()` behind a 600-second (10-minute) cooldown check, matching the device alert dedup behavior
- Used `datetime(created_at)` in the SQL query to normalize RFC 3339 timestamps for correct SQLite comparison

## Root cause

The agent disconnect handler (`agents.rs:handle_agent_ws`) created a new alert on every WebSocket disconnect without checking for recent duplicates. Device alerts already had deduplication via `recent_alert_exists()` with a 600-second cooldown, but agent alerts did not.

## Smoke Test

- `cargo check` passes
- 3 new unit tests added and passing:
  - `test_recent_agent_alert_exists_within_cooldown` — verifies dedup detects recent alerts (including RFC 3339 format)
  - `test_recent_agent_alert_not_exists_outside_cooldown` — verifies alerts older than cooldown are allowed
  - `test_recent_agent_alert_different_agent` — verifies dedup is per-agent, not global
- All 18 existing alert tests continue to pass

## Test plan

- [x] Unit tests for `recent_agent_alert_exists()` (3 tests)
- [x] E2E test verifying no duplicate agent_offline alerts within cooldown window
- [x] `cargo fmt --all` and `cargo check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deduplication for `agent_offline` alerts with a 600-second cooldown, mirroring the existing device alert pattern.

**Core logic is sound:** The alert INSERT gate in `agents.rs` (line 703) correctly blocks duplicate alerts while letting broadcasts and webhooks remain unconditional.

**However, the PR exposes an inconsistency with latent correctness implications:**
1. The new `recent_agent_alert_exists()` correctly normalizes RFC 3339 timestamps using `datetime(created_at)` before comparison.
2. The existing `recent_alert_exists()` (device variant, line 331) uses a bare `created_at` string comparison. Since RFC 3339 format uses `T` (ASCII 0x54) as the date/time separator and SQLite's `datetime()` uses a space (ASCII 0x20), lexicographic comparison makes any same-day RFC 3339 timestamp always greater than the SQLite datetime target—causing the device dedup to over-match for the entire current day rather than just 600 seconds.
3. This bug is masked in tests because the test helper `insert_test_alert` uses SQLite's `datetime('now')` format, not RFC 3339. Production code in `scanner/mod.rs` uses `Utc::now().to_rfc3339()`, which triggers the bug. The new agent tests correctly use RFC 3339 to validate the fix works correctly.

**Minor style issue:** The E2E test has a redundant `if` guard (lines 62–65) with a misleading comment—the assertion is only executed when duplicates are found (which fails the test), not as a preventive check.

Recommendations:
- Apply the `datetime()` normalization fix to `recent_alert_exists` to maintain consistency and correctness.
- Simplify the E2E assertion to clarify intent.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for agent dedup, but exposes and perpetuates a latent bug in device dedup that warrants fixing before this pattern spreads.
- The agent_offline dedup logic itself is correct and well-tested. However, the PR surfaces a real correctness issue in the parallel device dedup function that uses the same query pattern without proper RFC 3339 timestamp normalization. While the new agent code avoids this pitfall, the inconsistency between the two functions and the test gap (device tests never use RFC 3339, masking the production bug) suggest the device variant should be fixed simultaneously. The E2E test style issue is minor and doesn't affect functionality.
- `server/src/api/alerts.rs` — the `recent_alert_exists` function needs `datetime()` wrapping applied to the `created_at` comparison to match the fix pattern established in the new `recent_agent_alert_exists` function.

<sub>Last reviewed commit: 7cee836</sub>

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (4)</h4></summary>

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))
- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=beae9f31-4421-4dea-b358-985b3030d01f))
- Rule from `dashboard` - backend/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a504ee95-c8db-401f-9d25-091557a4fb94))
- Rule from `dashboard` - frontend/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0111cc3c-65b4-4bcb-893c-f747cb296ca9))
</details>


<!-- /greptile_comment -->