### PR TITLE
fix: alert card left border curly-brace artifact (#626)

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -477,7 +477,7 @@ export default function AlertsPage() {
           {alerts.map((alert) => (
             <Card
               key={alert.id}
-              className={`border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${
+              className={`rounded-l-none border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${
                 acknowledgingIds.has(alert.id)
                   ? "animate-ack-strike opacity-0"
                   : alert.acknowledged_at

--- a/web/tests/e2e/alert-card-border.spec.ts
+++ b/web/tests/e2e/alert-card-border.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect, login } from '../../e2e/fixtures';
+
+test.describe('Alert card left border accent', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('alert cards have flat left edge for clean border accent', async ({ page }) => {
+    await page.goto('/alerts/');
+    await expect(page.getByRole('heading', { name: 'Alerts', level: 1 })).toBeVisible({ timeout: 15000 });
+
+    // Wait for alerts API to finish loading
+    await page.waitForLoadState('networkidle');
+
+    const emptyState = page.getByText('All clear!');
+    if (await emptyState.isVisible().catch(() => false)) {
+      // No alerts — nothing to check, just verify page loaded
+      await page.screenshot({ path: 'tests/screenshots/alert-border-empty.png', fullPage: true });
+      return;
+    }
+
+    // All alert cards should have rounded-l-none (border-radius 0 on left side)
+    // to prevent the curly-brace artifact from rounded-2xl base Card
+    const alertCards = page.locator('.rounded-l-none.border-slate-800');
+    const count = await alertCards.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Verify the first card's computed left border-radius is 0
+    const firstCard = alertCards.first();
+    const borderRadii = await firstCard.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        topLeft: style.borderTopLeftRadius,
+        bottomLeft: style.borderBottomLeftRadius,
+      };
+    });
+
+    expect(borderRadii.topLeft).toBe('0px');
+    expect(borderRadii.bottomLeft).toBe('0px');
+
+    await page.screenshot({ path: 'tests/screenshots/alert-card-border-fix.png', fullPage: true });
+  });
+});


### PR DESCRIPTION
Closes #626

## Summary
- Alert cards on the alerts page had a curly-brace-shaped left border accent caused by the base Card component's `rounded-2xl` corners interacting with `border-l-2`
- Added `rounded-l-none` to alert cards so the left accent renders as a clean straight bar
- The dashboard stat card gradient issue (issue item #2) was already resolved by the revert in 893cca4 — HeroStat cards were replaced with flat StatCards that have no gradient backgrounds

## Changes
- `web/src/app/(app)/alerts/page.tsx` — add `rounded-l-none` to alert card className
- `web/tests/e2e/alert-card-border.spec.ts` — new E2E test verifying alert cards have 0px left border-radius

## Smoke Test
- Built frontend and server locally
- Ran full E2E test suite: 19 existing tests pass + 1 new test passes
- Verified alert cards render with flat left edge via computed style assertion

## Test plan
- [x] New E2E test asserts `borderTopLeftRadius` and `borderBottomLeftRadius` are `0px`
- [x] Existing alerts E2E tests pass (3 tests)
- [x] Existing alerts-severity E2E tests pass (2 tests)
- [x] Existing dashboard E2E tests pass (14 tests)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the curly-brace-shaped left border artifact on alert cards by adding `rounded-l-none` to the card's className, overriding the base `Card` component's `rounded-2xl` corners for the left edge. The fix is minimal and correct — the left corners are zeroed out while right-side rounding is preserved.

- **`alerts/page.tsx`**: Single-line, targeted Tailwind fix. The `rounded-l-none` utility correctly overrides just `border-top-left-radius` and `border-bottom-left-radius`, leaving the right-side rounding from the Card base class intact.
- **`alert-card-border.spec.ts`**: New E2E test follows the established fixture/screenshot patterns in the codebase. One concern: the test silently returns early when no alerts are present, meaning the core assertions (`0px` border-radius checks) are never reached in an empty environment — consider replacing the early `return` with `test.skip()` so vacuous passes are distinguishable in the test report.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is a single, correct Tailwind class addition with no risk to other components.
- The production code change is minimal and well-targeted. The test's empty-state early return is a non-blocking testing quality issue that doesn't affect the correctness of the fix or existing test coverage.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/alerts/page.tsx | Single-line fix adding `rounded-l-none` to alert card classNames to eliminate the curly-brace artifact caused by `rounded-2xl` interacting with `border-l-2`. |
| web/tests/e2e/alert-card-border.spec.ts | New E2E test verifying alert cards have 0px left border-radius; uses the correct fixture import path and follows established patterns, but silently skips its core assertion when no alerts are present. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/tests/e2e/alert-card-border.spec.ts
Line: 15-20

Comment:
**Test silently skips core assertion in empty state**

When there are no alerts, the test returns early (line 19) after only taking a screenshot — neither `expect(count).toBeGreaterThan(0)` nor the `borderRadii` assertions are reached. This means the regression test provides no protection in CI environments that don't have pre-seeded alert data: the test always passes (vacuously) and would never catch a future revert of the `rounded-l-none` fix.

Consider either skipping the test explicitly with `test.skip()` when the empty state is detected (so the status is distinguishable from a genuine pass), or better, seeding a test alert in `beforeEach` so the assertion always runs:

```ts
const emptyState = page.getByText('All clear!');
if (await emptyState.isVisible().catch(() => false)) {
  test.skip(true, 'No alerts present — cannot verify border fix');
  return;
}
```

This makes a vacuous pass visible as a skip in the test report rather than a false green.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: alert card left border curly-brace ..."](https://github.com/befeast/panoptikon/commit/e5a5009aa95bedbc94f87be37eb9b2b083ecb393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25970061)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->