### PR TITLE
fix: rename 'pfSense Firewall' to 'pfSense Router' in sidebar and pages (#644)

### DIFF
--- a/web/src/app/(app)/settings/pfsense/page.tsx
+++ b/web/src/app/(app)/settings/pfsense/page.tsx
@@ -416,7 +416,7 @@ export default function PfsenseSettingsPage() {
                   pfSense Connection
                 </CardTitle>
                 <CardDescription className="text-xs text-slate-500">
-                  Configure pfSense firewall integration via SSH.
+                  Configure pfSense router integration via SSH.
                 </CardDescription>
               </div>
             </div>

--- a/web/src/components/pfsense/PfSenseStatusHeader.tsx
+++ b/web/src/components/pfsense/PfSenseStatusHeader.tsx
@@ -12,7 +12,7 @@ export function PfSenseStatusHeader({ status }: { status: PfsenseStatus }) {
           <Shield className="h-5 w-5 text-blue-400" />
         </div>
         <div>
-          <h1 className="text-2xl font-semibold text-white">pfSense Firewall</h1>
+          <h1 className="text-2xl font-semibold text-white">pfSense Router</h1>
           <p className="text-xs text-slate-500">
             {status.hostname ?? "pfSense"}{" "}
             {status.version && (

--- a/web/src/lib/settings-nav.ts
+++ b/web/src/lib/settings-nav.ts
@@ -33,7 +33,7 @@ export const settingsNav: SettingsNavGroup[] = [
       {
         href: "/settings/pfsense",
         title: "pfSense",
-        description: "Configure pfSense firewall integration via SSH.",
+        description: "Configure pfSense router integration via SSH.",
       },
       {
         href: "/settings/dns",


### PR DESCRIPTION
Closes #644

## Summary
- Page heading: "pfSense Firewall" → "pfSense Router" (`PfSenseStatusHeader.tsx`)
- Settings nav description: "pfSense firewall integration" → "pfSense router integration" (`settings-nav.ts`)
- Settings page description: same text fix (`settings/pfsense/page.tsx`)

Internal code identifiers (API routes, type names, function names) are unchanged — only user-visible text was updated.

## Smoke Test
- `bun run build` passes with no errors
- Grepped for remaining pfSense + "firewall" user-visible text — none found
- No E2E tests reference the changed text strings

## Why No E2E Test
This is a text-only rename of 3 strings with no behavior change. No E2E tests reference the old text, and no new functionality was added.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a minimal, targeted text-only rename of three user-visible strings, replacing "firewall" with "router" in the pfSense section of the UI to better reflect pfSense's role in the application.

- `PfSenseStatusHeader.tsx`: Renames the status page heading from "pfSense Firewall" to "pfSense Router".
- `settings-nav.ts`: Updates the sidebar nav description to "Configure pfSense router integration via SSH."
- `settings/pfsense/page.tsx`: Updates the settings card description to match.

No internal identifiers, API routes, type names, or logic are affected. The change is consistent across all three touch points.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure text rename with no behavioral or structural changes.
- All three changes are straightforward string substitutions in user-visible labels. No logic, API surface, or component structure is touched, and the changes are consistent across every affected location.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/pfsense/PfSenseStatusHeader.tsx | Renames the page heading from "pfSense Firewall" to "pfSense Router". Simple, correct, single-line text change. |
| web/src/lib/settings-nav.ts | Updates the sidebar nav description from "pfSense firewall integration" to "pfSense router integration". No structural or logic changes. |
| web/src/app/(app)/settings/pfsense/page.tsx | Updates the settings page card description from "pfSense firewall integration" to "pfSense router integration". No behavioral change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rename pfSense Firewall to pfSense ..."](https://github.com/befeast/panoptikon/commit/4a3cb16ab5e1ee6b78ff80ddec7c1e4c3abb3934) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25987885)</sub>

<!-- /greptile_comment -->