### PR TITLE
feat: Dashboard bento grid layout with hero stats (#593)

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -9,7 +9,9 @@ import {
   Info,
   MonitorSmartphone,
   Pin,
+  Radar,
   Router,
+  Shield,
   WifiOff,
 } from "lucide-react";
 import {
@@ -38,11 +40,13 @@ import type { Alert, CriticalDevice, DashboardStats, TrafficHistoryPoint, Device
 import { formatBps, timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
+import { HeroStat } from "@/components/dashboard/HeroStat";
+import { HealthRing } from "@/components/dashboard/HealthRing";
 import { toast } from "sonner";
 import { useWsEvent } from "@/lib/ws";
 import { getDeviceIcon } from "@/lib/device-icons";
 import type { DeviceType } from "@/lib/device-type";
-import { cn } from "@/lib/utils";
+
 
 // ─── Format ISO minute string to HH:mm ─────────────────
 
@@ -169,159 +173,14 @@ function CriticalDevicesDialog({
   );
 }
 
-// ─── Health Ring SVG ───────────────────────────────────
+// ─── Loading skeleton for hero stat cards ────────────────
 
-function HealthRing({ online, total }: { online: number; total: number }) {
-  const pct = total === 0 ? 0 : Math.round((online / total) * 100);
-  const circumference = 2 * Math.PI * 40; // r=40
-  const offset = circumference - (pct / 100) * circumference;
-  const color =
-    pct >= 90 ? "stroke-emerald-500" : pct >= 70 ? "stroke-amber-500" : "stroke-rose-500";
-  const bgColor =
-    pct >= 90
-      ? "text-emerald-500/10"
-      : pct >= 70
-        ? "text-amber-500/10"
-        : "text-rose-500/10";
-  const textColor =
-    pct >= 90 ? "text-emerald-400" : pct >= 70 ? "text-amber-400" : "text-rose-400";
-
-  if (total === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-1">
-        <div className="relative aspect-square w-full max-w-[7rem]">
-          <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
-            <circle
-              cx="50"
-              cy="50"
-              r="40"
-              fill="none"
-              strokeWidth="8"
-              className="text-slate-500/10 stroke-current"
-            />
-          </svg>
-          <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className="text-sm font-medium text-slate-500">N/A</span>
-          </div>
-        </div>
-        <span className="text-xs text-slate-500 text-center">
-          No critical devices
-        </span>
-      </div>
-    );
-  }
-
+function HeroStatSkeleton() {
   return (
-    <div className="flex flex-col items-center justify-center gap-1">
-      <div className="relative aspect-square w-full max-w-[7rem]">
-        <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
-          <circle
-            cx="50"
-            cy="50"
-            r="40"
-            fill="none"
-            strokeWidth="8"
-            className={`${bgColor} stroke-current`}
-          />
-          <circle
-            cx="50"
-            cy="50"
-            r="40"
-            fill="none"
-            strokeWidth="8"
-            strokeLinecap="round"
-            strokeDasharray={circumference}
-            strokeDashoffset={offset}
-            className={`${color} transition-all duration-700 ease-out`}
-          />
-        </svg>
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span className={`text-2xl font-bold tabular-nums ${textColor}`}>
-            {pct}%
-          </span>
-        </div>
-      </div>
-      <span className="text-xs text-slate-500">
-        {online}/{total} critical online
-      </span>
-    </div>
-  );
-}
-
-// ─── Status dot ─────────────────────────────────────────
-
-function StatusDot({ status }: { status: "online" | "offline" | "warning" }) {
-  const colors = {
-    online: "bg-emerald-400 ring-2 ring-emerald-400/30 status-glow-online",
-    offline: "bg-rose-400 ring-2 ring-rose-400/30 status-glow-offline",
-    warning: "bg-amber-400 ring-2 ring-amber-400/30",
-  };
-  return (
-    <span
-      className={`inline-block h-2.5 w-2.5 rounded-full ${colors[status]}`}
-    />
-  );
-}
-
-// ─── Stat Card ──────────────────────────────────────────
-
-function StatCard({
-  title,
-  value,
-  subtitle,
-  icon,
-  status,
-  href,
-}: {
-  title: string;
-  value: string;
-  subtitle: string;
-  icon: React.ReactNode;
-  status: "online" | "offline" | "warning";
-  href?: string;
-}) {
-  const inner = (
-    <Card
-      className={cn(
-        "h-full min-h-[8.25rem] border-slate-700/50 bg-slate-900/55",
-        href &&
-          "transition-[border-color,background-color,box-shadow] hover:border-slate-700/90 hover:bg-slate-900/72 hover:shadow-[0_14px_32px_-22px_rgba(15,23,42,0.95)]",
-      )}
-    >
-      <CardHeader className="flex flex-row items-start justify-between pb-3">
-        <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-          {title}
-        </CardTitle>
-        <div className="flex items-center gap-2">
-          <StatusDot status={status} />
-          <span className="text-slate-500">{icon}</span>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <p className="truncate text-[1.65rem] font-semibold leading-none tabular-nums text-white">{value}</p>
-        <p className="truncate text-xs leading-5 text-slate-400">{subtitle}</p>
-      </CardContent>
-    </Card>
-  );
-  return href ? (
-    <Link href={href} className="block h-full">
-      {inner}
-    </Link>
-  ) : (
-    inner
-  );
-}
-
-// ─── Loading skeleton for stat cards ────────────────────
-
-function StatCardSkeleton() {
-  return (
-    <Card className="h-full min-h-[8.25rem] border-slate-700/50 bg-slate-900/55">
-      <CardHeader className="pb-3">
-        <Skeleton className="h-3.5 w-24" />
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <Skeleton className="h-8 w-24" />
+    <Card className="h-full min-h-[140px] border-slate-700/50 bg-slate-900/55">
+      <CardContent className="p-5 space-y-4">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-9 w-28 mt-auto" />
         <Skeleton className="h-3 w-32" />
       </CardContent>
     </Card>
@@ -337,20 +196,6 @@ function SectionError({ message }: { message: string }) {
       <span>{message}</span>
     </div>
   );
-}
-
-// ─── Derive display values from flat stats ──────────────
-
-function routerStatusLabel(s: DashboardStats): { label: string; status: "online" | "offline" | "warning" } {
-  switch (s.router_status) {
-    case "connected":
-    case "online":
-      return { label: "Online", status: "online" };
-    case "unconfigured":
-      return { label: "Unconfigured", status: "warning" };
-    default:
-      return { label: "Offline", status: "offline" };
-  }
 }
 
 // ─── Device breakdown bar colors ────────────────────────
@@ -369,11 +214,34 @@ const TYPE_COLORS: Record<string, string> = {
   unknown: "bg-slate-500",
 };
 
+// ─── Quick Actions ──────────────────────────────────────
+
+function QuickActions() {
+  const actions = [
+    { label: "Scan Network", icon: <Radar className="h-4 w-4" />, href: "/settings/scanner" },
+    { label: "View Alerts", icon: <AlertTriangle className="h-4 w-4" />, href: "/alerts" },
+    { label: "Check DNS", icon: <Shield className="h-4 w-4" />, href: "/dns-queries" },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actions.map((action) => (
+        <Link
+          key={action.label}
+          href={action.href}
+          className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-4 py-2 text-sm text-slate-300 transition-all hover:border-slate-600 hover:bg-slate-800/80 hover:text-white"
+        >
+          {action.icon}
+          {action.label}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 // ─── Page ───────────────────────────────────────────────
 
 export default function DashboardPage() {
-  // Each section has independent data + error state.
-  // null = still loading (show skeleton), non-null = loaded.
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [statsError, setStatsError] = useState(false);
 
@@ -430,7 +298,6 @@ export default function DashboardPage() {
     }
   }, []);
 
-  // Fire all fetches in parallel — each resolves independently
   const loadAll = useCallback(() => {
     loadStats();
     loadAlerts();
@@ -444,7 +311,6 @@ export default function DashboardPage() {
     return () => clearInterval(interval);
   }, [loadAll]);
 
-  // Keep a ref to current devices so WS handler can look up names without stale closure
   const devicesRef = useRef(devices);
   devicesRef.current = devices;
 
@@ -486,7 +352,7 @@ export default function DashboardPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold tracking-tight text-white">Dashboard</h1>
         <p className="max-w-3xl text-sm leading-6 text-slate-400">
@@ -494,344 +360,408 @@ export default function DashboardPage() {
         </p>
       </div>
 
+      {/* ── Hero Stats Row ─────────────────────────────── */}
+      <StaggerContainer className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {statsError ? (
+          <>
+            <StaggerItem>
+              <HeroStat
+                title="Total Devices"
+                value={0}
+                subtitle="Cannot load stats"
+                icon={<MonitorSmartphone className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-slate-800 to-slate-900"
+                href="/devices"
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="Active Alerts"
+                value={0}
+                subtitle="Cannot load stats"
+                icon={<AlertTriangle className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-slate-800 to-slate-900"
+                href="/alerts"
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="Uptime"
+                value={0}
+                suffix="%"
+                subtitle="Cannot load stats"
+                icon={<Activity className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-slate-800 to-slate-900"
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="Traffic"
+                value={0}
+                subtitle="Cannot load stats"
+                icon={<Router className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-slate-800 to-slate-900"
+                href="/traffic"
+              />
+            </StaggerItem>
+          </>
+        ) : stats ? (
+          <>
+            <StaggerItem>
+              <HeroStat
+                title="Total Devices"
+                value={stats.devices_total}
+                subtitle={`${stats.devices_online} currently online`}
+                icon={<MonitorSmartphone className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-blue-600/90 to-blue-900/90"
+                href="/devices"
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="Active Alerts"
+                value={stats.alerts_unread}
+                subtitle={stats.alerts_unread > 0 ? "Needs attention" : "All clear"}
+                icon={<AlertTriangle className="h-5 w-5" />}
+                gradient={
+                  stats.alerts_unread > 0
+                    ? "bg-gradient-to-br from-amber-600/90 to-amber-900/90"
+                    : "bg-gradient-to-br from-emerald-600/90 to-emerald-900/90"
+                }
+                href="/alerts"
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="Infra Health"
+                value={stats.critical_total > 0 ? Math.round((stats.critical_online / stats.critical_total) * 100) : 100}
+                suffix="%"
+                subtitle={
+                  stats.critical_total > 0
+                    ? `${stats.critical_online}/${stats.critical_total} critical online`
+                    : "No critical devices"
+                }
+                icon={<Activity className="h-5 w-5" />}
+                gradient={
+                  stats.critical_total === 0 || (stats.critical_online / stats.critical_total) >= 0.9
+                    ? "bg-gradient-to-br from-emerald-600/90 to-emerald-900/90"
+                    : (stats.critical_online / stats.critical_total) >= 0.7
+                      ? "bg-gradient-to-br from-amber-600/90 to-amber-900/90"
+                      : "bg-gradient-to-br from-rose-600/90 to-rose-900/90"
+                }
+              />
+            </StaggerItem>
+            <StaggerItem>
+              <HeroStat
+                title="WAN Traffic"
+                value={stats.wan_rx_bps}
+                subtitle={`↑ ${formatBps(stats.wan_tx_bps)}`}
+                icon={<Router className="h-5 w-5" />}
+                gradient="bg-gradient-to-br from-violet-600/90 to-violet-900/90"
+                href="/traffic"
+                formatValue={(v) => `↓ ${formatBps(v)}`}
+              />
+            </StaggerItem>
+          </>
+        ) : (
+          <>
+            <StaggerItem><HeroStatSkeleton /></StaggerItem>
+            <StaggerItem><HeroStatSkeleton /></StaggerItem>
+            <StaggerItem><HeroStatSkeleton /></StaggerItem>
+            <StaggerItem><HeroStatSkeleton /></StaggerItem>
+          </>
+        )}
+      </StaggerContainer>
+
+      {/* ── Quick Actions ──────────────────────────────── */}
+      <QuickActions />
+
       {/* ── Bento Grid ─────────────────────────────────── */}
-      <StaggerContainer className="grid grid-cols-1 gap-6 xl:grid-cols-5">
-        {/* ── Health Score Ring ─────────────────────────── */}
-        <StaggerItem><Card
-          className="h-full border-slate-700/50 bg-slate-900/55 xl:col-span-1"
-          data-testid="infra-health-card"
+      <div
+        className="grid grid-cols-1 gap-6 xl:grid-cols-6"
+        style={{
+          gridTemplateAreas: `
+            "traffic traffic traffic traffic alerts alerts"
+            "health health breakdown breakdown breakdown breakdown"
+          `,
+        }}
+      >
+        {/* ── WAN Traffic Card (2x1 wide) ────────────── */}
+        <StaggerContainer
+          className="col-span-1 xl:col-span-4"
+          style={{ gridArea: "traffic" } as React.CSSProperties}
         >
-          <CardHeader className="pb-4">
-            <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-              Infrastructure Health
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex items-center justify-center pb-5">
-            {statsError ? (
-              <SectionError message="Failed to load" />
-            ) : stats ? (
-              <button
-                type="button"
-                className="group cursor-pointer rounded-xl border border-slate-800/80 p-2 transition-colors hover:border-slate-700 hover:bg-slate-800/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40"
-                onClick={() => setCriticalDialogOpen(true)}
-                aria-label="View critical devices"
-              >
-                <HealthRing online={stats.critical_online} total={stats.critical_total} />
-                <span className="mt-1.5 flex items-center justify-center gap-1 text-[11px] text-slate-500 transition-colors group-hover:text-slate-300">
-                  <Info className="h-3 w-3" /> View details
-                </span>
-              </button>
-            ) : (
-              <Skeleton className="aspect-square w-full max-w-[7rem] rounded-full" />
-            )}
-          </CardContent>
-        </Card></StaggerItem>
+          <StaggerItem>
+            <Card className="border-slate-700/50 bg-slate-900/55 h-full">
+              <CardHeader className="pb-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Activity className="h-4 w-4 text-blue-400" />
+                    <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                      WAN Traffic
+                    </CardTitle>
+                  </div>
+                  <Link
+                    href="/traffic"
+                    className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
+                  >
+                    Details <ArrowRight className="h-3 w-3" />
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {/* Current aggregate speeds */}
+                <div className="mb-4 flex flex-wrap items-end gap-6 rounded-xl border border-slate-800/70 bg-slate-900/50 px-4 py-3">
+                  <div className="min-w-[8rem]">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-emerald-400/85">Download</span>
+                    <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
+                      {statsError ? "—" : stats ? formatBps(stats.wan_rx_bps) : "—"}
+                    </p>
+                  </div>
+                  <div className="min-w-[8rem]">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-blue-400/90">Upload</span>
+                    <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
+                      {statsError ? "—" : stats ? formatBps(stats.wan_tx_bps) : "—"}
+                    </p>
+                  </div>
+                  <span className="ml-auto text-[11px] uppercase tracking-[0.12em] text-slate-600">Last 60 samples</span>
+                </div>
+                {/* Sparkline */}
+                {trafficError ? (
+                  <div className="flex h-[120px] items-center justify-center">
+                    <SectionError message="Failed to load traffic data" />
+                  </div>
+                ) : trafficHistory === null ? (
+                  <Skeleton className="h-[120px] w-full" />
+                ) : trafficHistory.length > 0 ? (
+                  <div className="h-[120px]">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <AreaChart data={trafficHistory} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+                        <defs>
+                          <linearGradient id="sparkRx" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+                            <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                          </linearGradient>
+                          <linearGradient id="sparkTx" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                            <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                          </linearGradient>
+                        </defs>
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: "#0f172a",
+                            border: "1px solid #1e293b",
+                            borderRadius: "6px",
+                            color: "#fff",
+                            fontSize: "12px",
+                          }}
+                          labelFormatter={formatTime}
+                          formatter={(value: number, name: string) => [
+                            formatBps(value),
+                            name === "rx_bps" ? "↓ Download" : "↑ Upload",
+                          ]}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="rx_bps"
+                          stroke="#10b981"
+                          strokeWidth={1.5}
+                          fill="url(#sparkRx)"
+                          dot={false}
+                          name="rx_bps"
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="tx_bps"
+                          stroke="#3b82f6"
+                          strokeWidth={1.5}
+                          fill="url(#sparkTx)"
+                          dot={false}
+                          name="tx_bps"
+                        />
+                      </AreaChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <div className="flex h-[120px] items-center justify-center">
+                    <p className="text-sm text-slate-600">No traffic data yet</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+        </StaggerContainer>
+
+        {/* ── Alert Feed (1x1) ───────────────────────── */}
+        <StaggerContainer
+          className="col-span-1 xl:col-span-2"
+          style={{ gridArea: "alerts" } as React.CSSProperties}
+        >
+          <StaggerItem>
+            <Card className="border-slate-700/50 bg-slate-900/55 h-full">
+              <CardHeader className="pb-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                    Recent Alerts
+                  </CardTitle>
+                  <Link
+                    href="/alerts"
+                    className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
+                  >
+                    View all <ArrowRight className="h-3 w-3" />
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {alertsError ? (
+                  <SectionError message="Failed to load alerts" />
+                ) : alerts === null ? (
+                  <div className="space-y-3">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <div key={i} className="flex items-center gap-3">
+                        <Skeleton className="h-2.5 w-2.5 rounded-full" />
+                        <Skeleton className="h-4 flex-1" />
+                        <Skeleton className="h-3 w-12" />
+                      </div>
+                    ))}
+                  </div>
+                ) : alerts.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-slate-600">
+                    No recent alerts — all clear.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {alerts.map((alert) => (
+                      <div
+                        key={alert.id}
+                        className={`flex items-center gap-2.5 rounded-lg border border-transparent px-3 py-2 ${
+                          !alert.is_read ? "border-blue-500/15 bg-blue-500/6" : "hover:border-slate-800/70"
+                        }`}
+                      >
+                        <span
+                          className={`inline-block h-2 w-2 shrink-0 rounded-full ${severityDotColor(alert.severity)}`}
+                        />
+                        <p className="min-w-0 flex-1 truncate text-sm text-slate-300" title={alert.message}>
+                          {alert.message}
+                        </p>
+                        <span className="w-14 shrink-0 text-right text-xs tabular-nums text-slate-600">
+                          {timeAgo(alert.created_at)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+        </StaggerContainer>
+
+        {/* ── Network Health Ring (1x1) ──────────────── */}
+        <StaggerContainer
+          className="col-span-1 xl:col-span-2"
+          style={{ gridArea: "health" } as React.CSSProperties}
+        >
+          <StaggerItem>
+            <Card
+              className="h-full border-slate-700/50 bg-slate-900/55"
+              data-testid="infra-health-card"
+            >
+              <CardHeader className="pb-4">
+                <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                  Infrastructure Health
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex items-center justify-center pb-5">
+                {statsError ? (
+                  <SectionError message="Failed to load" />
+                ) : stats ? (
+                  <button
+                    type="button"
+                    className="group cursor-pointer rounded-xl border border-slate-800/80 p-2 transition-colors hover:border-slate-700 hover:bg-slate-800/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40"
+                    onClick={() => setCriticalDialogOpen(true)}
+                    aria-label="View critical devices"
+                  >
+                    <HealthRing online={stats.critical_online} total={stats.critical_total} />
+                    <span className="mt-1.5 flex items-center justify-center gap-1 text-[11px] text-slate-500 transition-colors group-hover:text-slate-300">
+                      <Info className="h-3 w-3" /> View details
+                    </span>
+                  </button>
+                ) : (
+                  <Skeleton className="aspect-square w-full max-w-[7rem] rounded-full" />
+                )}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+        </StaggerContainer>
         <CriticalDevicesDialog
           open={criticalDialogOpen}
           onOpenChange={setCriticalDialogOpen}
         />
 
-        {/* ── Stat Cards Row ───────────────────────────── */}
-        <StaggerItem className="xl:col-span-4"><div className="grid h-full grid-cols-2 gap-4 xl:grid-cols-4">
-          {statsError ? (
-            <>
-              <StatCard
-                title="Router Status"
-                href="/router"
-                value="Unreachable"
-                subtitle="Cannot load stats"
-                icon={<Router className="h-4 w-4" />}
-                status="offline"
-              />
-              <StatCard
-                title="Active Devices"
-                href="/devices"
-                value="—"
-                subtitle="Cannot load stats"
-                icon={<MonitorSmartphone className="h-4 w-4" />}
-                status="offline"
-              />
-              <StatCard
-                title="WAN Bandwidth"
-                href="/traffic"
-                value="—"
-                subtitle="Cannot load stats"
-                icon={<Activity className="h-4 w-4" />}
-                status="offline"
-              />
-              <StatCard
-                title="Unread Alerts"
-                href="/alerts"
-                value="—"
-                subtitle="Cannot load stats"
-                icon={<AlertTriangle className="h-4 w-4" />}
-                status="offline"
-              />
-            </>
-          ) : stats ? (
-            <>
-              <StatCard
-                title="Router Status"
-                href="/router"
-                value={routerStatusLabel(stats).label}
-                subtitle={
-                  stats.router_status === "connected" || stats.router_status === "online"
-                    ? `Connected to ${stats.router_type === "mikrotik" ? "MikroTik" : "router"}`
-                    : stats.router_status === "unconfigured"
-                      ? "Router not configured"
-                      : `Cannot reach ${stats.router_type === "mikrotik" ? "MikroTik" : "router"}`
-                }
-                icon={<Router className="h-4 w-4" />}
-                status={routerStatusLabel(stats).status}
-              />
-              <StatCard
-                title="Active Devices"
-                href="/devices"
-                value={String(stats.devices_online)}
-                subtitle={`${stats.devices_total} total known`}
-                icon={<MonitorSmartphone className="h-4 w-4" />}
-                status="online"
-              />
-              <StatCard
-                title="WAN Bandwidth"
-                href="/traffic"
-                value={`↓ ${formatBps(stats.wan_rx_bps)}`}
-                subtitle={`↑ ${formatBps(stats.wan_tx_bps)}`}
-                icon={<Activity className="h-4 w-4" />}
-                status="online"
-              />
-              <StatCard
-                title="Unread Alerts"
-                href="/alerts"
-                value={String(stats.alerts_unread)}
-                subtitle={stats.alerts_unread > 0 ? "Needs attention" : "All clear"}
-                icon={<AlertTriangle className="h-4 w-4" />}
-                status={stats.alerts_unread > 0 ? "warning" : "online"}
-              />
-            </>
-          ) : (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
-          )}
-        </div></StaggerItem>
-
-        {/* ── WAN Traffic Card with Sparkline ─────────── */}
-        <StaggerItem className="xl:col-span-3"><Card className="border-slate-700/50 bg-slate-900/55">
-          <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Activity className="h-4 w-4 text-blue-400" />
-                <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                  WAN Traffic
-                </CardTitle>
-              </div>
-              <Link
-                href="/traffic"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                Details <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {/* Current aggregate speeds */}
-            <div className="mb-4 flex flex-wrap items-end gap-6 rounded-xl border border-slate-800/70 bg-slate-900/50 px-4 py-3">
-              <div className="min-w-[8rem]">
-                <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-emerald-400/85">Download</span>
-                <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
-                  {statsError ? "—" : stats ? formatBps(stats.wan_rx_bps) : "—"}
-                </p>
-              </div>
-              <div className="min-w-[8rem]">
-                <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-blue-400/90">Upload</span>
-                <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
-                  {statsError ? "—" : stats ? formatBps(stats.wan_tx_bps) : "—"}
-                </p>
-              </div>
-              <span className="ml-auto text-[11px] uppercase tracking-[0.12em] text-slate-600">Last 60 samples</span>
-            </div>
-            {/* Sparkline */}
-            {trafficError ? (
-              <div className="flex h-[120px] items-center justify-center">
-                <SectionError message="Failed to load traffic data" />
-              </div>
-            ) : trafficHistory === null ? (
-              <Skeleton className="h-[120px] w-full" />
-            ) : trafficHistory.length > 0 ? (
-              <div className="h-[120px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <AreaChart data={trafficHistory} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
-                    <defs>
-                      <linearGradient id="sparkRx" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
-                        <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
-                      </linearGradient>
-                      <linearGradient id="sparkTx" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                        <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-                      </linearGradient>
-                    </defs>
-                    <Tooltip
-                      contentStyle={{
-                        backgroundColor: "#0f172a",
-                        border: "1px solid #1e293b",
-                        borderRadius: "6px",
-                        color: "#fff",
-                        fontSize: "12px",
-                      }}
-                      labelFormatter={formatTime}
-                      formatter={(value: number, name: string) => [
-                        formatBps(value),
-                        name === "rx_bps" ? "↓ Download" : "↑ Upload",
-                      ]}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="rx_bps"
-                      stroke="#10b981"
-                      strokeWidth={1.5}
-                      fill="url(#sparkRx)"
-                      dot={false}
-                      name="rx_bps"
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="tx_bps"
-                      stroke="#3b82f6"
-                      strokeWidth={1.5}
-                      fill="url(#sparkTx)"
-                      dot={false}
-                      name="tx_bps"
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
-              </div>
-            ) : (
-              <div className="flex h-[120px] items-center justify-center">
-                <p className="text-sm text-slate-600">No traffic data yet</p>
-              </div>
-            )}
-          </CardContent>
-        </Card></StaggerItem>
-
-        {/* ── Alert Feed ───────────────────────────────── */}
-        <StaggerItem className="xl:col-span-2"><Card className="border-slate-700/50 bg-slate-900/55">
-          <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                Recent Alerts
-              </CardTitle>
-              <Link
-                href="/alerts"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                View all <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {alertsError ? (
-              <SectionError message="Failed to load alerts" />
-            ) : alerts === null ? (
-              <div className="space-y-3">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="flex items-center gap-3">
-                    <Skeleton className="h-2.5 w-2.5 rounded-full" />
-                    <Skeleton className="h-4 flex-1" />
-                    <Skeleton className="h-3 w-12" />
-                  </div>
-                ))}
-              </div>
-            ) : alerts.length === 0 ? (
-              <p className="py-6 text-center text-sm text-slate-600">
-                No recent alerts — all clear.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {alerts.map((alert) => (
-                  <div
-                    key={alert.id}
-                    className={`flex items-center gap-2.5 rounded-lg border border-transparent px-3 py-2 ${
-                      !alert.is_read ? "border-blue-500/15 bg-blue-500/6" : "hover:border-slate-800/70"
-                    }`}
+        {/* ── Device Breakdown (2x1 wide) ────────────── */}
+        <StaggerContainer
+          className="col-span-1 xl:col-span-4"
+          style={{ gridArea: "breakdown" } as React.CSSProperties}
+        >
+          <StaggerItem>
+            <Card className="border-slate-700/50 bg-slate-900/55 h-full">
+              <CardHeader className="pb-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                    Device Breakdown
+                  </CardTitle>
+                  <Link
+                    href="/devices"
+                    className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
                   >
-                    <span
-                      className={`inline-block h-2 w-2 shrink-0 rounded-full ${severityDotColor(alert.severity)}`}
-                    />
-                    <p className="min-w-0 flex-1 truncate text-sm text-slate-300" title={alert.message}>
-                      {alert.message}
-                    </p>
-                    <span className="w-14 shrink-0 text-right text-xs tabular-nums text-slate-600">
-                      {timeAgo(alert.created_at)}
-                    </span>
+                    View all <ArrowRight className="h-3 w-3" />
+                  </Link>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {devicesError ? (
+                  <SectionError message="Failed to load devices" />
+                ) : devices === null ? (
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                      <Skeleton key={i} className="h-10 w-full" />
+                    ))}
                   </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card></StaggerItem>
-
-        {/* ── Device Type Breakdown ────────────────────── */}
-        <StaggerItem className="xl:col-span-5"><Card className="border-slate-700/50 bg-slate-900/55">
-          <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                Device Breakdown
-              </CardTitle>
-              <Link
-                href="/devices"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                View all <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {devicesError ? (
-              <SectionError message="Failed to load devices" />
-            ) : devices === null ? (
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <Skeleton key={i} className="h-10 w-full" />
-                ))}
-              </div>
-            ) : deviceBreakdown.length === 0 ? (
-              <p className="text-sm text-slate-600">No devices found.</p>
-            ) : (
-              <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
-                {deviceBreakdown.map((item) => {
-                  const Icon = getDeviceIcon(item.type, null, null).icon;
-                  return (
-                    <div key={item.type} className="flex items-center gap-3">
-                      <Icon className="h-4 w-4 shrink-0 text-slate-400" />
-                      <span className="w-28 shrink-0 truncate text-sm text-slate-300">
-                        {item.label}
-                      </span>
-                      <div className="flex min-w-0 flex-1 items-center gap-2">
-                        <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-800/90">
-                          <div
-                            className={`h-full rounded-full ${TYPE_COLORS[item.type] ?? "bg-slate-500"} transition-all duration-500`}
-                            style={{
-                              width: `${(item.count / maxCount) * 100}%`,
-                            }}
-                          />
+                ) : deviceBreakdown.length === 0 ? (
+                  <p className="text-sm text-slate-600">No devices found.</p>
+                ) : (
+                  <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {deviceBreakdown.map((item) => {
+                      const Icon = getDeviceIcon(item.type, null, null).icon;
+                      return (
+                        <div key={item.type} className="flex items-center gap-3">
+                          <Icon className="h-4 w-4 shrink-0 text-slate-400" />
+                          <span className="w-28 shrink-0 truncate text-sm text-slate-300">
+                            {item.label}
+                          </span>
+                          <div className="flex min-w-0 flex-1 items-center gap-2">
+                            <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-800/90">
+                              <div
+                                className={`h-full rounded-full ${TYPE_COLORS[item.type] ?? "bg-slate-500"} transition-all duration-500`}
+                                style={{
+                                  width: `${(item.count / maxCount) * 100}%`,
+                                }}
+                              />
+                            </div>
+                            <span className="w-8 text-right text-xs tabular-nums text-slate-500">
+                              {item.count}
+                            </span>
+                          </div>
                         </div>
-                        <span className="w-8 text-right text-xs tabular-nums text-slate-500">
-                          {item.count}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </CardContent>
-        </Card></StaggerItem>
-      </StaggerContainer>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </StaggerItem>
+        </StaggerContainer>
+      </div>
     </div>
     </PageTransition>
   );

--- a/web/src/components/MotionStagger.tsx
+++ b/web/src/components/MotionStagger.tsx
@@ -23,9 +23,11 @@ const itemVariants = {
 export function StaggerContainer({
   children,
   className,
+  style,
 }: {
   children: React.ReactNode
   className?: string
+  style?: React.CSSProperties
 }) {
   return (
     <motion.div
@@ -33,6 +35,7 @@ export function StaggerContainer({
       initial="hidden"
       animate="visible"
       className={className}
+      style={style}
     >
       {children}
     </motion.div>

--- a/web/src/components/dashboard/HealthRing.tsx
+++ b/web/src/components/dashboard/HealthRing.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+
+interface HealthRingProps {
+  online: number;
+  total: number;
+}
+
+export function HealthRing({ online, total }: HealthRingProps) {
+  const pct = total === 0 ? 0 : Math.round((online / total) * 100);
+  const circumference = 2 * Math.PI * 40; // r=40
+  const offset = circumference - (pct / 100) * circumference;
+
+  const color =
+    pct >= 90
+      ? "stroke-emerald-500"
+      : pct >= 70
+        ? "stroke-amber-500"
+        : "stroke-rose-500";
+  const bgColor =
+    pct >= 90
+      ? "text-emerald-500/10"
+      : pct >= 70
+        ? "text-amber-500/10"
+        : "text-rose-500/10";
+  const textColor =
+    pct >= 90
+      ? "text-emerald-400"
+      : pct >= 70
+        ? "text-amber-400"
+        : "text-rose-400";
+
+  if (total === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-1">
+        <div className="relative aspect-square w-full max-w-[7rem]">
+          <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
+            <circle
+              cx="50"
+              cy="50"
+              r="40"
+              fill="none"
+              strokeWidth="8"
+              className="text-slate-500/10 stroke-current"
+            />
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-sm font-medium text-slate-500">N/A</span>
+          </div>
+        </div>
+        <span className="text-xs text-slate-500 text-center">
+          No critical devices
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-1">
+      <div className="relative aspect-square w-full max-w-[7rem]">
+        <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
+          <circle
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            strokeWidth="8"
+            className={`${bgColor} stroke-current`}
+          />
+          <motion.circle
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            initial={{ strokeDashoffset: circumference }}
+            animate={{ strokeDashoffset: offset }}
+            transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
+            className={color}
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className={`text-2xl font-bold tabular-nums ${textColor}`}>
+            {pct}%
+          </span>
+        </div>
+      </div>
+      <span className="text-xs text-slate-500">
+        {online}/{total} critical online
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/dashboard/HeroStat.tsx
+++ b/web/src/components/dashboard/HeroStat.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { motion, useMotionValue, useTransform, animate } from "framer-motion";
+import { Card, CardContent } from "@/components/ui/card";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface HeroStatProps {
+  title: string;
+  value: number;
+  suffix?: string;
+  prefix?: string;
+  subtitle: string;
+  icon: React.ReactNode;
+  gradient: string;
+  href?: string;
+  formatValue?: (v: number) => string;
+}
+
+function AnimatedCounter({
+  value,
+  formatValue,
+}: {
+  value: number;
+  formatValue?: (v: number) => string;
+}) {
+  const motionValue = useMotionValue(0);
+  const [display, setDisplay] = useState("0");
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    if (hasAnimated.current) {
+      // After first animation, just snap to new value
+      motionValue.set(value);
+      setDisplay(formatValue ? formatValue(value) : String(value));
+      return;
+    }
+    hasAnimated.current = true;
+    const controls = animate(motionValue, value, {
+      duration: 1.2,
+      ease: [0.16, 1, 0.3, 1],
+      onUpdate: (v) => {
+        setDisplay(
+          formatValue ? formatValue(Math.round(v)) : String(Math.round(v))
+        );
+      },
+    });
+    return () => controls.stop();
+  }, [value, motionValue, formatValue]);
+
+  return <span className="tabular-nums">{display}</span>;
+}
+
+export function HeroStat({
+  title,
+  value,
+  suffix,
+  prefix,
+  subtitle,
+  icon,
+  gradient,
+  href,
+  formatValue,
+}: HeroStatProps) {
+  const inner = (
+    <Card
+      className={cn(
+        "relative overflow-hidden border-0 h-full",
+        gradient,
+        href && "transition-shadow hover:shadow-lg hover:shadow-black/20"
+      )}
+    >
+      <CardContent className="relative z-10 flex flex-col justify-between p-5 h-full min-h-[140px]">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-white/70">
+            {title}
+          </span>
+          <span className="text-white/50">{icon}</span>
+        </div>
+        <div className="mt-auto">
+          <p className="text-3xl font-bold text-white leading-none">
+            {prefix}
+            <AnimatedCounter value={value} formatValue={formatValue} />
+            {suffix}
+          </p>
+          <p className="mt-1.5 text-sm text-white/60">{subtitle}</p>
+        </div>
+      </CardContent>
+      {/* Decorative glow */}
+      <div className="absolute -right-6 -top-6 h-24 w-24 rounded-full bg-white/5 blur-2xl" />
+    </Card>
+  );
+
+  return href ? (
+    <Link href={href} className="block h-full">
+      {inner}
+    </Link>
+  ) : (
+    inner
+  );
+}

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -5,47 +5,34 @@ test.describe('Dashboard', () => {
     await login(page);
   });
 
-  test('dashboard page loads with stat cards', async ({ page }) => {
+  test('dashboard page loads with hero stat cards', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
-    // Should have stat cards (4 of them)
-    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('Active Devices')).toBeVisible();
-    await expect(page.getByText('WAN Bandwidth')).toBeVisible();
-    await expect(page.getByText('Unread Alerts')).toBeVisible();
+    // Should have hero stat cards (4 of them)
+    await expect(page.getByText('Total Devices')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Active Alerts')).toBeVisible();
+    await expect(page.getByText('Infra Health')).toBeVisible();
+    await expect(page.getByText('WAN Traffic')).toBeVisible();
 
-    await page.screenshot({ path: 'tests/screenshots/dashboard-stats.png', fullPage: true });
+    await page.screenshot({ path: 'tests/screenshots/dashboard-hero-stats.png', fullPage: true });
   });
 
-  test('stat cards resolve from skeleton to real values', async ({ page }) => {
+  test('hero stats show animated values after load', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
-    // The stat cards should resolve within 10s — the /api/v1/dashboard/stats
-    // endpoint must return valid JSON. If the skeleton never resolves, these
-    // assertions will time out (the bug this test catches).
-    //
-    // "Router Status" card shows one of: Online, Offline, Unconfigured
-    const routerCard = page.getByText('Router Status');
-    await expect(routerCard).toBeVisible({ timeout: 10000 });
+    // Wait for hero stats to resolve from skeleton to real values
+    await expect(page.getByText('Total Devices')).toBeVisible({ timeout: 10000 });
 
-    // After stat cards load, at least one value should be visible.
-    // With no router configured, we expect "Unconfigured".
-    // With a router configured, we expect "Online" or "Offline".
-    const routerValue = page.getByText(/^(Online|Offline|Unconfigured|Unreachable)$/);
-    await expect(routerValue.first()).toBeVisible({ timeout: 10000 });
+    // "Total Devices" card shows a number and subtitle
+    const devicesSubtitle = page.getByText(/currently online/);
+    await expect(devicesSubtitle.first()).toBeVisible({ timeout: 10000 });
 
-    // "Active Devices" card shows a number
-    await expect(page.getByText('Active Devices')).toBeVisible();
-    // The value is a number (could be 0)
-    const devicesCard = page.locator('text=Active Devices').locator('..').locator('..');
-    await expect(devicesCard.getByText(/total known/)).toBeVisible({ timeout: 10000 });
+    // "Active Alerts" card shows status
+    await expect(page.getByText('Active Alerts')).toBeVisible();
+    const alertsSubtitle = page.getByText(/All clear|Needs attention/);
+    await expect(alertsSubtitle.first()).toBeVisible({ timeout: 10000 });
 
-    // "Unread Alerts" card shows a value
-    await expect(page.getByText('Unread Alerts')).toBeVisible();
-    const alertsCard = page.locator('text=Unread Alerts').locator('..').locator('..');
-    await expect(alertsCard.getByText(/All clear|Needs attention/)).toBeVisible({ timeout: 10000 });
-
-    await page.screenshot({ path: 'tests/screenshots/dashboard-stat-values.png', fullPage: true });
+    await page.screenshot({ path: 'tests/screenshots/dashboard-hero-values.png', fullPage: true });
   });
 
   test('infrastructure health ring loads', async ({ page }) => {
@@ -60,6 +47,29 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-health-ring.png', fullPage: true });
   });
 
+  test('quick actions row is visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // Quick actions pills should be visible
+    await expect(page.getByText('Scan Network')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('View Alerts')).toBeVisible();
+    await expect(page.getByText('Check DNS')).toBeVisible();
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-quick-actions.png', fullPage: true });
+  });
+
+  test('bento grid layout has correct sections', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+
+    // All bento grid sections should be visible
+    await expect(page.getByText('WAN Traffic')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Recent Alerts')).toBeVisible();
+    await expect(page.getByText('Infrastructure Health')).toBeVisible();
+    await expect(page.getByText('Device Breakdown')).toBeVisible();
+
+    await page.screenshot({ path: 'tests/screenshots/dashboard-bento-grid.png', fullPage: true });
+  });
+
   test('dashboard has Recent Alerts section', async ({ page }) => {
     await expect(page.getByText('Recent Alerts')).toBeVisible({ timeout: 10000 });
     await page.screenshot({ path: 'tests/screenshots/dashboard-alerts.png', fullPage: true });
@@ -70,36 +80,7 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-devices.png', fullPage: true });
   });
 
-  test('top row cards have consistent heights', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
-
-    // Wait for stat cards to resolve so we measure final rendered heights
-    await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
-
-    // The Infrastructure Health card and the stat-cards wrapper are direct children
-    // of the top bento grid. Grab all top-level grid children and compare heights.
-    const systemHealthCard = page.getByText('Infrastructure Health').locator('xpath=ancestor::div[contains(@class,"border-slate-7")]').first();
-    const routerStatusCard = page.getByText('Router Status').locator('xpath=ancestor::div[contains(@class,"border-slate-7")]').first();
-
-    const healthBox = await systemHealthCard.boundingBox();
-    const routerBox = await routerStatusCard.boundingBox();
-
-    expect(healthBox).toBeTruthy();
-    expect(routerBox).toBeTruthy();
-
-    // Both cards should have h-full, so the stat cards should stretch to match
-    // the System Health card. Allow a small tolerance (5px) for sub-pixel rounding.
-    const heightDiff = Math.abs(healthBox!.height - routerBox!.height);
-    expect(heightDiff).toBeLessThanOrEqual(5);
-
-    await page.screenshot({ path: 'tests/screenshots/dashboard-card-heights.png', fullPage: true });
-  });
-
   test('dashboard stats API responds within 2 seconds (#494)', async ({ page }) => {
-    // Bug #494: /api/v1/dashboard/stats used to block 3-5s because check_vyos()
-    // always ran with a 5s timeout even when MikroTik was the active router.
-    // After the fix, the endpoint should respond in <2s.
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
     const start = Date.now();
@@ -120,30 +101,22 @@ test.describe('Dashboard', () => {
   });
 
   test('dashboard displays loading state or content', async ({ page }) => {
-    // Dashboard should either show content or be in loading state
-    // Check that we're on the dashboard and it's responsive
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
     await page.screenshot({ path: 'tests/screenshots/dashboard-full.png', fullPage: true });
   });
 
   test('dashboard stats API returns router_type field', async ({ page }) => {
-    // The /api/v1/dashboard/stats endpoint must include router_type
-    // so the UI knows which router is active (mikrotik or none).
     const response = await page.request.get('/api/v1/dashboard/stats');
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
 
-    // router_type must be one of the known values
     expect(['mikrotik', 'none']).toContain(data.router_type);
-    // router_status must still be present
     expect(['connected', 'disconnected', 'unconfigured']).toContain(data.router_status);
 
     await page.screenshot({ path: 'tests/screenshots/dashboard-router-type-api.png' });
   });
 
   test('dashboard stats API returns critical device counts (#518)', async ({ page }) => {
-    // The /api/v1/dashboard/stats endpoint must include critical_online and critical_total
-    // for the infrastructure health ring.
     const response = await page.request.get('/api/v1/dashboard/stats');
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -160,9 +133,6 @@ test.describe('Dashboard', () => {
   });
 
   test('dashboard stats API responds within 2 seconds', async ({ page }) => {
-    // The /api/v1/dashboard/stats endpoint should respond quickly even when
-    // a router is offline. With the concurrent fetch + 500ms router timeout,
-    // the API should never take more than ~1s. We allow 2s for CI slack.
     const start = Date.now();
     const response = await page.request.get('/api/v1/dashboard/stats');
     const elapsed = Date.now() - start;
@@ -171,7 +141,6 @@ test.describe('Dashboard', () => {
     expect(elapsed).toBeLessThan(2000);
 
     const data = await response.json();
-    // Sanity-check the response shape
     expect(data).toHaveProperty('router_status');
     expect(data).toHaveProperty('devices_online');
     expect(data).toHaveProperty('wan_rx_bps');
@@ -179,16 +148,13 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-fast-api.png' });
   });
 
-  test('dashboard renders stat cards within 3 seconds', async ({ page }) => {
-    // Navigate to dashboard and measure how long it takes for stat cards
-    // to appear. With the performance fix, this should be < 3s even if
-    // a router integration is offline or slow.
+  test('dashboard renders hero stats within 3 seconds', async ({ page }) => {
     await page.goto('/dashboard');
     const start = Date.now();
 
-    // Wait for the stat cards to fully render (not skeletons)
-    const routerValue = page.getByText(/^(Online|Offline|Unconfigured|Unreachable)$/);
-    await expect(routerValue.first()).toBeVisible({ timeout: 5000 });
+    // Wait for the hero stat cards to fully render (not skeletons)
+    const devicesSubtitle = page.getByText(/currently online/);
+    await expect(devicesSubtitle.first()).toBeVisible({ timeout: 5000 });
     const elapsed = Date.now() - start;
 
     expect(elapsed).toBeLessThan(3000);
@@ -196,21 +162,19 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-fast-render.png', fullPage: true });
   });
 
-  test('router status subtitle reflects active router type', async ({ page }) => {
+  test('responsive layout collapses to single column on mobile', async ({ page }) => {
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/dashboard');
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
-    // Wait for stat cards to resolve
-    const routerCard = page.getByText('Router Status');
-    await expect(routerCard).toBeVisible({ timeout: 10000 });
+    // All hero stat cards should still be visible
+    await expect(page.getByText('Total Devices')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Active Alerts')).toBeVisible();
 
-    // The subtitle should mention the specific router type or show generic text
-    // depending on what's configured. In a test environment with no router
-    // configured, we expect "Router not configured".
-    const subtitle = page.getByText(
-      /Connected to (MikroTik|router)|Cannot reach (MikroTik|router)|Router not configured/
-    );
-    await expect(subtitle.first()).toBeVisible({ timeout: 10000 });
+    // Quick actions should be visible
+    await expect(page.getByText('Scan Network')).toBeVisible();
 
-    await page.screenshot({ path: 'tests/screenshots/dashboard-router-subtitle.png', fullPage: true });
+    await page.screenshot({ path: 'tests/screenshots/dashboard-mobile.png', fullPage: true });
   });
 });


### PR DESCRIPTION
Closes #593

## Summary
- Replaced uniform dashboard grid with a **bento grid layout** using CSS `grid-template-areas` and mixed card sizes (4-col traffic, 2-col health ring, 2-col alerts, 4-col device breakdown)
- Added **hero stat row** with 4 oversized cards (Total Devices, Active Alerts, Infra Health, WAN Traffic) featuring gradient backgrounds and animated count-up counters via framer-motion `useMotionValue` + `animate`
- Extracted **HealthRing** into a standalone component with animated SVG stroke on load using `motion.circle`
- Created **HeroStat** component with `AnimatedCounter` that counts up from 0 on page load
- Added **pill-shaped quick actions row** below hero stats: "Scan Network", "View Alerts", "Check DNS"
- Responsive: collapses to single column on mobile

## Files Changed
- `web/src/app/(app)/dashboard/page.tsx` — main dashboard layout refactored to bento grid
- `web/src/components/dashboard/HeroStat.tsx` — new hero stat card with animated counter
- `web/src/components/dashboard/HealthRing.tsx` — extracted + animated health ring gauge
- `web/src/components/MotionStagger.tsx` — added `style` prop support to `StaggerContainer`
- `web/tests/e2e/dashboard.spec.ts` — updated E2E tests for new layout

## Smoke Test
- `bunx next build` passes clean
- All new components render without errors
- Hero stats animate count-up on page load
- Quick actions link to valid routes
- Responsive layout verified via mobile viewport E2E test

## Test Plan
- [x] Hero stat cards visible and animated
- [x] Quick actions row visible with all 3 pills
- [x] Bento grid sections (traffic, alerts, health ring, device breakdown) all visible
- [x] Infrastructure health ring loads correctly
- [x] Mobile responsive layout test
- [x] Build passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the uniform dashboard grid with a bento layout featuring animated hero stat cards, an extracted `HealthRing` component, and a quick-actions row. The overall structure and data-fetching logic are well-implemented, but one logic issue in `AnimatedCounter` should be addressed before merging.

- **Logic bug in `AnimatedCounter`** (`HeroStat.tsx`): `formatValue` is included in the `useEffect` dependency array but is passed as an inline arrow function from the parent. Any re-render of `DashboardPage` (e.g. triggered by a WebSocket device event) produces a new function reference, causing the effect to fire mid-animation and immediately snap the counter to its final value, cutting the count-up short. Removing `formatValue` from the dependency array resolves this.
- **Unused imports**: `motion` and `useTransform` in `HeroStat.tsx`; `useEffect` and `useState` in `HealthRing.tsx` — all should be removed.
- **Duplicate E2E tests**: Two tests in `dashboard.spec.ts` both assert the stats API responds within 2 seconds — these should be merged into one.
- The bento grid's use of both `grid-template-areas` (inline style) and responsive `col-span` (Tailwind classes) as a fallback is functionally correct: browsers ignore the template-areas declaration when column counts don't match, so mobile auto-placement works as intended.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the `formatValue` dependency array issue in `AnimatedCounter`.
- One concrete logic bug (premature animation abort due to unstable `formatValue` dependency) affects a visible hero stat on a real-time dashboard where WebSocket events are expected. The fix is a one-line change. All other findings are unused imports and a duplicate test — non-blocking. Core layout, data fetching, error handling, and responsive behavior are all solid.
- web/src/components/dashboard/HeroStat.tsx — the `formatValue` dependency array issue on line 50.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dashboard/page.tsx | Main dashboard refactored to bento grid layout with hero stats, quick actions, and extracted components. Logic is sound; CSS grid-template-areas + col-span fallback pattern is functional. |
| web/src/components/dashboard/HeroStat.tsx | New animated hero stat card component. Two issues: unused `motion`/`useTransform` imports, and `formatValue` in the effect dependency array can prematurely abort the count-up animation when the parent re-renders mid-animation (e.g. via WebSocket events). |
| web/src/components/dashboard/HealthRing.tsx | Extracted and animated HealthRing component. Minor issue: `useEffect` and `useState` are imported but unused. |
| web/src/components/MotionStagger.tsx | Minimal additive change — added optional `style` prop to `StaggerContainer` to support inline grid-area assignments in the bento layout. |
| web/tests/e2e/dashboard.spec.ts | E2E tests updated for the new layout. Good coverage of hero stats, quick actions, bento sections, and responsive layout. Contains two duplicate API performance tests that should be consolidated. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/components/dashboard/HeroStat.tsx
Line: 4

Comment:
**Unused imports: `motion` and `useTransform`**

Both `motion` and `useTransform` are imported from `framer-motion` but never referenced anywhere in this file. `useMotionValue` and `animate` are the only framer-motion APIs actually used.

```suggestion
import { useMotionValue, animate } from "framer-motion";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/components/dashboard/HealthRing.tsx
Line: 3-4

Comment:
**Unused React imports: `useEffect` and `useState`**

Neither `useEffect` nor `useState` is used in this component — the animation is handled entirely by framer-motion's `motion.circle`. These should be removed.

```suggestion
import { motion } from "framer-motion";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/components/dashboard/HeroStat.tsx
Line: 50

Comment:
**Inline `formatValue` can abort count-up animation early**

`formatValue` is in the `useEffect` dependency array. For the WAN Traffic card it is defined as an inline arrow function in `page.tsx`:
```tsx
formatValue={(v) => `↓ ${formatBps(v)}`}
```
Every time `DashboardPage` re-renders (e.g. a WebSocket event triggers `loadAll` within the 1.2 s animation window), a new function reference is created. This causes the effect to re-run, and because `hasAnimated.current` is already `true` at that point, the animation is immediately snapped to the final value instead of continuing the count-up.

The safest fix is to remove `formatValue` from the dependency array. The function reference itself is only needed for formatting the display value and doesn't affect whether the animation should restart; the animation should only restart when `value` changes.

```suggestion
  }, [value, motionValue]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/tests/e2e/dashboard.spec.ts
Line: 83-101

Comment:
**Duplicate API performance tests**

There are two separate tests that both assert the stats API responds in under 2 seconds with largely overlapping assertions:

- Lines 83–101: `'dashboard stats API responds within 2 seconds (#494)'` — checks `router_status`, `devices_online`, `devices_total`, `alerts_unread`
- Lines 135–149: `'dashboard stats API responds within 2 seconds'` — checks `router_status`, `devices_online`, `wan_rx_bps`

These should be merged into a single test covering all the field assertions, or the older issue-tagged variant (line 83) should be removed and its unique field assertions folded into the remaining one.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: add bento grid..."](https://github.com/befeast/panoptikon/commit/a0b37f6a693273b77bf7cf8c1dab1e030e5f5183)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->