### PR TITLE
feat: auto-enable pfSense integration after successful connection test (#643)

### DIFF
--- a/web/src/app/(app)/settings/pfsense/page.tsx
+++ b/web/src/app/(app)/settings/pfsense/page.tsx
@@ -169,6 +169,9 @@ function PfsensePanel() {
         setTestMsg(
           `Connected! ${data.hostname ? data.hostname : ""}${data.version ? ` · pfSense ${data.version}` : ""}`
         );
+        if (!enabled) {
+          setEnabled(true);
+        }
         setTimeout(() => setTestStatus("idle"), 5000);
       } else if (data.configured) {
         setTestStatus("error");

--- a/web/tests/e2e/settings-pfsense.spec.ts
+++ b/web/tests/e2e/settings-pfsense.spec.ts
@@ -92,4 +92,53 @@ test.describe("pfSense Settings — save / reload roundtrip", () => {
       page.getByText(/Connected|unreachable|Failed|Error|refused/i),
     ).toBeVisible({ timeout: 15000 });
   });
+
+  test("successful connection test auto-enables the integration toggle", async ({
+    page,
+  }) => {
+    // Ensure toggle starts OFF
+    const toggle = page.locator("#pf-enabled");
+    if ((await toggle.getAttribute("aria-checked")) === "true") {
+      await toggle.click();
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(
+        page.getByText("pfSense settings saved."),
+      ).toBeVisible({ timeout: 10000 });
+      await page.reload();
+      await expect(toggle).toBeVisible({ timeout: 15000 });
+    }
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    // Mock the test-connection API to return a successful response
+    await page.route("**/api/v1/pfsense/test-connection", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          configured: true,
+          reachable: true,
+          hostname: "pfSense-test",
+          version: "2.8.1-RELEASE",
+        }),
+      }),
+    );
+
+    await page.locator("#pf-host").fill("10.10.0.1");
+    await page.locator("#pf-username").fill("admin");
+
+    await page.getByRole("button", { name: "Test Connection" }).click();
+    await expect(page.getByText(/Connected!/)).toBeVisible({ timeout: 10000 });
+
+    // Toggle should be auto-enabled after successful connection
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    // Save button should be enabled (dirty state from toggle change)
+    await expect(
+      page.getByRole("button", { name: "Save" }),
+    ).toBeEnabled();
+
+    await page.screenshot({
+      path: "tests/screenshots/settings-pfsense-auto-enable.png",
+    });
+  });
 });


### PR DESCRIPTION
Closes #643

## Summary
- After a successful "Test Connection" in pfSense Settings, the **Enable pfSense integration** toggle is automatically turned ON
- The Save button becomes active (dirty state) so the user can save immediately
- If the toggle is already ON, nothing changes

## Changes
- `web/src/app/(app)/settings/pfsense/page.tsx` — Added `setEnabled(true)` in the `handleTest()` success path (3 lines)
- `web/tests/e2e/settings-pfsense.spec.ts` — Added E2E test that mocks a successful connection response and verifies the toggle auto-enables

## Smoke Test
- Frontend builds clean (`bun run build` passes)
- Rust backend compiles clean (`cargo check` passes)
- The change is a 3-line addition inside the existing `handleTest()` success branch — minimal risk

## Test plan
- [ ] E2E test: "successful connection test auto-enables the integration toggle" — mocks API, verifies toggle flips to ON and Save button is enabled
- [ ] Existing tests unchanged and unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a small quality-of-life improvement: after a successful pfSense connection test the `enabled` toggle is automatically flipped ON (if it wasn't already), putting the form into a dirty state so the user can save without an extra manual step. The change is a 3-line addition inside the existing `handleTest()` success branch in `page.tsx`, and is covered by a new Playwright E2E test that mocks the API response.

- The guard `if (!enabled) { setEnabled(true); }` is correct — it avoids a redundant React state update when the toggle is already on, and the `enabled` value read at that point in the async flow is always fresh (no stale-closure risk since no concurrent state mutation can flip it to `true` while the test is in-flight in a way that would matter).
- The `dirty` computation at line 93 already tracks `enabled !== savedEnabled`, so flipping the toggle automatically marks the form dirty and enables the Save button — no further changes were needed.
- The E2E test correctly registers the route mock before the button click, fills the minimum required fields (`host` + `username`), and asserts both the toggle state and Save button enablement. The optional setup block that ensures the toggle starts OFF is functionally sound, as the saved state will always be `false` after the explicit save + reload.
- No issues found.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, well-scoped change with direct E2E coverage and no logic issues.
- The production change is 3 lines inside an already-tested success branch, uses existing state setters correctly, and introduces no new API calls, side-effects, or regressions. The E2E test thoroughly covers the new behaviour with a mocked API.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/settings/pfsense/page.tsx | Adds 3 lines in the `handleTest()` success branch to call `setEnabled(true)` when the toggle is currently off, correctly marking the form dirty so the user can immediately save. |
| web/tests/e2e/settings-pfsense.spec.ts | Adds an E2E test that mocks the test-connection API to return a successful response and verifies the toggle flips to ON and the Save button becomes enabled; setup logic for ensuring the toggle starts OFF is functionally sound. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: auto-enable pfSense integration to..."](https://github.com/befeast/panoptikon/commit/6d586788903a3400f0cda5bedba5ecd5cf3f3aa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25987757)</sub>

<!-- /greptile_comment -->