### PR TITLE
fix(release): fix Blacksmith migration regression in arch mapping (#575)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   frontend:
     name: Build Frontend
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
   build-linux:
     name: Linux (${{ matrix.arch }})
     needs: frontend
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         include:
@@ -122,7 +122,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build-linux, build-macos]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #575

## Problem

The Blacksmith migration bot (PR #573) incorrectly changed the `arch` matrix value for `aarch64-apple-darwin` from `arm64` to the runner tag `blacksmith-4vcpu-ubuntu-2404-arm`. The `arch` field is a user-defined variable used in artifact/binary naming — not a runner selector. This would produce malformed artifact names like `panoptikon-server-darwin-blacksmith-4vcpu-ubuntu-2404-arm` on every release.

## Fix

Apply the Blacksmith runner migration correctly:
- `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404` for the 3 Linux/release jobs (frontend, build-linux, release)
- **Preserve `arch: arm64`** for `aarch64-apple-darwin` — this controls artifact naming, not runner selection
- macOS jobs remain on native runners (`macos-13` / `macos-latest`) since Blacksmith doesn't offer macOS runners

## Artifact Names (verified correct)

| Target | Artifact name |
|--------|--------------|
| `x86_64-unknown-linux-musl` | `panoptikon-server-linux-amd64` |
| `aarch64-unknown-linux-musl` | `panoptikon-server-linux-arm64` |
| `x86_64-apple-darwin` | `panoptikon-server-darwin-amd64` |
| `aarch64-apple-darwin` | `panoptikon-server-darwin-arm64` |

All names are backward-compatible with existing install scripts and download URLs.

## Smoke Test

Verified the matrix expansion manually:
- `${{ matrix.arch }}` resolves to `arm64` for `aarch64-apple-darwin` ✅
- Artifact upload names: `binaries-darwin-arm64` ✅
- Binary rename: `panoptikon-server-darwin-arm64` ✅
- No runner-tag fragments in any output file names ✅

## Why No E2E Test

This is a CI/CD workflow-only change (`.github/workflows/release.yml`). No application code, UI, or API behavior is modified. The change cannot be verified with Playwright E2E tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a Blacksmith runner migration that was applied too broadly in PR #573, restoring the three Linux-facing jobs (`frontend`, `build-linux`, `release`) to the new Blacksmith runner while leaving macOS jobs and all `arch` matrix variables untouched.

- **`frontend` / `build-linux` / `release`**: `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404` ✅
- **`build-macos`**: remains on `macos-13` / `macos-latest` (Blacksmith has no macOS runners) ✅
- **`arch` values** (`amd64`, `arm64`) in both Linux and macOS matrices are preserved, keeping artifact names (`panoptikon-server-darwin-arm64`, etc.) correct ✅
- Cross-compilation for `aarch64-unknown-linux-musl` continues to use the `cross` tool (Docker-based), so running on an x86_64 Blacksmith runner is not a regression
- No application code, tests, or API behaviour is affected

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is minimal, targeted, and fully reverses the regression introduced by the migration bot.
- Only three `runs-on` values are changed; no logic, artifact naming, or application code is touched. The fix is straightforward and matches the stated intent exactly.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Three `runs-on` values changed from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404` for the `frontend`, `build-linux`, and `release` jobs. macOS runners and all `arch` matrix values are untouched and correct. |

</details>



<sub>Last reviewed commit: e989c82</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->