### PR TITLE
[codex] Renew authenticated mesh shell

### DIFF
--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -20,12 +20,12 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     <SWRProvider>
     <WebSocketProvider>
       <TooltipProvider delayDuration={300}>
-        <div className="flex h-screen overflow-clip">
+        <div className="flex h-screen overflow-clip bg-slate-950/70">
           <Sidebar />
-          <div className="flex min-w-0 flex-1 flex-col overflow-clip">
+          <div className="flex min-w-0 flex-1 flex-col overflow-clip bg-[linear-gradient(180deg,rgba(15,23,42,0.45),rgba(2,6,23,0.18))]">
             <TopBar mobileMenu={<MobileSidebar />} />
             <Breadcrumbs />
-            <main className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-8 pt-4 md:px-6 md:pb-10 md:pt-6">
+            <main className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-8 pt-3 md:px-5 md:pb-10 md:pt-5">
               <div className="mx-auto w-full max-w-[1700px]">{children}</div>
             </main>
           </div>

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -18,13 +18,6 @@ export default function RouterRedirect() {
           router.replace("/router/pfsense");
           return;
         }
-        if (
-          settings.default_router === "xiaomi" &&
-          settings.xiaomi_mesh_enabled
-        ) {
-          router.replace("/router/xiaomi");
-          return;
-        }
       } catch {
         // fall through to default
       }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4,27 +4,27 @@
 
 @layer base {
   :root {
-    /* Panoptikon brand palette — graphite + signal cyan */
-    --background: 218 44% 5%;
+    /* Panoptikon mesh palette: graphite console + signal cyan */
+    --background: 222 47% 4%;
     --foreground: 216 44% 94%;
-    --card: 218 43% 10%;
+    --card: 220 40% 8%;
     --card-foreground: 216 44% 94%;
-    --popover: 218 43% 10%;
+    --popover: 220 40% 7%;
     --popover-foreground: 216 44% 94%;
     --primary: 188 85% 53%;
     --primary-foreground: 218 44% 5%;
-    --secondary: 216 43% 18%;
+    --secondary: 218 31% 14%;
     --secondary-foreground: 216 44% 94%;
-    --muted: 216 43% 18%;
-    --muted-foreground: 214 22% 73%;
+    --muted: 218 28% 13%;
+    --muted-foreground: 215 18% 67%;
     --accent: 38 92% 50%;
     --accent-foreground: 218 44% 5%;
     --destructive: 348 89% 60%;
     --destructive-foreground: 0 0% 100%;
-    --border: 218 35% 23%;
-    --input: 218 35% 23%;
+    --border: 217 30% 18%;
+    --input: 217 30% 18%;
     --ring: 188 85% 53%;
-    --radius: 0.5rem;
+    --radius: 0.375rem;
 
     /* Semantic status colors */
     --status-online: 160 84% 39%;    /* emerald-500 */
@@ -38,13 +38,33 @@
 
   body {
     @apply text-foreground;
-    background-color: #070B12;
+    background-color: #050914;
     background-image:
-      radial-gradient(circle at 14% -16%, rgba(34, 211, 238, 0.08) 0%, transparent 34%),
-      radial-gradient(circle at 88% -26%, rgba(30, 41, 59, 0.24) 0%, transparent 38%),
-      linear-gradient(180deg, #070B12 0%, #0E1624 100%);
+      linear-gradient(rgba(148, 163, 184, 0.025) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.025) 1px, transparent 1px),
+      linear-gradient(180deg, #050914 0%, #08111f 52%, #050914 100%);
+    background-size: 28px 28px, 28px 28px, auto;
     background-attachment: fixed;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+
+  ::selection {
+    background: rgba(34, 211, 238, 0.22);
+    color: #f8fafc;
+  }
+}
+
+@layer components {
+  .mesh-panel {
+    @apply rounded-md border border-slate-800/80 bg-slate-950/70 shadow-none;
+  }
+
+  .mesh-label {
+    @apply text-[11px] font-semibold uppercase tracking-wider text-slate-500;
+  }
+
+  .mesh-value {
+    @apply font-mono tabular-nums text-slate-100;
   }
 }
 
@@ -112,10 +132,10 @@
   content: '';
   position: absolute;
   left: 0;
-  top: 8px;
-  bottom: 8px;
-  width: 4px;
-  border-radius: 0 2px 2px 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 0 1px 1px 0;
   background: linear-gradient(to bottom, hsl(var(--primary)), hsl(188 85% 40%));
 }
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -45,7 +45,8 @@ const PAGES: PageItem[] = [
   { label: 'Agents', href: '/agents', icon: Cpu },
   { label: 'Traffic', href: '/traffic', icon: Activity },
   { label: 'Alerts', href: '/alerts', icon: Bell },
-  { label: 'Router', href: '/router', icon: Router },
+  { label: 'MikroTik Router', href: '/router/mikrotik', icon: Router },
+  { label: 'pfSense Router', href: '/router/pfsense', icon: Router },
   { label: 'Settings', href: '/settings', icon: Settings },
 ]
 
@@ -127,7 +128,7 @@ export function CommandPalette() {
     '[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:pt-3 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-slate-500'
 
   const itemClass =
-    'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-slate-300 outline-none aria-selected:bg-blue-500/15 aria-selected:text-white cursor-pointer transition-colors'
+    'flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm text-slate-300 outline-none aria-selected:bg-cyan-500/10 aria-selected:text-white cursor-pointer transition-colors'
 
   const groupDividerClass = `border-t border-slate-800 mt-1 pt-1 ${groupHeadingClass}`
 
@@ -138,7 +139,7 @@ export function CommandPalette() {
       label="Command palette"
       className="flex flex-col flex-1 min-h-0"
       overlayClassName="fixed inset-0 z-[99] bg-black/70 backdrop-blur-sm"
-      contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 z-[100] w-[min(560px,calc(100vw-2rem))] max-h-[min(480px,60vh)] flex flex-col overflow-hidden rounded-2xl border border-slate-600/80 bg-slate-900 shadow-[0_24px_80px_-12px_rgba(0,0,0,0.8)]"
+      contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 z-[100] w-[min(560px,calc(100vw-2rem))] max-h-[min(480px,60vh)] flex flex-col overflow-hidden rounded-md border border-slate-700/80 bg-slate-950 shadow-[0_24px_80px_-12px_rgba(0,0,0,0.8)]"
       shouldFilter={!hasResults}
     >
       {/* Search input */}
@@ -147,9 +148,9 @@ export function CommandPalette() {
         <Command.Input
           value={query}
           onValueChange={setQuery}
-          placeholder="Search pages, devices, actions…"
+          placeholder="Search pages, devices, actions..."
           autoFocus
-          className="flex-1 bg-transparent text-base text-white placeholder-slate-500 outline-none"
+          className="flex-1 bg-transparent font-mono text-base tabular-nums text-white placeholder-slate-500 outline-none"
         />
         <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-slate-600 bg-slate-800 px-1.5 py-0.5 text-[11px] font-medium text-slate-400">
           ESC
@@ -292,7 +293,7 @@ export function CommandPalette() {
           </Command.Item>
         </Command.Group>
 
-        {/* ── Pages (navigation) — last when search results exist ── */}
+        {/* Pages (navigation), last when search results exist */}
         <Command.Group heading="Pages" className={groupDividerClass}>
           {PAGES.map((page) => (
             <Command.Item

--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -11,21 +11,33 @@ interface RouterSelectorProps {
 }
 
 export function RouterSelector({ active }: RouterSelectorProps) {
+  const itemClass =
+    "border-slate-800 bg-slate-950/60 text-slate-400 hover:border-cyan-500/30 hover:bg-cyan-500/10 hover:text-cyan-100";
+  const activeClass =
+    "border-cyan-400/50 bg-cyan-500/15 text-cyan-100 shadow-none hover:bg-cyan-500/20";
+
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-2" aria-label="Router clients">
       <Button
         variant={active === "mikrotik" ? "default" : "outline"}
         size="sm"
         asChild
-        className={
-          active === "mikrotik"
-            ? "bg-pink-600 text-white hover:bg-pink-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-        }
+        className={active === "mikrotik" ? activeClass : itemClass}
       >
         <Link href="/router/mikrotik">
           <Router className="mr-1.5 h-3.5 w-3.5" />
           MikroTik
+        </Link>
+      </Button>
+      <Button
+        variant={active === "pfsense" ? "default" : "outline"}
+        size="sm"
+        asChild
+        className={active === "pfsense" ? activeClass : itemClass}
+      >
+        <Link href="/router/pfsense">
+          <Router className="mr-1.5 h-3.5 w-3.5" />
+          pfSense
         </Link>
       </Button>
       <Button
@@ -34,28 +46,13 @@ export function RouterSelector({ active }: RouterSelectorProps) {
         asChild
         className={
           active === "xiaomi"
-            ? "bg-orange-600 text-white hover:bg-orange-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            ? "border-amber-500/40 bg-amber-500/10 text-amber-100 hover:bg-amber-500/15"
+            : "border-slate-800 bg-slate-950/40 text-slate-500 hover:border-slate-700 hover:bg-slate-900 hover:text-slate-300"
         }
       >
         <Link href="/router/xiaomi">
           <Router className="mr-1.5 h-3.5 w-3.5" />
           Xiaomi
-        </Link>
-      </Button>
-      <Button
-        variant={active === "pfsense" ? "default" : "outline"}
-        size="sm"
-        asChild
-        className={
-          active === "pfsense"
-            ? "bg-blue-600 text-white hover:bg-blue-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-        }
-      >
-        <Link href="/router/pfsense">
-          <Router className="mr-1.5 h-3.5 w-3.5" />
-          pfSense
         </Link>
       </Button>
     </div>

--- a/web/src/components/layout/Breadcrumbs.tsx
+++ b/web/src/components/layout/Breadcrumbs.tsx
@@ -13,6 +13,8 @@ const segmentLabels: Record<string, string> = {
   mesh: "Mesh",
   traffic: "Traffic",
   router: "Router",
+  mikrotik: "MikroTik",
+  pfsense: "pfSense",
   caddy: "Caddy",
   services: "Services",
   nat: "NAT",
@@ -66,7 +68,7 @@ export function Breadcrumbs() {
   return (
     <nav
       aria-label="Breadcrumb"
-      className="flex items-center gap-1 px-3 py-1.5 text-xs text-slate-500 md:px-6 animate-in slide-in-from-left-2 fade-in duration-300"
+      className="flex items-center gap-1 border-b border-slate-900/80 bg-slate-950/35 px-3 py-1.5 text-xs text-slate-500 animate-in slide-in-from-left-2 fade-in duration-300 md:px-5"
     >
       {segments.map((segment, i) => {
         const href = "/" + segments.slice(0, i + 1).join("/");

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -27,7 +27,7 @@ export function MobileSidebar() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="flex h-9 w-9 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800 hover:text-white transition-colors md:hidden"
+        className="flex h-9 w-9 items-center justify-center rounded-md border border-slate-800/70 text-slate-400 transition-colors hover:border-cyan-500/30 hover:bg-cyan-500/10 hover:text-white md:hidden"
         aria-label="Open menu"
       >
         <Menu className="h-5 w-5" />
@@ -41,7 +41,7 @@ export function MobileSidebar() {
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           {/* Logo */}
           <div className="flex h-14 shrink-0 items-center border-b border-slate-800 px-4">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500 text-sm font-bold text-white">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/40 bg-cyan-500 text-sm font-bold text-slate-950">
               P
             </div>
             <span className="ml-2 text-lg font-semibold text-white">
@@ -62,7 +62,7 @@ export function MobileSidebar() {
                   <div
                     className={cn(
                       "flex w-full items-center gap-1 px-3 py-1.5",
-                      group.key !== "network" && "mt-3 border-t border-dotted border-slate-800/60 pt-2",
+                      group.key !== "network" && "mt-3 border-t border-slate-800/70 pt-2",
                     )}
                   >
                     <button
@@ -81,7 +81,7 @@ export function MobileSidebar() {
                     <span
                       className={cn(
                         "cursor-default select-none text-[11px] font-semibold uppercase tracking-wider",
-                        hasActive ? "text-blue-400" : "text-slate-500",
+                        hasActive ? "text-cyan-400" : "text-slate-500",
                       )}
                     >
                       {group.label}
@@ -108,12 +108,12 @@ export function MobileSidebar() {
                             className={cn(
                               "group/nav relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
                               active
-                                ? "bg-blue-500/10 text-blue-500"
+                                ? "bg-cyan-500/10 text-cyan-500"
                                 : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
                             )}
                           >
                             {active && (
-                              <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-blue-400 to-blue-600" />
+                              <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-gradient-to-b from-cyan-400 to-cyan-600" />
                             )}
                             <Icon className="h-[18px] w-[18px] shrink-0 transition-transform duration-150 group-hover/nav:scale-105" />
                             <span>{item.label}</span>
@@ -134,12 +134,12 @@ export function MobileSidebar() {
                 className={cn(
                   "group/nav relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
                   pathname?.startsWith("/settings")
-                    ? "bg-blue-500/10 text-blue-500"
+                    ? "bg-cyan-500/10 text-cyan-500"
                     : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
                 )}
               >
                 {pathname?.startsWith("/settings") && (
-                  <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-blue-400 to-blue-600" />
+                  <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-gradient-to-b from-cyan-400 to-cyan-600" />
                 )}
                 <Settings className="h-[18px] w-[18px] shrink-0 transition-transform duration-150 group-hover/nav:scale-105" />
                 <span>Settings</span>
@@ -161,7 +161,7 @@ export function MobileSidebar() {
               <span className="text-xs text-slate-500">
                 {wsConnected ? "Live" : "Disconnected"}
               </span>
-              <p className="ml-auto text-[10px] text-slate-700">
+              <p className="ml-auto font-mono text-[10px] tabular-nums text-slate-600">
                 Panoptikon {serverVersion ?? "..."}
               </p>
             </div>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -71,7 +71,8 @@ export const navGroups: NavGroup[] = [
     key: "routing",
     label: "Routing & Proxy",
     items: [
-      { href: "/router", label: "Router", icon: Router },
+      { href: "/router/mikrotik", label: "MikroTik", icon: Router },
+      { href: "/router/pfsense", label: "pfSense", icon: Shield },
       { href: "/caddy", label: "Caddy", icon: Shield },
       { href: "/services", label: "Services", icon: Workflow },
       { href: "/nat", label: "NAT", icon: ArrowRightLeft },
@@ -252,28 +253,28 @@ export function Sidebar() {
     <TooltipProvider delayDuration={0}>
       <aside
         className={cn(
-          "hidden md:flex flex-col border-r border-slate-800 bg-slate-950 transition-all duration-200",
+          "hidden md:flex flex-col border-r border-slate-800/80 bg-slate-950/95 transition-all duration-200",
           sidebarCollapsed ? "w-16" : "w-60",
         )}
       >
         {/* Logo + collapse toggle */}
-        <div className="flex h-[3.75rem] items-center justify-between border-b border-slate-800/75 px-3">
+        <div className="flex h-[3.75rem] items-center justify-between border-b border-slate-800/80 px-3">
           <Link
             href="/dashboard"
             className="flex items-center min-w-0"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-cyan-500 text-sm font-bold text-slate-950">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/40 bg-cyan-500 text-sm font-bold text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.18)]">
               P
             </div>
             {!sidebarCollapsed && (
-              <span className="ml-2 font-display text-lg font-semibold text-white">
+              <span className="ml-2 font-display text-lg font-semibold tracking-normal text-white">
                 Panoptikon
               </span>
             )}
           </Link>
           <button
             onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-800/60 hover:text-slate-300"
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-transparent text-slate-500 transition-colors hover:border-slate-700 hover:bg-slate-900 hover:text-slate-300"
             aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {sidebarCollapsed ? (
@@ -303,12 +304,12 @@ export function Sidebar() {
                     <div
                       className={cn(
                         "flex w-full items-center gap-1 px-3 py-1.5",
-                        group.key !== "network" && "mt-3 border-t border-dotted border-slate-800/60 pt-2",
+                        group.key !== "network" && "mt-3 border-t border-slate-800/70 pt-2",
                       )}
                     >
                       <button
                         onClick={() => toggleGroup(group.key)}
-                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded transition-colors text-slate-500 hover:bg-slate-800/60 hover:text-slate-300"
+                        className="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-transparent text-slate-500 transition-colors hover:border-slate-700 hover:bg-slate-900 hover:text-slate-300"
                         aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.label}`}
                         aria-expanded={!isCollapsed}
                       >
@@ -347,7 +348,7 @@ export function Sidebar() {
           {/* Settings — always visible, pinned after groups */}
           <div
             className={cn(
-              "mt-1 border-t border-slate-800/50 pt-1",
+              "mt-1 border-t border-slate-800/70 pt-1",
               sidebarCollapsed && "border-t-0",
             )}
           >
@@ -356,7 +357,7 @@ export function Sidebar() {
         </nav>
 
         {/* Version + connection status */}
-        <div className="border-t border-slate-800/50 p-2">
+        <div className="border-t border-slate-800/70 p-2">
           {!sidebarCollapsed ? (
             <div className="flex items-center gap-1.5 px-3 py-1">
               <Tooltip>
@@ -370,14 +371,11 @@ export function Sidebar() {
                     )}
                   />
                 </TooltipTrigger>
-                <TooltipContent
-                  side="top"
-                  className="border-slate-800 bg-slate-900"
-                >
-                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
+                <TooltipContent side="top" className="border-slate-800 bg-slate-900">
+                  <p>{wsConnected ? "Live: connected" : "Disconnected"}</p>
                 </TooltipContent>
               </Tooltip>
-              <p className="text-[10px] text-slate-700">
+              <p className="font-mono text-[10px] tabular-nums text-slate-600">
                 Panoptikon {serverVersion ?? "..."}
               </p>
             </div>
@@ -394,11 +392,8 @@ export function Sidebar() {
                     )}
                   />
                 </TooltipTrigger>
-                <TooltipContent
-                  side="right"
-                  className="border-slate-800 bg-slate-900"
-                >
-                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
+                <TooltipContent side="right" className="border-slate-800 bg-slate-900">
+                  <p>{wsConnected ? "Live: connected" : "Disconnected"}</p>
                 </TooltipContent>
               </Tooltip>
             </div>

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -224,7 +224,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   let runningIndex = 0;
 
   return (
-    <header className="sticky top-0 z-40 flex h-[3.75rem] items-center justify-between gap-3 border-b border-slate-800/75 bg-slate-950/70 px-3 backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/60 md:px-6">
+    <header className="sticky top-0 z-40 flex h-[3.75rem] items-center justify-between gap-3 border-b border-slate-800/80 bg-slate-950/85 px-3 backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/75 md:px-5">
       {/* Mobile menu button */}
       {mobileMenu}
 
@@ -239,13 +239,13 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
           onFocus={() => {
             if (results && query.length >= 2) setIsOpen(true);
           }}
-          placeholder="Search devices, IPs, MACs...  ⌘K"
-          className="h-8 w-full rounded-lg border border-slate-800/80 bg-slate-900 px-3 text-sm text-white placeholder-slate-500 transition-all duration-300 focus:border-blue-500/40 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:shadow-[0_0_15px_rgba(59,130,246,0.15)]"
+          placeholder="Search devices, IPs, MACs...  Cmd K"
+          className="h-8 w-full rounded-md border border-slate-800/80 bg-slate-950/80 px-3 font-mono text-sm tabular-nums text-white placeholder-slate-500 transition-all duration-150 focus:border-cyan-500/40 focus:outline-none focus:ring-2 focus:ring-cyan-500/15"
         />
 
         {/* Search Results Dropdown */}
         {isOpen && (
-          <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
+          <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-md border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
             {noResults && (
               <div className="px-4 py-3 text-sm text-slate-500">
                 No results for &ldquo;{query}&rdquo;
@@ -257,7 +257,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                 {/* Devices */}
                 {results.devices.length > 0 && (
                   <div>
-                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <div className="px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                       Devices
                     </div>
                     {results.devices.map((d: SearchDevice) => {
@@ -297,7 +297,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                 {/* Agents */}
                 {results.agents.length > 0 && (
                   <div>
-                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                    <div className="border-t border-slate-800 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                       Agents
                     </div>
                     {results.agents.map((a: SearchAgent) => {
@@ -332,7 +332,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                 {/* SSH Hosts */}
                 {results.ssh_targets.length > 0 && (
                   <div>
-                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                    <div className="border-t border-slate-800 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                       SSH Hosts
                     </div>
                     {results.ssh_targets.map((st: SearchSshTarget) => {
@@ -367,7 +367,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                 {/* Assets */}
                 {results.assets.length > 0 && (
                   <div>
-                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                    <div className="border-t border-slate-800 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                       Assets
                     </div>
                     {results.assets.map((asset: SearchAsset) => {
@@ -396,7 +396,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                 {/* Alerts */}
                 {results.alerts.length > 0 && (
                   <div>
-                    <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 border-t border-slate-800">
+                    <div className="border-t border-slate-800 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                       Alerts
                     </div>
                     {results.alerts.map((al: SearchAlert) => {
@@ -413,7 +413,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                           <SeverityBadge severity={al.severity} />
                           <span className="text-white truncate max-w-[300px]">
                             {al.message.length > 60
-                              ? al.message.slice(0, 60) + "…"
+                              ? al.message.slice(0, 60) + "..."
                               : al.message}
                           </span>
                         </button>
@@ -433,7 +433,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
         <div className="relative" ref={bellRef}>
           <button
             onClick={() => setBellOpen((v) => !v)}
-            className="relative flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800/85 hover:text-white"
+            className="relative flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-slate-400 transition-colors hover:border-cyan-500/30 hover:bg-cyan-500/10 hover:text-white"
             aria-label="Notifications"
           >
             <Bell className="h-5 w-5" />
@@ -445,14 +445,14 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
           </button>
 
           {bellOpen && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-xl border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
+            <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-md border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
               <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2.5">
                 <span className="text-sm font-semibold text-white">Notifications</span>
                 <div className="flex items-center gap-3">
                   {unreadCount > 0 && (
                     <button
                       onClick={handleMarkAllRead}
-                      className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                      className="text-xs text-cyan-400 transition-colors hover:text-cyan-300"
                     >
                       Mark all read
                     </button>
@@ -487,7 +487,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                     >
                       <div className="flex items-center gap-2">
                         {!alert.is_read && (
-                          <span className="h-2 w-2 rounded-full bg-blue-400 shrink-0" />
+                          <span className="h-2 w-2 shrink-0 rounded-full bg-cyan-400" />
                         )}
                         <SeverityBadge severity={alert.severity} />
                         <span className="text-xs text-slate-500 ml-auto">
@@ -508,7 +508,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                     setBellOpen(false);
                     router.push("/alerts");
                   }}
-                  className="flex w-full items-center justify-center px-4 py-2.5 text-sm text-blue-400 hover:text-blue-300 hover:bg-slate-800/60 transition-colors"
+                  className="flex w-full items-center justify-center px-4 py-2.5 text-sm text-cyan-400 transition-colors hover:bg-slate-800/60 hover:text-cyan-300"
                 >
                   View all alerts
                 </button>
@@ -520,7 +520,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
         {/* ── User Avatar Menu ── */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-500 text-sm font-medium text-white hover:bg-blue-600 transition-colors">
+            <button className="flex h-8 w-8 items-center justify-center rounded-md border border-cyan-400/30 bg-cyan-500/15 text-sm font-medium text-cyan-100 transition-colors hover:bg-cyan-500/25">
               A
             </button>
           </DropdownMenuTrigger>
@@ -561,8 +561,8 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
 function SeverityBadge({ severity }: { severity: string }) {
   const colors: Record<string, string> = {
     CRITICAL: "bg-rose-500/20 text-rose-400 border-rose-500/30",
-    WARNING: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-    INFO: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+    WARNING: "bg-amber-500/20 text-amber-300 border-amber-500/30",
+    INFO: "bg-cyan-500/15 text-cyan-300 border-cyan-500/30",
   };
   const cls = colors[severity] || colors.WARNING;
   return (

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,background-color,border-color,text-decoration-color,fill,stroke,transform] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:scale-[0.98] motion-reduce:active:scale-100",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,background-color,border-color,text-decoration-color,fill,stroke,transform] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:scale-[0.99] motion-reduce:active:scale-100",
   {
     variants: {
       variant: {
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-slate-800 bg-slate-950/50 text-slate-300 hover:border-cyan-500/30 hover:bg-cyan-500/10 hover:text-cyan-100",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -9,9 +9,9 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative overflow-hidden rounded-xl border border-slate-800 bg-slate-900/60 text-card-foreground shadow-[0_8px_26px_-18px_rgba(15,23,42,0.95)] backdrop-blur-xl supports-[backdrop-filter]:bg-slate-900/55",
-      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent",
-      "transition-[border-color] duration-200 ease-out hover:border-blue-500/20",
+      "relative overflow-hidden rounded-md border border-slate-800/80 bg-slate-950/70 text-card-foreground shadow-none backdrop-blur supports-[backdrop-filter]:bg-slate-950/65",
+      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-slate-700/45",
+      "transition-[border-color,background-color] duration-150 ease-out hover:border-cyan-500/20",
       selected && "card-selected",
       className
     )}
@@ -26,7 +26,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col gap-1.5 p-5", className)}
+    className={cn("flex flex-col gap-1.5 p-4", className)}
     {...props}
   />
 ))
@@ -39,7 +39,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-base font-semibold leading-tight tracking-tight",
+      "text-sm font-semibold leading-tight tracking-normal text-slate-100",
       className
     )}
     {...props}
@@ -53,7 +53,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+    className={cn("text-xs leading-relaxed text-muted-foreground", className)}
     {...props}
   />
 ))
@@ -63,7 +63,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -73,7 +73,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-5 pt-0", className)}
+    className={cn("flex items-center p-4 pt-0", className)}
     {...props}
   />
 ))

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -27,7 +27,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         {...props}
       >
         <div
-          className="h-full rounded-full bg-blue-500 transition-all duration-300 ease-in-out"
+          className="h-full rounded-full bg-cyan-500 transition-all duration-300 ease-in-out"
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -6,10 +6,10 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-auto rounded-md border border-slate-800/70">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn("w-full caption-bottom text-xs tabular-nums", className)}
       {...props}
     />
   </div>
@@ -20,7 +20,11 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn("bg-slate-950/80 [&_tr]:border-b [&_tr]:border-slate-800/80", className)}
+    {...props}
+  />
 ))
 TableHeader.displayName = "TableHeader"
 
@@ -58,7 +62,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-b border-slate-800/60 transition-colors hover:bg-cyan-500/[0.035] data-[state=selected]:bg-cyan-500/10",
       className
     )}
     {...props}
@@ -73,7 +77,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-9 px-3 text-left align-middle text-[11px] font-semibold uppercase tracking-wider text-slate-500 [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
@@ -87,7 +91,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("px-3 py-2 align-middle text-slate-300 [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))

--- a/web/tests/e2e/topbar-polish.spec.ts
+++ b/web/tests/e2e/topbar-polish.spec.ts
@@ -5,14 +5,14 @@ test.describe('TopBar polish (#602)', () => {
     await login(page);
   });
 
-  test('search input has blue glow on focus', async ({ page }) => {
+  test('search input has cyan focus treatment', async ({ page }) => {
     const searchInput = page.getByPlaceholder('Search devices, IPs, MACs');
     await expect(searchInput).toBeVisible();
 
     // Focus the search input
     await searchInput.click();
 
-    // Verify the focused input has the blue ring/glow classes applied
+    // Verify the focused input has the cyan ring treatment applied.
     // Playwright evaluates computed styles, so we check the box-shadow
     const boxShadow = await searchInput.evaluate((el) => {
       return window.getComputedStyle(el).boxShadow;


### PR DESCRIPTION
Refs #743

## Summary
- Renew the authenticated app shell, chrome, cards, tables, badges, buttons, and progress treatment around the mesh operator-console direction.
- Promote MikroTik and pfSense as first-class router clients in sidebar, command palette, router selector, breadcrumbs, and /router redirect behavior.
- Keep production routes in place and update the topbar e2e wording from blue glow to cyan focus treatment.

## Validation
- `cd web && npm install --no-package-lock --no-audit --no-fund` (used because `bun` is unavailable and `npm ci` fails: package-lock.json is out of sync with package.json)
- `cd web && npm run test`
- `cd web && npm run build`
- `cd web && npm run test:e2e -- navigation.spec.ts sidebar-rebrand.spec.ts topbar-polish.spec.ts` failed before app assertions because Playwright Chromium is not installed: `Executable doesn't exist at /home/god/.cache/ms-playwright/chromium_headless_shell-1223/chrome-headless-shell-linux64/chrome-headless-shell`; Playwright suggests `npx playwright install`.
