### PR TITLE
fix: search input white background — use valid Tailwind class (#637)

### DIFF
--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -240,7 +240,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
             if (results && query.length >= 2) setIsOpen(true);
           }}
           placeholder="Search devices, IPs, MACs...  ⌘K"
-          className="h-9 w-full rounded-xl border border-slate-800/80 bg-slate-900/68 px-3 text-sm text-white placeholder-slate-500 transition-all duration-300 focus:border-blue-500/40 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:shadow-[0_0_15px_rgba(59,130,246,0.15)]"
+          className="h-8 w-full rounded-lg border border-slate-800/80 bg-slate-900 px-3 text-sm text-white placeholder-slate-500 transition-all duration-300 focus:border-blue-500/40 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:shadow-[0_0_15px_rgba(59,130,246,0.15)]"
         />
 
         {/* Search Results Dropdown */}

--- a/web/tests/e2e/search-input-dark-bg.spec.ts
+++ b/web/tests/e2e/search-input-dark-bg.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E test for search input dark background fix (#637).
+ *
+ * Verifies:
+ * - TopBar search input has a dark background (not white)
+ * - Search input fits within the header height
+ * - Search input is focusable and accepts text
+ */
+test.describe("Search Input Dark Background (#637)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("search input has dark background, not white", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await expect(searchInput).toBeVisible();
+
+    // Verify the input has a dark background (bg-slate-900 = rgb(15, 23, 42))
+    const bgColor = await searchInput.evaluate((el) =>
+      window.getComputedStyle(el).backgroundColor,
+    );
+
+    // Parse the RGB values — must be dark (all channels < 50)
+    const match = bgColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    expect(match).not.toBeNull();
+    if (match) {
+      const r = Number(match[1]);
+      const g = Number(match[2]);
+      const b = Number(match[3]);
+      // White would be rgb(255, 255, 255) — dark slate-900 is rgb(15, 23, 42)
+      expect(r).toBeLessThan(50);
+      expect(g).toBeLessThan(50);
+      expect(b).toBeLessThan(60);
+    }
+
+    await page.screenshot({
+      path: "tests/screenshots/search-input-dark-bg.png",
+    });
+  });
+
+  test("search input is focusable and accepts text", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const searchInput = page.getByPlaceholder(/search devices/i);
+    await searchInput.click();
+    await expect(searchInput).toBeFocused();
+
+    // Type into the input to verify it accepts text
+    await searchInput.fill("test-query");
+    await expect(searchInput).toHaveValue("test-query");
+
+    await page.screenshot({
+      path: "tests/screenshots/search-input-focused.png",
+    });
+  });
+
+  test("search input fits within header row", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    const header = page.locator("header").first();
+    const searchInput = page.getByPlaceholder(/search devices/i);
+
+    const headerBox = await header.boundingBox();
+    const inputBox = await searchInput.boundingBox();
+
+    expect(headerBox).not.toBeNull();
+    expect(inputBox).not.toBeNull();
+
+    if (headerBox && inputBox) {
+      // Input should be vertically contained within the header
+      expect(inputBox.y).toBeGreaterThanOrEqual(headerBox.y);
+      expect(inputBox.y + inputBox.height).toBeLessThanOrEqual(
+        headerBox.y + headerBox.height,
+      );
+    }
+
+    await page.screenshot({
+      path: "tests/screenshots/search-input-header-alignment.png",
+    });
+  });
+});


### PR DESCRIPTION
Closes #637

## Summary

- **Root cause**: `bg-slate-900/68` uses `/68` which is not a standard Tailwind CSS opacity value. Tailwind purges this class during build, causing the search input to fall back to the browser's default white background.
- **Fix**: Changed to `bg-slate-900` (solid dark background) — a standard Tailwind class that is preserved in the CSS bundle.
- **Header alignment**: Reduced input from `h-9` (36px) to `h-8` (32px) and `rounded-xl` to `rounded-lg` for better fit within the `h-[3.75rem]` header row.

## Changes

- `web/src/components/layout/TopBar.tsx` — fixed `bg-slate-900/68` → `bg-slate-900`, `h-9` → `h-8`, `rounded-xl` → `rounded-lg`
- `web/tests/e2e/search-input-dark-bg.spec.ts` — new E2E test verifying dark background, focusability, and header alignment

## Smoke Test

- Verified `bun run build` passes with the new class
- Confirmed `bg-slate-900` is a standard Tailwind utility that won't be purged
- The CommandPalette component (`CommandPalette.tsx`) already uses `bg-slate-900` correctly — no changes needed there

## Test Plan

- [ ] Search input renders with dark background (not white)
- [ ] Search input is focusable and accepts text input
- [ ] Search input fits within the header row vertically
- [ ] Cmd+K command palette still works correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual bug where the TopBar search input was rendering with a white background due to `bg-slate-900/68` — a non-standard Tailwind opacity modifier (`/68` is not in the default opacity scale) that gets purged from the CSS bundle at build time. The fix replaces it with the solid, always-present `bg-slate-900` class, and also makes minor cosmetic adjustments (`h-9` → `h-8`, `rounded-xl` → `rounded-lg`) for better header alignment.

- **Root cause is correctly identified**: `/68` is not a default Tailwind opacity step; the remaining `/80`, `/40`, `/20` modifiers in the same class string are all valid default steps and are correctly left unchanged.
- **Fix is minimal and targeted**: only the broken class is changed; no unrelated modifications.
- **E2E test is well-structured**: follows the existing fixture import convention (`../../e2e/fixtures`), targets the correct `<header>` element, and uses realistic RGB thresholds for `bg-slate-900` (`rgb(15, 23, 42)`).
- No logic or functional issues found.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, correct bug fix with no unintended side effects.
- The change is a single-line CSS class correction with a clear root cause, backed by a well-written E2E test. The fix is consistent with how `bg-slate-900` is already used elsewhere in the codebase (e.g. `CommandPalette.tsx`), and no logic issues were found in either the component or the test.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/layout/TopBar.tsx | Corrects `bg-slate-900/68` to `bg-slate-900` (removes non-standard Tailwind opacity modifier that causes the class to be purged), and adjusts height/border-radius for header alignment. Change is correct and minimal. |
| web/tests/e2e/search-input-dark-bg.spec.ts | New E2E test verifying dark background, focusability, and header containment. Import path, locator strategy, and assertion thresholds are all correct and consistent with the rest of the test suite. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: search input white background — use..."](https://github.com/befeast/panoptikon/commit/e865da4402522dc099fd15375368173d9fd0b0be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26016385)</sub>

<!-- /greptile_comment -->