### PR TITLE
fix: Command+K device search opens detail panel (#741)

### DIFF
--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -34,13 +34,21 @@ export async function setupIfNeeded(page: Page): Promise<boolean> {
     await page.locator("#confirm").fill(PASSWORD);
     await setupButton.click();
     
-    // Should redirect to dashboard after setup
-    await page.waitForURL(/\/(dashboard|login)/, { timeout: 15000 });
-    
-    if (page.url().includes("/dashboard")) {
+    // Parallel CI workers can race initial setup. If this attempt loses
+    // the race, the app may stay on setup with an error; fall through to login.
+    await Promise.race([
+      page.waitForURL(/\/(dashboard|login)/, { timeout: 15000 }).catch(() => null),
+      dashboardHeading.waitFor({ state: "visible", timeout: 15000 }).catch(() => null),
+      signInButton.waitFor({ state: "visible", timeout: 15000 }).catch(() => null),
+      page.getByText("Setup failed. Please try again.").waitFor({ state: "visible", timeout: 15000 }).catch(() => null),
+    ]);
+
+    if (page.url().includes("/dashboard") || await dashboardHeading.isVisible()) {
       return true;
     }
-    // Another worker completed setup (race), need to login now
+
+    await page.goto("/login");
+    await signInButton.waitFor({ state: "visible", timeout: 20000 });
     return false;
   }
   

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -101,6 +101,7 @@ export default function DevicesPage() {
     if (match) {
       setSelectedDevice(match);
       selectedUrlParamConsumed.current = true;
+      window.history.replaceState(window.history.state, "", "/devices");
     }
   }, []);
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -171,7 +171,7 @@ export function CommandPalette() {
               <Command.Item
                 key={`device-${d.id}`}
                 value={`device ${d.name ?? ''} ${d.ip_address ?? ''} ${d.mac_address ?? ''}`}
-                onSelect={() => navigate(`/devices?highlight=${d.id}`)}
+                onSelect={() => navigate(`/devices?selected=${d.id}`)}
                 className={itemClass}
               >
                 <Monitor className="h-4 w-4 shrink-0 text-slate-400" />

--- a/web/tests/e2e/cmdk-device-deeplink.spec.ts
+++ b/web/tests/e2e/cmdk-device-deeplink.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+test.describe("Command+K device deep-link (#741)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("navigating to /devices?selected=<id> opens device detail sheet", async ({
+    page,
+  }) => {
+    // Go to /devices and wait for the page to load
+    await page.goto("/devices");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Wait for device content to appear (cards or table rows)
+    await page.waitForTimeout(2000);
+
+    // Get a device ID from the API
+    const deviceId = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/devices", { credentials: "include" });
+      const devices = await res.json();
+      return devices[0]?.id ?? null;
+    });
+
+    test.skip(!deviceId, "No devices available to test selected");
+
+    // Navigate to /devices?selected=<id>
+    await page.goto(`/devices?selected=${deviceId}`);
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Assert the Sheet panel is open — SheetContent renders as role="dialog"
+    // with data-state="open"
+    const sheet = page.locator('[role="dialog"][data-state="open"]');
+    await expect(sheet).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/devices$/, { timeout: 10000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-deeplink-selected-opens-sheet.png",
+      fullPage: true,
+    });
+  });
+
+  test("Command+K device search navigates to devices page with selected", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Get a device name from the API to search for
+    const deviceInfo = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/devices", { credentials: "include" });
+      const devices = await res.json();
+      if (!devices.length) return null;
+      const d = devices[0];
+      return {
+        searchTerm: d.name || d.hostname || d.ip_address || null,
+        id: d.id,
+      };
+    });
+
+    test.skip(!deviceInfo || !deviceInfo.searchTerm, "No devices available to test search");
+
+    // Open command palette with Ctrl+K
+    await page.keyboard.press("Control+k");
+    const dialogContent = page.locator("[cmdk-dialog]");
+    await expect(dialogContent).toBeVisible({ timeout: 3000 });
+
+    // Type the device name into the search input
+    const searchInput = page.locator("[cmdk-input]");
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill(deviceInfo!.searchTerm);
+
+    // Click the first device result
+    const firstDeviceItem = page.locator('[cmdk-item][data-value^="device "]').first();
+    await expect(firstDeviceItem).toBeVisible({ timeout: 3000 });
+    await firstDeviceItem.click();
+
+    // Assert we navigated to /devices
+    await expect(page).toHaveURL(/\/devices$/, { timeout: 10000 });
+
+    // Assert the detail sheet is open
+    const sheet = page.locator('[role="dialog"][data-state="open"]');
+    await expect(sheet).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-deeplink-search-opens-sheet.png",
+      fullPage: true,
+    });
+  });
+});

--- a/web/tests/e2e/cmdk-device-deeplink.spec.ts
+++ b/web/tests/e2e/cmdk-device-deeplink.spec.ts
@@ -1,41 +1,102 @@
 import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+const device = {
+  id: "device-alpha",
+  mac: "AA:BB:CC:DD:EE:01",
+  name: "Core Switch",
+  hostname: "core-switch",
+  vendor: "MikroTik",
+  icon: "router",
+  notes: null,
+  is_known: true,
+  is_favorite: false,
+  first_seen_at: "2026-05-17T03:00:00.000Z",
+  last_seen_at: "2026-05-17T03:00:00.000Z",
+  is_online: true,
+  ips: ["192.168.1.2"],
+  mdns_services: null,
+  agent: null,
+  muted_until: null,
+  os_family: "RouterOS",
+  os_version: null,
+  device_type: "router",
+  device_model: null,
+  device_brand: null,
+  enrichment_source: null,
+  enrichment_corrected: null,
+  is_randomized_mac: false,
+  custom_name: null,
+  custom_type: null,
+  custom_os: null,
+  custom_vendor: null,
+  custom_model: null,
+  icon_override: null,
+  is_manual: false,
+  location: "Rack",
+  owner: "NetOps",
+  tags: "core,router",
+  status_timeline: [true, true, true, true],
+};
+
+async function mockDeviceSearch(page: Page) {
+  await page.route("**/api/v1/devices", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([device]),
+    }),
+  );
+  await page.route("**/api/v1/devices/*/sysinfo", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "null",
+    }),
+  );
+  await page.route("**/api/v1/search?*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        devices: [
+          {
+            id: device.id,
+            name: device.name,
+            hostname: device.hostname,
+            vendor: device.vendor,
+            ip_address: device.ips[0],
+            mac_address: device.mac,
+            is_online: device.is_online,
+          },
+        ],
+        agents: [],
+        ssh_targets: [],
+        assets: [],
+      }),
+    }),
+  );
+}
 
 test.describe("Command+K device deep-link (#741)", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
+    await mockDeviceSearch(page);
   });
 
   test("navigating to /devices?selected=<id> opens device detail sheet", async ({
     page,
   }) => {
-    // Go to /devices and wait for the page to load
-    await page.goto("/devices");
+    await page.goto(`/devices?selected=${device.id}`);
     await expect(
       page.getByRole("heading", { name: "Devices", level: 1 }),
     ).toBeVisible({ timeout: 15000 });
 
-    // Wait for device content to appear (cards or table rows)
-    await page.waitForTimeout(2000);
-
-    // Get a device ID from the API
-    const deviceId = await page.evaluate(async () => {
-      const res = await fetch("/api/v1/devices", { credentials: "include" });
-      const devices = await res.json();
-      return devices[0]?.id ?? null;
-    });
-
-    test.skip(!deviceId, "No devices available to test selected");
-
-    // Navigate to /devices?selected=<id>
-    await page.goto(`/devices?selected=${deviceId}`);
-    await expect(
-      page.getByRole("heading", { name: "Devices", level: 1 }),
-    ).toBeVisible({ timeout: 15000 });
-
-    // Assert the Sheet panel is open — SheetContent renders as role="dialog"
-    // with data-state="open"
     const sheet = page.locator('[role="dialog"][data-state="open"]');
     await expect(sheet).toBeVisible({ timeout: 10000 });
+    await expect(
+      sheet.getByRole("heading", { name: "core-switch" }),
+    ).toBeVisible();
     await expect(page).toHaveURL(/\/devices$/, { timeout: 10000 });
 
     await page.screenshot({
@@ -52,41 +113,27 @@ test.describe("Command+K device deep-link (#741)", () => {
       page.getByRole("heading", { name: "Dashboard", level: 1 }),
     ).toBeVisible({ timeout: 10000 });
 
-    // Get a device name from the API to search for
-    const deviceInfo = await page.evaluate(async () => {
-      const res = await fetch("/api/v1/devices", { credentials: "include" });
-      const devices = await res.json();
-      if (!devices.length) return null;
-      const d = devices[0];
-      return {
-        searchTerm: d.name || d.hostname || d.ip_address || null,
-        id: d.id,
-      };
-    });
-
-    test.skip(!deviceInfo || !deviceInfo.searchTerm, "No devices available to test search");
-
-    // Open command palette with Ctrl+K
     await page.keyboard.press("Control+k");
     const dialogContent = page.locator("[cmdk-dialog]");
     await expect(dialogContent).toBeVisible({ timeout: 3000 });
 
-    // Type the device name into the search input
     const searchInput = page.locator("[cmdk-input]");
     await expect(searchInput).toBeVisible();
-    await searchInput.fill(deviceInfo!.searchTerm);
+    await searchInput.fill(device.name);
 
-    // Click the first device result
-    const firstDeviceItem = page.locator('[cmdk-item][data-value^="device "]').first();
+    const firstDeviceItem = page
+      .locator('[cmdk-item][data-value^="device "]')
+      .first();
     await expect(firstDeviceItem).toBeVisible({ timeout: 3000 });
     await firstDeviceItem.click();
 
-    // Assert we navigated to /devices
     await expect(page).toHaveURL(/\/devices$/, { timeout: 10000 });
 
-    // Assert the detail sheet is open
     const sheet = page.locator('[role="dialog"][data-state="open"]');
     await expect(sheet).toBeVisible({ timeout: 10000 });
+    await expect(
+      sheet.getByRole("heading", { name: "core-switch" }),
+    ).toBeVisible();
 
     await page.screenshot({
       path: "tests/screenshots/cmdk-deeplink-search-opens-sheet.png",


### PR DESCRIPTION
## Summary

- **Fixes #741** — selecting a device from Command+K search now opens the device detail sheet instead of just navigating to the device list
- Reads `?highlight=<id>` query param on the `/devices` page and auto-opens the detail Sheet panel
- Cleans up the URL after opening so back-navigation works cleanly
- Wrapped component in `<Suspense>` as required by Next.js `useSearchParams`

## Test plan

- [ ] Open Command+K, search for a device name, click the result → detail sheet opens
- [ ] Navigate directly to `/devices?highlight=<id>` → detail sheet opens
- [ ] Close the sheet → URL is clean `/devices` with no query param
- [ ] E2E test: `bunx playwright test cmdk-device-deeplink`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up Command+K device search to open the device detail sheet by changing the navigation query param from `?highlight=` to `?selected=` and adding `window.history.replaceState` (preserving existing history state) to clean up the URL once the sheet opens. It also adds a full E2E test covering both the deeplink and the Command+K paths, and hardens the shared `setupIfNeeded` fixture against parallel-CI races.

- **`CommandPalette.tsx`**: `onSelect` now navigates to `/devices?selected=<id>` (was `?highlight=<id>`), matching what the devices page already reads via `params.get(\"selected\")`.
- **`devices/page.tsx`**: `selectDeviceFromUrl` now calls `window.history.replaceState(window.history.state, \"\", \"/devices\")` after a match, preserving App Router navigation metadata while stripping the query string.
- **`cmdk-device-deeplink.spec.ts`** (new): Playwright spec with mocked API routes covers the direct deeplink path and the full Command+K interaction, including sheet-open and URL-cleanup assertions.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one minor edge case: the `?selected` query param is left in the URL indefinitely when the device ID has no match in the loaded list.

The core change is small and correct — renaming the query param and adding a properly guarded `replaceState` call. The one gap is that `selectDeviceFromUrl` never cleans up the URL when the device is absent from the loaded list, leaving the query string visible in the address bar until the user navigates away. This affects only deleted or invalid device IDs; the primary use case (Command+K → sheet open) works correctly.

web/src/app/(app)/devices/page.tsx — the `selectDeviceFromUrl` function's no-match path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/devices/page.tsx | Adds `window.history.replaceState` (correctly preserving existing history state) to clean up the `?selected` query param after opening the device detail sheet; the only new gap is that the param is never removed when the device ID is absent from the loaded list. |
| web/src/components/CommandPalette.tsx | Renames the navigation query param from `?highlight=` to `?selected=`, aligning it with what `selectDeviceFromUrl` on the devices page reads. |
| web/tests/e2e/cmdk-device-deeplink.spec.ts | New E2E spec covering the deeplink and Command+K navigation paths; mocks devices/search/sysinfo APIs, asserts sheet opens and URL is cleaned up. |
| web/e2e/fixtures.ts | Replaces a single `waitForURL` after setup-form submission with a `Promise.race` across four signals, making the fixture resilient to parallel CI workers racing the initial setup. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/src/app/(app)/devices/page.tsx`, line 92-106 ([link](https://github.com/befeast/panoptikon/blob/a27c441095a557a8f7f778e88b823ef2a5dda9e6/web/src/app/(app)/devices/page.tsx#L92-L106)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **`selectedUrlParamConsumed` never resets, breaking repeated Command+K use on the same page**

   `selectedUrlParamConsumed.current` is set to `true` after the first successful sheet open and is never reset to `false`. If the user is already on `/devices` and selects a device via Command+K (which calls `router.push('/devices?selected=B')`), the component does not remount — the ref retains its `true` value. The next polling cycle calls `selectDeviceFromUrl` but hits the early-return guard immediately, so the sheet never opens for any subsequent Command+K selection made while staying on the page.

   The ref should be reset to `false` when the sheet is closed (`onOpenChange` at line 752), so that the next URL param can be consumed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/devices/page.tsx
   Line: 92-106

   Comment:
   **`selectedUrlParamConsumed` never resets, breaking repeated Command+K use on the same page**

   `selectedUrlParamConsumed.current` is set to `true` after the first successful sheet open and is never reset to `false`. If the user is already on `/devices` and selects a device via Command+K (which calls `router.push('/devices?selected=B')`), the component does not remount — the ref retains its `true` value. The next polling cycle calls `selectDeviceFromUrl` but hits the early-return guard immediately, so the sheet never opens for any subsequent Command+K selection made while staying on the page.

   The ref should be reset to `false` when the sheet is closed (`onOpenChange` at line 752), so that the next URL param can be consumed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `web/src/app/(app)/devices/page.tsx`, line 752-754 ([link](https://github.com/befeast/panoptikon/blob/4095566e3dff6d952b0600e7278d2b146218e025/web/src/app/(app)/devices/page.tsx#L752-L754)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> `selectedUrlParamConsumed` ref is never reset when the sheet closes, so a second Command+K selection while already on `/devices` silently fails. Because the component doesn't remount on same-page navigation, the ref retains `true` from the first open; `selectDeviceFromUrl` hits the early-return guard immediately and the sheet never opens again.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/devices/page.tsx
   Line: 752-754

   Comment:
   `selectedUrlParamConsumed` ref is never reset when the sheet closes, so a second Command+K selection while already on `/devices` silently fails. Because the component doesn't remount on same-page navigation, the ref retains `true` from the first open; `selectDeviceFromUrl` hits the early-return guard immediately and the sheet never opens again.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/app/(app)/devices/page.tsx:99-106
**Stale `?selected` param never cleaned up for unknown IDs**

When `selectedId` is present but no device in `loadedDevices` matches (e.g., a deleted device, a stale bookmarked link, or a race where the device isn't loaded yet on the first cycle), the function returns without touching the URL. Because `selectedUrlParamConsumed.current` stays `false`, every 15-second polling cycle re-enters the check — but for a permanently absent ID the URL retains `?selected=<id>` until the user navigates away. Consider calling `window.history.replaceState(window.history.state, "", "/devices")` (and setting `selectedUrlParamConsumed.current = true`) after a second or third failed attempt, or after verifying the device truly doesn't exist, so the URL doesn't stay dirty forever.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test: isolate Command K device deeplink ..."](https://github.com/befeast/panoptikon/commit/b28ab206eeb1a718b2c29e4bab34cf61425ba67a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27362093)</sub>

<!-- /greptile_comment -->