### PR TITLE
fix: layout regressions from UI polish PRs (#626)

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -490,7 +490,7 @@ export default function AlertsPage() {
           {alerts.map((alert) => (
             <Card
               key={alert.id}
-              className={`border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${severityBorderClass(alert.severity)} ${
+              className={`rounded-l-none border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${severityBorderClass(alert.severity)} ${
                 acknowledgingIds.has(alert.id)
                   ? "animate-ack-strike opacity-0"
                   : alert.acknowledged_at

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -509,7 +509,7 @@ export default function DashboardPage() {
                 value={stats.devices_total}
                 subtitle={`${stats.devices_online} currently online`}
                 icon={<MonitorSmartphone className="h-5 w-5" />}
-                gradient="bg-gradient-to-br from-blue-600/90 to-blue-900/90"
+                gradient="bg-gradient-to-br from-blue-500/20 to-blue-900/40"
                 href="/devices"
               />
             </StaggerItem>
@@ -521,8 +521,8 @@ export default function DashboardPage() {
                 icon={<AlertTriangle className="h-5 w-5" />}
                 gradient={
                   stats.alerts_unread > 0
-                    ? "bg-gradient-to-br from-amber-600/90 to-amber-900/90"
-                    : "bg-gradient-to-br from-emerald-600/90 to-emerald-900/90"
+                    ? "bg-gradient-to-br from-amber-500/20 to-amber-900/40"
+                    : "bg-gradient-to-br from-emerald-500/20 to-emerald-900/40"
                 }
                 href="/alerts"
               />
@@ -540,10 +540,10 @@ export default function DashboardPage() {
                 icon={<Activity className="h-5 w-5" />}
                 gradient={
                   stats.critical_total === 0 || (stats.critical_online / stats.critical_total) >= 0.9
-                    ? "bg-gradient-to-br from-emerald-600/90 to-emerald-900/90"
+                    ? "bg-gradient-to-br from-emerald-500/20 to-emerald-900/40"
                     : (stats.critical_online / stats.critical_total) >= 0.7
-                      ? "bg-gradient-to-br from-amber-600/90 to-amber-900/90"
-                      : "bg-gradient-to-br from-rose-600/90 to-rose-900/90"
+                      ? "bg-gradient-to-br from-amber-500/20 to-amber-900/40"
+                      : "bg-gradient-to-br from-rose-500/20 to-rose-900/40"
                 }
               />
             </StaggerItem>
@@ -553,7 +553,7 @@ export default function DashboardPage() {
                 value={stats.wan_rx_bps}
                 subtitle={`↑ ${formatBps(stats.wan_tx_bps)}`}
                 icon={<Router className="h-5 w-5" />}
-                gradient="bg-gradient-to-br from-violet-600/90 to-violet-900/90"
+                gradient="bg-gradient-to-br from-violet-500/20 to-violet-900/40"
                 href="/traffic"
                 formatValue={(v) => `↓ ${formatBps(v)}`}
               />

--- a/web/src/components/dashboard/HeroStat.tsx
+++ b/web/src/components/dashboard/HeroStat.tsx
@@ -66,7 +66,7 @@ export function HeroStat({
   const inner = (
     <Card
       className={cn(
-        "relative overflow-hidden border-0 h-full",
+        "relative overflow-hidden border-slate-700/40 h-full",
         gradient,
         href && "transition-shadow hover:shadow-lg hover:shadow-black/20"
       )}

--- a/web/tests/e2e/alerts.spec.ts
+++ b/web/tests/e2e/alerts.spec.ts
@@ -5,7 +5,7 @@ test.describe('Alerts page', () => {
     await login(page);
   });
 
-  test.skip('alerts page loads with heading', async ({ page }) => {
+  test('alerts page loads with heading', async ({ page }) => {
     await page.goto('/alerts/');
     await page.waitForURL('**/alerts**', { timeout: 15000 });
     await expect(page.locator('h1, [role="heading"]').filter({ hasText: /Alerts/i })).toBeVisible({ timeout: 30000 });

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -6,7 +6,7 @@ test.describe('Dashboard', () => {
     await login(page);
   });
 
-  test.skip('dashboard page loads with hero stat cards', async ({ page }) => {
+  test('dashboard page loads with hero stat cards', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
     // Wait for API calls to settle before checking hero stats


### PR DESCRIPTION
Closes #626

## Summary
- **Alert cards**: Added `rounded-l-none` to alert cards so the `border-l-4` severity accent renders as a clean straight bar instead of a curly-brace shape caused by the base Card's `rounded-2xl` border radius
- **HeroStat cards**: Toned down gradient backgrounds from `/90` to `/20`–`/40` opacity for subtle glassmorphism tint instead of solid color blocks. Restored `border-slate-700/40` so card edge is visible through the translucent background
- **E2E tests**: Re-enabled skipped tests for dashboard hero stats and alerts page heading that were disabled during UI polish PRs #615–#620

## Root cause
The base `Card` component uses `rounded-2xl` (1rem border radius). When alert cards applied `border-l-4` for the severity accent, the border followed the curved corners, creating a curly-brace appearance. For HeroStat, the gradient overlays at 90% opacity were effectively solid, hiding the glassmorphism `backdrop-blur` effect.

## Smoke Test
- Verified `severityBorderClass()` still returns `border-l-4 border-l-{color}` classes unchanged — E2E selectors (`[class*="border-l-4"]`, `.animate-pulse-critical`) still match
- Verified gradient values changed from `/90` to `/20`–`/40` across all 4 HeroStat gradient variants (blue, amber/emerald, emerald/amber/rose, violet)
- E2E tests fail only due to `ERR_CONNECTION_REFUSED` (no local server) — no assertion failures from changed selectors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two layout regressions introduced by earlier UI-polish PRs (#615–#620) and re-enables the E2E tests that were disabled while those changes landed.

- **Alert cards** — `rounded-l-none` is added to each alert `Card`, preventing the base `rounded-2xl` corner radius from curving the `border-l-4` severity accent into a bracket shape.
- **HeroStat cards** — gradient opacity is toned down from `/90` to `/20`–`/40` (all four variants) so the `backdrop-blur` glassmorphism effect is visible again, and `border-0` is restored to `border-slate-700/40` to keep the card edge visible against the translucent background.
- **E2E tests** — `test.skip` is removed from `'alerts page loads with heading'` and `'dashboard page loads with hero stat cards'`; the alerts test is clean, but the dashboard test lacks an explicit `page.goto('/dashboard')` before asserting the heading, which could make it flaky if login redirects to `/agents` or `/devices` instead of `/dashboard`.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; the CSS regressions are fixed correctly and the only outstanding item is a minor flakiness risk in one re-enabled E2E test.
- All three visual fixes (rounded-l-none, gradient opacity, border restoration) are correct and well-scoped. The one logic concern — the re-enabled dashboard test asserting the heading without first navigating to /dashboard — is low-risk in practice since the app typically redirects there after login, but it could cause intermittent CI failures.
- web/tests/e2e/dashboard.spec.ts — re-enabled test at line 9 should call `page.goto('/dashboard')` before the heading assertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/alerts/page.tsx | Adds `rounded-l-none` to alert Card elements so the `border-l-4` severity accent renders as a flat bar instead of following the base Card's `rounded-2xl` corners — a clean one-line fix with no logic changes. |
| web/src/app/(app)/dashboard/page.tsx | Reduces HeroStat gradient opacity from `/90` to `/20`–`/40` across all four color variants (blue, amber, emerald, rose, violet), making the glassmorphism backdrop-blur visible again. All six changed lines are symmetrical and correct. |
| web/src/components/dashboard/HeroStat.tsx | Restores card border from `border-0` to `border-slate-700/40` so the translucent HeroStat edge is visible; pairs correctly with the reduced gradient opacity in dashboard/page.tsx. |
| web/tests/e2e/dashboard.spec.ts | Re-enables the previously-skipped `'dashboard page loads with hero stat cards'` test; test relies on login() leaving the page at /dashboard but does not call page.goto('/dashboard') explicitly, creating a potential flakiness vector if login redirects elsewhere. |
| web/tests/e2e/alerts.spec.ts | Re-enables the `'alerts page loads with heading'` test; test explicitly calls `page.goto('/alerts/')` so there is no navigation ambiguity — straightforward and correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/tests/e2e/dashboard.spec.ts
Line: 9-10

Comment:
**Missing explicit navigation before heading assertion**

After `login()`, the page is confirmed to be at whichever URL matches `/\/(dashboard|agents|devices)/` — it is not guaranteed to land on `/dashboard`. If the app redirects to `/agents` or `/devices` after a successful login, the `getByRole('heading', { name: 'Dashboard', level: 1 })` assertion will time out and fail.

Every other test in this file that relies on being on the dashboard calls `await page.goto('/dashboard')` first (see the `'dashboard renders hero stats within 3 seconds'` test at line 168 and the `'responsive layout collapses to single column on mobile'` test at line 185). The re-enabled test should do the same:

```suggestion
  test('dashboard page loads with hero stat cards', async ({ page }) => {
    await page.goto('/dashboard');
    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: layout regressions from UI polish P..."](https://github.com/befeast/panoptikon/commit/a7d12cd80b575b545aaef3690195a85a96c8ef51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25965400)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->