### PR TITLE
feat: Design system overhaul: gradient accents, display font, color depth (#591)

### DIFF
--- a/web/src/app/(app)/agents/detail/content.tsx
+++ b/web/src/app/(app)/agents/detail/content.tsx
@@ -75,7 +75,7 @@ export default function AgentDetailContent() {
 
   if (!agent || !reports) {
     return (
-      <div className="space-y-6">
+      <div className="space-y-8">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-64 w-full" />
         <Skeleton className="h-64 w-full" />
@@ -102,7 +102,7 @@ export default function AgentDetailContent() {
   });
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Back link + header */}
       <div>
         <Link
@@ -113,7 +113,7 @@ export default function AgentDetailContent() {
           Back to Agents
         </Link>
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold text-white">
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">
             {agent.name ?? agent.id.slice(0, 8)}
           </h1>
           <Badge
@@ -146,7 +146,7 @@ export default function AgentDetailContent() {
 
       {/* Charts */}
       {chartData.length > 0 ? (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
           {/* CPU Chart */}
           <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
             <h2 className="text-sm font-medium text-slate-400 mb-3">CPU Usage %</h2>

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -116,11 +116,11 @@ export default function AgentsPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-semibold text-white">Agents</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Agents</h1>
           <HelpTooltip text="Lightweight agents installed on your machines that report system info (CPU, memory, disk, OS) back to Panoptikon." />
         </div>
         <AddAgentDialog

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -292,11 +292,11 @@ export default function AlertsPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-2xl font-semibold text-white">Alerts</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Alerts</h1>
           <HelpTooltip text="Notifications about network events — new devices, devices going offline, and security alerts. Configure rules in Settings → Alert Rules." />
           {activeCount > 0 && (
             <Badge variant="secondary" className="gap-1">

--- a/web/src/app/(app)/assets/detail/content.tsx
+++ b/web/src/app/(app)/assets/detail/content.tsx
@@ -179,9 +179,9 @@ export default function AssetDetailContent() {
 
   if (!device) {
     return (
-      <div className="space-y-6">
+      <div className="space-y-8">
         <Skeleton className="h-8 w-64" />
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
           <Skeleton className="h-64 w-full" />
           <Skeleton className="h-64 w-full" />
           <Skeleton className="h-64 w-full" />
@@ -222,7 +222,7 @@ export default function AssetDetailContent() {
   const hasLiveMetrics = chartData.length > 0;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Back link + Header */}
       <div>
         <Link
@@ -538,7 +538,7 @@ function InfoGrid({
     .join(" ") || effectiveDiskSize;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
       {/* Hardware Column */}
       <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
         <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center gap-2">
@@ -691,7 +691,7 @@ function InfoGrid({
             <Tag size={14} />
             Asset Management
           </h3>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
             <EditableInfoRow
               label="Purchase Date"
               value={device.purchase_date}
@@ -729,7 +729,7 @@ function InfoGrid({
 
 function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
       {/* CPU Chart */}
       <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
         <h2 className="text-sm font-medium text-slate-400 mb-3">CPU Usage %</h2>

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -410,10 +410,10 @@ ${filtered
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold text-white">Assets</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Assets</h1>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -1009,7 +1009,7 @@ function AssetFormDialog({
 
       <div className="space-y-4 pt-2">
         {/* Name + Type */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Name</Label>
             <Input
@@ -1035,7 +1035,7 @@ function AssetFormDialog({
         </div>
 
         {/* Status + Location */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Status</Label>
             <select
@@ -1061,7 +1061,7 @@ function AssetFormDialog({
         </div>
 
         {/* Owner + Tags */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Owner</Label>
             <Input
@@ -1086,7 +1086,7 @@ function AssetFormDialog({
         </div>
 
         {/* Serial + Purchase Date */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Serial Number</Label>
             <Input

--- a/web/src/app/(app)/caddy/page.tsx
+++ b/web/src/app/(app)/caddy/page.tsx
@@ -203,11 +203,11 @@ export default function CaddyPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-5xl space-y-6 py-8">
+      <div className="mx-auto max-w-5xl space-y-8 py-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               Caddy Reverse Proxy
             </h1>
             <HelpTooltip text="Manage reverse-proxy hosts that Caddy serves. Add domains, point them to internal services, and enable automatic HTTPS." />

--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -256,7 +256,7 @@ export default function CertificatesPage() {
 
   if (loading) {
     return (
-      <div className="space-y-6">
+      <div className="space-y-8">
         <div className="flex items-center justify-between">
           <Skeleton className="h-8 w-48" />
           <Skeleton className="h-9 w-32" />
@@ -299,12 +299,12 @@ export default function CertificatesPage() {
   ).length;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               SSL Certificates
             </h1>
             <HelpTooltip text="View and manage SSL/TLS certificates provisioned through Caddy. Request free Let's Encrypt certs or upload your own." />

--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -231,9 +231,9 @@ export default function CloudflareTunnelPage() {
   if (loading && !status) {
     return (
       <PageTransition>
-        <div className="space-y-6">
+        <div className="space-y-8">
           <Skeleton className="h-8 w-64" />
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-5 md:grid-cols-3">
             <Skeleton className="h-32" />
             <Skeleton className="h-32" />
             <Skeleton className="h-32" />
@@ -248,13 +248,13 @@ export default function CloudflareTunnelPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Cloud className="h-6 w-6 text-orange-400" />
             <div>
-              <h1 className="text-2xl font-semibold text-white">
+              <h1 className="text-3xl font-bold tracking-tight font-display text-white">
                 Cloudflare Tunnel
               </h1>
               <p className="text-sm text-slate-400">
@@ -312,7 +312,7 @@ export default function CloudflareTunnelPage() {
 
         {/* Summary cards */}
         {!notConfigured && status && (
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-5 md:grid-cols-3">
             {/* Tunnel Status */}
             <Card className="border-slate-800 bg-slate-900/80">
               <CardHeader className="pb-2">

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -448,16 +448,16 @@ export default function DashboardPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight text-white">Dashboard</h1>
+        <h1 className="text-3xl font-bold tracking-tight font-display text-white">Dashboard</h1>
         <p className="max-w-3xl text-sm leading-6 text-slate-400">
           Network health, traffic, and alerts at a glance.
         </p>
       </div>
 
       {/* ── Hero Stats Row ─────────────────────────────── */}
-      <StaggerContainer className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <StaggerContainer className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4">
         {statsError ? (
           <>
             <StaggerItem>

--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -200,7 +200,7 @@ function DdnsFormDialog({
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-5">
             <div className="space-y-2">
               <Label>Provider</Label>
               <select
@@ -253,7 +253,7 @@ function DdnsFormDialog({
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-5">
             <div className="space-y-2">
               <Label>Username</Label>
               <Input
@@ -300,7 +300,7 @@ function DdnsFormDialog({
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-3 gap-5">
             <div className="space-y-2">
               <Label>IP Source</Label>
               <select
@@ -459,11 +459,11 @@ export default function DdnsPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-white">Dynamic DNS</h1>
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">Dynamic DNS</h1>
             <p className="text-sm text-slate-400">
               Manage DDNS client configurations for automatic DNS updates
             </p>
@@ -485,13 +485,13 @@ export default function DdnsPage() {
 
         {/* Status cards */}
         {statusData === null ? (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
             {[...Array(4)].map((_, i) => (
               <Skeleton key={i} className="h-24 bg-slate-800" />
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
             <Card className="border-slate-800/70 bg-slate-900/55">
               <CardHeader className="pb-2">
                 <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -340,7 +340,7 @@ export default function DevicesPage() {
         <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-semibold tracking-tight text-white">Devices</h1>
+              <h1 className="text-3xl font-bold tracking-tight font-display text-white">Devices</h1>
               <HelpTooltip text="All devices discovered on your network. Use Scan Now to discover new devices, Re-identify to fingerprint them, and Resolve Names to look up hostnames via DNS." />
             </div>
             <p className="max-w-2xl text-sm leading-6 text-slate-300/80">
@@ -2554,7 +2554,7 @@ function AddAssetDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6">
+        <div className="space-y-8">
           {/* Name (required) */}
           <div>
             <label className="text-[11px] font-medium text-slate-400">

--- a/web/src/app/(app)/dns-logs/page.tsx
+++ b/web/src/app/(app)/dns-logs/page.tsx
@@ -144,12 +144,12 @@ export default function DnsLogsPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
             <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-semibold tracking-tight text-white">
+              <h1 className="text-3xl font-bold tracking-tight font-display text-white">
                 DNS Query Log
               </h1>
               <HelpTooltip text="Shows DNS queries made by devices on your network. Useful for spotting suspicious domains and debugging connectivity. Data is kept for 7 days." />
@@ -197,7 +197,7 @@ export default function DnsLogsPage() {
         </div>
 
         {/* Stats Cards */}
-        <div className="grid gap-4 md:grid-cols-4" data-testid="dns-stats-grid">
+        <div className="grid gap-5 md:grid-cols-4" data-testid="dns-stats-grid">
           <Card className="border-slate-800/70 bg-slate-900/55">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
@@ -451,7 +451,7 @@ export default function DnsLogsPage() {
           </TabsContent>
 
           {/* Statistics Tab */}
-          <TabsContent value="stats" className="space-y-6">
+          <TabsContent value="stats" className="space-y-8">
             <div className="grid gap-6 lg:grid-cols-2">
               {/* Top Queried Domains */}
               <Card>

--- a/web/src/app/(app)/dns-queries/page.tsx
+++ b/web/src/app/(app)/dns-queries/page.tsx
@@ -129,11 +129,11 @@ export default function DnsQueriesPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-semibold text-white">DNS Query Log</h1>
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">DNS Query Log</h1>
             {stats && (
               <Badge variant="secondary" className="gap-1">
                 <Globe className="h-3 w-3" />
@@ -145,7 +145,7 @@ export default function DnsQueriesPage() {
 
         {/* Stats cards */}
         {stats === null ? (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
             {Array.from({ length: 4 }).map((_, i) => (
               <Card key={i} className="border-slate-800 bg-slate-900">
                 <CardContent className="py-4">
@@ -156,7 +156,7 @@ export default function DnsQueriesPage() {
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
             <Card className="border-slate-800 bg-slate-900">
               <CardContent className="py-4">
                 <div className="flex items-center gap-2 text-xs text-slate-500 mb-1">
@@ -211,7 +211,7 @@ export default function DnsQueriesPage() {
 
         {/* Top domains + Per-device stats */}
         {stats && (stats.top_queried_domains.length > 0 || stats.per_device_stats.length > 0) && (
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
             {/* Top queried domains */}
             {stats.top_queried_domains.length > 0 && (
               <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -124,15 +124,15 @@ export default function NatPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
-        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-4">
+      <div className="space-y-8">
+        <section className="flex flex-col gap-5 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-5">
             <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-violet-500/30 bg-gradient-to-br from-violet-500/20 via-fuchsia-500/10 to-blue-500/10 text-violet-300">
               <ArrowRightLeft className="h-6 w-6" />
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-semibold tracking-tight text-white">NAT / Port Forwarding</h1>
+                <h1 className="text-3xl font-bold tracking-tight font-display text-white">NAT / Port Forwarding</h1>
                 <HelpTooltip text="Manage MikroTik NAT and port-forwarding rules from the same command-center style UI." />
               </div>
               <p className="text-sm text-slate-400">
@@ -155,7 +155,7 @@ export default function NatPage() {
           </Button>
         </section>
 
-        <section className="grid gap-4 sm:grid-cols-1 lg:max-w-md">
+        <section className="grid gap-5 sm:grid-cols-1 lg:max-w-md">
           <SummaryCard
             title="MikroTik NAT Rules"
             value={summary?.mikrotik_rule_count ?? null}
@@ -383,7 +383,7 @@ function SummaryCard({
 }) {
   return (
     <Card className={surfaceClass}>
-      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+      <CardContent className="flex min-h-[96px] items-center gap-5 p-4">
         <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
           {icon}
         </div>
@@ -486,7 +486,7 @@ function MikrotikNatDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
               <Label className="text-slate-400">Chain</Label>
               <Input
@@ -507,7 +507,7 @@ function MikrotikNatDialog({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
               <Label className="text-slate-400">Protocol</Label>
               <Input
@@ -528,7 +528,7 @@ function MikrotikNatDialog({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
               <Label className="text-slate-400">To Addresses</Label>
               <Input

--- a/web/src/app/(app)/npm/page.tsx
+++ b/web/src/app/(app)/npm/page.tsx
@@ -2244,7 +2244,7 @@ export default function NpmPage() {
   const reachable = status?.reachable ?? false;
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6">
+    <div className="mx-auto max-w-6xl space-y-8">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
@@ -2252,7 +2252,7 @@ export default function NpmPage() {
             <Globe className="h-5 w-5 text-orange-400" />
           </div>
           <div>
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               Nginx Proxy Manager
             </h1>
             <p className="text-sm text-slate-400">

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -156,14 +156,14 @@ export default function QosPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
-        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-4">
+      <div className="space-y-8">
+        <section className="flex flex-col gap-5 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-5">
             <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-blue-500/30 bg-gradient-to-br from-blue-500/20 via-cyan-500/10 to-indigo-500/10 text-blue-300">
               <Gauge className="h-6 w-6" />
             </div>
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white">QoS / Traffic Shaping</h1>
+              <h1 className="text-3xl font-bold tracking-tight font-display text-white">QoS / Traffic Shaping</h1>
               <p className="text-sm text-slate-400">
                 Queue policies, bandwidth limits, and hierarchical shaping.
               </p>
@@ -184,7 +184,7 @@ export default function QosPage() {
           </Button>
         </section>
 
-        <section className="grid gap-4 sm:grid-cols-2">
+        <section className="grid gap-5 sm:grid-cols-2">
           <SummaryCard
             title="MikroTik Simple Queues"
             value={summary?.mikrotik_simple_queue_count ?? null}
@@ -519,7 +519,7 @@ function SummaryCard({
 }) {
   return (
     <Card className={surfaceClass}>
-      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+      <CardContent className="flex min-h-[96px] items-center gap-5 p-4">
         <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
           {icon}
         </div>

--- a/web/src/app/(app)/router/mikrotik/page.tsx
+++ b/web/src/app/(app)/router/mikrotik/page.tsx
@@ -30,11 +30,11 @@ export default function MikrotikRouterPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         <RouterSelector active="mikrotik" />
 
         {!settingsLoaded ? (
-          <div className="space-y-6">
+          <div className="space-y-8">
             <Skeleton className="h-10 w-64" />
             <Skeleton className="h-96 w-full" />
           </div>

--- a/web/src/app/(app)/router/xiaomi/page.tsx
+++ b/web/src/app/(app)/router/xiaomi/page.tsx
@@ -32,11 +32,11 @@ export default function XiaomiRouterPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         <RouterSelector active="xiaomi" />
 
         {!settingsLoaded ? (
-          <div className="space-y-6">
+          <div className="space-y-8">
             <Skeleton className="h-10 w-64" />
             <Skeleton className="h-96 w-full" />
           </div>

--- a/web/src/app/(app)/services/page.tsx
+++ b/web/src/app/(app)/services/page.tsx
@@ -277,11 +277,11 @@ export default function ServicesPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-5xl space-y-6 py-8 px-4">
+      <div className="mx-auto max-w-5xl space-y-8 py-8 px-4">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-white">Services</h1>
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">Services</h1>
             <p className="mt-1 text-sm text-slate-400">
               Manage reverse proxy entries and port-forwarding rules
             </p>

--- a/web/src/app/(app)/settings/advanced/page.tsx
+++ b/web/src/app/(app)/settings/advanced/page.tsx
@@ -17,7 +17,7 @@ import Link from "next/link";
 export default function AdvancedSettingsPage() {
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -25,7 +25,7 @@ export default function AdvancedSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Advanced</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Advanced</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/alert-rules/page.tsx
+++ b/web/src/app/(app)/settings/alert-rules/page.tsx
@@ -132,7 +132,7 @@ export default function AlertRulesPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-2xl space-y-6 py-8">
+      <div className="mx-auto max-w-2xl space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -140,7 +140,7 @@ export default function AlertRulesPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Alert Rules</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Alert Rules</h1>
         </div>
 
         {status === "success" && statusMsg && (

--- a/web/src/app/(app)/settings/audit-log/page.tsx
+++ b/web/src/app/(app)/settings/audit-log/page.tsx
@@ -101,9 +101,9 @@ export default function AuditLogPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-4xl space-y-6 py-8">
+      <div className="mx-auto max-w-4xl space-y-8 py-8">
         <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold text-white">Audit Log</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Audit Log</h1>
           <a
             href="/settings"
             className="text-sm text-slate-400 hover:text-slate-300"

--- a/web/src/app/(app)/settings/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/settings/cloudflare-tunnel/page.tsx
@@ -102,7 +102,7 @@ export default function CloudflareTunnelSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -110,7 +110,7 @@ export default function CloudflareTunnelSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">
             Cloudflare Tunnel
           </h1>
         </div>

--- a/web/src/app/(app)/settings/config-backup/page.tsx
+++ b/web/src/app/(app)/settings/config-backup/page.tsx
@@ -283,7 +283,7 @@ export default function ConfigBackupPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-3xl space-y-6 py-8">
+      <div className="mx-auto max-w-3xl space-y-8 py-8">
         {/* Header with back link */}
         <div className="flex items-center gap-3">
           <a
@@ -293,7 +293,7 @@ export default function ConfigBackupPage() {
             <ArrowLeft className="h-4 w-4" />
           </a>
           <div>
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               Config Backup & Rollback
             </h1>
             <p className="text-sm text-slate-500">

--- a/web/src/app/(app)/settings/dns-blocklists/page.tsx
+++ b/web/src/app/(app)/settings/dns-blocklists/page.tsx
@@ -253,7 +253,7 @@ export default function DnsBlocklistsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-5xl space-y-6 py-8">
+      <div className="mx-auto max-w-5xl space-y-8 py-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -263,7 +263,7 @@ export default function DnsBlocklistsPage() {
             >
               <ArrowLeft className="h-4 w-4" />
             </Link>
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               DNS Blocklists
             </h1>
           </div>
@@ -303,7 +303,7 @@ export default function DnsBlocklistsPage() {
         </div>
 
         {/* Stats cards */}
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
           <Card className="border-slate-800 bg-slate-900">
             <CardContent className="py-3">
               <p className="text-xs text-slate-500">Blocked Domains</p>

--- a/web/src/app/(app)/settings/dns/page.tsx
+++ b/web/src/app/(app)/settings/dns/page.tsx
@@ -158,7 +158,7 @@ export default function DnsSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-5xl space-y-6 py-8">
+      <div className="mx-auto max-w-5xl space-y-8 py-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -168,7 +168,7 @@ export default function DnsSettingsPage() {
             >
               <ArrowLeft className="h-4 w-4" />
             </Link>
-            <h1 className="text-2xl font-semibold text-white">
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">
               Unbound DNS
             </h1>
           </div>

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -105,7 +105,7 @@ export default function SettingsPage() {
   return (
     <PageTransition>
       <div className="mx-auto max-w-5xl py-8">
-        <h1 className="text-2xl font-semibold text-white">Settings</h1>
+        <h1 className="text-3xl font-bold tracking-tight font-display text-white">Settings</h1>
 
         <div className="mt-8 space-y-8">
           {settingsNav.map((group) => {

--- a/web/src/app/(app)/settings/password/page.tsx
+++ b/web/src/app/(app)/settings/password/page.tsx
@@ -90,7 +90,7 @@ export default function PasswordSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -98,7 +98,7 @@ export default function PasswordSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Change Password</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Change Password</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/retention/page.tsx
+++ b/web/src/app/(app)/settings/retention/page.tsx
@@ -169,7 +169,7 @@ export default function RetentionSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -177,7 +177,7 @@ export default function RetentionSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Data Retention</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Data Retention</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/router/page.tsx
+++ b/web/src/app/(app)/settings/router/page.tsx
@@ -294,7 +294,7 @@ function StatusMessages({
 export default function RouterSettingsPage() {
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -302,7 +302,7 @@ export default function RouterSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">
             Router Settings
           </h1>
         </div>

--- a/web/src/app/(app)/settings/scanner/page.tsx
+++ b/web/src/app/(app)/settings/scanner/page.tsx
@@ -157,7 +157,7 @@ export default function ScannerSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -165,7 +165,7 @@ export default function ScannerSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Network Scanner</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Network Scanner</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/speedtest/page.tsx
+++ b/web/src/app/(app)/settings/speedtest/page.tsx
@@ -109,7 +109,7 @@ export default function SpeedtestSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -117,7 +117,7 @@ export default function SpeedtestSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Speed Test</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Speed Test</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">
@@ -137,7 +137,7 @@ export default function SpeedtestSettingsPage() {
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
               <div className="space-y-1.5">
                 <Label htmlFor="speedtest-auto" className="text-xs text-slate-400">
                   Auto-run interval (hours)

--- a/web/src/app/(app)/settings/tailscale/page.tsx
+++ b/web/src/app/(app)/settings/tailscale/page.tsx
@@ -77,12 +77,12 @@ export default function TailscaleSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-6xl space-y-6 py-8">
+      <div className="mx-auto max-w-6xl space-y-8 py-8">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Shield className="h-6 w-6 text-blue-500" />
-            <h1 className="text-2xl font-semibold text-white">Tailscale</h1>
+            <h1 className="text-3xl font-bold tracking-tight font-display text-white">Tailscale</h1>
             {data && (
               <Badge
                 variant="outline"
@@ -108,7 +108,7 @@ export default function TailscaleSettingsPage() {
         </div>
 
         {/* Summary Cards */}
-        <div className="grid gap-4 sm:grid-cols-4">
+        <div className="grid gap-5 sm:grid-cols-4">
           <SummaryCard
             title="Status"
             value={data?.backend_state ?? null}
@@ -290,7 +290,7 @@ function SummaryCard({
 }) {
   return (
     <Card className="border-slate-800 bg-slate-900">
-      <CardContent className="flex items-center gap-4 p-5">
+      <CardContent className="flex items-center gap-5 p-5">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-800">
           {icon}
         </div>

--- a/web/src/app/(app)/settings/webhook/page.tsx
+++ b/web/src/app/(app)/settings/webhook/page.tsx
@@ -105,7 +105,7 @@ export default function WebhookSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -113,7 +113,7 @@ export default function WebhookSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Webhook Notifications</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Webhook Notifications</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -213,7 +213,7 @@ export default function XiaomiMeshSettingsPage() {
 
   return (
     <PageTransition>
-      <div className="mx-auto max-w-lg space-y-6 py-8">
+      <div className="mx-auto max-w-lg space-y-8 py-8">
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
@@ -221,7 +221,7 @@ export default function XiaomiMeshSettingsPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold text-white">Xiaomi Mesh</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Xiaomi Mesh</h1>
         </div>
 
         <Card className="border-slate-800 bg-slate-900">

--- a/web/src/app/(app)/ssh-hosts/page.tsx
+++ b/web/src/app/(app)/ssh-hosts/page.tsx
@@ -118,10 +118,10 @@ export default function SshHostsPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold text-white">SSH Hosts</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">SSH Hosts</h1>
           <SshTargetFormDialog
             open={addOpen}
             onOpenChange={setAddOpen}
@@ -455,7 +455,7 @@ function SshTargetFormDialog({
       </DialogHeader>
 
       <div className="space-y-4 pt-2">
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Name</Label>
             <Input
@@ -474,7 +474,7 @@ function SshTargetFormDialog({
           </div>
         </div>
 
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-3 gap-5">
           <div className="space-y-2">
             <Label>Port</Label>
             <Input
@@ -536,7 +536,7 @@ function SshTargetFormDialog({
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-5">
           <div className="space-y-2">
             <Label>Poll Interval (seconds)</Label>
             <Input

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -80,10 +80,10 @@ export default function TrafficPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-semibold text-white">Traffic</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">Traffic</h1>
           <HelpTooltip text="Network bandwidth usage over time. Requires NetFlow/sFlow export from your router to be configured in Settings." />
         </div>
         <DropdownMenu>

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -128,14 +128,14 @@ export default function VpnStatusPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
-        <section className="flex flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-4">
+      <div className="space-y-8">
+        <section className="flex flex-col gap-5 rounded-2xl border border-slate-800/70 bg-slate-950/40 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-5">
             <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-indigo-500/30 bg-gradient-to-br from-indigo-500/20 via-blue-500/10 to-cyan-500/10 text-indigo-300">
               <Shield className="h-6 w-6" />
             </div>
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white">VPN Status</h1>
+              <h1 className="text-3xl font-bold tracking-tight font-display text-white">VPN Status</h1>
               <p className="text-sm text-slate-400">
                 WireGuard tunnels, peer connectivity, and transfer stats.
               </p>
@@ -153,7 +153,7 @@ export default function VpnStatusPage() {
           </Button>
         </section>
 
-        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <section className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
           <SummaryCard
             title="Interfaces"
             value={data ? overviewInterfaces.length : null}
@@ -312,7 +312,7 @@ function SummaryCard({
 }) {
   return (
     <Card className={surfaceClass}>
-      <CardContent className="flex min-h-[96px] items-center gap-4 p-4">
+      <CardContent className="flex min-h-[96px] items-center gap-5 p-4">
         <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
           {icon}
         </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -30,6 +30,15 @@
     --status-online: 160 84% 39%;    /* emerald-500 */
     --status-offline: 350 89% 60%;   /* rose-500 */
     --status-warning: 43 96% 56%;    /* amber-400 */
+
+    /* ── Gradient accent tokens ────────────────────────── */
+    --gradient-primary: linear-gradient(135deg, #3b82f6, #6366f1);       /* blue-500 → indigo-500 */
+    --gradient-primary-hover: linear-gradient(135deg, #2563eb, #4f46e5); /* blue-600 → indigo-600 */
+    --gradient-warm: linear-gradient(135deg, #f59e0b, #f97316);          /* amber-500 → orange-500 */
+    --gradient-warm-hover: linear-gradient(135deg, #d97706, #ea580c);    /* amber-600 → orange-600 */
+    --gradient-text: linear-gradient(135deg, #60a5fa, #818cf8);          /* blue-400 → indigo-400 */
+    --gradient-text-warm: linear-gradient(135deg, #fbbf24, #fb923c);     /* amber-400 → orange-400 */
+    --gradient-surface: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(99, 102, 241, 0.08));
   }
 
   * {
@@ -40,6 +49,8 @@
     @apply text-foreground;
     background-color: #020617;
     background-image:
+      radial-gradient(circle at 10% 0%, rgba(99, 102, 241, 0.12) 0%, transparent 50%),
+      radial-gradient(circle at 90% 100%, rgba(16, 185, 129, 0.08) 0%, transparent 50%),
       radial-gradient(circle at 16% -18%, rgba(37, 99, 235, 0.16) 0%, transparent 42%),
       radial-gradient(circle at 88% -26%, rgba(30, 41, 59, 0.24) 0%, transparent 38%),
       linear-gradient(180deg, #020617 0%, #030712 62%, #020617 100%);
@@ -52,6 +63,32 @@
 .tabular-nums {
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum" 1;
+}
+
+/* ── Gradient text utility ─────────────────────────── */
+.gradient-text {
+  background: var(--gradient-text);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.gradient-text-warm {
+  background: var(--gradient-text-warm);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* ── Inter variable font smooth weight hierarchy ───── */
+.font-weight-medium {
+  font-variation-settings: "wght" 500;
+}
+.font-weight-semibold {
+  font-variation-settings: "wght" 600;
+}
+.font-weight-bold {
+  font-variation-settings: "wght" 700;
 }
 
 /* ── Neon glow status dots ───────────────────────────── */

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono, Plus_Jakarta_Sans } from "next/font/google";
 import { Toaster } from "sonner";
 import "./globals.css";
 
@@ -11,6 +11,12 @@ const inter = Inter({
 const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
+});
+
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  variable: "--font-display",
+  weight: ["500", "600", "700", "800"],
 });
 
 export const metadata: Metadata = {
@@ -26,7 +32,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased text-slate-50`}
+        className={`${inter.variable} ${jetbrainsMono.variable} ${plusJakartaSans.variable} font-sans antialiased text-slate-50`}
       >
         {children}
         <Toaster theme="dark" position="bottom-right" richColors />

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -161,7 +161,7 @@ function StatusHeader({ status }: { status: MikrotikStatus }) {
           <Router className="h-5 w-5 text-pink-400" />
         </div>
         <div>
-          <h1 className="text-2xl font-semibold text-white">MikroTik Router</h1>
+          <h1 className="text-3xl font-bold tracking-tight font-display text-white">MikroTik Router</h1>
           <p className="text-xs text-slate-500">
             {status.board_name ?? "RouterOS"}{" "}
             {status.version && (

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col gap-1.5 p-5", className)}
+    className={cn("flex flex-col gap-1.5 p-5 md:p-6", className)}
     {...props}
   />
 ))
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-5 pt-0 md:p-6 md:pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-5 pt-0", className)}
+    className={cn("flex items-center p-5 pt-0 md:p-6 md:pt-0", className)}
     {...props}
   />
 ))

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -58,8 +58,9 @@ const config: Config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["Inter", "system-ui", "sans-serif"],
-        mono: ["JetBrains Mono", "monospace"],
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "var(--font-sans)", "system-ui", "sans-serif"],
+        mono: ["var(--font-mono)", "monospace"],
       },
       keyframes: {
         "accordion-down": {

--- a/web/tests/e2e/design-system.spec.ts
+++ b/web/tests/e2e/design-system.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "../../e2e/fixtures";
+
+test.describe("Design system overhaul", () => {
+  test("page headings use display font and updated sizing", async ({
+    authenticatedPage: page,
+  }) => {
+    // Dashboard heading should be visible with updated classes
+    const heading = page.locator("h1").first();
+    await expect(heading).toBeVisible({ timeout: 15000 });
+    await expect(heading).toHaveClass(/font-display/);
+    await expect(heading).toHaveClass(/text-3xl/);
+    await expect(heading).toHaveClass(/font-bold/);
+    await expect(heading).toHaveClass(/tracking-tight/);
+    await page.screenshot({ path: "test-results/design-system-heading.png" });
+  });
+
+  test("gradient CSS variables are defined", async ({
+    authenticatedPage: page,
+  }) => {
+    // Verify gradient CSS variables exist on :root
+    const gradientPrimary = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--gradient-primary")
+        .trim()
+    );
+    expect(gradientPrimary).toContain("linear-gradient");
+
+    const gradientWarm = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--gradient-warm")
+        .trim()
+    );
+    expect(gradientWarm).toContain("linear-gradient");
+
+    const gradientText = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--gradient-text")
+        .trim()
+    );
+    expect(gradientText).toContain("linear-gradient");
+  });
+
+  test("body background includes colored radials for depth", async ({
+    authenticatedPage: page,
+  }) => {
+    const bgImage = await page.evaluate(() =>
+      getComputedStyle(document.body).backgroundImage
+    );
+    // Should have indigo and emerald radial gradients
+    expect(bgImage).toContain("radial-gradient");
+    // At least 4 gradient layers (2 new colored radials + 2 original + 1 linear)
+    const gradientCount = (bgImage.match(/gradient/g) || []).length;
+    expect(gradientCount).toBeGreaterThanOrEqual(4);
+    await page.screenshot({ path: "test-results/design-system-background.png" });
+  });
+
+  test("gradient-text utility class renders correctly", async ({
+    authenticatedPage: page,
+  }) => {
+    // Inject a test element with gradient-text class to verify the utility
+    await page.evaluate(() => {
+      const el = document.createElement("span");
+      el.className = "gradient-text";
+      el.textContent = "Test";
+      el.id = "gradient-test";
+      document.body.appendChild(el);
+    });
+    const el = page.locator("#gradient-test");
+    const bgClip = await el.evaluate((node) =>
+      getComputedStyle(node).webkitBackgroundClip
+    );
+    expect(bgClip).toBe("text");
+  });
+
+  test("card grid uses updated gap spacing", async ({
+    authenticatedPage: page,
+  }) => {
+    // Dashboard card grid should use gap-5
+    const grid = page.locator(".grid.gap-5").first();
+    await expect(grid).toBeVisible({ timeout: 15000 });
+    await page.screenshot({ path: "test-results/design-system-spacing.png" });
+  });
+
+  test("display font (Plus Jakarta Sans) is loaded", async ({
+    authenticatedPage: page,
+  }) => {
+    // The --font-display CSS variable should be set on body
+    const fontDisplayVar = await page.evaluate(() => {
+      const body = document.body;
+      const classes = body.className;
+      // Plus Jakarta Sans font variable should be present as a class
+      return classes;
+    });
+    // The Next.js font variable class should be present
+    expect(fontDisplayVar).toContain("__variable");
+
+    // Verify the heading actually uses the display font family
+    const heading = page.locator("h1").first();
+    await expect(heading).toBeVisible({ timeout: 15000 });
+    const fontFamily = await heading.evaluate((node) =>
+      getComputedStyle(node).fontFamily
+    );
+    // Next.js font optimization may hash the name, but "Jakarta" should be present
+    expect(fontFamily.toLowerCase()).toMatch(/jakarta/i);
+  });
+});


### PR DESCRIPTION
Closes #591

## Summary

Upgrades the core design system to break away from the standard shadcn dark dashboard look, adding personality through gradient accents, a display font, and improved spacing.

## Changes

### Color Palette
- **Gradient accent tokens** defined as CSS variables in `globals.css`: `--gradient-primary` (blue→indigo), `--gradient-warm` (amber→orange), `--gradient-text`, `--gradient-text-warm`, `--gradient-surface`, plus hover variants
- **Body background** updated with colored radials — faint indigo glow top-left, faint emerald glow bottom-right for depth

### Typography
- **Plus Jakarta Sans** loaded as display font (`--font-display`) for page headings
- All 36 page h1 headings updated: `text-2xl font-semibold` → `text-3xl font-bold tracking-tight font-display`
- **Gradient text utilities**: `.gradient-text` and `.gradient-text-warm` classes for key dashboard numbers
- **Inter variable font** `font-variation-settings` utilities for smooth weight hierarchy
- Tailwind font families now use CSS variable references for proper Next.js font optimization

### Spacing
- Card grid gaps: `gap-4` → `gap-5` across all page card grids
- Section spacing: `space-y-6` → `space-y-8` across all page containers
- Card component padding: `p-5` → responsive `p-5 md:p-6` on CardHeader, CardContent, CardFooter

## Files Changed
- `web/src/app/globals.css` — gradient tokens, body radials, gradient-text utility, font-variation-settings
- `web/src/app/layout.tsx` — Plus Jakarta Sans font import
- `web/tailwind.config.ts` — display font family, CSS variable font references
- `web/src/components/ui/card.tsx` — responsive card padding
- 36 page files — heading classes updated
- 4 page files — grid gap updated
- ~30 page files — section spacing updated

## Smoke Test
- `bun run build` passes cleanly
- No existing E2E test selectors broken (verified all test files for CSS class references)
- The `command-palette-ux.spec.ts` `.grid.gap-5` selector now correctly matches after gap-4→gap-5 change

## E2E Test
Added `web/tests/e2e/design-system.spec.ts` covering:
- Page headings have `font-display`, `text-3xl`, `font-bold`, `tracking-tight` classes
- Gradient CSS variables (`--gradient-primary`, `--gradient-warm`, `--gradient-text`) are defined
- Body background has ≥4 gradient layers (colored radials)
- `.gradient-text` utility applies `background-clip: text`
- Card grids use `gap-5` spacing
- Plus Jakarta Sans display font is loaded and applied to headings

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a focused design system overhaul across 44 files, introducing gradient accent tokens, the Plus Jakarta Sans display font, updated heading styles, and refined spacing — all without touching any application logic.

- **Gradient tokens** (`--gradient-primary`, `--gradient-warm`, `--gradient-text`, etc.) are correctly defined as CSS custom properties in `:root` and consumed via the `background: var(...)` shorthand in the `.gradient-text` / `.gradient-text-warm` utilities. Three tokens (`--gradient-primary-hover`, `--gradient-warm-hover`, `--gradient-surface`) are defined but have no consumers yet; they appear to be reserved for follow-up work.
- **Font setup** is correct: Plus Jakarta Sans is loaded with `next/font/google`, injected as `--font-display`, and referenced in `tailwind.config.ts` alongside the existing `--font-sans` / `--font-mono` variables. All 36 page `h1` headings are updated consistently.
- **Card responsive padding** (`md:p-6 md:pt-0`) preserves the existing top-padding-reset pattern at the new breakpoint — no layout regressions expected.
- **E2E test** covers all new design tokens and font loading. The assertion `expect(fontDisplayVar).toContain("__variable")` depends on Next.js's internal CSS class-naming convention, which could become brittle across major Next.js upgrades.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are purely presentational, the build passes cleanly, and no application logic is affected.
- The diff is mechanically consistent (36 headings updated uniformly, spacing values changed uniformly), no logic is altered, CSS patterns are valid, and the author verified both the build and E2E selectors. The one brittle assertion in the new E2E test is non-blocking.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/globals.css | Adds gradient accent tokens, body radial glows, gradient-text utilities, and font-variation-settings helpers. All new CSS is syntactically correct; gradient variables are stored as full `linear-gradient()` values and consumed via `background: var(...)` which is valid. `--gradient-primary-hover`, `--gradient-warm-hover`, and `--gradient-surface` are defined but have no usages yet in this PR (they appear to be reserved for future use). |
| web/src/app/layout.tsx | Adds Plus Jakarta Sans via `next/font/google` with the correct `variable: "--font-display"` and discrete weights [500, 600, 700, 800]. The variable class is correctly injected into the `<body>` className alongside the existing font variables. |
| web/tailwind.config.ts | Adds `display` font family and switches `sans`/`mono` to CSS variable references (`var(--font-sans)`, `var(--font-mono)`, `var(--font-display)`). Valid Tailwind v3 pattern for Next.js font optimization. |
| web/src/components/ui/card.tsx | Adds responsive `md:p-6` to CardHeader, CardContent, and CardFooter. `md:pt-0` correctly overrides the top-padding reset at the md+ breakpoint, preserving the expected layout where header supplies top spacing. |
| web/tests/e2e/design-system.spec.ts | New E2E test file covering heading classes, gradient CSS variables, background radials, gradient-text utility, gap spacing, and display font loading. The fixture import path matches the project convention. One minor concern: the display font test relies on an internal Next.js class-naming convention (`__variable`) that may be brittle across Next.js upgrades. |
| web/src/components/MikrotikRouter.tsx | Single heading class update: `text-2xl font-semibold` → `text-3xl font-bold tracking-tight font-display`. Consistent with all other page h1 changes. |
| web/src/app/(app)/dashboard/page.tsx | Heading class, spacing, and grid gap updates consistent with the design overhaul. No logic issues. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: design system overhaul — gradient ..."](https://github.com/befeast/panoptikon/commit/55bafebc357edd2e654afbd79d089e68b8663931) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25964477)</sub>

<!-- /greptile_comment -->