### PR TITLE
ci: migrate safe subset to Blacksmith runners (ci/docker/version-bump only) (#574)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   rust:
     name: Rust Build & Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -81,7 +81,7 @@ jobs:
 
   frontend:
     name: Frontend Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: web
@@ -104,7 +104,7 @@ jobs:
 
   e2e:
     name: E2E Tests (Playwright)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [rust]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docker:
     name: Build & Push to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     # Skip if commit message contains [skip-bump] or starts with "chore: bump version"
     if: |


### PR DESCRIPTION
## Summary

Migrates the three safe CI workflows to Blacksmith runners (`blacksmith-4vcpu-ubuntu-2404`), matching the runner already used in `release.yml`.

### Changed workflows
| Workflow | Jobs migrated |
|----------|--------------|
| `ci.yml` | `rust`, `frontend`, `e2e` (all 3) |
| `docker.yml` | `docker` |
| `version-bump.yml` | `bump-version` |

### Intentionally unchanged
- `deploy.yml` — uses `self-hosted` (out of scope)
- `release.yml` — already on Blacksmith

### What changed
- `runs-on: ubuntu-latest` → `runs-on: blacksmith-4vcpu-ubuntu-2404` (5 jobs total)
- All job names, steps, actions, and cache configuration remain identical
- No self-hosted assumptions introduced

## Why No E2E Test
Pure CI/CD configuration change — no application behavior or UI changes.

Closes #574

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates five CI jobs across three workflow files from `ubuntu-latest` to the `blacksmith-4vcpu-ubuntu-2404` runner, aligning them with the runner already in use in `release.yml`. The changes are purely mechanical — only the `runs-on` value is touched in each job.

- All three files (`ci.yml`, `docker.yml`, `version-bump.yml`) receive identical, minimal one-line changes per job.
- The Blacksmith runner is already proven in this repo (`release.yml`), so no new runner assumptions are introduced.
- The `actions/cache` keys in `ci.yml` rely on `${{ runner.os }}`, which still resolves to `Linux` on the Blacksmith Ubuntu runner — cache key semantics are preserved (though a cold-cache run should be expected the first time after migration).
- The multi-platform Docker build in `docker.yml` (`linux/amd64,linux/arm64`) continues to use QEMU emulation, which is unaffected by the runner change.
- The loop-prevention logic in `version-bump.yml` (`[skip-bump]` suffix) and its `contents: write` permissions are untouched.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure runner label swap with no logic changes.
- All five changes are single-line `runs-on` substitutions. The target runner is already active in the repo, no job logic, secrets handling, or caching strategy is modified, and the change is consistent across all affected workflows.
- No files require special attention.

<sub>Last reviewed commit: f89a928</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->