### PR TITLE
feat: Stat cards: sparklines, animated counters, gradient icon backgrounds (#597)

### DIFF
--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -215,25 +215,29 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
       <InfoStatCard
         icon={<Monitor className="h-5 w-5 text-pink-400" />}
-        iconColorClass="bg-pink-500/10"
+        iconColorClass="bg-gradient-to-br from-pink-500/20 to-pink-500/5"
+        glowColorClass="bg-pink-500/[0.07]"
         label="Version"
         value={status.version ?? "\u2014"}
       />
       <InfoStatCard
         icon={<Clock className="h-5 w-5 text-emerald-400" />}
-        iconColorClass="bg-emerald-500/10"
+        iconColorClass="bg-gradient-to-br from-emerald-500/20 to-emerald-500/5"
+        glowColorClass="bg-emerald-500/[0.07]"
         label="Uptime"
         value={status.uptime ?? "\u2014"}
       />
       <InfoStatCard
         icon={<Cpu className="h-5 w-5 text-amber-400" />}
-        iconColorClass="bg-amber-500/10"
+        iconColorClass="bg-gradient-to-br from-amber-500/20 to-amber-500/5"
+        glowColorClass="bg-amber-500/[0.07]"
         label="CPU Load"
         value={status.cpu_load ? `${status.cpu_load}%` : "\u2014"}
       />
       <InfoStatCard
         icon={<MemoryStick className="h-5 w-5 text-purple-400" />}
-        iconColorClass="bg-purple-500/10"
+        iconColorClass="bg-gradient-to-br from-purple-500/20 to-purple-500/5"
+        glowColorClass="bg-purple-500/[0.07]"
         label="Memory"
         value={
           memUsed
@@ -243,13 +247,15 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
       />
       <InfoStatCard
         icon={<HardDrive className="h-5 w-5 text-cyan-400" />}
-        iconColorClass="bg-cyan-500/10"
+        iconColorClass="bg-gradient-to-br from-cyan-500/20 to-cyan-500/5"
+        glowColorClass="bg-cyan-500/[0.07]"
         label="Platform"
         value={platformValue}
       />
       <InfoStatCard
         icon={<Server className="h-5 w-5 text-blue-400" />}
-        iconColorClass="bg-blue-500/10"
+        iconColorClass="bg-gradient-to-br from-blue-500/20 to-blue-500/5"
+        glowColorClass="bg-blue-500/[0.07]"
         label="Board"
         value={status.board_name ?? "\u2014"}
       />

--- a/web/src/components/ui/info-stat-card.tsx
+++ b/web/src/components/ui/info-stat-card.tsx
@@ -1,45 +1,98 @@
+"use client";
+
 import * as React from "react";
+import { useEffect, useRef, useState } from "react";
+import { useMotionValue, animate } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { Sparkline } from "@/components/ui/sparkline";
 
 interface InfoStatCardProps {
   icon: React.ReactNode;
   iconColorClass: string;
   label: string;
   value: string;
+  numericValue?: number;
+  formatValue?: (v: number) => string;
+  sparklineData?: number[];
+  sparklineColorClass?: string;
+  glowColorClass?: string;
   className?: string;
 }
 
 /**
  * Reusable card for displaying a single icon + label + value stat.
- * Purely informational — no hover, shadow or interactive affordance.
  *
  * Layout tokens:
- *  - Icon block: 40×40 (h-10 w-10), centered, rounded-lg
+ *  - Icon block: 48×48 (h-12 w-12), centered, rounded-lg, gradient bg
  *  - Label:      11px uppercase tracking-wider, slate-500
  *  - Value:      14px (text-sm) semibold white, truncated with title tooltip
  *  - Min height: 80px (min-h-[5rem]) for comfortable card rhythm
  *  - Gap:        16px (gap-4) between icon and text
  *  - Padding:    16px all around (p-4)
+ *
+ * Optional features:
+ *  - numericValue + formatValue → animated counter (counts up from 0)
+ *  - sparklineData → mini trend line next to value
+ *  - glowColorClass → subtle radial glow in bottom-right
  */
+
+function AnimatedValue({
+  value,
+  formatValue,
+}: {
+  value: number;
+  formatValue?: (v: number) => string;
+}) {
+  const motionValue = useMotionValue(0);
+  const [display, setDisplay] = useState("0");
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    if (hasAnimated.current) {
+      motionValue.set(value);
+      setDisplay(formatValue ? formatValue(value) : String(value));
+      return;
+    }
+    hasAnimated.current = true;
+    const controls = animate(motionValue, value, {
+      duration: 0.6,
+      ease: "easeOut",
+      onUpdate: (v) => {
+        setDisplay(
+          formatValue ? formatValue(Math.round(v)) : String(Math.round(v)),
+        );
+      },
+    });
+    return () => controls.stop();
+  }, [value, motionValue, formatValue]);
+
+  return <span className="tabular-nums">{display}</span>;
+}
+
 export function InfoStatCard({
   icon,
   iconColorClass,
   label,
   value,
+  numericValue,
+  formatValue,
+  sparklineData,
+  sparklineColorClass,
+  glowColorClass,
   className,
 }: InfoStatCardProps) {
   return (
     <Card
       className={cn(
-        "border-slate-800/50 bg-slate-900/60 shadow-none",
+        "relative overflow-hidden border-slate-800/50 bg-slate-900/60 shadow-none",
         className,
       )}
     >
       <CardContent className="flex min-h-[5rem] items-center gap-4 p-4">
         <div
           className={cn(
-            "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+            "flex h-12 w-12 shrink-0 items-center justify-center rounded-lg",
             iconColorClass,
           )}
         >
@@ -49,14 +102,36 @@ export function InfoStatCard({
           <p className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
             {label}
           </p>
-          <p
-            className="truncate text-sm font-semibold text-white"
-            title={value !== "\u2014" ? value : undefined}
-          >
-            {value}
-          </p>
+          <div className="flex items-center gap-2">
+            <p
+              className="truncate text-sm font-semibold text-white"
+              title={value !== "\u2014" ? value : undefined}
+            >
+              {numericValue != null ? (
+                <AnimatedValue value={numericValue} formatValue={formatValue} />
+              ) : (
+                value
+              )}
+            </p>
+            {sparklineData && sparklineData.length >= 2 && (
+              <Sparkline
+                data={sparklineData}
+                strokeClass={sparklineColorClass}
+              />
+            )}
+          </div>
         </div>
       </CardContent>
+
+      {/* Subtle background glow — radial, bottom-right, 5-10% opacity */}
+      {glowColorClass && (
+        <div
+          className={cn(
+            "pointer-events-none absolute -bottom-4 -right-4 h-24 w-24 rounded-full blur-2xl",
+            glowColorClass,
+          )}
+        />
+      )}
     </Card>
   );
 }

--- a/web/src/components/ui/sparkline.tsx
+++ b/web/src/components/ui/sparkline.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SparklineProps {
+  data: number[];
+  className?: string;
+  strokeClass?: string;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Tiny inline SVG trend line for stat cards.
+ * Renders a polyline from the given data points — no charting library needed.
+ */
+export function Sparkline({
+  data,
+  className,
+  strokeClass = "stroke-slate-400",
+  width = 64,
+  height = 24,
+}: SparklineProps) {
+  if (data.length < 2) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+
+  const d = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * width;
+      const y = height - ((v - min) / range) * (height - 2) - 1;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      fill="none"
+      className={cn("shrink-0", className)}
+      aria-hidden
+    >
+      <path
+        d={d}
+        className={cn("fill-none stroke-[1.5]", strokeClass)}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/web/tests/e2e/stat-card-enhancements.spec.ts
+++ b/web/tests/e2e/stat-card-enhancements.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E tests for InfoStatCard visual enhancements (#597).
+ *
+ * Verifies:
+ * - Gradient icon backgrounds (bg-gradient-to-br)
+ * - Upgraded icon container size (48×48 → h-12 w-12)
+ * - Subtle background glow div
+ * - Card still renders without overflow
+ */
+test.describe("Stat Card Enhancements (#597)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("router page InfoStatCards have upgraded icon containers and glow", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    await page.goto("/router/mikrotik/");
+
+    // RouterSelector is always present
+    await expect(
+      page.getByRole("link", { name: /MikroTik/i }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Wait for page body to resolve
+    const systemTab = page.getByRole("tab", { name: "System" });
+    const anyFallback = page.getByText(/not configured|unreachable/i);
+    await expect(systemTab.or(anyFallback)).toBeVisible({ timeout: 20000 });
+
+    if (await systemTab.isVisible()) {
+      await systemTab.click();
+
+      // InfoStatCards use border-slate-800 and bg-slate-900
+      const cards = page.locator(
+        '[class*="border-slate-800"][class*="bg-slate-900"]',
+      );
+      const cardCount = await cards.count();
+      expect(cardCount).toBeGreaterThanOrEqual(1);
+
+      for (let i = 0; i < Math.min(cardCount, 6); i++) {
+        const card = cards.nth(i);
+
+        // Card should have overflow-hidden (needed for glow containment)
+        await expect(card).toHaveCSS("overflow", "hidden");
+
+        // Icon container should be 48×48 (h-12 w-12)
+        const iconContainer = card.locator(".h-12.w-12").first();
+        if ((await iconContainer.count()) > 0) {
+          const box = await iconContainer.boundingBox();
+          if (box) {
+            expect(box.width).toBeGreaterThanOrEqual(44); // 48px with tolerance
+            expect(box.height).toBeGreaterThanOrEqual(44);
+          }
+        }
+
+        // Card min-height preserved (80px with 4px tolerance)
+        const cardBox = await card.boundingBox();
+        if (cardBox) {
+          expect(cardBox.height).toBeGreaterThanOrEqual(76);
+        }
+      }
+
+      // Verify at least one glow div exists (blur-2xl positioned element)
+      const glowDivs = page.locator('[class*="blur-2xl"][class*="rounded-full"]');
+      expect(await glowDivs.count()).toBeGreaterThanOrEqual(1);
+    }
+
+    // No horizontal overflow
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+
+    await page.screenshot({
+      path: "tests/screenshots/stat-card-enhancements.png",
+      fullPage: true,
+    });
+  });
+
+  test("stat cards render without overflow at 375px mobile", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/router/mikrotik/");
+
+    // Wait for page to settle
+    const systemTab = page.getByRole("tab", { name: "System" });
+    const anyFallback = page.getByText(/not configured|unreachable/i);
+    await expect(
+      systemTab.or(anyFallback),
+    ).toBeVisible({ timeout: 20000 });
+
+    // No horizontal overflow at mobile width
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+
+    await page.screenshot({
+      path: "tests/screenshots/stat-card-mobile-375.png",
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #597

## Summary
Upgrades `InfoStatCard` from plain "icon + label + number" to visually rich status indicators.

## Changes
- **Animated counters**: Numbers count up from 0 on first render using framer-motion `useMotionValue` (600ms easeOut). Subsequent value changes snap immediately.
- **Sparkline component** (`web/src/components/ui/sparkline.tsx`): Optional mini SVG trend line rendered next to the stat value. Color matches the card's accent via `sparklineColorClass` prop.
- **Icon upgrade**: Container increased from 40×40 to 48×48. Gradient backgrounds (`bg-gradient-to-br from-{color}-500/20 to-{color}-500/5`) replace flat colors.
- **Subtle background glow**: Faint radial glow (blur-2xl, ~7% opacity) in bottom-right corner matching icon color, via optional `glowColorClass` prop.

## New/Modified Files
- `web/src/components/ui/info-stat-card.tsx` — upgraded with animated counter, sparkline support, glow, larger icon container
- `web/src/components/ui/sparkline.tsx` — new lightweight SVG sparkline component
- `web/src/components/MikrotikRouter.tsx` — updated to use gradient icon backgrounds and glow colors
- `web/tests/e2e/stat-card-enhancements.spec.ts` — E2E test for the enhancements

## Backward Compatibility
All new props (`numericValue`, `formatValue`, `sparklineData`, `sparklineColorClass`, `glowColorClass`) are optional. Existing callers that only pass `icon`, `iconColorClass`, `label`, and `value` continue to work unchanged.

## Smoke Test
- `bun run build` passes with no errors
- Existing E2E tests unaffected (card structure selectors still match)

## Test Plan
- [x] Build passes (`bunx next build`)
- [x] E2E test covers icon container size, overflow-hidden, glow div presence, no horizontal overflow
- [x] Mobile responsive test at 375px

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `InfoStatCard` from a plain icon/label/value layout into a visually richer stat widget — adding an animated counter, an optional SVG sparkline, gradient icon backgrounds, and a subtle radial glow. All new props are optional, so existing call-sites are unaffected. The `Sparkline` component is clean and self-contained.

- **`info-stat-card.tsx`** — `AnimatedValue` correctly handles both initial animation and subsequent snap-to-value updates; the `"use client"` directive is appropriately added for the framer-motion hooks.
- **`sparkline.tsx`** — SVG path generation is correct, zero-division is guarded with `|| 1`, and `aria-hidden` is set for decorative use.
- **`MikrotikRouter.tsx`** — prop changes are mechanical and consistent across all six stat cards.
- **E2E spec** — import path, screenshot paths, and viewport patterns all match the existing test suite conventions.
- **Potential issue**: `formatValue` in the `useEffect` dependency array in `AnimatedValue` can prematurely cancel the initial counting animation when the parent passes an inline function reference. Since `formatValue` is only used inside the animation's `onUpdate` callback, it can safely be dropped from the deps array (or callers should stabilise it with `useCallback`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one targeted fix — the `formatValue` dependency issue could silently break the counter animation for future callers.
- The implementation is clean and backward-compatible. The only concrete logic issue is the unstable `formatValue` reference in the `useEffect` deps, which would cancel the initial animation mid-flight for callers that pass inline functions. Since `formatValue` is not yet used by any existing caller in the codebase, this does not break anything today, but it is a correctness trap for the first consumer who does use it.
- web/src/components/ui/info-stat-card.tsx — `AnimatedValue` useEffect dependency array

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/ui/info-stat-card.tsx | Adds animated counter (`AnimatedValue`), sparkline support, glow overlay, and 48×48 icon container. One subtle issue: `formatValue` in the `useEffect` dependency array can prematurely cancel the initial counter animation if the parent passes an unstable function reference. |
| web/src/components/ui/sparkline.tsx | New lightweight SVG sparkline with correct path generation, zero-division guard (`|| 1`), and `aria-hidden` for accessibility. No issues found. |
| web/src/components/MikrotikRouter.tsx | Straightforward prop updates: flat `bg-{color}-500/10` replaced by gradient classes, `glowColorClass` added to each stat card. No logic changes. |
| web/tests/e2e/stat-card-enhancements.spec.ts | New E2E spec covering icon container size, overflow-hidden, glow div presence, and horizontal overflow at both desktop and 375 px mobile. Import path and screenshot path conventions match existing tests. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/components/ui/info-stat-card.tsx
Line: 51-68

Comment:
**Unstable `formatValue` reference can cancel the in-flight counter animation**

`formatValue` is included in the `useEffect` dependency array (line 68). If a parent component passes an inline arrow function (e.g. `formatValue={(v) => \`${v}%\`}`), a new function reference is created on every parent re-render. React will then:

1. Run the effect cleanup → `controls.stop()` cancels the counting animation mid-flight.
2. Re-run the effect → `hasAnimated.current` is already `true`, so the value **snaps** to the final number instead of counting up.

The user would see the counter jump abruptly to the final value, defeating the purpose of the animation.

The fix is to exclude `formatValue` from the dependency array (or wrap it in `useCallback` at the call-site). Since `formatValue` is only needed at the time the animation progresses via `onUpdate`, and the animation is already referencing the latest closure value captured at effect run time, excluding it from deps is the safe choice:

```
  }, [value, motionValue]); // formatValue intentionally omitted — animation closure captures it once
```

Alternatively, document that callers must stabilise `formatValue` with `useCallback`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: stat cards with animated counters,..."](https://github.com/befeast/panoptikon/commit/3b91191b0c055e63cbf76de2e120e4bd67837f6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25963289)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->