### PR TITLE
feat: Login page visual upgrade: animated background, glow card (#594)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -192,3 +192,103 @@
 .animate-ack-strike * {
   text-decoration: inherit;
 }
+
+/* ── Login / Setup animated gradient mesh background ── */
+@keyframes gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes float-orb {
+  0%, 100% {
+    transform: translate(0, 0) scale(1);
+    opacity: 0.12;
+  }
+  33% {
+    transform: translate(30px, -20px) scale(1.1);
+    opacity: 0.18;
+  }
+  66% {
+    transform: translate(-20px, 15px) scale(0.95);
+    opacity: 0.1;
+  }
+}
+
+@keyframes float-orb-reverse {
+  0%, 100% {
+    transform: translate(0, 0) scale(1);
+    opacity: 0.1;
+  }
+  33% {
+    transform: translate(-25px, 20px) scale(1.05);
+    opacity: 0.15;
+  }
+  66% {
+    transform: translate(15px, -25px) scale(0.9);
+    opacity: 0.08;
+  }
+}
+
+@keyframes ring-glow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+
+.login-bg {
+  background: linear-gradient(
+    135deg,
+    #020617 0%,
+    #0f172a 25%,
+    #020617 50%,
+    #0c1425 75%,
+    #020617 100%
+  );
+  background-size: 400% 400%;
+  animation: gradient-shift 15s ease infinite;
+}
+
+.login-orb {
+  animation: float-orb 12s ease-in-out infinite;
+}
+
+.login-orb-reverse {
+  animation: float-orb-reverse 14s ease-in-out infinite;
+}
+
+.login-card-glow {
+  box-shadow:
+    0 0 80px 20px rgba(59, 130, 246, 0.06),
+    0 0 40px 10px rgba(59, 130, 246, 0.04),
+    inset 0 1px 0 0 rgba(148, 163, 184, 0.08);
+}
+
+.input-focus-glow:focus-within {
+  animation: ring-glow 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-bg {
+    animation: none;
+  }
+  .login-orb,
+  .login-orb-reverse {
+    animation: none;
+  }
+  .input-focus-glow:focus-within {
+    animation: none;
+  }
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -15,6 +15,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
+  const [version, setVersion] = useState<string | null>(null);
 
   // Check auth status — redirect to /setup if first-run, /dashboard if already logged in.
   useEffect(() => {
@@ -34,6 +35,14 @@ export default function LoginPage() {
         // API not reachable — show login form anyway.
         setReady(true);
       });
+
+    // Fetch version (public endpoint)
+    fetch("/api/v1/version")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.version) setVersion(data.version);
+      })
+      .catch(() => {});
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -57,70 +66,94 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-950">
-      <Card className="w-full max-w-sm border-slate-800 bg-slate-900">
-        <CardHeader className="items-center pb-2">
-          {/* Logo */}
-          <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
-            <Shield className="h-7 w-7 text-white" />
-          </div>
-          <h1 className="text-2xl font-bold text-white">Panoptikon</h1>
-          <p className="text-sm text-slate-500">
-            Sign in to your network dashboard
-          </p>
-        </CardHeader>
+    <div className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden">
+      {/* Animated gradient orbs */}
+      <div className="login-orb pointer-events-none absolute -left-32 -top-32 h-[500px] w-[500px] rounded-full bg-blue-500/10 blur-3xl" />
+      <div className="login-orb-reverse pointer-events-none absolute -bottom-40 -right-40 h-[600px] w-[600px] rounded-full bg-indigo-500/8 blur-3xl" />
+      <div className="login-orb pointer-events-none absolute left-1/2 top-1/3 h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-cyan-500/5 blur-3xl" />
 
-        <CardContent>
-          {!ready ? (
-            /* Loading state */
-            <div className="space-y-4 pt-4">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
+      <div className="relative z-10 w-full max-w-sm px-4">
+        {/* Glow behind card */}
+        <div className="pointer-events-none absolute inset-0 -z-10 mx-auto flex items-center justify-center">
+          <div className="h-64 w-64 rounded-full bg-blue-500/10 blur-3xl" />
+        </div>
+
+        <Card className="login-card-glow w-full border-slate-800 bg-slate-900/90 backdrop-blur-sm">
+          <CardHeader className="items-center pb-2">
+            {/* Logo */}
+            <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
+              <Shield className="h-7 w-7 text-white" />
             </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="space-y-4 pt-2">
-              <div className="space-y-2">
-                <Label htmlFor="password">Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-                  <Input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="pl-9 pr-9"
-                    placeholder="••••••••"
-                    autoFocus
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
-                    tabIndex={-1}
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
+            <h1 className="bg-gradient-to-r from-blue-400 via-blue-300 to-cyan-400 bg-clip-text text-2xl font-bold text-transparent">
+              Panoptikon
+            </h1>
+            <p className="text-sm text-slate-500">
+              Sign in to your network dashboard
+            </p>
+          </CardHeader>
+
+          <CardContent>
+            {!ready ? (
+              /* Loading state */
+              <div className="space-y-4 pt-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
               </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+                <div className="space-y-2">
+                  <Label htmlFor="password">Password</Label>
+                  <div className="input-focus-glow relative rounded-md">
+                    <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className="pl-9 pr-9 transition-shadow duration-200"
+                      placeholder="••••••••"
+                      autoFocus
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 transition-colors duration-200 hover:text-white"
+                      tabIndex={-1}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                    >
+                      <span className="inline-block transition-transform duration-200">
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </span>
+                    </button>
+                  </div>
+                </div>
 
-              {error && (
-                <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
-                  {error}
-                </p>
-              )}
+                {error && (
+                  <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
+                    {error}
+                  </p>
+                )}
 
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? "Signing in..." : "Sign In"}
-              </Button>
-            </form>
-          )}
-        </CardContent>
-      </Card>
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? "Signing in..." : "Sign In"}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Version info */}
+        {version && (
+          <p className="mt-4 text-center text-xs text-slate-600">
+            v{version}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -16,6 +16,7 @@ export default function SetupPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [checking, setChecking] = useState(true);
+  const [version, setVersion] = useState<string | null>(null);
 
   // If setup is already complete, redirect to login.
   useEffect(() => {
@@ -31,6 +32,14 @@ export default function SetupPage() {
         // If API unreachable, show setup form anyway — it'll fail on submit.
         setChecking(false);
       });
+
+    // Fetch version (public endpoint)
+    fetch("/api/v1/version")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.version) setVersion(data.version);
+      })
+      .catch(() => {});
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -61,86 +70,110 @@ export default function SetupPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-950 p-4">
-      <Card className="w-full max-w-md border-slate-800 bg-slate-900">
-        <CardHeader className="items-center pb-2">
-          <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
-            <Shield className="h-7 w-7 text-white" />
-          </div>
-          <h1 className="text-2xl font-bold text-white">Welcome to Panoptikon</h1>
-          <p className="text-center text-sm text-slate-500">
-            Set up your admin password to get started.
-          </p>
-        </CardHeader>
+    <div className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden p-4">
+      {/* Animated gradient orbs */}
+      <div className="login-orb pointer-events-none absolute -left-32 -top-32 h-[500px] w-[500px] rounded-full bg-blue-500/10 blur-3xl" />
+      <div className="login-orb-reverse pointer-events-none absolute -bottom-40 -right-40 h-[600px] w-[600px] rounded-full bg-indigo-500/8 blur-3xl" />
+      <div className="login-orb pointer-events-none absolute left-1/2 top-1/3 h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-cyan-500/5 blur-3xl" />
 
-        <CardContent>
-          {checking ? (
-            <div className="space-y-4 pt-4">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
+      <div className="relative z-10 w-full max-w-md">
+        {/* Glow behind card */}
+        <div className="pointer-events-none absolute inset-0 -z-10 mx-auto flex items-center justify-center">
+          <div className="h-64 w-64 rounded-full bg-blue-500/10 blur-3xl" />
+        </div>
+
+        <Card className="login-card-glow w-full border-slate-800 bg-slate-900/90 backdrop-blur-sm">
+          <CardHeader className="items-center pb-2">
+            <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
+              <Shield className="h-7 w-7 text-white" />
             </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="space-y-4 pt-2">
-              {/* Password section */}
-              <div className="space-y-2">
-                <Label htmlFor="password">Admin Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-                  <Input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="pl-9 pr-9"
-                    placeholder="Min. 8 characters"
-                    autoFocus
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
-                    tabIndex={-1}
-                  >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
+            <h1 className="bg-gradient-to-r from-blue-400 via-blue-300 to-cyan-400 bg-clip-text text-2xl font-bold text-transparent">
+              Welcome to Panoptikon
+            </h1>
+            <p className="text-center text-sm text-slate-500">
+              Set up your admin password to get started.
+            </p>
+          </CardHeader>
+
+          <CardContent>
+            {checking ? (
+              <div className="space-y-4 pt-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="confirm">Confirm Password</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-                  <Input
-                    id="confirm"
-                    type={showPassword ? "text" : "password"}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="pl-9"
-                    placeholder="Repeat password"
-                    required
-                  />
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+                {/* Password section */}
+                <div className="space-y-2">
+                  <Label htmlFor="password">Admin Password</Label>
+                  <div className="input-focus-glow relative rounded-md">
+                    <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className="pl-9 pr-9 transition-shadow duration-200"
+                      placeholder="Min. 8 characters"
+                      autoFocus
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 transition-colors duration-200 hover:text-white"
+                      tabIndex={-1}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                    >
+                      <span className="inline-block transition-transform duration-200">
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </span>
+                    </button>
+                  </div>
                 </div>
-              </div>
 
-              {error && (
-                <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
-                  {error}
-                </p>
-              )}
+                <div className="space-y-2">
+                  <Label htmlFor="confirm">Confirm Password</Label>
+                  <div className="input-focus-glow relative rounded-md">
+                    <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                    <Input
+                      id="confirm"
+                      type={showPassword ? "text" : "password"}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      className="pl-9 transition-shadow duration-200"
+                      placeholder="Repeat password"
+                      required
+                    />
+                  </div>
+                </div>
 
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? "Setting up..." : "Complete Setup"}
-              </Button>
-            </form>
-          )}
-        </CardContent>
-      </Card>
+                {error && (
+                  <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
+                    {error}
+                  </p>
+                )}
+
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? "Setting up..." : "Complete Setup"}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Version info */}
+        {version && (
+          <p className="mt-4 text-center text-xs text-slate-600">
+            v{version}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/tests/e2e/login-visual.spec.ts
+++ b/web/tests/e2e/login-visual.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "../../e2e/fixtures";
+
+/**
+ * E2E tests for the login page visual upgrade:
+ * animated background, glow card, gradient text, input focus effects.
+ */
+test.describe("Login page visual upgrade", () => {
+  test("login page has animated background and glow card", async ({
+    page,
+  }) => {
+    await page.goto("/login/");
+
+    // Wait for the page to hydrate
+    await expect(
+      page.getByRole("heading", { name: "Panoptikon", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByText("Sign in to your network dashboard"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Animated background: the outer container has login-bg class
+    const bgContainer = page.locator(".login-bg");
+    await expect(bgContainer).toBeVisible();
+
+    // Gradient orbs exist (animated floating blurred elements)
+    const orbs = page.locator(".login-orb");
+    expect(await orbs.count()).toBeGreaterThanOrEqual(1);
+
+    // Login card has glow effect class
+    const glowCard = page.locator(".login-card-glow");
+    await expect(glowCard).toBeVisible();
+
+    // Brand name has gradient text (transparent text color with bg-clip-text)
+    const heading = page.getByRole("heading", {
+      name: "Panoptikon",
+      level: 1,
+    });
+    await expect(heading).toHaveClass(/bg-gradient-to-r/);
+    await expect(heading).toHaveClass(/bg-clip-text/);
+
+    // Password input and Sign In button are present
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sign In" }),
+    ).toBeVisible();
+
+    // Input focus glow wrapper exists
+    const focusGlow = page.locator(".input-focus-glow");
+    expect(await focusGlow.count()).toBeGreaterThanOrEqual(1);
+
+    // Eye toggle button has aria-label
+    const eyeToggle = page.locator('button[aria-label="Show password"]');
+    await expect(eyeToggle).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/login-visual-upgrade.png",
+      fullPage: true,
+    });
+  });
+
+  test("login page works on mobile viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/login/");
+
+    await expect(
+      page.getByRole("heading", { name: "Panoptikon", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByText("Sign in to your network dashboard"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Card should be visible and not overflow
+    const card = page.locator(".login-card-glow");
+    await expect(card).toBeVisible();
+    const box = await card.boundingBox();
+    expect(box).toBeTruthy();
+    expect(box!.width).toBeLessThanOrEqual(375);
+
+    await page.screenshot({
+      path: "tests/screenshots/login-visual-mobile.png",
+      fullPage: true,
+    });
+  });
+
+  test("password eye toggle switches icon", async ({ page }) => {
+    await page.goto("/login/");
+
+    await expect(
+      page.getByText("Sign in to your network dashboard"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Initially "Show password" button is visible
+    const showBtn = page.locator('button[aria-label="Show password"]');
+    await expect(showBtn).toBeVisible();
+
+    // Click to show password
+    await showBtn.click();
+
+    // Now "Hide password" button should be visible
+    const hideBtn = page.locator('button[aria-label="Hide password"]');
+    await expect(hideBtn).toBeVisible();
+
+    // Password input should now be type="text"
+    await expect(page.locator("#password")).toHaveAttribute("type", "text");
+
+    // Click to hide again
+    await hideBtn.click();
+    await expect(page.locator("#password")).toHaveAttribute(
+      "type",
+      "password",
+    );
+
+    await page.screenshot({
+      path: "tests/screenshots/login-eye-toggle.png",
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #594

## Summary

- **Animated gradient mesh background** with floating orbs behind the login card, using CSS `@keyframes` (no JS libraries, zero bundle impact)
- **Soft glow effect** behind the login card (blue-500/10 radial gradient + card box-shadow)
- **Gradient text** treatment on the Panoptikon brand name (blue-400 → cyan-400)
- **Top-edge inner glow** on the card via `inset` box-shadow
- **Smooth focus transitions** on input fields with a pulsing ring glow animation
- **Animated eye icon toggle** with smooth color transition and proper `aria-label`
- **Version info** displayed below the card in muted text (fetched from public `/api/v1/version` endpoint)
- **`prefers-reduced-motion`** respected — all animations disabled for users who prefer reduced motion
- **Mobile-responsive** — card and orbs scale properly on small viewports
- Same visual treatment applied to the **setup page**

## Files Changed

- `web/src/app/globals.css` — Added keyframe animations (`gradient-shift`, `float-orb`, `ring-glow`) and utility classes (`login-bg`, `login-orb`, `login-card-glow`, `input-focus-glow`) with reduced-motion media query
- `web/src/app/login/page.tsx` — Upgraded with animated background, glow card, gradient text, version display, input focus glow, accessible eye toggle
- `web/src/app/setup/page.tsx` — Matching visual treatment
- `web/tests/e2e/login-visual.spec.ts` — E2E tests for visual elements, mobile viewport, and eye toggle

## Smoke Test

- `bun run build` passes clean with no errors
- Existing E2E auth tests (`auth.spec.ts`) unchanged — heading text, IDs, and button labels preserved
- New E2E test covers: animated background class presence, glow card visibility, gradient text classes, mobile viewport card sizing, password eye toggle with aria-labels

## Test Plan

- [x] Animated background visible (`.login-bg` class with gradient shift animation)
- [x] Login card has glow effect (`.login-card-glow` with box-shadow)
- [x] Gradient text on brand name (bg-gradient-to-r + bg-clip-text)
- [x] Smooth input focus animations (`.input-focus-glow`)
- [x] Works on mobile (card fits within 375px viewport)
- [x] Respects `prefers-reduced-motion` (all animations disabled)
- [x] Version info displayed in muted text below card
- [x] Setup page has matching treatment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a purely visual upgrade to the login and setup pages — animated gradient mesh background, floating blur orbs, a glow card effect, gradient brand text, smooth input focus animation, accessible password eye toggle, and a version badge fetched from `/api/v1/version`. No functional auth logic is changed.

- **Animations are well-scoped**: all new keyframes and utility classes are namespaced under `login-*` / `input-focus-glow` in `globals.css`, reducing the chance of accidental bleed into other pages.
- **`prefers-reduced-motion` is correctly handled**: the media query disables every animation added in this PR.
- **Accessibility improved**: the eye-toggle button gains an `aria-label` that updates with state (`"Show password"` / `"Hide password"`), tested by the new E2E spec.
- **Version fetch is safe**: `data.version` is rendered as a JSX text node (not `dangerouslySetInnerHTML`), so React escapes it automatically. The fire-and-forget fetch pattern with `.catch(() => {})` is consistent with the rest of the codebase.
- **E2E tests**: the new `login-visual.spec.ts` uses the same fixture import convention (`../../e2e/fixtures`) as all other specs in `web/tests/e2e/`. Screenshot output is written to `tests/screenshots/` rather than the `e2e/screenshots/` location used by the single existing screenshot (`web/e2e/screenshots/agent-created-dialog.png`) — a minor inconsistency but not a blocker since Playwright auto-creates the directory.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are purely cosmetic with no modifications to auth logic.
- All functional auth paths are untouched. New CSS is properly scoped, reduced-motion is respected, accessibility is improved, and the version fetch is harmless and sanitized by React. The only nit is a screenshot output path inconsistency in the new E2E spec.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/globals.css | Adds keyframe animations (`gradient-shift`, `float-orb`, `float-orb-reverse`, `ring-glow`) and utility classes for the login/setup pages. `prefers-reduced-motion` media query properly disables all animations. No logic issues. |
| web/src/app/login/page.tsx | Adds animated background orbs, glow card, gradient brand text, accessible eye toggle with `aria-label`, and a version fetch from `/api/v1/version`. Version is rendered as a JSX text node (safe from XSS). Logic is sound. |
| web/src/app/setup/page.tsx | Mirrors the login page visual treatment exactly. Same version fetch pattern. No logic issues. |
| web/tests/e2e/login-visual.spec.ts | New E2E tests covering animated background, glow card, gradient text, mobile viewport, and eye toggle. Import path `../../e2e/fixtures` correctly resolves to `web/e2e/fixtures.ts`. Screenshot output paths (`tests/screenshots/`) differ from the existing convention used by `web/e2e/screenshots/`, which may create inconsistency but Playwright auto-creates directories so tests won't fail. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: login page visual upgrade with ani..."](https://github.com/befeast/panoptikon/commit/33365c3f3fbda7d1c510d52264007dee4a2a444b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25971027)</sub>

<!-- /greptile_comment -->