### PR TITLE
fix: search is broken — no results returned (#627)

### DIFF
--- a/server/src/api/search.rs
+++ b/server/src/api/search.rs
@@ -101,76 +101,84 @@ pub async fn search(
 
     let like_term = format!("%{q}%");
 
-    // Search devices by IP (via device_ips), hostname, name, custom_name, MAC, or vendor
-    let device_rows = sqlx::query(
-        r#"SELECT DISTINCT d.id, d.hostname, d.mac, d.vendor, d.is_online,
+    // Search devices by IP (via subquery), hostname, name, custom_name, MAC, or vendor.
+    // Uses a correlated EXISTS subquery for IP matching instead of LEFT JOIN to avoid
+    // the NULL-filtering problem where LEFT JOIN + WHERE on the joined table effectively
+    // becomes an INNER JOIN, hiding devices without current IPs from all search results.
+    let devices: Vec<SearchDevice> = match sqlx::query(
+        r#"SELECT d.id, d.hostname, d.mac, d.vendor, d.is_online,
                   COALESCE(d.custom_name, d.name) AS display_name,
                   (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id AND di.is_current = 1 LIMIT 1) AS ip_address
            FROM devices d
-           LEFT JOIN device_ips di ON di.device_id = d.id AND di.is_current = 1
-           WHERE di.ip LIKE ?1
-              OR d.hostname LIKE ?1
+           WHERE d.hostname LIKE ?1
               OR d.mac LIKE ?1
               OR d.vendor LIKE ?1
               OR d.name LIKE ?1
               OR d.custom_name LIKE ?1
+              OR EXISTS (
+                  SELECT 1 FROM device_ips di
+                  WHERE di.device_id = d.id AND di.is_current = 1 AND di.ip LIKE ?1
+              )
            LIMIT 5"#,
     )
     .bind(&like_term)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| {
-        tracing::error!("Search devices failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let devices: Vec<SearchDevice> = device_rows
-        .into_iter()
-        .map(|row| SearchDevice {
-            id: row.try_get("id").unwrap_or_default(),
-            ip_address: row.try_get("ip_address").unwrap_or(None),
-            hostname: row.try_get("hostname").unwrap_or(None),
-            name: row.try_get("display_name").unwrap_or(None),
-            mac_address: row.try_get("mac").unwrap_or_default(),
-            vendor: row.try_get("vendor").unwrap_or(None),
-            is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
-        })
-        .collect();
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|row| SearchDevice {
+                id: row.try_get("id").unwrap_or_default(),
+                ip_address: row.try_get("ip_address").unwrap_or(None),
+                hostname: row.try_get("hostname").unwrap_or(None),
+                name: row.try_get("display_name").unwrap_or(None),
+                mac_address: row.try_get("mac").unwrap_or_default(),
+                vendor: row.try_get("vendor").unwrap_or(None),
+                is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!("Search devices failed: {e}");
+            Vec::new()
+        }
+    };
 
     // Search agents by name or hostname (from latest report)
-    let agent_rows = sqlx::query(
+    let agents: Vec<SearchAgent> = match sqlx::query(
         r#"SELECT a.id, a.name,
                   (SELECT ar.hostname FROM agent_reports ar WHERE ar.agent_id = a.id ORDER BY ar.reported_at DESC LIMIT 1) AS hostname,
                   CASE WHEN a.last_report_at IS NOT NULL
                             AND a.last_report_at > datetime('now', '-120 seconds')
                        THEN 1 ELSE 0 END AS is_online
            FROM agents a
-           LEFT JOIN agent_reports ar ON ar.agent_id = a.id
            WHERE a.name LIKE ?1
-              OR ar.hostname LIKE ?1
-           GROUP BY a.id
+              OR EXISTS (
+                  SELECT 1 FROM agent_reports ar
+                  WHERE ar.agent_id = a.id AND ar.hostname LIKE ?1
+              )
            LIMIT 5"#,
     )
     .bind(&like_term)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| {
-        tracing::error!("Search agents failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let agents: Vec<SearchAgent> = agent_rows
-        .into_iter()
-        .map(|row| SearchAgent {
-            id: row.try_get("id").unwrap_or_default(),
-            name: row.try_get("name").unwrap_or(None),
-            hostname: row.try_get("hostname").unwrap_or(None),
-            is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
-        })
-        .collect();
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|row| SearchAgent {
+                id: row.try_get("id").unwrap_or_default(),
+                name: row.try_get("name").unwrap_or(None),
+                hostname: row.try_get("hostname").unwrap_or(None),
+                is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!("Search agents failed: {e}");
+            Vec::new()
+        }
+    };
 
     // Search alerts by message
-    let alert_rows = sqlx::query(
+    let alerts: Vec<SearchAlert> = match sqlx::query(
         r#"SELECT id, message, severity, created_at
            FROM alerts
            WHERE message LIKE ?1
@@ -180,25 +188,26 @@ pub async fn search(
     .bind(&like_term)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| {
-        tracing::error!("Search alerts failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let alerts: Vec<SearchAlert> = alert_rows
-        .into_iter()
-        .map(|row| SearchAlert {
-            id: row.try_get("id").unwrap_or_default(),
-            message: row.try_get("message").unwrap_or_default(),
-            severity: row
-                .try_get::<String, _>("severity")
-                .unwrap_or_else(|_| "WARNING".to_string()),
-            created_at: row.try_get("created_at").unwrap_or_default(),
-        })
-        .collect();
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|row| SearchAlert {
+                id: row.try_get("id").unwrap_or_default(),
+                message: row.try_get("message").unwrap_or_default(),
+                severity: row
+                    .try_get::<String, _>("severity")
+                    .unwrap_or_else(|_| "WARNING".to_string()),
+                created_at: row.try_get("created_at").unwrap_or_default(),
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!("Search alerts failed: {e}");
+            Vec::new()
+        }
+    };
 
     // Search SSH targets by name, host, or username
-    let ssh_rows = sqlx::query(
+    let ssh_targets: Vec<SearchSshTarget> = match sqlx::query(
         r#"SELECT st.id, st.name, st.host, st.username,
                   CASE WHEN sr.reported_at IS NOT NULL
                             AND sr.reported_at > datetime('now', '-120 seconds')
@@ -214,24 +223,25 @@ pub async fn search(
     .bind(&like_term)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| {
-        tracing::error!("Search SSH targets failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let ssh_targets: Vec<SearchSshTarget> = ssh_rows
-        .into_iter()
-        .map(|row| SearchSshTarget {
-            id: row.try_get("id").unwrap_or_default(),
-            name: row.try_get("name").unwrap_or_default(),
-            host: row.try_get("host").unwrap_or_default(),
-            username: row.try_get("username").unwrap_or_default(),
-            is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
-        })
-        .collect();
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|row| SearchSshTarget {
+                id: row.try_get("id").unwrap_or_default(),
+                name: row.try_get("name").unwrap_or_default(),
+                host: row.try_get("host").unwrap_or_default(),
+                username: row.try_get("username").unwrap_or_default(),
+                is_online: row.try_get::<i32, _>("is_online").unwrap_or(0) != 0,
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!("Search SSH targets failed: {e}");
+            Vec::new()
+        }
+    };
 
     // Search assets by name, location, owner, serial_number, or tags
-    let asset_rows = sqlx::query(
+    let assets: Vec<SearchAsset> = match sqlx::query(
         r#"SELECT id, name, asset_type, location, serial_number
            FROM assets
            WHERE name LIKE ?1
@@ -244,23 +254,24 @@ pub async fn search(
     .bind(&like_term)
     .fetch_all(&state.db)
     .await
-    .map_err(|e| {
-        tracing::error!("Search assets failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    let assets: Vec<SearchAsset> = asset_rows
-        .into_iter()
-        .map(|row| SearchAsset {
-            id: row.try_get("id").unwrap_or_default(),
-            name: row.try_get("name").unwrap_or_default(),
-            asset_type: row
-                .try_get::<String, _>("asset_type")
-                .unwrap_or_else(|_| "unknown".to_string()),
-            location: row.try_get("location").unwrap_or(None),
-            serial_number: row.try_get("serial_number").unwrap_or(None),
-        })
-        .collect();
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|row| SearchAsset {
+                id: row.try_get("id").unwrap_or_default(),
+                name: row.try_get("name").unwrap_or_default(),
+                asset_type: row
+                    .try_get::<String, _>("asset_type")
+                    .unwrap_or_else(|_| "unknown".to_string()),
+                location: row.try_get("location").unwrap_or(None),
+                serial_number: row.try_get("serial_number").unwrap_or(None),
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!("Search assets failed: {e}");
+            Vec::new()
+        }
+    };
 
     Ok(Json(SearchResponse {
         devices,
@@ -279,17 +290,19 @@ pub async fn search_devices(
     let like_term = format!("%{term}%");
 
     let rows = sqlx::query(
-        r#"SELECT DISTINCT d.id, d.hostname, d.mac, d.vendor, d.is_online,
+        r#"SELECT d.id, d.hostname, d.mac, d.vendor, d.is_online,
                   COALESCE(d.custom_name, d.name) AS display_name,
                   (SELECT di.ip FROM device_ips di WHERE di.device_id = d.id AND di.is_current = 1 LIMIT 1) AS ip_address
            FROM devices d
-           LEFT JOIN device_ips di ON di.device_id = d.id AND di.is_current = 1
-           WHERE di.ip LIKE ?1
-              OR d.hostname LIKE ?1
+           WHERE d.hostname LIKE ?1
               OR d.mac LIKE ?1
               OR d.vendor LIKE ?1
               OR d.name LIKE ?1
               OR d.custom_name LIKE ?1
+              OR EXISTS (
+                  SELECT 1 FROM device_ips di
+                  WHERE di.device_id = d.id AND di.is_current = 1 AND di.ip LIKE ?1
+              )
            LIMIT 5"#,
     )
     .bind(&like_term)
@@ -324,10 +337,11 @@ pub async fn search_agents(
                             AND a.last_report_at > datetime('now', '-120 seconds')
                        THEN 1 ELSE 0 END AS is_online
            FROM agents a
-           LEFT JOIN agent_reports ar ON ar.agent_id = a.id
            WHERE a.name LIKE ?1
-              OR ar.hostname LIKE ?1
-           GROUP BY a.id
+              OR EXISTS (
+                  SELECT 1 FROM agent_reports ar
+                  WHERE ar.agent_id = a.id AND ar.hostname LIKE ?1
+              )
            LIMIT 5"#,
     )
     .bind(&like_term)
@@ -768,5 +782,46 @@ mod tests {
             "Should return at most 5 devices, got {}",
             results.len()
         );
+    }
+
+    #[tokio::test]
+    async fn test_search_devices_without_ip() {
+        let pool = test_db().await;
+        // Device with no IP — should still be found by hostname
+        insert_device(
+            &pool,
+            "FF:FF:FF:00:00:01",
+            Some("no-ip-host"),
+            Some("TestVendor"),
+            None,
+        )
+        .await;
+        // Device with IP for comparison
+        insert_device(
+            &pool,
+            "FF:FF:FF:00:00:02",
+            Some("has-ip-host"),
+            None,
+            Some("10.0.0.99"),
+        )
+        .await;
+
+        // Search by hostname of the IP-less device
+        let results = search_devices(&pool, "no-ip").await.unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "Should find device without IP by hostname"
+        );
+        assert_eq!(results[0].hostname.as_deref(), Some("no-ip-host"));
+        assert!(results[0].ip_address.is_none());
+
+        // Search by vendor of the IP-less device
+        let results = search_devices(&pool, "TestVendor").await.unwrap();
+        assert_eq!(results.len(), 1, "Should find device without IP by vendor");
+
+        // Search by MAC of the IP-less device
+        let results = search_devices(&pool, "FF:FF:FF:00:00:01").await.unwrap();
+        assert_eq!(results.len(), 1, "Should find device without IP by MAC");
     }
 }

--- a/web/tests/e2e/search.spec.ts
+++ b/web/tests/e2e/search.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E tests for global search functionality (#627).
+ *
+ * Verifies:
+ * - Search input is visible in the top bar
+ * - Typing a query shows the search results dropdown
+ * - Short queries (< 2 chars) do not trigger search
+ * - Results dropdown closes on Escape
+ */
+test.describe("Global Search (#627)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("search input is visible in the top bar", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await expect(searchInput).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/search-input-visible.png",
+    });
+  });
+
+  test("typing a query opens search results dropdown", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await searchInput.click();
+    // Type a search term that likely won't match anything in test DB
+    await searchInput.fill("test-search-query");
+
+    // Wait for the debounce (300ms) + API call
+    await page.waitForTimeout(500);
+
+    // The dropdown should appear — either with results or "No results" message
+    const dropdown = page.locator(".absolute.left-0.right-0.top-full");
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/search-dropdown-open.png",
+    });
+  });
+
+  test("short query does not open dropdown", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await searchInput.click();
+    await searchInput.fill("a"); // single char — too short
+
+    await page.waitForTimeout(500);
+
+    // Dropdown should NOT appear for single-character queries
+    const dropdown = page.locator(".absolute.left-0.right-0.top-full");
+    await expect(dropdown).not.toBeVisible();
+  });
+
+  test("Escape closes search dropdown", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await searchInput.click();
+    await searchInput.fill("test-query");
+
+    await page.waitForTimeout(500);
+
+    const dropdown = page.locator(".absolute.left-0.right-0.top-full");
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
+
+    // Press Escape to close
+    await page.keyboard.press("Escape");
+    await expect(dropdown).not.toBeVisible({ timeout: 2000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/search-dropdown-closed.png",
+    });
+  });
+
+  test("search API returns valid response structure", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Intercept the search API call to verify response structure
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes("/api/v1/search?q="),
+    );
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await searchInput.fill("test");
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    // Verify the response has all expected fields (arrays)
+    expect(body).toHaveProperty("devices");
+    expect(body).toHaveProperty("agents");
+    expect(body).toHaveProperty("alerts");
+    expect(body).toHaveProperty("ssh_targets");
+    expect(body).toHaveProperty("assets");
+    expect(Array.isArray(body.devices)).toBe(true);
+    expect(Array.isArray(body.agents)).toBe(true);
+    expect(Array.isArray(body.alerts)).toBe(true);
+    expect(Array.isArray(body.ssh_targets)).toBe(true);
+    expect(Array.isArray(body.assets)).toBe(true);
+
+    await page.screenshot({
+      path: "tests/screenshots/search-api-response.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #627

## Summary

- **Root cause**: Device and agent search queries used `LEFT JOIN` + `WHERE` on joined table columns (`di.ip LIKE ?1`, `ar.hostname LIKE ?1`). In SQLite, `NULL LIKE '%term%'` evaluates to NULL (falsy), so this pattern excluded entities without matching join rows from **all** search results — not just IP/hostname searches. Additionally, if any one of the 5 search queries failed (SQL error), the entire `/api/v1/search` endpoint returned HTTP 500, and the frontend silently caught the error showing "no results."

- **Fix**: Replaced `LEFT JOIN` + `WHERE` with correlated `EXISTS` subqueries for IP and hostname matching. This ensures devices without IPs and agents without reports are still searchable by name, MAC, vendor, etc. Also made each query resilient — errors are logged but return empty results for that entity type instead of failing the whole endpoint.

## Changes

- `server/src/api/search.rs`: Rewrite device search to use `EXISTS` subquery instead of `LEFT JOIN` for IP matching; same for agent hostname search. Each query now uses `match` for error handling (returns partial results on failure instead of 500).
- `server/src/api/search.rs` (tests): Add `test_search_devices_without_ip` regression test — verifies devices without IPs are findable by hostname, vendor, and MAC.
- `web/tests/e2e/search.spec.ts`: New Playwright E2E test verifying search input visibility, dropdown behavior, short query filtering, Escape closing, and API response structure.

## Smoke Test

- `cargo test search` — all 11 tests pass (10 existing + 1 new regression test)
- `cargo check` — no errors
- `cargo fmt --all` — formatted

## Test plan

- [ ] Verify search returns results for device name, IP, MAC queries
- [ ] Verify devices without IP addresses are still searchable by hostname
- [ ] Verify search dropdown appears and shows results or "no results" message
- [ ] Verify short queries (< 2 chars) don't trigger search
- [ ] Verify Escape closes the search dropdown

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes a long-standing search regression where devices without IP addresses (and agents without reports) were invisible to all search queries. The root cause — SQLite evaluating `NULL LIKE '%term%'` as NULL (falsy), causing an effective `INNER JOIN` — is accurately diagnosed and cleanly resolved by switching to correlated `EXISTS` subqueries. Removing `DISTINCT` and `GROUP BY a.id` is also correct, since `EXISTS` no longer produces duplicate rows. The per-query error handling change (graceful empty results instead of HTTP 500) is a reasonable resilience improvement.

- **`server/src/api/search.rs`**: Fix applied consistently to both the HTTP handler's inline queries and the standalone `search_devices` / `search_agents` test-helper functions. Regression test `test_search_devices_without_ip` covers hostname, vendor, and MAC search for IP-less devices.
- **`web/tests/e2e/search.spec.ts`**: New E2E coverage is welcome, but the dropdown is located by a compound Tailwind CSS class selector (`.absolute.left-0.right-0.top-full`) that could silently match an unrelated element if the UI is ever refactored. A `data-testid` or ARIA-role locator would make the tests more reliable.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the core Rust fix is correct and well-tested; the only open item is a test-selector quality issue that does not affect production behaviour.
- The SQL fix is logically sound and consistently applied across all query sites. The removal of DISTINCT/GROUP BY is correct. Error handling is a deliberate and reasonable improvement. The single P1 comment targets test selector fragility in the E2E suite, not the production code path, so it does not block merging.
- web/tests/e2e/search.spec.ts — dropdown locator should use a stable selector to avoid false positives

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/search.rs | Replaces LEFT JOIN + WHERE with correlated EXISTS subqueries for device IP and agent hostname matching, correctly fixing the NULL-filtering bug in SQLite. Error handling refactored from early-return 500 to per-query graceful degradation. DISTINCT and GROUP BY correctly removed since EXISTS eliminates duplicate rows. Regression test added. |
| web/tests/e2e/search.spec.ts | New Playwright E2E tests covering search UI behaviour. Tests rely on a brittle CSS utility-class selector (.absolute.left-0.right-0.top-full) to locate the dropdown, and use page.waitForTimeout for debounce waits — both can cause false positives or flaky failures. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/tests/e2e/search.spec.ts
Line: 46-47

Comment:
**Fragile CSS class selector may match wrong element**

The dropdown is located via `.absolute.left-0.right-0.top-full` — a compound Tailwind utility selector. If any other absolutely-positioned element on the page shares these same classes (e.g. a notification banner, a tooltip, or any future component), the locator will silently match the wrong element. This means:

- `await expect(dropdown).toBeVisible()` could pass even when the search dropdown never rendered.
- `await expect(dropdown).not.toBeVisible()` after pressing Escape could pass because a *different* element happens to not be visible.

The same pattern appears at lines 67, 83, and 84. Prefer a `data-testid` attribute or an ARIA role/label so the selector is semantically bound to the search results dropdown:

```ts
const dropdown = page.getByTestId("search-results-dropdown");
// or
const dropdown = page.getByRole("listbox", { name: /search results/i });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rewrite search queries to use EXIST..."](https://github.com/befeast/panoptikon/commit/5c3c39eb8b237e7644cb0d5002d54490e6ab98cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25966638)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->