### PR TITLE
feat(ui): unify VPN, QoS and NAT pages with approved dark command-center style

### DIFF
--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -14,9 +14,9 @@ import {
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -50,43 +50,34 @@ import {
 import { PageTransition } from "@/components/PageTransition";
 import { HelpTooltip } from "@/components/HelpTooltip";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-  fetchNatSummary,
-  fetchMikrotikNatRules,
   createMikrotikNatRule,
-  updateMikrotikNatRule,
   deleteMikrotikNatRule,
+  fetchMikrotikNatRules,
+  fetchNatSummary,
+  updateMikrotikNatRule,
 } from "@/lib/api";
-import type {
-  NatSummary,
-  MikrotikNatRuleWithId,
-} from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type { MikrotikNatRuleWithId, NatSummary } from "@/lib/types";
 import { toast } from "sonner";
+
+const surfaceClass =
+  "border-slate-800/70 bg-gradient-to-b from-slate-900/80 to-slate-900/55 shadow-[0_12px_30px_rgba(2,6,23,0.35)]";
 
 export default function NatPage() {
   const [summary, setSummary] = useState<NatSummary | null>(null);
   const [mtRules, setMtRules] = useState<MikrotikNatRuleWithId[] | null>(null);
   const [search, setSearch] = useState("");
-  const [activeTab, setActiveTab] = useState("mikrotik");
 
-  // Dialogs
   const [showAddMt, setShowAddMt] = useState(false);
-  const [editMtRule, setEditMtRule] = useState<MikrotikNatRuleWithId | null>(
-    null
-  );
-  const [pendingDeleteMt, setPendingDeleteMt] =
-    useState<MikrotikNatRuleWithId | null>(null);
+  const [editMtRule, setEditMtRule] = useState<MikrotikNatRuleWithId | null>(null);
+  const [pendingDeleteMt, setPendingDeleteMt] = useState<MikrotikNatRuleWithId | null>(null);
 
   const load = useCallback(async () => {
     try {
       const s = await fetchNatSummary();
       setSummary(s);
     } catch {
-      // summary is best-effort
+      // best-effort summary
     }
   }, []);
 
@@ -101,13 +92,9 @@ export default function NatPage() {
 
   useEffect(() => {
     load();
-  }, [load]);
+    loadMt();
+  }, [load, loadMt]);
 
-  useEffect(() => {
-    if (activeTab === "mikrotik") loadMt();
-  }, [activeTab, loadMt]);
-
-  // -- Filter helpers --
   const filteredMt = useMemo(() => {
     if (!mtRules) return null;
     if (!search.trim()) return mtRules;
@@ -117,18 +104,15 @@ export default function NatPage() {
         (r.comment ?? "").toLowerCase().includes(q) ||
         (r.to_addresses ?? "").toLowerCase().includes(q) ||
         (r.dst_port ?? "").toLowerCase().includes(q) ||
-        (r.action ?? "").toLowerCase().includes(q)
+        (r.action ?? "").toLowerCase().includes(q),
     );
   }, [mtRules, search]);
 
-  // -- MikroTik Handlers --
   async function handleDeleteMt() {
     if (!pendingDeleteMt || !pendingDeleteMt.id) return;
     try {
       await deleteMikrotikNatRule(pendingDeleteMt.id);
-      setMtRules(
-        (prev) => prev?.filter((r) => r.id !== pendingDeleteMt.id) ?? null
-      );
+      setMtRules((prev) => prev?.filter((r) => r.id !== pendingDeleteMt.id) ?? null);
       toast.success("Deleted MikroTik NAT rule");
       load();
     } catch {
@@ -140,205 +124,183 @@ export default function NatPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-6xl space-y-6 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <ArrowRightLeft className="h-6 w-6 text-blue-500" />
-            <h1 className="text-2xl font-semibold text-white">
-              NAT / Port Forwarding
-            </h1>
-            <HelpTooltip text="View and manage NAT (port forwarding) rules on your MikroTik router." />
+      <div className="space-y-6">
+        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-violet-500/30 bg-gradient-to-br from-violet-500/20 via-fuchsia-500/10 to-blue-500/10 text-violet-300">
+              <ArrowRightLeft className="h-6 w-6" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-semibold tracking-tight text-white">NAT / Port Forwarding</h1>
+                <HelpTooltip text="Manage MikroTik NAT and port-forwarding rules from the same command-center style UI." />
+              </div>
+              <p className="text-sm text-slate-400">
+                Inspect rule chains, targets, and translation endpoints.
+              </p>
+            </div>
           </div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  load();
-                  if (activeTab === "mikrotik") loadMt();
-                }}
-                className="border-slate-800 text-slate-300 hover:bg-slate-800"
-              >
-                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-                Refresh
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs border-slate-700 bg-slate-800 text-slate-200">
-              Reload NAT rules from the router
-            </TooltipContent>
-          </Tooltip>
-        </div>
 
-        {/* Summary Cards */}
-        <div className="grid gap-4 sm:grid-cols-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              load();
+              loadMt();
+            }}
+            className="border-slate-700 bg-slate-900/60 text-slate-200 hover:bg-slate-800"
+          >
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+        </section>
+
+        <section className="grid gap-4 sm:grid-cols-1 lg:max-w-md">
           <SummaryCard
             title="MikroTik NAT Rules"
             value={summary?.mikrotik_rule_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<Network className="h-4 w-4 text-orange-400" />}
+            icon={<Network className="h-4 w-4 text-amber-300" />}
+            iconClass="border-amber-500/30 bg-amber-500/15"
           />
-        </div>
+        </section>
 
-        {/* Search */}
-        <div className="relative max-w-sm">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-slate-500" />
-          <Input
-            placeholder="Filter rules..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-9 bg-slate-900 border-slate-800 text-slate-300"
-          />
-        </div>
+        <section className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="relative max-w-md flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <Input
+              placeholder="Filter by comment, action, destination port..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="border-slate-800 bg-slate-950/70 pl-10 text-white placeholder:text-slate-600"
+            />
+          </div>
 
-        {/* MikroTik NAT Rules */}
-        <Card className="bg-slate-900/50 border-slate-800">
-          <CardHeader className="flex flex-row items-center justify-between">
-            <div>
-              <CardTitle className="text-white">
-                MikroTik NAT Rules
-              </CardTitle>
-              <CardDescription className="text-slate-400">
-                Firewall NAT rules on the MikroTik router.
-              </CardDescription>
-            </div>
-            <Button
-              size="sm"
-              onClick={() => setShowAddMt(true)}
-              className="bg-blue-600 hover:bg-blue-700"
-            >
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
-              Add Rule
-            </Button>
+          <Button
+            size="sm"
+            onClick={() => setShowAddMt(true)}
+            className="bg-blue-600 text-white hover:bg-blue-500"
+          >
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            Add Rule
+          </Button>
+        </section>
+
+        <Card className={surfaceClass}>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base text-white">MikroTik NAT Rules</CardTitle>
+            <CardDescription className="text-xs text-slate-500">
+              Firewall NAT rules synchronized from the router.
+            </CardDescription>
           </CardHeader>
-          <CardContent>
-            {filteredMt === null ? (
-              <div className="space-y-2">
-                {[...Array(3)].map((_, i) => (
-                  <Skeleton key={i} className="h-10 bg-slate-800" />
-                ))}
-              </div>
-            ) : filteredMt.length === 0 ? (
-              <p className="text-sm text-slate-500 py-8 text-center">
-                {search
-                  ? "No matching rules."
-                  : "No NAT rules configured."}
-              </p>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-slate-800">
-                    <TableHead className="text-slate-400">Chain</TableHead>
-                    <TableHead className="text-slate-400">
-                      Action
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      Protocol
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      Dst Port
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      To Address
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      To Port
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      Comment
-                    </TableHead>
-                    <TableHead className="text-slate-400">
-                      Status
-                    </TableHead>
-                    <TableHead className="text-slate-400 text-right">
-                      Actions
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredMt.map((rule, idx) => (
-                    <TableRow
-                      key={rule.id ?? idx}
-                      className="border-slate-800 hover:bg-slate-800/50"
-                    >
-                      <TableCell className="text-slate-300">
-                        {rule.chain ?? "-"}
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="secondary"
-                          className={
-                            rule.action === "dst-nat"
-                              ? "bg-blue-900/50 text-blue-300"
-                              : rule.action === "masquerade"
-                                ? "bg-green-900/50 text-green-300"
-                                : "bg-slate-800 text-slate-300"
-                          }
-                        >
-                          {rule.action ?? "-"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-slate-300">
-                        {rule.protocol ?? "any"}
-                      </TableCell>
-                      <TableCell className="text-slate-300 font-mono">
-                        {rule.dst_port ?? "-"}
-                      </TableCell>
-                      <TableCell className="text-slate-300 font-mono">
-                        {rule.to_addresses ?? "-"}
-                      </TableCell>
-                      <TableCell className="text-slate-300 font-mono">
-                        {rule.to_ports ?? "-"}
-                      </TableCell>
-                      <TableCell className="text-slate-400 max-w-[200px] truncate">
-                        {rule.comment ?? "-"}
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="secondary"
-                          className={
-                            rule.disabled
-                              ? "bg-slate-800 text-slate-500"
-                              : "bg-green-900/50 text-green-300"
-                          }
-                        >
-                          {rule.disabled ? "Disabled" : "Active"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex justify-end gap-1">
-                          {rule.id && (
-                            <>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setEditMtRule(rule)}
-                                className="h-7 w-7 p-0 text-slate-400 hover:text-white"
-                              >
-                                <Pencil className="h-3.5 w-3.5" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setPendingDeleteMt(rule)}
-                                className="h-7 w-7 p-0 text-slate-400 hover:text-red-400"
-                              >
-                                <Trash2 className="h-3.5 w-3.5" />
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
+
+          <CardContent className="p-0">
+            <div className="overflow-x-auto border-t border-slate-800/70">
+              {filteredMt === null ? (
+                <div className="space-y-2 p-4">
+                  {[...Array(4)].map((_, i) => (
+                    <Skeleton key={i} className="h-10 bg-slate-800" />
                   ))}
-                </TableBody>
-              </Table>
-            )}
+                </div>
+              ) : filteredMt.length === 0 ? (
+                <div className="py-12 text-center text-sm text-slate-500">
+                  {search ? "No matching rules." : "No NAT rules configured."}
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-slate-800/70 hover:bg-transparent">
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Chain</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Action</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Protocol</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Dst Port</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">To Address</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">To Port</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Comment</TableHead>
+                      <TableHead className="text-xs uppercase tracking-wide text-slate-500">Status</TableHead>
+                      <TableHead className="text-right text-xs uppercase tracking-wide text-slate-500">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+
+                  <TableBody>
+                    {filteredMt.map((rule, idx) => (
+                      <TableRow
+                        key={rule.id ?? idx}
+                        className="border-slate-800/70 hover:bg-slate-800/35"
+                      >
+                        <TableCell className="text-slate-200">{rule.chain ?? "-"}</TableCell>
+
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "rounded-md border text-[11px] uppercase",
+                              rule.action === "dst-nat"
+                                ? "border-blue-500/30 bg-blue-500/10 text-blue-300"
+                                : rule.action === "masquerade"
+                                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                                  : "border-slate-700 bg-slate-900/70 text-slate-400",
+                            )}
+                          >
+                            {rule.action ?? "-"}
+                          </Badge>
+                        </TableCell>
+
+                        <TableCell className="text-slate-300">{rule.protocol ?? "any"}</TableCell>
+                        <TableCell className="font-mono text-xs text-slate-300">{rule.dst_port ?? "-"}</TableCell>
+                        <TableCell className="font-mono text-xs text-slate-300">{rule.to_addresses ?? "-"}</TableCell>
+                        <TableCell className="font-mono text-xs text-slate-300">{rule.to_ports ?? "-"}</TableCell>
+                        <TableCell className="max-w-[220px] truncate text-slate-400" title={rule.comment ?? undefined}>
+                          {rule.comment ?? "-"}
+                        </TableCell>
+
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "rounded-md border text-[11px] uppercase",
+                              rule.disabled
+                                ? "border-slate-700 bg-slate-900/70 text-slate-500"
+                                : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300",
+                            )}
+                          >
+                            {rule.disabled ? "disabled" : "active"}
+                          </Badge>
+                        </TableCell>
+
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-1">
+                            {rule.id && (
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setEditMtRule(rule)}
+                                  className="h-7 w-7 p-0 text-slate-400 hover:text-white"
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setPendingDeleteMt(rule)}
+                                  className="h-7 w-7 p-0 text-slate-400 hover:text-rose-400"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
           </CardContent>
         </Card>
 
-        {/* MikroTik Add Dialog */}
         <MikrotikNatDialog
           open={showAddMt}
           onOpenChange={setShowAddMt}
@@ -350,14 +312,11 @@ export default function NatPage() {
               load();
               setShowAddMt(false);
             } catch (err) {
-              toast.error(
-                err instanceof Error ? err.message : "Failed to create rule"
-              );
+              toast.error(err instanceof Error ? err.message : "Failed to create rule");
             }
           }}
         />
 
-        {/* MikroTik Edit Dialog */}
         <MikrotikNatDialog
           open={!!editMtRule}
           onOpenChange={(open) => {
@@ -373,14 +332,11 @@ export default function NatPage() {
               load();
               setEditMtRule(null);
             } catch (err) {
-              toast.error(
-                err instanceof Error ? err.message : "Failed to update rule"
-              );
+              toast.error(err instanceof Error ? err.message : "Failed to update rule");
             }
           }}
         />
 
-        {/* MikroTik Delete Confirm */}
         <AlertDialog
           open={!!pendingDeleteMt}
           onOpenChange={(open) => {
@@ -389,24 +345,18 @@ export default function NatPage() {
         >
           <AlertDialogContent className="bg-slate-900 border-slate-800">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white">
-                Delete MikroTik NAT Rule
-              </AlertDialogTitle>
+              <AlertDialogTitle className="text-white">Delete MikroTik NAT Rule</AlertDialogTitle>
               <AlertDialogDescription className="text-slate-400">
                 Are you sure you want to delete this NAT rule
-                {pendingDeleteMt?.comment
-                  ? ` (${pendingDeleteMt.comment})`
-                  : ""}
-                ? This will remove it from the MikroTik router.
+                {pendingDeleteMt?.comment ? ` (${pendingDeleteMt.comment})` : ""}?
+                This will remove it from the MikroTik router.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-slate-700 text-slate-300">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel className="border-slate-700 text-slate-300">Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDeleteMt}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-rose-600 text-white hover:bg-rose-500"
               >
                 Delete
               </AlertDialogAction>
@@ -418,39 +368,40 @@ export default function NatPage() {
   );
 }
 
-// ─── Summary Card ────────────────────────────────────────────
-
 function SummaryCard({
   title,
   value,
   available,
   icon,
+  iconClass,
 }: {
   title: string;
   value: number | null;
   available: boolean | null;
   icon: React.ReactNode;
+  iconClass: string;
 }) {
   return (
-    <Card className="bg-slate-900/50 border-slate-800">
-      <CardContent className="flex items-center gap-3 pt-6">
-        {icon}
-        <div>
-          <p className="text-xs text-slate-500">{title}</p>
+    <Card className={surfaceClass}>
+      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
+          {icon}
+        </div>
+
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">{title}</p>
           {available === null ? (
-            <Skeleton className="h-5 w-10 mt-1 bg-slate-800" />
+            <Skeleton className="mt-2 h-6 w-14 bg-slate-800" />
           ) : available ? (
-            <p className="text-lg font-semibold text-white">{value ?? 0}</p>
+            <p className="mt-1 text-2xl font-semibold text-white">{value ?? 0}</p>
           ) : (
-            <p className="text-sm text-slate-500">Not configured</p>
+            <p className="mt-1 text-sm text-slate-500">Not configured</p>
           )}
         </div>
       </CardContent>
     </Card>
   );
 }
-
-// ─── MikroTik NAT Dialog ─────────────────────────────────────
 
 function MikrotikNatDialog({
   open,
@@ -533,6 +484,7 @@ function MikrotikNatDialog({
             {existing ? "Edit MikroTik NAT Rule" : "Add MikroTik NAT Rule"}
           </DialogTitle>
         </DialogHeader>
+
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1.5">
@@ -541,7 +493,7 @@ function MikrotikNatDialog({
                 value={chain}
                 onChange={(e) => setChain(e.target.value)}
                 placeholder="dstnat"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
             <div className="space-y-1.5">
@@ -550,10 +502,11 @@ function MikrotikNatDialog({
                 value={action}
                 onChange={(e) => setAction(e.target.value)}
                 placeholder="dst-nat"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
           </div>
+
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1.5">
               <Label className="text-slate-400">Protocol</Label>
@@ -561,7 +514,7 @@ function MikrotikNatDialog({
                 value={protocol}
                 onChange={(e) => setProtocol(e.target.value)}
                 placeholder="tcp"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
             <div className="space-y-1.5">
@@ -570,10 +523,11 @@ function MikrotikNatDialog({
                 value={dstPort}
                 onChange={(e) => setDstPort(e.target.value)}
                 placeholder="8080"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
           </div>
+
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1.5">
               <Label className="text-slate-400">To Addresses</Label>
@@ -581,7 +535,7 @@ function MikrotikNatDialog({
                 value={toAddresses}
                 onChange={(e) => setToAddresses(e.target.value)}
                 placeholder="192.168.1.100"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
             <div className="space-y-1.5">
@@ -590,19 +544,21 @@ function MikrotikNatDialog({
                 value={toPorts}
                 onChange={(e) => setToPorts(e.target.value)}
                 placeholder="80"
-                className="bg-slate-800 border-slate-700 text-slate-200"
+                className="bg-slate-950 border-slate-800 text-slate-200"
               />
             </div>
           </div>
+
           <div className="space-y-1.5">
             <Label className="text-slate-400">Comment</Label>
             <Input
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder="Web server"
-              className="bg-slate-800 border-slate-700 text-slate-200"
+              className="bg-slate-950 border-slate-800 text-slate-200"
             />
           </div>
+
           <div className="flex items-center gap-2">
             <input
               type="checkbox"
@@ -615,6 +571,7 @@ function MikrotikNatDialog({
               Disabled
             </Label>
           </div>
+
           <div className="flex justify-end gap-2 pt-2">
             <Button
               variant="outline"
@@ -626,7 +583,7 @@ function MikrotikNatDialog({
             <Button
               onClick={handleSubmit}
               disabled={saving || !chain || !action}
-              className="bg-blue-600 hover:bg-blue-700"
+              className="bg-blue-600 hover:bg-blue-500 text-white"
             >
               {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
               {existing ? "Update" : "Create"}

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -15,9 +15,9 @@ import {
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -51,19 +51,23 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
 import {
-  fetchQosSummary,
-  fetchMikrotikSimpleQueues,
   createMikrotikSimpleQueue,
-  updateMikrotikSimpleQueue,
   deleteMikrotikSimpleQueue,
   fetchMikrotikQueueTree,
+  fetchMikrotikSimpleQueues,
+  fetchQosSummary,
+  updateMikrotikSimpleQueue,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 import type {
-  QosSummary,
-  MikrotikSimpleQueue,
   MikrotikQueueTree,
+  MikrotikSimpleQueue,
+  QosSummary,
 } from "@/lib/types";
 import { toast } from "sonner";
+
+const surfaceClass =
+  "border-slate-800/70 bg-gradient-to-b from-slate-900/80 to-slate-900/55 shadow-[0_12px_30px_rgba(2,6,23,0.35)]";
 
 export default function QosPage() {
   const [summary, setSummary] = useState<QosSummary | null>(null);
@@ -72,11 +76,8 @@ export default function QosPage() {
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState("overview");
 
-  // Dialogs
   const [showAddMtQueue, setShowAddMtQueue] = useState(false);
-  const [editMtQueue, setEditMtQueue] = useState<MikrotikSimpleQueue | null>(
-    null
-  );
+  const [editMtQueue, setEditMtQueue] = useState<MikrotikSimpleQueue | null>(null);
   const [pendingDeleteMtQueue, setPendingDeleteMtQueue] =
     useState<MikrotikSimpleQueue | null>(null);
 
@@ -85,7 +86,7 @@ export default function QosPage() {
       const s = await fetchQosSummary();
       setSummary(s);
     } catch {
-      // summary is best-effort
+      // best-effort summary
     }
   }, []);
 
@@ -107,7 +108,6 @@ export default function QosPage() {
     load();
   }, [load]);
 
-  // Default to MikroTik tab when available
   useEffect(() => {
     if (!summary) return;
     if (summary.mikrotik_available) {
@@ -119,7 +119,6 @@ export default function QosPage() {
     if (activeTab === "mikrotik") loadMtQueues();
   }, [activeTab, loadMtQueues]);
 
-  // -- Filter helpers --
   const filteredMtQueues = useMemo(() => {
     if (!mtQueues) return null;
     if (!search.trim()) return mtQueues;
@@ -128,7 +127,7 @@ export default function QosPage() {
       (queue) =>
         queue.name.toLowerCase().includes(q) ||
         queue.target.toLowerCase().includes(q) ||
-        (queue.comment ?? "").toLowerCase().includes(q)
+        (queue.comment ?? "").toLowerCase().includes(q),
     );
   }, [mtQueues, search]);
 
@@ -137,21 +136,15 @@ export default function QosPage() {
     if (!search.trim()) return mtTree;
     const q = search.toLowerCase();
     return mtTree.filter(
-      (t) =>
-        t.name.toLowerCase().includes(q) ||
-        (t.parent ?? "").toLowerCase().includes(q)
+      (t) => t.name.toLowerCase().includes(q) || (t.parent ?? "").toLowerCase().includes(q),
     );
   }, [mtTree, search]);
 
-  // -- Handlers --
   async function handleDeleteMtQueue() {
     if (!pendingDeleteMtQueue || !pendingDeleteMtQueue.id) return;
     try {
       await deleteMikrotikSimpleQueue(pendingDeleteMtQueue.id);
-      setMtQueues(
-        (prev) =>
-          prev?.filter((q) => q.id !== pendingDeleteMtQueue.id) ?? null
-      );
+      setMtQueues((prev) => prev?.filter((q) => q.id !== pendingDeleteMtQueue.id) ?? null);
       toast.success(`Deleted queue '${pendingDeleteMtQueue.name}'`);
       load();
     } catch {
@@ -163,15 +156,20 @@ export default function QosPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-6xl space-y-6 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Gauge className="h-6 w-6 text-blue-500" />
-            <h1 className="text-2xl font-semibold text-white">
-              QoS / Traffic Shaping
-            </h1>
+      <div className="space-y-6">
+        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-500/30 bg-gradient-to-br from-blue-500/20 via-cyan-500/10 to-indigo-500/10 text-blue-300">
+              <Gauge className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-white">QoS / Traffic Shaping</h1>
+              <p className="text-sm text-slate-400">
+                Queue policies, bandwidth limits, and hierarchical shaping.
+              </p>
+            </div>
           </div>
+
           <Button
             variant="outline"
             size="sm"
@@ -179,107 +177,101 @@ export default function QosPage() {
               load();
               if (activeTab === "mikrotik") loadMtQueues();
             }}
-            className="border-slate-800 text-slate-300 hover:bg-slate-800"
+            className="border-slate-700 bg-slate-900/60 text-slate-200 hover:bg-slate-800"
           >
             <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
             Refresh
           </Button>
-        </div>
+        </section>
 
-        {/* Summary Cards */}
-        <div className="grid gap-4 sm:grid-cols-2">
+        <section className="grid gap-4 sm:grid-cols-2">
           <SummaryCard
             title="MikroTik Simple Queues"
             value={summary?.mikrotik_simple_queue_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<Network className="h-4 w-4 text-orange-400" />}
+            icon={<Network className="h-4 w-4 text-amber-300" />}
+            iconClass="border-amber-500/30 bg-amber-500/15"
           />
           <SummaryCard
             title="MikroTik Queue Tree"
             value={summary?.mikrotik_queue_tree_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<Network className="h-4 w-4 text-orange-400" />}
+            icon={<Network className="h-4 w-4 text-cyan-300" />}
+            iconClass="border-cyan-500/30 bg-cyan-500/15"
           />
-        </div>
+        </section>
 
-        {/* Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="bg-slate-900 border border-slate-800">
+          <TabsList className="h-auto rounded-xl border border-slate-800/80 bg-slate-900/70 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+              className="rounded-lg px-4 data-[state=active]:bg-slate-800 data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
+
             {summary?.mikrotik_available && (
               <TabsTrigger
                 value="mikrotik"
-                className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+                className="rounded-lg px-4 data-[state=active]:bg-slate-800 data-[state=active]:text-white"
               >
                 MikroTik Queues
               </TabsTrigger>
             )}
           </TabsList>
 
-          {/* Overview Tab */}
-          <TabsContent value="overview" className="space-y-4">
-            <Card className="border-slate-800 bg-slate-900">
+          <TabsContent value="overview" className="space-y-4 pt-2">
+            <Card className={surfaceClass}>
               <CardHeader>
-                <CardTitle className="text-white">
-                  Traffic Shaping Overview
-                </CardTitle>
+                <CardTitle className="text-base text-white">Traffic Shaping Overview</CardTitle>
                 <CardDescription className="text-slate-400">
-                  Manage bandwidth queues and traffic policies on your
-                  router. Use MikroTik simple queues for per-device bandwidth limits.
+                  Simple queues apply per-target limits, while queue tree entries define
+                  hierarchical policy and prioritization.
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-3 text-sm text-slate-400">
-                  {summary?.mikrotik_available && (
-                    <p>
-                      MikroTik router configured with{" "}
-                      <span className="font-medium text-white">
-                        {summary.mikrotik_simple_queue_count}
-                      </span>{" "}
-                      simple{" "}
-                      {summary.mikrotik_simple_queue_count === 1
-                        ? "queue"
-                        : "queues"}{" "}
-                      and{" "}
-                      <span className="font-medium text-white">
-                        {summary.mikrotik_queue_tree_count}
-                      </span>{" "}
-                      queue tree{" "}
-                      {summary.mikrotik_queue_tree_count === 1
-                        ? "entry"
-                        : "entries"}
-                      .
-                    </p>
-                  )}
-                  {!summary?.mikrotik_available && (
-                    <p>
-                      No router is configured. Go to{" "}
-                      <span className="font-medium text-white">Settings</span>{" "}
-                      to configure a router.
-                    </p>
-                  )}
-                </div>
+                {summary?.mikrotik_available ? (
+                  <div className="grid gap-3 text-sm text-slate-300 md:grid-cols-2">
+                    <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Simple queues</p>
+                      <p className="mt-1 text-slate-200">
+                        <span className="font-semibold text-white">
+                          {summary.mikrotik_simple_queue_count}
+                        </span>{" "}
+                        configured
+                      </p>
+                    </div>
+                    <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Queue tree</p>
+                      <p className="mt-1 text-slate-200">
+                        <span className="font-semibold text-white">
+                          {summary.mikrotik_queue_tree_count}
+                        </span>{" "}
+                        entries
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-400">
+                    No router is configured. Configure router credentials in Settings.
+                  </p>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
-          {/* MikroTik Queues Tab */}
-          <TabsContent value="mikrotik" className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="relative flex-1 max-w-md">
+          <TabsContent value="mikrotik" className="space-y-4 pt-2">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="relative max-w-md flex-1">
                 <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
                 <Input
-                  placeholder="Filter queues..."
+                  placeholder="Filter by queue name, target, or comment..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  className="border-slate-800 bg-slate-950 pl-10 text-white placeholder:text-slate-600"
+                  className="border-slate-800 bg-slate-950/70 pl-10 text-white placeholder:text-slate-600"
                 />
               </div>
+
               <Button
                 size="sm"
                 onClick={() => setShowAddMtQueue(true)}
@@ -290,228 +282,179 @@ export default function QosPage() {
               </Button>
             </div>
 
-            {/* Simple Queues */}
-            <Card className="border-slate-800 bg-slate-900">
+            <Card className={surfaceClass}>
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-white">
-                  Simple Queues
-                </CardTitle>
+                <CardTitle className="text-base text-white">Simple Queues</CardTitle>
                 <CardDescription className="text-xs text-slate-500">
-                  Per-target bandwidth limits (IP/subnet).
+                  Per-target bandwidth limits for IPs/subnets.
                 </CardDescription>
               </CardHeader>
               <CardContent className="p-0">
-                <Table>
-                  <TableHeader>
-                    <TableRow className="border-slate-800 hover:bg-transparent">
-                      <TableHead className="text-slate-400">Name</TableHead>
-                      <TableHead className="text-slate-400">Target</TableHead>
-                      <TableHead className="text-slate-400">
-                        Max Limit
-                      </TableHead>
-                      <TableHead className="text-slate-400">
-                        Priority
-                      </TableHead>
-                      <TableHead className="text-slate-400">Rate</TableHead>
-                      <TableHead className="text-slate-400">Status</TableHead>
-                      <TableHead className="text-right text-slate-400">
-                        Actions
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredMtQueues === null ? (
-                      Array.from({ length: 3 }).map((_, i) => (
-                        <TableRow key={i} className="border-slate-800">
-                          {Array.from({ length: 7 }).map((_, j) => (
-                            <TableCell key={j}>
-                              <Skeleton className="h-4 w-20 bg-slate-800" />
-                            </TableCell>
-                          ))}
-                        </TableRow>
-                      ))
-                    ) : filteredMtQueues.length === 0 ? (
-                      <TableRow className="border-slate-800 hover:bg-transparent">
-                        <TableCell
-                          colSpan={7}
-                          className="py-12 text-center text-slate-500"
-                        >
-                          {search
-                            ? "No queues match your filter."
-                            : "No simple queues configured."}
-                        </TableCell>
+                <div className="overflow-x-auto border-t border-slate-800/70">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="border-slate-800/70 hover:bg-transparent">
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Name</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Target</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Max Limit</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Priority</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Rate</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Status</TableHead>
+                        <TableHead className="text-right text-xs uppercase tracking-wide text-slate-500">Actions</TableHead>
                       </TableRow>
-                    ) : (
-                      filteredMtQueues.map((queue) => (
-                        <TableRow
-                          key={queue.id ?? queue.name}
-                          className="border-slate-800 hover:bg-slate-800/30"
-                        >
-                          <TableCell className="font-medium text-white">
-                            {queue.name}
-                          </TableCell>
-                          <TableCell className="text-slate-400">
-                            {queue.target}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs text-slate-400">
-                            {queue.max_limit ?? "—"}
-                          </TableCell>
-                          <TableCell className="text-slate-400">
-                            {queue.priority ?? "—"}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs text-slate-400">
-                            {queue.rate ?? "—"}
-                          </TableCell>
-                          <TableCell>
-                            <Badge
-                              variant="outline"
-                              className={
-                                queue.disabled
-                                  ? "border-slate-700 text-slate-500"
-                                  : queue.dynamic
-                                    ? "border-amber-500/30 text-amber-400"
-                                    : "border-emerald-500/30 text-emerald-400"
-                              }
-                            >
-                              {queue.disabled
-                                ? "disabled"
-                                : queue.dynamic
-                                  ? "dynamic"
-                                  : "active"}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex justify-end gap-1">
-                              {!queue.dynamic && queue.id && (
-                                <>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => setEditMtQueue(queue)}
-                                    className="h-8 w-8 p-0 text-slate-400 hover:text-white"
-                                  >
-                                    <Pencil className="h-3.5 w-3.5" />
-                                  </Button>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() =>
-                                      setPendingDeleteMtQueue(queue)
-                                    }
-                                    className="h-8 w-8 p-0 text-slate-400 hover:text-rose-400"
-                                  >
-                                    <Trash2 className="h-3.5 w-3.5" />
-                                  </Button>
-                                </>
-                              )}
-                            </div>
+                    </TableHeader>
+
+                    <TableBody>
+                      {filteredMtQueues === null ? (
+                        Array.from({ length: 3 }).map((_, i) => (
+                          <TableRow key={i} className="border-slate-800/70">
+                            {Array.from({ length: 7 }).map((_, j) => (
+                              <TableCell key={j}>
+                                <Skeleton className="h-4 w-20 bg-slate-800" />
+                              </TableCell>
+                            ))}
+                          </TableRow>
+                        ))
+                      ) : filteredMtQueues.length === 0 ? (
+                        <TableRow className="border-slate-800/70 hover:bg-transparent">
+                          <TableCell colSpan={7} className="py-12 text-center text-slate-500">
+                            {search ? "No queues match your filter." : "No simple queues configured."}
                           </TableCell>
                         </TableRow>
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
+                      ) : (
+                        filteredMtQueues.map((queue) => (
+                          <TableRow
+                            key={queue.id ?? queue.name}
+                            className="border-slate-800/70 hover:bg-slate-800/35"
+                          >
+                            <TableCell className="font-medium text-white">{queue.name}</TableCell>
+                            <TableCell className="text-slate-300">{queue.target}</TableCell>
+                            <TableCell className="font-mono text-xs text-slate-400">{queue.max_limit ?? "—"}</TableCell>
+                            <TableCell className="text-slate-300">{queue.priority ?? "—"}</TableCell>
+                            <TableCell className="font-mono text-xs text-slate-400">{queue.rate ?? "—"}</TableCell>
+                            <TableCell>
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  "rounded-md border text-[11px] uppercase",
+                                  queue.disabled
+                                    ? "border-slate-700 bg-slate-900/70 text-slate-500"
+                                    : queue.dynamic
+                                      ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
+                                      : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300",
+                                )}
+                              >
+                                {queue.disabled ? "disabled" : queue.dynamic ? "dynamic" : "active"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex justify-end gap-1">
+                                {!queue.dynamic && queue.id && (
+                                  <>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => setEditMtQueue(queue)}
+                                      className="h-8 w-8 p-0 text-slate-400 hover:text-white"
+                                    >
+                                      <Pencil className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => setPendingDeleteMtQueue(queue)}
+                                      className="h-8 w-8 p-0 text-slate-400 hover:text-rose-400"
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
               </CardContent>
             </Card>
 
-            {/* Queue Tree (read-only) */}
-            <Card className="border-slate-800 bg-slate-900">
+            <Card className={surfaceClass}>
               <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-white">
-                  Queue Tree
-                </CardTitle>
+                <CardTitle className="text-base text-white">Queue Tree</CardTitle>
                 <CardDescription className="text-xs text-slate-500">
                   Hierarchical queue entries (read-only view).
                 </CardDescription>
               </CardHeader>
               <CardContent className="p-0">
-                <Table>
-                  <TableHeader>
-                    <TableRow className="border-slate-800 hover:bg-transparent">
-                      <TableHead className="text-slate-400">Name</TableHead>
-                      <TableHead className="text-slate-400">Parent</TableHead>
-                      <TableHead className="text-slate-400">
-                        Packet Mark
-                      </TableHead>
-                      <TableHead className="text-slate-400">
-                        Max Limit
-                      </TableHead>
-                      <TableHead className="text-slate-400">
-                        Priority
-                      </TableHead>
-                      <TableHead className="text-slate-400">Rate</TableHead>
-                      <TableHead className="text-slate-400">Status</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredMtTree === null ? (
-                      Array.from({ length: 2 }).map((_, i) => (
-                        <TableRow key={i} className="border-slate-800">
-                          {Array.from({ length: 7 }).map((_, j) => (
-                            <TableCell key={j}>
-                              <Skeleton className="h-4 w-20 bg-slate-800" />
-                            </TableCell>
-                          ))}
-                        </TableRow>
-                      ))
-                    ) : filteredMtTree.length === 0 ? (
-                      <TableRow className="border-slate-800 hover:bg-transparent">
-                        <TableCell
-                          colSpan={7}
-                          className="py-12 text-center text-slate-500"
-                        >
-                          {search
-                            ? "No tree entries match your filter."
-                            : "No queue tree entries."}
-                        </TableCell>
+                <div className="overflow-x-auto border-t border-slate-800/70">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="border-slate-800/70 hover:bg-transparent">
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Name</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Parent</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Packet Mark</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Max Limit</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Priority</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Rate</TableHead>
+                        <TableHead className="text-xs uppercase tracking-wide text-slate-500">Status</TableHead>
                       </TableRow>
-                    ) : (
-                      filteredMtTree.map((entry) => (
-                        <TableRow
-                          key={entry.id ?? entry.name}
-                          className="border-slate-800 hover:bg-slate-800/30"
-                        >
-                          <TableCell className="font-medium text-white">
-                            {entry.name}
-                          </TableCell>
-                          <TableCell className="text-slate-400">
-                            {entry.parent ?? "—"}
-                          </TableCell>
-                          <TableCell className="text-slate-400">
-                            {entry.packet_mark ?? "—"}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs text-slate-400">
-                            {entry.max_limit ?? "—"}
-                          </TableCell>
-                          <TableCell className="text-slate-400">
-                            {entry.priority ?? "—"}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs text-slate-400">
-                            {entry.rate ?? "—"}
-                          </TableCell>
-                          <TableCell>
-                            <Badge
-                              variant="outline"
-                              className={
-                                entry.disabled
-                                  ? "border-slate-700 text-slate-500"
-                                  : "border-emerald-500/30 text-emerald-400"
-                              }
-                            >
-                              {entry.disabled ? "disabled" : "active"}
-                            </Badge>
+                    </TableHeader>
+
+                    <TableBody>
+                      {filteredMtTree === null ? (
+                        Array.from({ length: 2 }).map((_, i) => (
+                          <TableRow key={i} className="border-slate-800/70">
+                            {Array.from({ length: 7 }).map((_, j) => (
+                              <TableCell key={j}>
+                                <Skeleton className="h-4 w-20 bg-slate-800" />
+                              </TableCell>
+                            ))}
+                          </TableRow>
+                        ))
+                      ) : filteredMtTree.length === 0 ? (
+                        <TableRow className="border-slate-800/70 hover:bg-transparent">
+                          <TableCell colSpan={7} className="py-12 text-center text-slate-500">
+                            {search ? "No tree entries match your filter." : "No queue tree entries."}
                           </TableCell>
                         </TableRow>
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
+                      ) : (
+                        filteredMtTree.map((entry) => (
+                          <TableRow
+                            key={entry.id ?? entry.name}
+                            className="border-slate-800/70 hover:bg-slate-800/35"
+                          >
+                            <TableCell className="font-medium text-white">{entry.name}</TableCell>
+                            <TableCell className="text-slate-300">{entry.parent ?? "—"}</TableCell>
+                            <TableCell className="text-slate-300">{entry.packet_mark ?? "—"}</TableCell>
+                            <TableCell className="font-mono text-xs text-slate-400">{entry.max_limit ?? "—"}</TableCell>
+                            <TableCell className="text-slate-300">{entry.priority ?? "—"}</TableCell>
+                            <TableCell className="font-mono text-xs text-slate-400">{entry.rate ?? "—"}</TableCell>
+                            <TableCell>
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  "rounded-md border text-[11px] uppercase",
+                                  entry.disabled
+                                    ? "border-slate-700 bg-slate-900/70 text-slate-500"
+                                    : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300",
+                                )}
+                              >
+                                {entry.disabled ? "disabled" : "active"}
+                              </Badge>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
               </CardContent>
             </Card>
           </TabsContent>
         </Tabs>
 
-        {/* MikroTik Add/Edit Queue Dialog */}
         <MikrotikQueueFormDialog
           open={showAddMtQueue || editMtQueue !== null}
           onOpenChange={(open) => {
@@ -529,7 +472,6 @@ export default function QosPage() {
           }}
         />
 
-        {/* MikroTik Delete Confirmation */}
         <AlertDialog
           open={pendingDeleteMtQueue !== null}
           onOpenChange={(open) => {
@@ -538,15 +480,10 @@ export default function QosPage() {
         >
           <AlertDialogContent className="border-slate-800 bg-slate-900">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white">
-                Delete Simple Queue
-              </AlertDialogTitle>
+              <AlertDialogTitle className="text-white">Delete Simple Queue</AlertDialogTitle>
               <AlertDialogDescription className="text-slate-400">
                 Are you sure you want to delete queue{" "}
-                <span className="font-medium text-white">
-                  {pendingDeleteMtQueue?.name}
-                </span>
-                ?
+                <span className="font-medium text-white">{pendingDeleteMtQueue?.name}</span>?
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -567,41 +504,40 @@ export default function QosPage() {
   );
 }
 
-// ─── Summary Card ──────────────────────────────────────────
-
 function SummaryCard({
   title,
   value,
   available,
   icon,
+  iconClass,
 }: {
   title: string;
   value: number | null;
   available: boolean | null;
   icon: React.ReactNode;
+  iconClass: string;
 }) {
   return (
-    <Card className="border-slate-800 bg-slate-900">
-      <CardContent className="flex items-center gap-4 p-5">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-800">
+    <Card className={surfaceClass}>
+      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
           {icon}
         </div>
-        <div>
-          <p className="text-xs text-slate-500">{title}</p>
+
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">{title}</p>
           {available === null ? (
-            <Skeleton className="mt-1 h-6 w-8 bg-slate-800" />
+            <Skeleton className="mt-2 h-6 w-14 bg-slate-800" />
           ) : available ? (
-            <p className="text-2xl font-bold text-white">{value ?? 0}</p>
+            <p className="mt-1 text-2xl font-semibold text-white">{value ?? 0}</p>
           ) : (
-            <p className="text-sm text-slate-600">Not configured</p>
+            <p className="mt-1 text-sm text-slate-500">Not configured</p>
           )}
         </div>
       </CardContent>
     </Card>
   );
 }
-
-// ─── MikroTik Queue Form ───────────────────────────────────
 
 function MikrotikQueueFormDialog({
   open,
@@ -690,9 +626,7 @@ function MikrotikQueueFormDialog({
       }
       onSaved();
     } catch (err) {
-      setFormError(
-        err instanceof Error ? err.message : "Failed to save queue"
-      );
+      setFormError(err instanceof Error ? err.message : "Failed to save queue");
     } finally {
       setLoading(false);
     }
@@ -702,10 +636,9 @@ function MikrotikQueueFormDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="border-slate-800 bg-slate-900 sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="text-white">
-            {isEdit ? "Edit Simple Queue" : "Add Simple Queue"}
-          </DialogTitle>
+          <DialogTitle className="text-white">{isEdit ? "Edit Simple Queue" : "Add Simple Queue"}</DialogTitle>
         </DialogHeader>
+
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="queue-name" className="text-xs text-slate-400">
@@ -734,10 +667,7 @@ function MikrotikQueueFormDialog({
           </div>
 
           <div className="space-y-1.5">
-            <Label
-              htmlFor="queue-max-limit"
-              className="text-xs text-slate-400"
-            >
+            <Label htmlFor="queue-max-limit" className="text-xs text-slate-400">
               Max Limit (upload/download)
             </Label>
             <Input
@@ -760,9 +690,7 @@ function MikrotikQueueFormDialog({
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-slate-400">
-                Burst Threshold
-              </Label>
+              <Label className="text-xs text-slate-400">Burst Threshold</Label>
               <Input
                 value={burstThreshold}
                 onChange={(e) => setBurstThreshold(e.target.value)}
@@ -819,14 +747,8 @@ function MikrotikQueueFormDialog({
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={loading}
-              className="bg-blue-600 text-white hover:bg-blue-500"
-            >
-              {loading && (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              )}
+            <Button type="submit" disabled={loading} className="bg-blue-600 text-white hover:bg-blue-500">
+              {loading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
               {isEdit ? "Update" : "Create"}
             </Button>
           </div>

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -13,9 +13,9 @@ import {
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,7 +32,11 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageTransition } from "@/components/PageTransition";
 import { fetchVpnStatus } from "@/lib/api";
-import type { VpnStatusResponse, VpnInterfaceStatus } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type { VpnInterfaceStatus, VpnStatusResponse } from "@/lib/types";
+
+const surfaceClass =
+  "border-slate-800/70 bg-gradient-to-b from-slate-900/80 to-slate-900/55 shadow-[0_12px_30px_rgba(2,6,23,0.35)]";
 
 /** Format bytes into a human-readable string. */
 function formatBytes(bytes: number | null): string {
@@ -79,7 +83,6 @@ export default function VpnStatusPage() {
 
   useEffect(() => {
     load();
-    // Auto-refresh every 30 seconds
     const id = setInterval(load, 30_000);
     return () => clearInterval(id);
   }, [load]);
@@ -109,16 +112,15 @@ export default function VpnStatusPage() {
         ),
       }))
       .filter(
-        (iface) =>
-          iface.name.toLowerCase().includes(q) || iface.peers.length > 0,
+        (iface) => iface.name.toLowerCase().includes(q) || iface.peers.length > 0,
       );
   }, [data, search]);
 
-  // Group interfaces by source
   const mikrotikInterfaces = useMemo(
     () => filteredInterfaces?.filter((i) => i.source === "mikrotik") ?? [],
     [filteredInterfaces],
   );
+
   const overviewInterfaces = useMemo(() => {
     if (!data) return [];
     return data.interfaces;
@@ -126,134 +128,132 @@ export default function VpnStatusPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-6xl space-y-6 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Shield className="h-6 w-6 text-blue-500" />
-            <h1 className="text-2xl font-semibold text-white">VPN Status</h1>
+      <div className="space-y-6">
+        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-indigo-500/30 bg-gradient-to-br from-indigo-500/20 via-blue-500/10 to-cyan-500/10 text-indigo-300">
+              <Shield className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight text-white">VPN Status</h1>
+              <p className="text-sm text-slate-400">
+                WireGuard tunnels, peer connectivity, and transfer stats.
+              </p>
+            </div>
           </div>
+
           <Button
             variant="outline"
             size="sm"
             onClick={load}
-            className="border-slate-800 text-slate-300 hover:bg-slate-800"
+            className="border-slate-700 bg-slate-900/60 text-slate-200 hover:bg-slate-800"
           >
             <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
             Refresh
           </Button>
-        </div>
+        </section>
 
-        {/* Summary Cards */}
-        <div className="grid gap-4 sm:grid-cols-4">
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           <SummaryCard
             title="Interfaces"
             value={data ? overviewInterfaces.length : null}
             loading={loading && !data}
-            icon={<Shield className="h-4 w-4 text-blue-400" />}
+            icon={<Shield className="h-4 w-4 text-indigo-300" />}
+            iconClass="border-indigo-500/30 bg-indigo-500/15"
           />
           <SummaryCard
             title="Peers Online"
             value={data?.online_peers ?? null}
             loading={loading && !data}
-            icon={<Wifi className="h-4 w-4 text-emerald-400" />}
-            subtitle={
-              data
-                ? `of ${data.total_peers} total`
-                : undefined
-            }
+            icon={<Wifi className="h-4 w-4 text-emerald-300" />}
+            iconClass="border-emerald-500/30 bg-emerald-500/15"
+            subtitle={data ? `of ${data.total_peers} total` : undefined}
           />
           <SummaryCard
             title="Total RX"
             value={data ? formatBytes(data.total_rx_bytes) : null}
             loading={loading && !data}
-            icon={<ArrowDownToLine className="h-4 w-4 text-cyan-400" />}
+            icon={<ArrowDownToLine className="h-4 w-4 text-cyan-300" />}
+            iconClass="border-cyan-500/30 bg-cyan-500/15"
             isText
           />
           <SummaryCard
             title="Total TX"
             value={data ? formatBytes(data.total_tx_bytes) : null}
             loading={loading && !data}
-            icon={<ArrowUpFromLine className="h-4 w-4 text-amber-400" />}
+            icon={<ArrowUpFromLine className="h-4 w-4 text-amber-300" />}
+            iconClass="border-amber-500/30 bg-amber-500/15"
             isText
           />
-        </div>
+        </section>
 
-        {/* Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="bg-slate-900 border border-slate-800">
+          <TabsList className="h-auto rounded-xl border border-slate-800/80 bg-slate-900/70 p-1">
             <TabsTrigger
               value="overview"
-              className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+              className="rounded-lg px-4 data-[state=active]:bg-slate-800 data-[state=active]:text-white"
             >
               Overview
             </TabsTrigger>
-
             {data?.mikrotik_available && (
               <TabsTrigger
                 value="mikrotik"
-                className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"
+                className="rounded-lg px-4 data-[state=active]:bg-slate-800 data-[state=active]:text-white"
               >
                 MikroTik
               </TabsTrigger>
             )}
           </TabsList>
 
-          {/* Overview Tab */}
-          <TabsContent value="overview" className="space-y-4">
-            <Card className="border-slate-800 bg-slate-900">
-              <CardHeader>
-                <CardTitle className="text-white">
-                  VPN Tunnel Overview
-                </CardTitle>
-                <CardDescription className="text-slate-400">
-                  Real-time WireGuard peer status across all configured routers.
-                  Peers are considered online if their last handshake was within
-                  3 minutes. Data refreshes automatically every 30 seconds.
+          <TabsContent value="overview" className="space-y-4 pt-2">
+            <Card className={surfaceClass}>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base text-white">Tunnel Overview</CardTitle>
+                <CardDescription className="text-sm text-slate-400">
+                  Peers are treated as online when the last handshake is within
+                  3 minutes. Data auto-refreshes every 30 seconds.
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-3 text-sm text-slate-400">
-                  {data?.mikrotik_available && (
-                    <p>
-                      MikroTik:{" "}
-                      <span className="font-medium text-white">
-                        {mikrotikInterfaces.length}
-                      </span>{" "}
-                      {mikrotikInterfaces.length === 1
-                        ? "interface"
-                        : "interfaces"}
-                      {" with "}
-                      <span className="font-medium text-white">
-                        {mikrotikInterfaces.reduce(
-                          (sum, i) => sum + i.peers_total,
-                          0,
-                        )}
-                      </span>{" "}
-                      peers (
-                      <span className="text-emerald-400">
-                        {mikrotikInterfaces.reduce(
-                          (sum, i) => sum + i.peers_online,
-                          0,
-                        )}{" "}
-                        online
-                      </span>
-                      )
-                    </p>
-                  )}
-                  {!data?.mikrotik_available && !loading && (
-                    <p>
-                      No router is configured. Go to{" "}
-                      <span className="font-medium text-white">Settings</span>{" "}
-                      to configure a router.
-                    </p>
+                <div className="grid gap-2 text-sm text-slate-300 md:grid-cols-2">
+                  {data?.mikrotik_available ? (
+                    <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-3">
+                      <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">
+                        MikroTik coverage
+                      </p>
+                      <p className="mt-1 text-slate-200">
+                        <span className="font-semibold text-white">
+                          {mikrotikInterfaces.length}
+                        </span>{" "}
+                        interface{mikrotikInterfaces.length === 1 ? "" : "s"},{" "}
+                        <span className="font-semibold text-white">
+                          {mikrotikInterfaces.reduce((sum, i) => sum + i.peers_total, 0)}
+                        </span>{" "}
+                        peer{mikrotikInterfaces.reduce((sum, i) => sum + i.peers_total, 0) === 1 ? "" : "s"}
+                        ,{" "}
+                        <span className="font-semibold text-emerald-300">
+                          {mikrotikInterfaces.reduce((sum, i) => sum + i.peers_online, 0)} online
+                        </span>
+                      </p>
+                    </div>
+                  ) : (
+                    !loading && (
+                      <div className="rounded-lg border border-slate-800/80 bg-slate-950/50 p-3 text-slate-400">
+                        No router is configured. Configure router credentials in Settings.
+                      </div>
+                    )
                   )}
                 </div>
               </CardContent>
             </Card>
 
-            {/* All interfaces overview */}
-            {overviewInterfaces.length > 0 && (
+            {overviewInterfaces.length === 0 && !loading ? (
+              <Card className={surfaceClass}>
+                <CardContent className="py-12 text-center text-sm text-slate-500">
+                  No VPN interfaces found.
+                </CardContent>
+              </Card>
+            ) : (
               <div className="space-y-4">
                 {overviewInterfaces.map((iface) => (
                   <InterfaceCard key={`${iface.source}-${iface.name}`} iface={iface} />
@@ -262,19 +262,19 @@ export default function VpnStatusPage() {
             )}
           </TabsContent>
 
-          {/* MikroTik Tab */}
-          <TabsContent value="mikrotik" className="space-y-4">
+          <TabsContent value="mikrotik" className="space-y-4 pt-2">
             <div className="relative max-w-md">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <Input
-                placeholder="Filter peers..."
+                placeholder="Filter peers, endpoints, or allowed IPs..."
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="border-slate-800 bg-slate-950 pl-10 text-white placeholder:text-slate-600"
+                className="border-slate-800 bg-slate-950/70 pl-10 text-white placeholder:text-slate-600"
               />
             </div>
+
             {mikrotikInterfaces.length === 0 ? (
-              <Card className="border-slate-800 bg-slate-900">
+              <Card className={surfaceClass}>
                 <CardContent className="py-12 text-center text-slate-500">
                   {search
                     ? "No interfaces or peers match your filter."
@@ -283,7 +283,7 @@ export default function VpnStatusPage() {
               </Card>
             ) : (
               mikrotikInterfaces.map((iface) => (
-                <InterfaceCard key={iface.name} iface={iface} />
+                <InterfaceCard key={`${iface.source}-${iface.name}`} iface={iface} />
               ))
             )}
           </TabsContent>
@@ -293,13 +293,12 @@ export default function VpnStatusPage() {
   );
 }
 
-// ─── Summary Card ──────────────────────────────────────────
-
 function SummaryCard({
   title,
   value,
   loading,
   icon,
+  iconClass,
   subtitle,
   isText,
 }: {
@@ -307,159 +306,163 @@ function SummaryCard({
   value: number | string | null;
   loading: boolean;
   icon: React.ReactNode;
+  iconClass: string;
   subtitle?: string;
   isText?: boolean;
 }) {
   return (
-    <Card className="border-slate-800 bg-slate-900">
-      <CardContent className="flex items-center gap-4 p-5">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-800">
+    <Card className={surfaceClass}>
+      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
           {icon}
         </div>
-        <div>
-          <p className="text-xs text-slate-500">{title}</p>
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            {title}
+          </p>
           {loading ? (
-            <Skeleton className="mt-1 h-6 w-12 bg-slate-800" />
-          ) : isText ? (
-            <p className="text-lg font-bold text-white">{value ?? "—"}</p>
+            <Skeleton className="mt-2 h-6 w-20 bg-slate-800" />
           ) : (
-            <p className="text-2xl font-bold text-white">{value ?? 0}</p>
+            <p className={cn("mt-1 font-semibold text-white", isText ? "text-base" : "text-2xl")}>{value ?? "—"}</p>
           )}
-          {subtitle && (
-            <p className="text-xs text-slate-500">{subtitle}</p>
-          )}
+          {subtitle && <p className="text-xs text-slate-500">{subtitle}</p>}
         </div>
       </CardContent>
     </Card>
   );
 }
 
-// ─── Interface Card with Peer Table ─────────────────────────
-
 function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
   const isUp = iface.status === "up" || iface.status === "u/u";
 
   return (
-    <Card className="border-slate-800 bg-slate-900">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <CardTitle className="text-sm font-medium text-white">
-              {iface.name}
-            </CardTitle>
+    <Card className={surfaceClass}>
+      <CardHeader className="space-y-3 pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <CardTitle className="text-base font-semibold text-white">{iface.name}</CardTitle>
             <Badge
               variant="outline"
-              className={
+              className={cn(
+                "rounded-md border text-[11px] uppercase",
                 isUp
-                  ? "border-emerald-500/30 text-emerald-400"
-                  : "border-rose-500/30 text-rose-400"
-              }
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                  : "border-rose-500/30 bg-rose-500/10 text-rose-300",
+              )}
             >
               {isUp ? "up" : "down"}
             </Badge>
-            <Badge
-              variant="outline"
-              className="border-slate-700 text-slate-400"
-            >
+            <Badge variant="outline" className="rounded-md border-slate-700 bg-slate-900/60 text-[11px] uppercase text-slate-400">
               {iface.source}
             </Badge>
           </div>
-          <div className="text-xs text-slate-500">
-            {iface.peers_online}/{iface.peers_total} peers online
+
+          <div className="rounded-md border border-slate-800/80 bg-slate-950/60 px-2 py-1 text-xs text-slate-400">
+            <span className="font-medium text-slate-200">{iface.peers_online}</span>
+            <span className="mx-1 text-slate-600">/</span>
+            <span>{iface.peers_total}</span> online
           </div>
         </div>
-        <CardDescription className="text-xs text-slate-500">
-          {[
-            iface.address && `Address: ${iface.address}`,
-            iface.port && `Port: ${iface.port}`,
-            iface.public_key &&
-              `Key: ${iface.public_key.substring(0, 12)}...`,
-          ]
-            .filter(Boolean)
-            .join(" | ")}
-        </CardDescription>
+
+        <div className="flex flex-wrap gap-2 text-[11px] text-slate-400">
+          {iface.address && (
+            <span className="rounded-md border border-slate-800/80 bg-slate-950/60 px-2 py-1 font-mono">
+              {iface.address}
+            </span>
+          )}
+          {iface.port && (
+            <span className="rounded-md border border-slate-800/80 bg-slate-950/60 px-2 py-1">
+              Port {iface.port}
+            </span>
+          )}
+          {iface.public_key && (
+            <span className="max-w-full truncate rounded-md border border-slate-800/80 bg-slate-950/60 px-2 py-1 font-mono">
+              Key {iface.public_key.substring(0, 12)}...
+            </span>
+          )}
+        </div>
       </CardHeader>
+
       <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow className="border-slate-800 hover:bg-transparent">
-              <TableHead className="text-slate-400">Status</TableHead>
-              <TableHead className="text-slate-400">Peer</TableHead>
-              <TableHead className="text-slate-400">Endpoint</TableHead>
-              <TableHead className="text-slate-400">Allowed IPs</TableHead>
-              <TableHead className="text-slate-400">Last Handshake</TableHead>
-              <TableHead className="text-right text-slate-400">RX</TableHead>
-              <TableHead className="text-right text-slate-400">TX</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {iface.peers.length === 0 ? (
-              <TableRow className="border-slate-800 hover:bg-transparent">
-                <TableCell
-                  colSpan={7}
-                  className="py-8 text-center text-slate-500"
-                >
-                  No peers configured.
-                </TableCell>
+        <div className="overflow-x-auto border-t border-slate-800/70">
+          <Table>
+            <TableHeader>
+              <TableRow className="border-slate-800/70 hover:bg-transparent">
+                <TableHead className="text-xs uppercase tracking-wide text-slate-500">Status</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide text-slate-500">Peer</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide text-slate-500">Endpoint</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide text-slate-500">Allowed IPs</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide text-slate-500">Last Handshake</TableHead>
+                <TableHead className="text-right text-xs uppercase tracking-wide text-slate-500">RX</TableHead>
+                <TableHead className="text-right text-xs uppercase tracking-wide text-slate-500">TX</TableHead>
               </TableRow>
-            ) : (
-              iface.peers.map((peer, idx) => (
-                <TableRow
-                  key={peer.public_key ?? idx}
-                  className="border-slate-800 hover:bg-slate-800/30"
-                >
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      {peer.connectivity === "online" ? (
-                        <Wifi className="h-3.5 w-3.5 text-emerald-400" />
-                      ) : (
-                        <WifiOff className="h-3.5 w-3.5 text-slate-600" />
-                      )}
-                      <Badge
-                        variant="outline"
-                        className={
-                          peer.connectivity === "online"
-                            ? "border-emerald-500/30 text-emerald-400"
-                            : "border-slate-700 text-slate-500"
-                        }
-                      >
-                        {peer.connectivity}
-                      </Badge>
-                    </div>
-                  </TableCell>
-                  <TableCell className="font-medium text-white">
-                    {peer.name || (
-                      <span className="text-slate-500">
-                        {peer.public_key
-                          ? `${peer.public_key.substring(0, 8)}...`
-                          : "Unknown"}
-                      </span>
-                    )}
-                  </TableCell>
-                  <TableCell className="max-w-[180px] font-mono text-xs text-slate-400">
-                    <span className="block truncate">{peer.endpoint ?? "—"}</span>
-                  </TableCell>
-                  <TableCell className="max-w-[200px] font-mono text-xs text-slate-400">
-                    <span className="block truncate">
-                      {peer.allowed_ips.length > 0
-                        ? peer.allowed_ips.join(", ")
-                        : "—"}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-slate-400">
-                    {timeAgo(peer.last_handshake)}
-                  </TableCell>
-                  <TableCell className="text-right font-mono text-xs text-slate-400">
-                    {formatBytes(peer.rx_bytes)}
-                  </TableCell>
-                  <TableCell className="text-right font-mono text-xs text-slate-400">
-                    {formatBytes(peer.tx_bytes)}
+            </TableHeader>
+
+            <TableBody>
+              {iface.peers.length === 0 ? (
+                <TableRow className="border-slate-800/70 hover:bg-transparent">
+                  <TableCell colSpan={7} className="py-9 text-center text-sm text-slate-500">
+                    No peers configured.
                   </TableCell>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+              ) : (
+                iface.peers.map((peer, idx) => (
+                  <TableRow
+                    key={peer.public_key ?? `${iface.name}-${idx}`}
+                    className="border-slate-800/70 hover:bg-slate-800/35"
+                  >
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {peer.connectivity === "online" ? (
+                          <Wifi className="h-3.5 w-3.5 text-emerald-400" />
+                        ) : (
+                          <WifiOff className="h-3.5 w-3.5 text-slate-600" />
+                        )}
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "rounded-md border text-[11px] uppercase",
+                            peer.connectivity === "online"
+                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                              : "border-slate-700 bg-slate-900/70 text-slate-500",
+                          )}
+                        >
+                          {peer.connectivity}
+                        </Badge>
+                      </div>
+                    </TableCell>
+
+                    <TableCell className="max-w-[220px]">
+                      <div className="truncate font-medium text-white" title={peer.name || undefined}>
+                        {peer.name || (
+                          <span className="font-mono text-slate-500">
+                            {peer.public_key ? `${peer.public_key.substring(0, 12)}...` : "Unknown"}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+
+                    <TableCell className="max-w-[220px] font-mono text-xs text-slate-400">
+                      <span className="block truncate" title={peer.endpoint ?? undefined}>
+                        {peer.endpoint ?? "—"}
+                      </span>
+                    </TableCell>
+
+                    <TableCell className="max-w-[260px] font-mono text-xs text-slate-400">
+                      <span className="block truncate" title={peer.allowed_ips.join(", ") || undefined}>
+                        {peer.allowed_ips.length > 0 ? peer.allowed_ips.join(", ") : "—"}
+                      </span>
+                    </TableCell>
+
+                    <TableCell className="text-slate-400">{timeAgo(peer.last_handshake)}</TableCell>
+                    <TableCell className="text-right font-mono text-xs text-slate-400">{formatBytes(peer.rx_bytes)}</TableCell>
+                    <TableCell className="text-right font-mono text-xs text-slate-400">{formatBytes(peer.tx_bytes)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
This PR upgrades **VPN**, **QoS**, and **NAT** pages to match the approved Panoptikon UI methodology (dark layered surfaces, consistent hierarchy, modern badges/cards/tables) based on the latest dashboard/router/alerts references.

## What changed
- Restyled `/vpn-status` with:
  - command-center header block
  - unified metric cards
  - cleaner overview block
  - table styling and status badges aligned with approved palette
- Restyled `/qos` with:
  - same page shell and card language
  - consistent tabs/search/actions surface
  - upgraded Simple Queues / Queue Tree tables
  - polished Add/Edit dialog styling (no backend changes)
- Restyled `/nat` with:
  - consistent page shell + summary card
  - unified filter/actions row
  - modernized NAT rules table and status/action affordances
  - polished Add/Edit dialog styling (no backend changes)

## Before / After (UI)
### Before
- Mixed visual patterns between pages (different surface depth, spacing, card styles, and table rhythm).
- Inconsistent visual hierarchy for summary metrics and section headers.
- Uneven badge/action styling across VPN/QoS/NAT views.

### After
- Shared dark layered surfaces and spacing rhythm across all 3 pages.
- Unified top-level hierarchy (icon tile + title + contextual subtitle + refresh action).
- Consistent metric cards, section cards, and table treatment.
- Modernized status badges and action affordances with subtle accents (no overdone glow).

## Scope
- ✅ Frontend only
- ✅ Existing data wiring preserved
- ❌ No backend/API changes

## Validation
- `cd web && bun run build` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies the VPN Status, QoS, and NAT pages under the approved Panoptikon dark command-center visual language — consistent header blocks, `surfaceClass` cards, upgraded table/badge treatment, and modernised Add/Edit dialogs. All existing data-wiring and business logic is preserved; the changes are entirely cosmetic and structural.

Key observations:
- The NAT page correctly removes the now-redundant `activeTab` state (there was only ever one data source) and combines the two `useEffect` calls into one, simplifying the load sequence with no functional regression.
- The QoS and VPN pages retain their tab-based lazy-loading patterns, which are unchanged in behaviour.
- **`surfaceClass` is declared identically at module level in all three files**, and the `SummaryCard` component body is duplicated between `nat/page.tsx` and `qos/page.tsx`. These should be extracted to a shared location to avoid drift.
- In `qos/page.tsx`, `loadMtQueues` silently catches errors and sets both lists to empty arrays with no user notification, which can mislead operators into thinking no queues exist when the router is unreachable.
- In `vpn-status/page.tsx`, the `overviewInterfaces` `useMemo` provides no computational benefit and can be replaced with a plain `data?.interfaces ?? []`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — frontend-only restyling with no backend changes and no breaking functional regressions.
- All three files are pure UI changes; data wiring, API calls, and state logic are preserved. The only functional concerns are a silent error-swallow in QoS (pre-existing pattern) and a trivially redundant memo in VPN — neither blocks correctness. The main risk is the duplicated `surfaceClass`/`SummaryCard` pattern creating future maintenance drift, but that doesn't affect runtime behaviour.
- No files require special attention; the QoS `loadMtQueues` error-handling improvement is the most impactful optional follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/nat/page.tsx | Pure UI restyling: removed the now-redundant `activeTab` state (single data source), unified header/card/table treatment, and added `surfaceClass` constant. `surfaceClass` and `SummaryCard` are duplicated identically in the QoS file. |
| web/src/app/(app)/qos/page.tsx | UI restyling with tab-based lazy loading preserved. `loadMtQueues` silently swallows errors (sets empty arrays, no toast), which can mislead users into thinking no queues exist when a connectivity failure occurred. `surfaceClass` and `SummaryCard` are duplicated from the NAT file. |
| web/src/app/(app)/vpn-status/page.tsx | Restyled with new summary metric cards and unified dark surface language. `overviewInterfaces` useMemo is trivially redundant (returns `data.interfaces` unchanged). `surfaceClass` duplicated from the other two pages. |

</details>



<sub>Last reviewed commit: 6ad4ed5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->