### PR TITLE
fix: Cmd+K search popover — white text on white background, input not focusable (#637)

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -136,8 +136,8 @@ export function CommandPalette() {
       open={open}
       onOpenChange={setOpen}
       label="Command palette"
-      className="fixed inset-0 z-[100]"
-      overlayClassName="fixed inset-0 bg-black/70 backdrop-blur-sm"
+      className="flex flex-col flex-1 min-h-0"
+      overlayClassName="fixed inset-0 z-[99] bg-black/70 backdrop-blur-sm"
       contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 z-[100] w-[min(560px,calc(100vw-2rem))] max-h-[min(480px,60vh)] flex flex-col overflow-hidden rounded-2xl border border-slate-600/80 bg-slate-900 shadow-[0_24px_80px_-12px_rgba(0,0,0,0.8)]"
       shouldFilter={!hasResults}
     >
@@ -148,6 +148,7 @@ export function CommandPalette() {
           value={query}
           onValueChange={setQuery}
           placeholder="Search pages, devices, actions…"
+          autoFocus
           className="flex-1 bg-transparent text-base text-white placeholder-slate-500 outline-none"
         />
         <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-slate-600 bg-slate-800 px-1.5 py-0.5 text-[11px] font-medium text-slate-400">

--- a/web/tests/e2e/command-palette-ux.spec.ts
+++ b/web/tests/e2e/command-palette-ux.spec.ts
@@ -124,6 +124,103 @@ test.describe("Command Palette UX (#571)", () => {
   });
 });
 
+test.describe("Command Palette Dark Theme & Focus (#637)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("command palette has dark background and input is focusable", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Open command palette
+    await page.keyboard.press("Control+k");
+
+    const dialogContent = page.locator('[cmdk-dialog]');
+    await expect(dialogContent).toBeVisible({ timeout: 3000 });
+
+    // Verify the dialog content has a dark background (bg-slate-900 ~ rgb(15, 23, 42))
+    const bgColor = await dialogContent.evaluate((el) =>
+      window.getComputedStyle(el).backgroundColor,
+    );
+    // bg-slate-900 is rgb(15, 23, 42) — ensure it's dark (R,G,B all < 50)
+    const match = bgColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    expect(match).not.toBeNull();
+    if (match) {
+      expect(Number(match[1])).toBeLessThan(50);
+      expect(Number(match[2])).toBeLessThan(50);
+      expect(Number(match[3])).toBeLessThan(60);
+    }
+
+    // Verify the search input is focused and can receive text
+    const searchInput = page.locator('[cmdk-input]');
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toBeFocused();
+
+    // Type into the input to verify it's truly focusable
+    await page.keyboard.type("dash");
+    await expect(searchInput).toHaveValue("dash");
+
+    // Verify placeholder text is visible (has slate-500 color, not white)
+    // Clear and check placeholder attribute exists
+    await searchInput.fill("");
+    const placeholder = await searchInput.getAttribute("placeholder");
+    expect(placeholder).toBeTruthy();
+
+    await page.screenshot({
+      path: "tests/screenshots/command-palette-dark-theme.png",
+      fullPage: true,
+    });
+  });
+
+  test("command palette content renders inside the dialog box", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialogContent = page.locator('[cmdk-dialog]');
+    await expect(dialogContent).toBeVisible({ timeout: 3000 });
+
+    // Verify the cmdk-root is NOT fixed/full-viewport (it should be inside the dialog)
+    const cmdk_root = page.locator('[cmdk-root]');
+    const rootPosition = await cmdk_root.evaluate((el) =>
+      window.getComputedStyle(el).position,
+    );
+    // cmdk-root should NOT be fixed positioned (that would escape the dialog)
+    expect(rootPosition).not.toBe("fixed");
+
+    // Verify items are visually within the dialog bounding box
+    const dialogBox = await dialogContent.boundingBox();
+    const firstItem = page.locator('[cmdk-item]').first();
+    const itemBox = await firstItem.boundingBox();
+
+    expect(dialogBox).not.toBeNull();
+    expect(itemBox).not.toBeNull();
+    if (dialogBox && itemBox) {
+      // Item should be within dialog bounds
+      expect(itemBox.x).toBeGreaterThanOrEqual(dialogBox.x);
+      expect(itemBox.y).toBeGreaterThanOrEqual(dialogBox.y);
+      expect(itemBox.x + itemBox.width).toBeLessThanOrEqual(
+        dialogBox.x + dialogBox.width + 1,
+      );
+    }
+
+    await page.screenshot({
+      path: "tests/screenshots/command-palette-content-inside-dialog.png",
+      fullPage: true,
+    });
+  });
+});
+
 test.describe("Section Spacing (#571)", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);


### PR DESCRIPTION
Closes #637

## Summary
- **Root cause**: `className="fixed inset-0 z-[100]"` on `Command.Dialog` was passed to the `cmdk-root` element (a child of `Dialog.Content`), causing it to escape the styled dialog box via `position: fixed` and cover the full viewport with no background. The input, items, and groups rendered outside the dark `bg-slate-900` dialog content box, making text invisible against the page background.
- **Fix**: Replaced `fixed inset-0 z-[100]` with `flex flex-col flex-1 min-h-0` so the cmdk-root fills its parent dialog content naturally instead of escaping it
- Added explicit `z-[99]` on overlay for proper z-stacking
- Added `autoFocus` on `Command.Input` for reliable input focus on open

## What changed
- `web/src/components/CommandPalette.tsx` — fixed `className` and `overlayClassName` on `Command.Dialog`, added `autoFocus` to input
- `web/tests/e2e/command-palette-ux.spec.ts` — added E2E tests verifying dark background, input focusability, and content rendering within dialog bounds

## Smoke Test
- `bun run build` passes with no errors
- Verified cmdk source: `className` prop goes to `cmdk-root` element inside `Dialog.Content`, confirming `fixed inset-0` was the root cause
- E2E tests verify: dark background (RGB < 50), input is focused and typeable, items render within dialog bounding box

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes a visual regression in the `Cmd+K` command palette where `position: fixed` on the `cmdk-root` element (the element that receives `className` on `Command.Dialog`) caused it to escape the styled `Dialog.Content` container, rendering the input and items against the page background with no dark surface. Replacing `fixed inset-0 z-[100]` with `flex flex-col flex-1 min-h-0` lets `cmdk-root` fill its parent naturally, and adding `autoFocus` on `Command.Input` ensures reliable focus on open.

- The z-stacking is correct: `overlayClassName` gets `z-[99]`, `contentClassName` gets `z-[100]`, and `cmdk-root` no longer needs its own z-index since it sits inside the already-elevated `Dialog.Content`.
- The two new E2E tests are well-targeted: one checks background color on `[cmdk-dialog]` (which maps to `Dialog.Content` per cmdk's attribute placement, ensuring `bg-slate-900` is present) and that the input receives focus; the other confirms `[cmdk-root]`'s computed `position` is no longer `fixed`, directly asserting the root cause is resolved.
- No logic errors found; the fix, z-index model, and test selectors are all consistent with how cmdk exposes its attributes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the fix is minimal, targeted, and backed by new E2E tests.
- The root cause is well-diagnosed and the one-line className change directly resolves it without side-effects. Overlay/content z-stacking is correct (99 under 100). The `autoFocus` addition is additive and consistent with dialog UX patterns. The new E2E tests validate the exact regression path. No logic errors were found in either changed file.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Correctly fixes the positioning bug by replacing `fixed inset-0 z-[100]` on `className` (applied to `cmdk-root` inside `Dialog.Content`) with `flex flex-col flex-1 min-h-0`, adds `z-[99]` to the overlay, and adds `autoFocus` to the input. Layout and z-stacking are correct. |
| web/tests/e2e/command-palette-ux.spec.ts | Two new test scenarios validate the fix: dark background on `[cmdk-dialog]` (Dialog.Content, which receives `contentClassName` including `bg-slate-900`) and `[cmdk-root]` position not being `fixed`. Tests are correctly scoped and the assertions are consistent with the cmdk attribute placement. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Cmd+K search popover white text on ..."](https://github.com/befeast/panoptikon/commit/16c644b48346054f7636cd14f73d3b5038656b62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25985915)</sub>

<!-- /greptile_comment -->