### PR TITLE
fix: use IP as fallback title for unnamed device cards

### DIFF
--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -650,6 +650,22 @@ export default function DevicesPage() {
 
 // ─── Device Card ────────────────────────────────────────
 
+function getDevicePrimaryTitle(device: Device, primaryIp: string): { title: string; isUnnamed: boolean } {
+  const customName = device.custom_name?.trim();
+  const hostname = device.hostname?.trim();
+  const discoveredName = device.name?.trim();
+
+  if (customName) return { title: customName, isUnnamed: false };
+  if (hostname) return { title: hostname, isUnnamed: false };
+  if (discoveredName) return { title: discoveredName, isUnnamed: false };
+
+  if (primaryIp && primaryIp !== "—") {
+    return { title: primaryIp, isUnnamed: true };
+  }
+
+  return { title: "Unknown Device", isUnnamed: true };
+}
+
 function DeviceCard({
   device,
   onClick,
@@ -660,7 +676,7 @@ function DeviceCard({
   const [waking, setWaking] = useState(false);
   const ips = device.ips ?? [];
   const primaryIp = ips[0] ?? "—";
-  const displayName = device.custom_name ?? device.hostname ?? device.name ?? device.vendor ?? device.mac;
+  const { title: displayName, isUnnamed } = getDevicePrimaryTitle(device, primaryIp);
   const effectiveType = device.custom_type ?? device.device_type;
   const { icon: DevIcon } = getDeviceIcon(device.custom_vendor ?? device.vendor, device.hostname, device.mdns_services, effectiveType);
   const vendorDisplay = device.custom_vendor ?? device.vendor ?? null;
@@ -711,6 +727,11 @@ function DeviceCard({
                 }`}
               />
               <span className="min-w-0 flex-1 truncate font-medium text-white">{displayName}</span>
+              {isUnnamed && (
+                <Badge variant="outline" className="shrink-0 border-slate-600 text-[10px] text-slate-400">
+                  Unknown
+                </Badge>
+              )}
               {device.is_critical && (
                 <Pin className="h-3 w-3 shrink-0 text-amber-400" />
               )}
@@ -1040,7 +1061,7 @@ function DevicesTable({
 function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => void }) {
   const ips = device.ips ?? [];
   const primaryIp = ips[0] ?? "—";
-  const displayName = device.custom_name ?? device.hostname ?? device.name ?? device.vendor ?? device.mac;
+  const { title: displayName, isUnnamed } = getDevicePrimaryTitle(device, primaryIp);
   const [waking, setWaking] = useState(false);
   const [sysinfo, setSysinfo] = useState<DeviceSysinfo | null>(null);
 
@@ -1090,6 +1111,9 @@ function DeviceDetail({ device, onUpdate }: { device: Device; onUpdate: () => vo
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <SheetTitle className="text-white">{displayName}</SheetTitle>
+              {isUnnamed && (
+                <Badge variant="outline" className="border-slate-600 text-[10px] text-slate-400">Unknown</Badge>
+              )}
               {device.custom_name && (
                 <Badge variant="outline" className="border-cyan-500/50 text-cyan-400 text-[10px]">custom</Badge>
               )}


### PR DESCRIPTION
Fixes #552

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes #552 by extracting a `getDevicePrimaryTitle` helper that selects a device's display name in order of preference (`custom_name` → `hostname` → `name` → primary IP → `"Unknown Device"`), and applies it consistently to both `DeviceCard` and `DeviceDetail`. It also surfaces an `"Unknown"` badge whenever no proper name is found.

**Key changes:**
- New `getDevicePrimaryTitle` function centralizes the title-resolution logic and returns an `isUnnamed` flag.
- Both `DeviceCard` and `DeviceDetail` now render an `"Unknown"` badge when `isUnnamed` is `true`.

**Issues found:**
- The `"Unknown"` badge is shown even when the IP address is successfully resolved as the title. This creates a misleading label, since the device is clearly identified by its IP. A label like `"No name"` would be more accurate across all fallback states.
- A whitespace-only `custom_name` (e.g. `"  "`) trims to empty inside `getDevicePrimaryTitle`, causing `isUnnamed: true`, but the original `device.custom_name` remains truthy in `DeviceDetail`, so both the `"Unknown"` and `"custom"` badges render simultaneously — creating a visual contradiction.

<h3>Confidence Score: 3/5</h3>

- Safe to merge from a correctness standpoint, but UX concerns should be addressed to improve user experience.
- The core fix is correct and well-scoped. The helper function properly prioritizes device name sources and is used consistently. However, two UX/edge-case issues are present: (1) the "Unknown" badge label contradicts the IP address shown as the title, which could confuse users, and (2) a whitespace-only `custom_name` causes both "Unknown" and "custom" badges to render simultaneously, creating a visual conflict. These are legitimate concerns that should be resolved to fully complete the fix.
- web/src/app/(app)/devices/page.tsx — Address badge labeling and whitespace-only custom_name edge case

<sub>Last reviewed commit: 4f4b695</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->