### PR TITLE
feat: Settings pages: visual sections, inline validation, save animation (#599)

### DIFF
--- a/web/src/app/(app)/settings/password/page.tsx
+++ b/web/src/app/(app)/settings/password/page.tsx
@@ -9,17 +9,12 @@ import {
   AlertCircle,
   ArrowLeft,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { SaveButton } from "@/components/settings/save-button";
+import { PasswordStrength } from "@/components/settings/password-strength";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -46,8 +41,8 @@ export default function PasswordSettingsPage() {
     next === confirm &&
     pwStatus !== "loading";
 
-  async function handlePasswordSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function handlePasswordSubmit(e?: React.FormEvent) {
+    e?.preventDefault();
     if (!canSubmitPw) return;
 
     setPwStatus("loading");
@@ -88,6 +83,19 @@ export default function PasswordSettingsPage() {
     }
   }
 
+  const confirmValid =
+    confirm === ""
+      ? "idle"
+      : confirm === next && next.length >= 8
+        ? "valid"
+        : "invalid";
+  const nextValid =
+    next === ""
+      ? "idle"
+      : next.length >= 8
+        ? "valid"
+        : "invalid";
+
   return (
     <PageTransition>
       <div className="mx-auto max-w-lg space-y-6 py-8">
@@ -101,143 +109,137 @@ export default function PasswordSettingsPage() {
           <h1 className="text-2xl font-semibold text-white">Change Password</h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
-                <Lock className="h-4 w-4 text-blue-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Password
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  After changing, you&apos;ll be redirected to login again.
-                </CardDescription>
-              </div>
+        <SettingsSection
+          icon={<Lock className="h-4 w-4 text-blue-400" />}
+          iconBg="bg-blue-500/10"
+          title="Password"
+          description="After changing, you'll be redirected to login again."
+        >
+          {pwStatus === "success" ? (
+            <div className="flex flex-col items-center gap-3 py-6 text-center">
+              <CheckCircle className="h-10 w-10 text-emerald-400" />
+              <p className="text-sm text-emerald-400">
+                Password changed! Redirecting to login…
+              </p>
             </div>
-          </CardHeader>
-          <CardContent>
-            {pwStatus === "success" ? (
-              <div className="flex flex-col items-center gap-3 py-6 text-center">
-                <CheckCircle className="h-10 w-10 text-emerald-400" />
-                <p className="text-sm text-emerald-400">
-                  Password changed! Redirecting to login…
-                </p>
+          ) : (
+            <form onSubmit={handlePasswordSubmit} className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="current" className="text-xs text-slate-400">
+                  Current password
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="current"
+                    type={showCurrent ? "text" : "password"}
+                    value={current}
+                    onChange={(e) => setCurrent(e.target.value)}
+                    className="border-slate-800 bg-slate-950 pr-10 text-white placeholder:text-slate-600"
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowCurrent((v) => !v)}
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+                    tabIndex={-1}
+                  >
+                    {showCurrent ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
               </div>
-            ) : (
-              <form onSubmit={handlePasswordSubmit} className="space-y-4">
-                <div className="space-y-1.5">
-                  <Label htmlFor="current" className="text-xs text-slate-400">
-                    Current password
-                  </Label>
-                  <div className="relative">
-                    <Input
-                      id="current"
-                      type={showCurrent ? "text" : "password"}
-                      value={current}
-                      onChange={(e) => setCurrent(e.target.value)}
-                      className="border-slate-800 bg-slate-950 pr-10 text-white placeholder:text-slate-600"
-                      placeholder="••••••••"
-                      autoComplete="current-password"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowCurrent((v) => !v)}
-                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
-                      tabIndex={-1}
-                    >
-                      {showCurrent ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                </div>
 
-                <div className="space-y-1.5">
-                  <Label htmlFor="new" className="text-xs text-slate-400">
-                    New password
-                  </Label>
-                  <div className="relative">
-                    <Input
-                      id="new"
-                      type={showNext ? "text" : "password"}
-                      value={next}
-                      onChange={(e) => setNext(e.target.value)}
-                      className="border-slate-800 bg-slate-950 pr-10 text-white placeholder:text-slate-600"
-                      placeholder="Min. 8 characters"
-                      autoComplete="new-password"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowNext((v) => !v)}
-                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
-                      tabIndex={-1}
-                    >
-                      {showNext ? (
-                        <EyeOff className="h-4 w-4" />
-                      ) : (
-                        <Eye className="h-4 w-4" />
-                      )}
-                    </button>
-                  </div>
-                  {next.length > 0 && (
-                    <div className="mt-1 flex gap-1">
-                      {[1, 2, 3, 4].map((i) => (
-                        <div
-                          key={i}
-                          className={`h-0.5 flex-1 rounded-full transition-colors ${
-                            next.length >= i * 4
-                              ? next.length < 8
-                                ? "bg-rose-500"
-                                : next.length < 12
-                                  ? "bg-yellow-500"
-                                  : "bg-emerald-500"
-                              : "bg-slate-800"
-                          }`}
-                        />
-                      ))}
-                    </div>
-                  )}
+              <div className="space-y-1.5">
+                <Label htmlFor="new" className="text-xs text-slate-400">
+                  New password
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="new"
+                    type={showNext ? "text" : "password"}
+                    value={next}
+                    onChange={(e) => setNext(e.target.value)}
+                    className={`border-slate-800 bg-slate-950 pr-10 text-white placeholder:text-slate-600 ${
+                      nextValid === "invalid"
+                        ? "border-rose-500/50 focus-visible:ring-rose-500/30"
+                        : nextValid === "valid"
+                          ? "border-emerald-500/50 focus-visible:ring-emerald-500/30"
+                          : ""
+                    }`}
+                    placeholder="Min. 8 characters"
+                    autoComplete="new-password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowNext((v) => !v)}
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+                    tabIndex={-1}
+                  >
+                    {showNext ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
                 </div>
+                <PasswordStrength password={next} />
+              </div>
 
-                <div className="space-y-1.5">
-                  <Label htmlFor="confirm" className="text-xs text-slate-400">
-                    Confirm new password
-                  </Label>
+              <div className="space-y-1.5">
+                <Label htmlFor="confirm" className="text-xs text-slate-400">
+                  Confirm new password
+                </Label>
+                <div className="relative">
                   <Input
                     id="confirm"
                     type="password"
                     value={confirm}
                     onChange={(e) => setConfirm(e.target.value)}
-                    className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
+                    className={`border-slate-800 bg-slate-950 text-white placeholder:text-slate-600 ${
+                      confirmValid === "invalid"
+                        ? "border-rose-500/50 focus-visible:ring-rose-500/30"
+                        : confirmValid === "valid"
+                          ? "border-emerald-500/50 focus-visible:ring-emerald-500/30"
+                          : ""
+                    }`}
                     placeholder="••••••••"
                     autoComplete="new-password"
                   />
+                  {confirmValid === "valid" && (
+                    <CheckCircle className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-fade-in text-emerald-400" />
+                  )}
+                  {confirmValid === "invalid" && (
+                    <AlertCircle className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-fade-in text-rose-400" />
+                  )}
                 </div>
-
-                {(validationError || (pwStatus === "error" && pwError)) && (
-                  <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                    <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                    <p className="text-xs text-rose-400">
-                      {pwStatus === "error" && pwError ? pwError : validationError}
-                    </p>
-                  </div>
+                {confirmValid === "invalid" && (
+                  <p className="animate-fade-in text-[11px] text-rose-400">
+                    Passwords do not match
+                  </p>
                 )}
+              </div>
 
-                <Button
-                  type="submit"
-                  disabled={!canSubmitPw}
-                  className="w-full bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
-                >
-                  {pwStatus === "loading" ? "Changing…" : "Change Password"}
-                </Button>
-              </form>
-            )}
-          </CardContent>
-        </Card>
+              {pwStatus === "error" && pwError && (
+                <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+                  <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+                  <p className="text-xs text-rose-400">{pwError}</p>
+                </div>
+              )}
+
+              <SaveButton
+                status={pwStatus}
+                disabled={!canSubmitPw}
+                onClick={() => handlePasswordSubmit()}
+                label="Change Password"
+                className="w-full bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
+              />
+            </form>
+          )}
+        </SettingsSection>
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/settings/retention/page.tsx
+++ b/web/src/app/(app)/settings/retention/page.tsx
@@ -8,18 +8,13 @@ import {
   CheckCircle,
   AlertCircle,
   ArrowLeft,
+  Clock,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { ValidatedInput } from "@/components/settings/validated-input";
+import { SaveButton } from "@/components/settings/save-button";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -81,6 +76,16 @@ export default function RetentionSettingsPage() {
     retTrafficHours !== savedRetTrafficHours ||
     retAlertsDays !== savedRetAlertsDays ||
     retAgentDays !== savedRetAgentDays;
+
+  const trafficNum = parseInt(retTrafficHours, 10);
+  const trafficValid =
+    retTrafficHours === "" ? "idle" : !isNaN(trafficNum) && trafficNum >= 1 ? "valid" : "invalid";
+  const alertsNum = parseInt(retAlertsDays, 10);
+  const alertsValid =
+    retAlertsDays === "" ? "idle" : !isNaN(alertsNum) && alertsNum >= 1 ? "valid" : "invalid";
+  const agentNum = parseInt(retAgentDays, 10);
+  const agentValid =
+    retAgentDays === "" ? "idle" : !isNaN(agentNum) && agentNum >= 1 ? "valid" : "invalid";
 
   async function handleRetentionSave() {
     settingsLoadTokenRef.current++;
@@ -180,127 +185,108 @@ export default function RetentionSettingsPage() {
           <h1 className="text-2xl font-semibold text-white">Data Retention</h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-500/10">
-                <Database className="h-4 w-4 text-amber-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Retention Configuration
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  Configure how long data is kept and manage database size.
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-950 px-3 py-2">
-              <span className="text-xs text-slate-400">Current DB size</span>
-              <span className="text-sm font-medium text-white">
-                {dbSizeBytes !== null ? formatBytes(dbSizeBytes) : "..."}
-              </span>
-            </div>
+        <SettingsSection
+          icon={<Clock className="h-4 w-4 text-amber-400" />}
+          iconBg="bg-amber-500/10"
+          title="Retention Periods"
+          description="Configure how long each type of data is kept."
+        >
+          <ValidatedInput
+            inputId="ret-traffic"
+            label="Traffic samples retention (hours)"
+            type="number"
+            min={1}
+            value={retTrafficHours}
+            onChange={(e) => setRetTrafficHours(e.target.value)}
+            placeholder="48"
+            validationState={trafficValid as "idle" | "valid" | "invalid"}
+            error="Must be at least 1 hour"
+          />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="ret-traffic" className="text-xs text-slate-400">
-                Traffic samples retention (hours)
-              </Label>
-              <Input
-                id="ret-traffic"
-                type="number"
-                min={1}
-                value={retTrafficHours}
-                onChange={(e) => setRetTrafficHours(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="48"
-              />
-            </div>
+          <ValidatedInput
+            inputId="ret-alerts"
+            label="Acknowledged alerts retention (days)"
+            type="number"
+            min={1}
+            value={retAlertsDays}
+            onChange={(e) => setRetAlertsDays(e.target.value)}
+            placeholder="90"
+            validationState={alertsValid as "idle" | "valid" | "invalid"}
+            error="Must be at least 1 day"
+          />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="ret-alerts" className="text-xs text-slate-400">
-                Acknowledged alerts retention (days)
-              </Label>
-              <Input
-                id="ret-alerts"
-                type="number"
-                min={1}
-                value={retAlertsDays}
-                onChange={(e) => setRetAlertsDays(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="90"
-              />
-            </div>
+          <ValidatedInput
+            inputId="ret-agent"
+            label="Agent reports retention (days)"
+            type="number"
+            min={1}
+            value={retAgentDays}
+            onChange={(e) => setRetAgentDays(e.target.value)}
+            placeholder="7"
+            validationState={agentValid as "idle" | "valid" | "invalid"}
+            error="Must be at least 1 day"
+          />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="ret-agent" className="text-xs text-slate-400">
-                Agent reports retention (days)
-              </Label>
-              <Input
-                id="ret-agent"
-                type="number"
-                min={1}
-                value={retAgentDays}
-                onChange={(e) => setRetAgentDays(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="7"
-              />
+          {retentionStatus === "success" && retentionMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{retentionMsg}</p>
             </div>
+          )}
+          {retentionStatus === "error" && retentionMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{retentionMsg}</p>
+            </div>
+          )}
 
-            {retentionStatus === "success" && retentionMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{retentionMsg}</p>
-              </div>
+          <SaveButton
+            status={retentionStatus}
+            disabled={!retentionDirty}
+            onClick={handleRetentionSave}
+          />
+        </SettingsSection>
+
+        <SettingsSection
+          icon={<Database className="h-4 w-4 text-amber-400" />}
+          iconBg="bg-amber-500/10"
+          title="Database Maintenance"
+          description="Monitor database size and reclaim space."
+        >
+          <div className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-950 px-3 py-2">
+            <span className="text-xs text-slate-400">Current DB size</span>
+            <span className="text-sm font-medium text-white">
+              {dbSizeBytes !== null ? formatBytes(dbSizeBytes) : "..."}
+            </span>
+          </div>
+
+          {vacuumStatus === "success" && vacuumMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{vacuumMsg}</p>
+            </div>
+          )}
+          {vacuumStatus === "error" && vacuumMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{vacuumMsg}</p>
+            </div>
+          )}
+
+          <Button
+            variant="outline"
+            onClick={handleVacuum}
+            disabled={vacuumStatus === "loading"}
+            className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+          >
+            {vacuumStatus === "loading" ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
             )}
-            {retentionStatus === "error" && retentionMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{retentionMsg}</p>
-              </div>
-            )}
-            {vacuumStatus === "success" && vacuumMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{vacuumMsg}</p>
-              </div>
-            )}
-            {vacuumStatus === "error" && vacuumMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{vacuumMsg}</p>
-              </div>
-            )}
-
-            <div className="flex gap-2">
-              <Button
-                onClick={handleRetentionSave}
-                disabled={!retentionDirty || retentionStatus === "loading"}
-                className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
-              >
-                {retentionStatus === "loading" ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                ) : null}
-                Save
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handleVacuum}
-                disabled={vacuumStatus === "loading"}
-                className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
-              >
-                {vacuumStatus === "loading" ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-                )}
-                VACUUM
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+            VACUUM
+          </Button>
+        </SettingsSection>
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -9,13 +9,6 @@ import {
   AlertCircle,
   ArrowLeft,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,6 +17,9 @@ import {
   testMikrotikConnection,
 } from "@/lib/api";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { ValidatedInput } from "@/components/settings/validated-input";
+import { SaveButton } from "@/components/settings/save-button";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -74,6 +70,9 @@ function MikrotikPanel() {
     user !== (savedUser ?? "") ||
     password.length > 0 ||
     enabled !== savedEnabled;
+
+  const urlValid = url === "" ? "idle" : /^https?:\/\/.+/.test(url) ? "valid" : "invalid";
+  const userValid = user === "" ? "idle" : "valid";
 
   async function handleSave() {
     loadTokenRef.current++;
@@ -163,33 +162,26 @@ function MikrotikPanel() {
         />
       </div>
 
-      <div className="space-y-1.5">
-        <Label htmlFor="mt-url" className="text-xs text-slate-400">
-          Router URL
-        </Label>
-        <Input
-          id="mt-url"
-          type="url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-          placeholder="http://10.10.0.125"
-        />
-      </div>
+      <ValidatedInput
+        inputId="mt-url"
+        label="Router URL"
+        type="url"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="http://10.10.0.125"
+        validationState={urlValid as "idle" | "valid" | "invalid"}
+        error="Enter a valid URL (http:// or https://)"
+      />
 
-      <div className="space-y-1.5">
-        <Label htmlFor="mt-user" className="text-xs text-slate-400">
-          Username
-        </Label>
-        <Input
-          id="mt-user"
-          type="text"
-          value={user}
-          onChange={(e) => setUser(e.target.value)}
-          className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-          placeholder="admin"
-        />
-      </div>
+      <ValidatedInput
+        inputId="mt-user"
+        label="Username"
+        type="text"
+        value={user}
+        onChange={(e) => setUser(e.target.value)}
+        placeholder="admin"
+        validationState={userValid as "idle" | "valid" | "invalid"}
+      />
 
       <div className="space-y-1.5">
         <Label htmlFor="mt-password" className="text-xs text-slate-400">
@@ -218,16 +210,12 @@ function MikrotikPanel() {
       />
 
       <div className="flex gap-2">
-        <Button
+        <SaveButton
+          status={saveStatus}
+          disabled={!dirty}
           onClick={handleSave}
-          disabled={!dirty || saveStatus === "loading"}
           className="bg-pink-600 text-white hover:bg-pink-500 disabled:opacity-40"
-        >
-          {saveStatus === "loading" && (
-            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-          )}
-          Save
-        </Button>
+        />
         <Button
           variant="outline"
           onClick={handleTest}
@@ -307,26 +295,14 @@ export default function RouterSettingsPage() {
           </h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
-                <Router className="h-4 w-4 text-blue-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Router Connection
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  Configure MikroTik router integration.
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <MikrotikPanel />
-          </CardContent>
-        </Card>
+        <SettingsSection
+          icon={<Router className="h-4 w-4 text-blue-400" />}
+          iconBg="bg-blue-500/10"
+          title="Router Connection"
+          description="Configure MikroTik router integration."
+        >
+          <MikrotikPanel />
+        </SettingsSection>
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/settings/scanner/page.tsx
+++ b/web/src/app/(app)/settings/scanner/page.tsx
@@ -3,22 +3,16 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Radar,
-  Loader2,
   CheckCircle,
   AlertCircle,
   ArrowLeft,
+  Layers,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { ValidatedInput } from "@/components/settings/validated-input";
+import { SaveButton } from "@/components/settings/save-button";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -92,6 +86,10 @@ export default function ScannerSettingsPage() {
     netbiosEnabled !== savedNetbiosEnabled ||
     snmpEnabled !== savedSnmpEnabled ||
     httpFingerprintEnabled !== savedHttpFingerprintEnabled;
+
+  const intervalNum = parseInt(scanInterval, 10);
+  const intervalValid =
+    scanInterval === "" ? "idle" : !isNaN(intervalNum) && intervalNum >= 10 ? "valid" : "invalid";
 
   async function handleScannerSave() {
     settingsLoadTokenRef.current++;
@@ -168,216 +166,191 @@ export default function ScannerSettingsPage() {
           <h1 className="text-2xl font-semibold text-white">Network Scanner</h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-cyan-500/10">
-                <Radar className="h-4 w-4 text-cyan-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Scanner Configuration
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  Configure ARP scanning interval, target subnets, and ping sweep.
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-1.5">
-              <Label htmlFor="scan-interval" className="text-xs text-slate-400">
-                Scan interval (seconds)
-              </Label>
-              <Input
-                id="scan-interval"
-                type="number"
-                min={10}
-                value={scanInterval}
-                onChange={(e) => setScanInterval(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="60"
-              />
-            </div>
+        <SettingsSection
+          icon={<Radar className="h-4 w-4 text-cyan-400" />}
+          iconBg="bg-cyan-500/10"
+          title="Scan Configuration"
+          description="Configure ARP scanning interval, target subnets, and ping sweep."
+        >
+          <ValidatedInput
+            inputId="scan-interval"
+            label="Scan interval (seconds)"
+            type="number"
+            min={10}
+            value={scanInterval}
+            onChange={(e) => setScanInterval(e.target.value)}
+            placeholder="60"
+            validationState={intervalValid as "idle" | "valid" | "invalid"}
+            error="Must be at least 10 seconds"
+          />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="scan-subnets" className="text-xs text-slate-400">
-                Subnets to scan (comma-separated CIDR)
-              </Label>
-              <Input
-                id="scan-subnets"
-                type="text"
-                value={scanSubnets}
-                onChange={(e) => setScanSubnets(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="10.0.0.0/24, 192.168.1.0/24"
+          <ValidatedInput
+            inputId="scan-subnets"
+            label="Subnets to scan (comma-separated CIDR)"
+            type="text"
+            value={scanSubnets}
+            onChange={(e) => setScanSubnets(e.target.value)}
+            placeholder="10.0.0.0/24, 192.168.1.0/24"
+            hint="Leave empty to auto-detect from router interfaces."
+          />
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              role="switch"
+              aria-checked={pingSweepEnabled}
+              onClick={() => setPingSweepEnabled((v) => !v)}
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                pingSweepEnabled ? "bg-cyan-500" : "bg-slate-700"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                  pingSweepEnabled ? "translate-x-4" : "translate-x-0.5"
+                }`}
               />
-              <p className="text-[10px] text-slate-600">
-                Leave empty to auto-detect from router interfaces.
-              </p>
+            </button>
+            <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setPingSweepEnabled((v) => !v)}>
+              Active ping sweep
+            </Label>
+          </div>
+        </SettingsSection>
+
+        <SettingsSection
+          icon={<Layers className="h-4 w-4 text-cyan-400" />}
+          iconBg="bg-cyan-500/10"
+          title="Enrichment Sources"
+          description="Enable additional discovery methods for richer device data."
+        >
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={nmapEnabled}
+                data-testid="nmap-toggle"
+                onClick={() => setNmapEnabled((v) => !v)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                  nmapEnabled ? "bg-cyan-500" : "bg-slate-700"
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                    nmapEnabled ? "translate-x-4" : "translate-x-0.5"
+                  }`}
+                />
+              </button>
+              <div>
+                <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setNmapEnabled((v) => !v)}>
+                  Nmap service detection
+                </Label>
+                <p className="text-[10px] text-slate-600">
+                  Scan open ports and detect services (requires nmap)
+                </p>
+              </div>
             </div>
 
             <div className="flex items-center gap-3">
               <button
                 type="button"
                 role="switch"
-                aria-checked={pingSweepEnabled}
-                onClick={() => setPingSweepEnabled((v) => !v)}
+                aria-checked={netbiosEnabled}
+                data-testid="netbios-toggle"
+                onClick={() => setNetbiosEnabled((v) => !v)}
                 className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
-                  pingSweepEnabled ? "bg-cyan-500" : "bg-slate-700"
+                  netbiosEnabled ? "bg-cyan-500" : "bg-slate-700"
                 }`}
               >
                 <span
                   className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                    pingSweepEnabled ? "translate-x-4" : "translate-x-0.5"
+                    netbiosEnabled ? "translate-x-4" : "translate-x-0.5"
                   }`}
                 />
               </button>
-              <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setPingSweepEnabled((v) => !v)}>
-                Active ping sweep
-              </Label>
-            </div>
-
-            <div className="mt-2 border-t border-slate-800 pt-4">
-              <p className="mb-3 text-xs font-medium text-slate-300">
-                Enrichment Sources
-              </p>
-              <div className="space-y-3">
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={nmapEnabled}
-                    data-testid="nmap-toggle"
-                    onClick={() => setNmapEnabled((v) => !v)}
-                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
-                      nmapEnabled ? "bg-cyan-500" : "bg-slate-700"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                        nmapEnabled ? "translate-x-4" : "translate-x-0.5"
-                      }`}
-                    />
-                  </button>
-                  <div>
-                    <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setNmapEnabled((v) => !v)}>
-                      Nmap service detection
-                    </Label>
-                    <p className="text-[10px] text-slate-600">
-                      Scan open ports and detect services (requires nmap)
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={netbiosEnabled}
-                    data-testid="netbios-toggle"
-                    onClick={() => setNetbiosEnabled((v) => !v)}
-                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
-                      netbiosEnabled ? "bg-cyan-500" : "bg-slate-700"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                        netbiosEnabled ? "translate-x-4" : "translate-x-0.5"
-                      }`}
-                    />
-                  </button>
-                  <div>
-                    <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setNetbiosEnabled((v) => !v)}>
-                      NetBIOS name lookup
-                    </Label>
-                    <p className="text-[10px] text-slate-600">
-                      Discover Windows machine names (requires nmblookup)
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={snmpEnabled}
-                    data-testid="snmp-toggle"
-                    onClick={() => setSnmpEnabled((v) => !v)}
-                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
-                      snmpEnabled ? "bg-cyan-500" : "bg-slate-700"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                        snmpEnabled ? "translate-x-4" : "translate-x-0.5"
-                      }`}
-                    />
-                  </button>
-                  <div>
-                    <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setSnmpEnabled((v) => !v)}>
-                      SNMP discovery
-                    </Label>
-                    <p className="text-[10px] text-slate-600">
-                      Query managed switches/routers via SNMP (requires snmpget)
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={httpFingerprintEnabled}
-                    data-testid="http-fingerprint-toggle"
-                    onClick={() => setHttpFingerprintEnabled((v) => !v)}
-                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
-                      httpFingerprintEnabled ? "bg-cyan-500" : "bg-slate-700"
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
-                        httpFingerprintEnabled ? "translate-x-4" : "translate-x-0.5"
-                      }`}
-                    />
-                  </button>
-                  <div>
-                    <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setHttpFingerprintEnabled((v) => !v)}>
-                      HTTP fingerprinting
-                    </Label>
-                    <p className="text-[10px] text-slate-600">
-                      Detect web servers and infer device type from HTTP headers
-                    </p>
-                  </div>
-                </div>
+              <div>
+                <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setNetbiosEnabled((v) => !v)}>
+                  NetBIOS name lookup
+                </Label>
+                <p className="text-[10px] text-slate-600">
+                  Discover Windows machine names (requires nmblookup)
+                </p>
               </div>
             </div>
 
-            {scannerStatus === "success" && scannerMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{scannerMsg}</p>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={snmpEnabled}
+                data-testid="snmp-toggle"
+                onClick={() => setSnmpEnabled((v) => !v)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                  snmpEnabled ? "bg-cyan-500" : "bg-slate-700"
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                    snmpEnabled ? "translate-x-4" : "translate-x-0.5"
+                  }`}
+                />
+              </button>
+              <div>
+                <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setSnmpEnabled((v) => !v)}>
+                  SNMP discovery
+                </Label>
+                <p className="text-[10px] text-slate-600">
+                  Query managed switches/routers via SNMP (requires snmpget)
+                </p>
               </div>
-            )}
-            {scannerStatus === "error" && scannerMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{scannerMsg}</p>
-              </div>
-            )}
+            </div>
 
-            <Button
-              onClick={handleScannerSave}
-              disabled={!scannerDirty || scannerStatus === "loading"}
-              className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
-            >
-              {scannerStatus === "loading" ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : null}
-              Save
-            </Button>
-          </CardContent>
-        </Card>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={httpFingerprintEnabled}
+                data-testid="http-fingerprint-toggle"
+                onClick={() => setHttpFingerprintEnabled((v) => !v)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+                  httpFingerprintEnabled ? "bg-cyan-500" : "bg-slate-700"
+                }`}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                    httpFingerprintEnabled ? "translate-x-4" : "translate-x-0.5"
+                  }`}
+                />
+              </button>
+              <div>
+                <Label className="text-xs text-slate-400 cursor-pointer" onClick={() => setHttpFingerprintEnabled((v) => !v)}>
+                  HTTP fingerprinting
+                </Label>
+                <p className="text-[10px] text-slate-600">
+                  Detect web servers and infer device type from HTTP headers
+                </p>
+              </div>
+            </div>
+          </div>
+        </SettingsSection>
+
+        {scannerStatus === "success" && scannerMsg && (
+          <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+            <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+            <p className="text-xs text-emerald-400">{scannerMsg}</p>
+          </div>
+        )}
+        {scannerStatus === "error" && scannerMsg && (
+          <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+            <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+            <p className="text-xs text-rose-400">{scannerMsg}</p>
+          </div>
+        )}
+
+        <SaveButton
+          status={scannerStatus}
+          disabled={!scannerDirty}
+          onClick={handleScannerSave}
+        />
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/settings/speedtest/page.tsx
+++ b/web/src/app/(app)/settings/speedtest/page.tsx
@@ -3,22 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Radar,
-  Loader2,
   CheckCircle,
   AlertCircle,
   ArrowLeft,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { ValidatedInput } from "@/components/settings/validated-input";
+import { SaveButton } from "@/components/settings/save-button";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -57,6 +49,13 @@ export default function SpeedtestSettingsPage() {
   const speedtestDirty =
     speedtestRetDays !== savedSpeedtestRetDays ||
     speedtestAutoHours !== savedSpeedtestAutoHours;
+
+  const autoNum = parseInt(speedtestAutoHours, 10);
+  const autoValid =
+    speedtestAutoHours === "" ? "idle" : !isNaN(autoNum) && autoNum >= 0 ? "valid" : "invalid";
+  const retNum = parseInt(speedtestRetDays, 10);
+  const retValid =
+    speedtestRetDays === "" ? "idle" : !isNaN(retNum) && retNum >= 1 ? "valid" : "invalid";
 
   async function handleSpeedtestSave() {
     settingsLoadTokenRef.current++;
@@ -120,82 +119,57 @@ export default function SpeedtestSettingsPage() {
           <h1 className="text-2xl font-semibold text-white">Speed Test</h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
-                <Radar className="h-4 w-4 text-blue-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Speed Test Configuration
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  Configure automatic speed tests and result retention.
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="speedtest-auto" className="text-xs text-slate-400">
-                  Auto-run interval (hours)
-                </Label>
-                <Input
-                  id="speedtest-auto"
-                  type="number"
-                  min={0}
-                  value={speedtestAutoHours}
-                  onChange={(e) => setSpeedtestAutoHours(e.target.value)}
-                  className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                  placeholder="0 = disabled"
-                />
-                <p className="text-[10px] text-slate-600">
-                  Set to 0 to disable. E.g. 6 = every 6 hours.
-                </p>
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="speedtest-ret" className="text-xs text-slate-400">
-                  History retention (days)
-                </Label>
-                <Input
-                  id="speedtest-ret"
-                  type="number"
-                  min={1}
-                  value={speedtestRetDays}
-                  onChange={(e) => setSpeedtestRetDays(e.target.value)}
-                  className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                  placeholder="90"
-                />
-              </div>
-            </div>
+        <SettingsSection
+          icon={<Radar className="h-4 w-4 text-blue-400" />}
+          iconBg="bg-blue-500/10"
+          title="Speed Test Configuration"
+          description="Configure automatic speed tests and result retention."
+        >
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <ValidatedInput
+              inputId="speedtest-auto"
+              label="Auto-run interval (hours)"
+              type="number"
+              min={0}
+              value={speedtestAutoHours}
+              onChange={(e) => setSpeedtestAutoHours(e.target.value)}
+              placeholder="0 = disabled"
+              hint="Set to 0 to disable. E.g. 6 = every 6 hours."
+              validationState={autoValid as "idle" | "valid" | "invalid"}
+              error="Must be 0 or more hours"
+            />
+            <ValidatedInput
+              inputId="speedtest-ret"
+              label="History retention (days)"
+              type="number"
+              min={1}
+              value={speedtestRetDays}
+              onChange={(e) => setSpeedtestRetDays(e.target.value)}
+              placeholder="90"
+              validationState={retValid as "idle" | "valid" | "invalid"}
+              error="Must be at least 1 day"
+            />
+          </div>
 
-            {speedtestStatus === "success" && speedtestMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{speedtestMsg}</p>
-              </div>
-            )}
-            {speedtestStatus === "error" && speedtestMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{speedtestMsg}</p>
-              </div>
-            )}
+          {speedtestStatus === "success" && speedtestMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{speedtestMsg}</p>
+            </div>
+          )}
+          {speedtestStatus === "error" && speedtestMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{speedtestMsg}</p>
+            </div>
+          )}
 
-            <Button
-              onClick={handleSpeedtestSave}
-              disabled={!speedtestDirty || speedtestStatus === "loading"}
-              className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
-            >
-              {speedtestStatus === "loading" ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : null}
-              Save
-            </Button>
-          </CardContent>
-        </Card>
+          <SaveButton
+            status={speedtestStatus}
+            disabled={!speedtestDirty}
+            onClick={handleSpeedtestSave}
+          />
+        </SettingsSection>
       </div>
     </PageTransition>
   );

--- a/web/src/app/(app)/settings/webhook/page.tsx
+++ b/web/src/app/(app)/settings/webhook/page.tsx
@@ -9,17 +9,11 @@ import {
   AlertCircle,
   ArrowLeft,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { PageTransition } from "@/components/PageTransition";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { ValidatedInput } from "@/components/settings/validated-input";
+import { SaveButton } from "@/components/settings/save-button";
 import Link from "next/link";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -49,6 +43,8 @@ export default function WebhookSettingsPage() {
   }, []);
 
   const webhookDirty = webhookUrl !== (savedWebhookUrl ?? "");
+  const urlValid =
+    webhookUrl === "" ? "idle" : /^https?:\/\/.+/.test(webhookUrl) ? "valid" : "invalid";
 
   async function handleWebhookSave() {
     settingsLoadTokenRef.current++;
@@ -116,89 +112,69 @@ export default function WebhookSettingsPage() {
           <h1 className="text-2xl font-semibold text-white">Webhook Notifications</h1>
         </div>
 
-        <Card className="border-slate-800 bg-slate-900">
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/10">
-                <Bell className="h-4 w-4 text-purple-400" />
-              </div>
-              <div>
-                <CardTitle className="text-base text-white">
-                  Webhook Configuration
-                </CardTitle>
-                <CardDescription className="text-xs text-slate-500">
-                  POST alert payloads to Discord, Slack, ntfy.sh, or any URL.
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-1.5">
-              <Label htmlFor="webhook-url" className="text-xs text-slate-400">
-                Webhook URL
-              </Label>
-              <Input
-                id="webhook-url"
-                type="url"
-                value={webhookUrl}
-                onChange={(e) => setWebhookUrl(e.target.value)}
-                className="border-slate-800 bg-slate-950 text-white placeholder:text-slate-600"
-                placeholder="https://ntfy.sh/my-topic or Discord webhook URL"
-              />
-            </div>
+        <SettingsSection
+          icon={<Bell className="h-4 w-4 text-purple-400" />}
+          iconBg="bg-purple-500/10"
+          title="Webhook Configuration"
+          description="POST alert payloads to Discord, Slack, ntfy.sh, or any URL."
+        >
+          <ValidatedInput
+            inputId="webhook-url"
+            label="Webhook URL"
+            type="url"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+            placeholder="https://ntfy.sh/my-topic or Discord webhook URL"
+            validationState={urlValid as "idle" | "valid" | "invalid"}
+            error="Enter a valid URL (http:// or https://)"
+          />
 
-            {webhookStatus === "success" && webhookMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{webhookMsg}</p>
-              </div>
-            )}
-            {webhookStatus === "error" && webhookMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{webhookMsg}</p>
-              </div>
-            )}
-            {testStatus === "success" && testMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
-                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
-                <p className="text-xs text-emerald-400">{testMsg}</p>
-              </div>
-            )}
-            {testStatus === "error" && testMsg && (
-              <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
-                <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
-                <p className="text-xs text-rose-400">{testMsg}</p>
-              </div>
-            )}
-
-            <div className="flex gap-2">
-              <Button
-                onClick={handleWebhookSave}
-                disabled={!webhookDirty || webhookStatus === "loading"}
-                className="bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
-              >
-                {webhookStatus === "loading" ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                ) : null}
-                Save
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handleWebhookTest}
-                disabled={!savedWebhookUrl || testStatus === "loading"}
-                className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
-              >
-                {testStatus === "loading" ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Send className="mr-1.5 h-3.5 w-3.5" />
-                )}
-                Test
-              </Button>
+          {webhookStatus === "success" && webhookMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{webhookMsg}</p>
             </div>
-          </CardContent>
-        </Card>
+          )}
+          {webhookStatus === "error" && webhookMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{webhookMsg}</p>
+            </div>
+          )}
+          {testStatus === "success" && testMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+              <p className="text-xs text-emerald-400">{testMsg}</p>
+            </div>
+          )}
+          {testStatus === "error" && testMsg && (
+            <div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2">
+              <AlertCircle className="h-4 w-4 shrink-0 text-rose-400" />
+              <p className="text-xs text-rose-400">{testMsg}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <SaveButton
+              status={webhookStatus}
+              disabled={!webhookDirty}
+              onClick={handleWebhookSave}
+            />
+            <Button
+              variant="outline"
+              onClick={handleWebhookTest}
+              disabled={!savedWebhookUrl || testStatus === "loading"}
+              className="border-slate-800 text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+            >
+              {testStatus === "loading" ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Send className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              Test
+            </Button>
+          </div>
+        </SettingsSection>
       </div>
     </PageTransition>
   );

--- a/web/src/components/settings/password-strength.tsx
+++ b/web/src/components/settings/password-strength.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Check, X } from "lucide-react";
+
+function getStrength(password: string): {
+  score: number;
+  label: string;
+  color: string;
+  gradient: string;
+} {
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (password.length >= 12) score++;
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++;
+  if (/\d/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+
+  if (score <= 1)
+    return {
+      score,
+      label: "Weak",
+      color: "text-rose-400",
+      gradient: "from-rose-500 to-rose-600",
+    };
+  if (score <= 2)
+    return {
+      score,
+      label: "Fair",
+      color: "text-amber-400",
+      gradient: "from-rose-500 via-amber-500 to-amber-500",
+    };
+  if (score <= 3)
+    return {
+      score,
+      label: "Good",
+      color: "text-yellow-400",
+      gradient: "from-amber-500 via-yellow-500 to-emerald-500",
+    };
+  return {
+    score,
+    label: "Strong",
+    color: "text-emerald-400",
+    gradient: "from-emerald-500 to-emerald-400",
+  };
+}
+
+interface PasswordStrengthProps {
+  password: string;
+}
+
+export function PasswordStrength({ password }: PasswordStrengthProps) {
+  if (!password) return null;
+
+  const { score, label, color, gradient } = getStrength(password);
+  const widthPercent = Math.min((score / 5) * 100, 100);
+
+  const requirements = [
+    { met: password.length >= 8, text: "At least 8 characters" },
+    {
+      met: /[A-Z]/.test(password) && /[a-z]/.test(password),
+      text: "Upper & lowercase letters",
+    },
+    { met: /\d/.test(password), text: "At least one number" },
+    { met: /[^A-Za-z0-9]/.test(password), text: "Special character" },
+  ];
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
+          <div
+            className={`h-full rounded-full bg-gradient-to-r ${gradient} transition-all duration-500 ease-out`}
+            style={{ width: `${widthPercent}%` }}
+          />
+        </div>
+        <span className={`text-[11px] font-medium ${color}`}>{label}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+        {requirements.map((req) => (
+          <div key={req.text} className="flex items-center gap-1.5">
+            {req.met ? (
+              <Check className="h-3 w-3 text-emerald-400" />
+            ) : (
+              <X className="h-3 w-3 text-slate-600" />
+            )}
+            <span
+              className={`text-[10px] ${req.met ? "text-slate-400" : "text-slate-600"}`}
+            >
+              {req.text}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/save-button.tsx
+++ b/web/src/components/settings/save-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type SaveStatus = "idle" | "loading" | "success" | "error";
+
+interface SaveButtonProps {
+  status: SaveStatus;
+  disabled?: boolean;
+  onClick: () => void;
+  label?: string;
+  className?: string;
+}
+
+export function SaveButton({
+  status,
+  disabled,
+  onClick,
+  label = "Save",
+  className = "bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40",
+}: SaveButtonProps) {
+  const [animating, setAnimating] = useState<"success" | "error" | null>(null);
+
+  useEffect(() => {
+    if (status === "success") {
+      setAnimating("success");
+      const t = setTimeout(() => setAnimating(null), 1500);
+      return () => clearTimeout(t);
+    }
+    if (status === "error") {
+      setAnimating("error");
+      const t = setTimeout(() => setAnimating(null), 600);
+      return () => clearTimeout(t);
+    }
+  }, [status]);
+
+  return (
+    <Button
+      onClick={onClick}
+      disabled={disabled || status === "loading"}
+      className={`${className} ${
+        animating === "success"
+          ? "animate-save-glow bg-emerald-600 hover:bg-emerald-500"
+          : ""
+      } ${animating === "error" ? "animate-shake" : ""}`}
+    >
+      {status === "loading" ? (
+        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+      ) : animating === "success" ? (
+        <Check className="mr-1.5 h-3.5 w-3.5 animate-fade-in" />
+      ) : null}
+      {animating === "success" ? "Saved" : label}
+    </Button>
+  );
+}

--- a/web/src/components/settings/settings-section.tsx
+++ b/web/src/components/settings/settings-section.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
+interface SettingsSectionProps {
+  icon: React.ReactNode;
+  iconBg: string;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export function SettingsSection({
+  icon,
+  iconBg,
+  title,
+  description,
+  children,
+}: SettingsSectionProps) {
+  return (
+    <Card className="border-slate-800 bg-slate-900">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-9 w-9 items-center justify-center rounded-lg ${iconBg}`}
+          >
+            {icon}
+          </div>
+          <div>
+            <CardTitle className="text-base text-white">{title}</CardTitle>
+            <CardDescription className="text-xs text-slate-500">
+              {description}
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">{children}</CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/settings/validated-input.tsx
+++ b/web/src/components/settings/validated-input.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CheckCircle, AlertCircle } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type ValidationState = "idle" | "valid" | "invalid";
+
+interface ValidatedInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  hint?: string;
+  error?: string;
+  validationState?: ValidationState;
+  inputId: string;
+}
+
+export function ValidatedInput({
+  label,
+  hint,
+  error,
+  validationState = "idle",
+  inputId,
+  className,
+  ...props
+}: ValidatedInputProps) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId} className="text-xs text-slate-400">
+        {label}
+      </Label>
+      <div className="relative">
+        <Input
+          id={inputId}
+          className={`border-slate-800 bg-slate-950 text-white placeholder:text-slate-600 pr-9 ${
+            validationState === "invalid"
+              ? "border-rose-500/50 focus-visible:ring-rose-500/30"
+              : validationState === "valid"
+                ? "border-emerald-500/50 focus-visible:ring-emerald-500/30"
+                : ""
+          } ${className ?? ""}`}
+          {...props}
+        />
+        {validationState === "valid" && (
+          <CheckCircle className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-fade-in text-emerald-400" />
+        )}
+        {validationState === "invalid" && (
+          <AlertCircle className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-fade-in text-rose-400" />
+        )}
+      </div>
+      {error && validationState === "invalid" && (
+        <p className="animate-fade-in text-[11px] text-rose-400">{error}</p>
+      )}
+      {hint && validationState !== "invalid" && (
+        <p className="text-[10px] text-slate-600">{hint}</p>
+      )}
+    </div>
+  );
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -73,11 +73,35 @@ const config: Config = {
         shimmer: {
           "100%": { transform: "translateX(100%)" },
         },
+        shake: {
+          "0%, 100%": { transform: "translateX(0)" },
+          "20%": { transform: "translateX(-4px)" },
+          "40%": { transform: "translateX(4px)" },
+          "60%": { transform: "translateX(-4px)" },
+          "80%": { transform: "translateX(2px)" },
+        },
+        "save-glow": {
+          "0%": { boxShadow: "0 0 0 0 rgba(16,185,129,0.5)" },
+          "50%": { boxShadow: "0 0 12px 4px rgba(16,185,129,0.3)" },
+          "100%": { boxShadow: "0 0 0 0 rgba(16,185,129,0)" },
+        },
+        "fade-in": {
+          from: { opacity: "0", transform: "scale(0.8)" },
+          to: { opacity: "1", transform: "scale(1)" },
+        },
+        "strength-fill": {
+          from: { width: "0%" },
+          to: { width: "var(--strength-width)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         shimmer: "shimmer 1.5s linear infinite",
+        shake: "shake 0.4s ease-in-out",
+        "save-glow": "save-glow 0.8s ease-out",
+        "fade-in": "fade-in 0.2s ease-out",
+        "strength-fill": "strength-fill 0.4s ease-out forwards",
       },
     },
   },

--- a/web/tests/e2e/settings-visual-polish.spec.ts
+++ b/web/tests/e2e/settings-visual-polish.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Settings visual polish — sections, validation, save animation", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("scanner page shows two visual sections with icons", async ({ page }) => {
+    await page.goto("/settings/scanner/");
+    await expect(
+      page.getByRole("heading", { name: "Network Scanner", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Two section cards with distinct headers
+    await expect(page.getByText("Scan Configuration")).toBeVisible();
+    await expect(page.getByText("Enrichment Sources")).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-scanner-sections.png",
+    });
+  });
+
+  test("retention page shows two visual sections", async ({ page }) => {
+    await page.goto("/settings/retention/");
+    await expect(
+      page.getByRole("heading", { name: "Data Retention", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(page.getByText("Retention Periods")).toBeVisible();
+    await expect(page.getByText("Database Maintenance")).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-retention-sections.png",
+    });
+  });
+
+  test("scanner inline validation shows error for interval < 10", async ({
+    page,
+  }) => {
+    await page.goto("/settings/scanner/");
+    await expect(page.locator("#scan-interval")).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState("networkidle");
+
+    // Type an invalid interval
+    await page.locator("#scan-interval").fill("5");
+
+    // Inline error message should appear
+    await expect(page.getByText("Must be at least 10 seconds")).toBeVisible();
+
+    // Fix the value
+    await page.locator("#scan-interval").fill("30");
+
+    // Error should disappear and checkmark should appear
+    await expect(
+      page.getByText("Must be at least 10 seconds"),
+    ).not.toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-scanner-validation.png",
+    });
+  });
+
+  test("save button shows animated success state", async ({ page }) => {
+    await page.goto("/settings/scanner/");
+    await expect(page.locator("#scan-interval")).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState("networkidle");
+
+    // Make a change to enable save
+    const currentVal = await page.locator("#scan-interval").inputValue();
+    const newVal = currentVal === "60" ? "90" : "60";
+    await page.locator("#scan-interval").fill(newVal);
+
+    // Click save
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Button should briefly show "Saved" text
+    await expect(
+      page.getByRole("button", { name: "Saved" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Success message should also appear
+    await expect(page.getByText("Scanner settings saved.")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-save-animation.png",
+    });
+
+    // Restore original value
+    await page.locator("#scan-interval").fill(currentVal);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("Scanner settings saved.")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("password page shows strength meter", async ({ page }) => {
+    await page.goto("/settings/password/");
+    await expect(
+      page.getByRole("heading", { name: "Change Password", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Type a short password — should show "Weak"
+    await page.locator("#new").fill("abc");
+    await expect(page.getByText("Weak")).toBeVisible();
+
+    // Requirements should show inline
+    await expect(page.getByText("At least 8 characters")).toBeVisible();
+    await expect(page.getByText("Special character")).toBeVisible();
+
+    // Type a strong password — should show "Strong"
+    await page.locator("#new").fill("MyStr0ng!Pass99");
+    await expect(page.getByText("Strong")).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-password-strength.png",
+    });
+  });
+
+  test("password confirm inline validation", async ({ page }) => {
+    await page.goto("/settings/password/");
+    await expect(page.locator("#new")).toBeVisible({ timeout: 15000 });
+
+    await page.locator("#new").fill("StrongPass1!");
+    await page.locator("#confirm").fill("mismatch");
+
+    // Should show mismatch error inline
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
+
+    // Fix the confirmation
+    await page.locator("#confirm").fill("StrongPass1!");
+    await expect(
+      page.getByText("Passwords do not match"),
+    ).not.toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-password-confirm-validation.png",
+    });
+  });
+
+  test("webhook URL inline validation", async ({ page }) => {
+    await page.goto("/settings/webhook/");
+    await expect(page.locator("#webhook-url")).toBeVisible({ timeout: 15000 });
+
+    // Type an invalid URL
+    await page.locator("#webhook-url").fill("not-a-url");
+    await expect(
+      page.getByText("Enter a valid URL"),
+    ).toBeVisible();
+
+    // Type a valid URL
+    await page.locator("#webhook-url").fill("https://hooks.slack.com/test");
+    await expect(page.getByText("Enter a valid URL")).not.toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-webhook-validation.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #599

## Summary
- **Visual sections**: Scanner page split into "Scan Configuration" + "Enrichment Sources" cards; Retention page split into "Retention Periods" + "Database Maintenance" cards. All sections have icons and clear separation.
- **Inline validation**: Animated checkmark/error icons appear immediately on form fields (URL, numbers, password confirmation). Uses shared `ValidatedInput` component.
- **Save button animation**: Success triggers a green glow + "Saved" checkmark morph (0.8s); errors trigger a red shake animation (0.4s). Uses shared `SaveButton` component.
- **Password strength meter**: Animated gradient bar (red→yellow→green) with inline requirements checklist (8+ chars, mixed case, number, special char). Uses shared `PasswordStrength` component.

## Files changed
- `web/tailwind.config.ts` — Added shake, save-glow, fade-in keyframes/animations
- `web/src/components/settings/` — 4 new shared components (SettingsSection, ValidatedInput, SaveButton, PasswordStrength)
- `web/src/app/(app)/settings/{scanner,retention,router,password,webhook,speedtest}/page.tsx` — Updated to use shared components

## Smoke Test
- `next build` passes with no errors after rebase on main
- All input IDs, button names, and success messages preserved for backward-compatible E2E tests

## E2E Tests
- `web/tests/e2e/settings-visual-polish.spec.ts` — 7 tests covering:
  - Scanner/retention pages show visual sections with icons
  - Scanner inline validation (interval < 10 shows error)
  - Save button "Saved" animation state
  - Password strength meter (Weak/Strong labels)
  - Password confirm mismatch validation
  - Webhook URL inline validation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a visual polish layer across all settings pages: shared `SettingsSection`, `ValidatedInput`, `SaveButton`, and `PasswordStrength` components replace per-page card markup, inline validation replaces submit-time validation, and CSS animations are added for save feedback. The refactor is well-structured and the new components integrate cleanly with the rest of the settings layout. Two logic bugs need attention before merging:

- **Double form submission in `password/page.tsx`**: `SaveButton` renders a `<button>` without an explicit `type` attribute. HTML defaults this to `type="submit"` inside a `<form>`, so clicking the button fires both its `onClick` handler *and* the form's `onSubmit` handler. Because React 18 batches the state updates across both callbacks, both see `canSubmitPw === true` before any re-render and two simultaneous password-change API calls are dispatched. Adding `type="button"` to `SaveButton` (either at the call site or in the component itself) resolves this.
- **Misleading confirm-password error message**: `confirmValid` requires `confirm === next && next.length >= 8`. When both fields contain the same value but it's shorter than 8 characters, `confirmValid` becomes `"invalid"` and "Passwords do not match" is displayed — even though the passwords are identical. The fix is to separate the match-check from the length-check so the confirm field only reports whether the two values are equal.

<h3>Confidence Score: 3/5</h3>

- Two targeted fixes in password/page.tsx are required before merge — one prevents a double API call, one fixes a misleading validation message.
- The shared components and all other settings pages are clean. The bugs are isolated to the password change flow: double-submission could trigger two simultaneous password-change requests, and the wrong error message surfaces for a common user path (typing a short matching password). Both are quick fixes but affect the primary user path of the password page.
- web/src/app/(app)/settings/password/page.tsx and web/src/components/settings/save-button.tsx need the most attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/password/page.tsx | Refactored to use shared components; has two logic bugs: `SaveButton` inside `<form onSubmit>` causes double API submission, and `confirmValid` shows "Passwords do not match" when passwords match but are too short. |
| web/src/components/settings/save-button.tsx | New shared component for animated save button. Does not set `type="button"`, which causes double-submission when placed inside a `<form>` — contributing to the bug in `password/page.tsx`. |
| web/src/components/settings/validated-input.tsx | New shared component for validated inputs with inline icons and error/hint display. Clean implementation, no issues found. |
| web/src/components/settings/settings-section.tsx | New shared card-section wrapper with icon, title, description, and children. Straightforward extraction of repeated card markup. |
| web/src/components/settings/password-strength.tsx | New password strength meter with gradient bar and requirements checklist. Logic is correct; uses CSS transitions rather than the `animate-strength-fill` keyframe (which goes unused). |
| web/src/app/(app)/settings/scanner/page.tsx | Split into "Scan Configuration" + "Enrichment Sources" sections; the `SaveButton` and status messages are placed outside both `SettingsSection` cards (unlike other pages), but the page still functions correctly. |
| web/tailwind.config.ts | Added shake, save-glow, fade-in, and strength-fill keyframes/animations. The `strength-fill` animation is defined but unused (PasswordStrength uses a CSS transition instead), but this is harmless. |
| web/tests/e2e/settings-visual-polish.spec.ts | 7 E2E tests covering sections, validation, save animation, and password strength. Tests use screenshot artifacts. Covers the primary flows well. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/app/(app)/settings/password/page.tsx
Line: 126-233

Comment:
**Double form submission via SaveButton inside `<form onSubmit>`**

`SaveButton` renders a `<Button>` (shadcn `button.tsx`) which does not set a `type` attribute. Inside an HTML `<form>`, a `<button>` without an explicit `type` defaults to `type="submit"`. This means clicking the `SaveButton` triggers **both**:

1. The button's `onClick` → `handlePasswordSubmit()` (no event)
2. The form's `onSubmit` → `handlePasswordSubmit(e)` (with event)

Because React 18 batches state updates across both handlers within the same click interaction, both handlers run against the same pre-render state. `canSubmitPw` evaluates to `true` in both, so two API calls are dispatched simultaneously.

The simplest fix is to add `type="button"` to `SaveButton` so it doesn't trigger the form submit. The form's `onSubmit` can then continue to handle Enter-key submission independently, or be removed entirely if submit-button-only is desired.

```suggestion
              <SaveButton
                status={pwStatus}
                disabled={!canSubmitPw}
                onClick={() => handlePasswordSubmit()}
                label="Change Password"
                className="w-full bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40"
                type="button"
              />
```

Alternatively, add `type="button"` inside `SaveButton` itself so it applies to every usage:

```tsx
// save-button.tsx
<Button
  type="button"
  onClick={onClick}
  disabled={disabled || status === "loading"}
  ...
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/app/(app)/settings/password/page.tsx
Line: 86-91

Comment:
**Misleading "Passwords do not match" error when passwords do match**

`confirmValid` is computed as `"valid"` only when `confirm === next && next.length >= 8`. When a user types a matching confirmation but the new password is shorter than 8 characters (e.g., both fields contain `"hello"`), `confirmValid` becomes `"invalid"` and the message "Passwords do not match" is displayed — even though the passwords are identical.

This mismatch between the validation condition and the error text will confuse users who correctly typed the same password in both fields.

The condition should be separated into two independent checks:

```suggestion
  const confirmValid =
    confirm === ""
      ? "idle"
      : confirm === next
        ? "valid"
        : "invalid";
```

The minimum length requirement is already surfaced via `nextValid` and the `PasswordStrength` component on the new-password field, so the confirm field only needs to verify that the two values match.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: settings pages visual sections, in..."](https://github.com/befeast/panoptikon/commit/b8bbe4c4bb0eccd0a6becaf2c289af4c27a5ac43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25963643)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->