### PR TITLE
UX renewal: router workspace for MikroTik and pfSense

### DIFF
--- a/web/src/app/(app)/router/mikrotik/page.tsx
+++ b/web/src/app/(app)/router/mikrotik/page.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Router, Settings } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { fetchSettings } from "@/lib/api";
 import MikrotikRouter from "@/components/MikrotikRouter";
 import { PageTransition } from "@/components/PageTransition";
-import { RouterSelector } from "@/components/RouterSelector";
+import {
+  RouterWorkspace,
+  RouterWorkspaceLoading,
+  RouterWorkspaceState,
+} from "@/components/router/RouterWorkspace";
 
 export default function MikrotikRouterPage() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
@@ -30,43 +29,20 @@ export default function MikrotikRouterPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-8">
-        <RouterSelector active="mikrotik" />
-
+      <RouterWorkspace active="mikrotik">
         {!settingsLoaded ? (
-          <div className="space-y-8">
-            <Skeleton className="h-10 w-64" />
-            <Skeleton className="h-96 w-full" />
-          </div>
+          <RouterWorkspaceLoading />
         ) : mikrotikEnabled ? (
           <MikrotikRouter />
         ) : (
-          <div className="flex min-h-[60vh] items-center justify-center">
-            <Card className="w-full max-w-md border-slate-800 bg-slate-900">
-              <CardContent className="flex flex-col items-center gap-4 py-12">
-                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/10">
-                  <Router className="h-8 w-8 text-amber-400" />
-                </div>
-                <h1 className="text-xl font-semibold text-white">
-                  MikroTik Not Configured
-                </h1>
-                <p className="text-center text-sm text-slate-500">
-                  Enable MikroTik integration in Settings to use this page.
-                </p>
-                <Link href="/settings/router">
-                  <Button
-                    variant="outline"
-                    className="border-slate-800 text-slate-300 hover:bg-slate-800"
-                  >
-                    <Settings className="mr-2 h-4 w-4" />
-                    Configure Router
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-          </div>
+          <RouterWorkspaceState
+            title="MikroTik Not Configured"
+            description="Enable the MikroTik integration and save a RouterOS endpoint before using the router workspace."
+            settingsHref="/settings/router"
+            settingsLabel="Configure Router"
+          />
         )}
-      </div>
+      </RouterWorkspace>
     </PageTransition>
   );
 }

--- a/web/src/app/(app)/router/page.tsx
+++ b/web/src/app/(app)/router/page.tsx
@@ -19,10 +19,14 @@ export default function RouterRedirect() {
           return;
         }
         if (
-          settings.default_router === "xiaomi" &&
-          settings.xiaomi_mesh_enabled
+          settings.default_router === "mikrotik" &&
+          settings.mikrotik_enabled
         ) {
-          router.replace("/router/xiaomi");
+          router.replace("/router/mikrotik");
+          return;
+        }
+        if (settings.pfsense_enabled && !settings.mikrotik_enabled) {
+          router.replace("/router/pfsense");
           return;
         }
       } catch {
@@ -34,8 +38,10 @@ export default function RouterRedirect() {
   }, [router]);
 
   return (
-    <div className="flex items-center justify-center h-64">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+    <div className="flex min-h-64 items-center justify-center">
+      <div className="rounded-md border border-slate-800 bg-slate-950 px-4 py-3 text-sm text-slate-400">
+        Selecting router workspace...
+      </div>
     </div>
   );
 }

--- a/web/src/app/(app)/router/pfsense/page.tsx
+++ b/web/src/app/(app)/router/pfsense/page.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Shield, Settings } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { fetchSettings } from "@/lib/api";
 import PfSenseRouter from "@/components/pfsense/PfSenseRouter";
 import { PageTransition } from "@/components/PageTransition";
-import { RouterSelector } from "@/components/RouterSelector";
+import {
+  RouterWorkspace,
+  RouterWorkspaceLoading,
+  RouterWorkspaceState,
+} from "@/components/router/RouterWorkspace";
 
 export default function PfSenseRouterPage() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
@@ -30,43 +29,20 @@ export default function PfSenseRouterPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
-        <RouterSelector active="pfsense" />
-
+      <RouterWorkspace active="pfsense">
         {!settingsLoaded ? (
-          <div className="space-y-6">
-            <Skeleton className="h-10 w-64" />
-            <Skeleton className="h-96 w-full" />
-          </div>
+          <RouterWorkspaceLoading />
         ) : pfsenseEnabled ? (
           <PfSenseRouter />
         ) : (
-          <div className="flex min-h-[60vh] items-center justify-center">
-            <Card className="w-full max-w-md border-slate-800 bg-slate-900">
-              <CardContent className="flex flex-col items-center gap-4 py-12">
-                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-500/10">
-                  <Shield className="h-8 w-8 text-blue-400" />
-                </div>
-                <h1 className="text-xl font-semibold text-white">
-                  pfSense Not Configured
-                </h1>
-                <p className="text-center text-sm text-slate-500">
-                  Enable pfSense integration in Settings to use this page.
-                </p>
-                <Link href="/settings/pfsense">
-                  <Button
-                    variant="outline"
-                    className="border-slate-800 text-slate-300 hover:bg-slate-800"
-                  >
-                    <Settings className="mr-2 h-4 w-4" />
-                    Configure pfSense
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-          </div>
+          <RouterWorkspaceState
+            title="pfSense Not Configured"
+            description="Enable the pfSense integration and save a firewall host before using the router workspace."
+            settingsHref="/settings/pfsense"
+            settingsLabel="Configure pfSense"
+          />
         )}
-      </div>
+      </RouterWorkspace>
     </PageTransition>
   );
 }

--- a/web/src/app/(app)/router/xiaomi/page.tsx
+++ b/web/src/app/(app)/router/xiaomi/page.tsx
@@ -12,7 +12,7 @@ import { fetchSettings } from "@/lib/api";
 import XiaomiRouter from "@/components/XiaomiRouter";
 import XiaomiMeshTopology from "@/components/XiaomiMeshTopology";
 import { PageTransition } from "@/components/PageTransition";
-import { RouterSelector } from "@/components/RouterSelector";
+import { RouterWorkspace } from "@/components/router/RouterWorkspace";
 
 export default function XiaomiRouterPage() {
   const [tab, setTab] = useHashTab("system", ["system", "mesh"]);
@@ -34,9 +34,7 @@ export default function XiaomiRouterPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-8">
-        <RouterSelector active="xiaomi" />
-
+      <RouterWorkspace active="xiaomi">
         {!settingsLoaded ? (
           <div className="space-y-8">
             <Skeleton className="h-10 w-64" />
@@ -81,7 +79,7 @@ export default function XiaomiRouterPage() {
             </Card>
           </div>
         )}
-      </div>
+      </RouterWorkspace>
     </PageTransition>
   );
 }

--- a/web/src/components/MikrotikRouter.tsx
+++ b/web/src/components/MikrotikRouter.tsx
@@ -140,6 +140,7 @@ import {
 } from "@/lib/api";
 import { formatBps } from "@/lib/format";
 import { useData } from "@/hooks/useData";
+import { RouterWorkspaceState } from "@/components/router/RouterWorkspace";
 import type {
   MikrotikStatus,
   MikrotikInterface,
@@ -194,42 +195,49 @@ function formatMemory(bytes: string | null): string {
 
 function StatusHeader({ status }: { status: MikrotikStatus }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4">
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-pink-500/10">
-          <Router className="h-5 w-5 text-pink-400" />
+    <div className="rounded-md border border-slate-800 bg-slate-950/90 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-cyan-500/20 bg-cyan-500/10">
+            <Router className="h-5 w-5 text-cyan-300" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-cyan-300/80">
+              RouterOS workspace
+            </p>
+            <h1 className="truncate text-2xl font-semibold tracking-tight text-white">
+              MikroTik Router
+            </h1>
+            <p className="truncate text-xs text-slate-500">
+              {status.board_name ?? "RouterOS"}{" "}
+              {status.version && (
+                <span className="text-slate-600">&middot; RouterOS {status.version}</span>
+              )}
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-white">MikroTik Router</h1>
-          <p className="text-xs text-slate-500">
-            {status.board_name ?? "RouterOS"}{" "}
-            {status.version && (
-              <span className="text-slate-600">&middot; RouterOS {status.version}</span>
-            )}
-          </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {status.reachable ? (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+            >
+              &#9679; Connected
+            </Badge>
+          ) : (
+            <Badge
+              variant="outline"
+              className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+            >
+              &#9679; Unreachable
+            </Badge>
+          )}
+          {status.uptime && (
+            <Badge variant="outline" className="border-slate-800 text-slate-400">
+              Uptime: {status.uptime}
+            </Badge>
+          )}
         </div>
-      </div>
-      <div className="flex items-center gap-2">
-        {status.reachable ? (
-          <Badge
-            variant="outline"
-            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-          >
-            &#9679; Connected
-          </Badge>
-        ) : (
-          <Badge
-            variant="outline"
-            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
-          >
-            &#9679; Unreachable
-          </Badge>
-        )}
-        {status.uptime && (
-          <Badge variant="outline" className="border-slate-800 text-slate-400">
-            Uptime: {status.uptime}
-          </Badge>
-        )}
       </div>
     </div>
   );
@@ -253,8 +261,8 @@ function SystemTab({ status }: { status: MikrotikStatus }) {
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
       <InfoStatCard
-        icon={<Monitor className="h-5 w-5 text-pink-400" />}
-        iconColorClass="bg-pink-500/10"
+        icon={<Monitor className="h-5 w-5 text-cyan-400" />}
+        iconColorClass="bg-cyan-500/10"
         label="Version"
         value={status.version ?? "\u2014"}
       />
@@ -4119,15 +4127,29 @@ export default function MikrotikRouter() {
   }
 
   if (!status?.configured || !status?.reachable) {
+    if (status?.configured && !status.reachable) {
+      return (
+        <div className="space-y-5">
+          <StatusHeader status={status} />
+          <RouterWorkspaceState
+            title="MikroTik router is unreachable"
+            description="The integration is enabled, but RouterOS did not respond. Last-known status fields remain visible below when the API returns them."
+            settingsHref="/settings/router"
+            settingsLabel="Check Connection"
+            tone="rose"
+          />
+          <SystemTab status={status} />
+        </div>
+      );
+    }
+
     return (
-      <div className="flex flex-col items-center gap-4 py-12 text-center">
-        <AlertCircle className="h-10 w-10 text-amber-400" />
-        <p className="text-sm text-slate-400">
-          {!status?.configured
-            ? "MikroTik router is not configured. Enable it in Settings."
-            : "MikroTik router is unreachable. Check connection settings."}
-        </p>
-      </div>
+      <RouterWorkspaceState
+        title="MikroTik router is not configured"
+        description="Enable the MikroTik integration and provide RouterOS credentials before managing interfaces, VLANs, DHCP, DNS, firewall, and routing."
+        settingsHref="/settings/router"
+        settingsLabel="Configure Router"
+      />
     );
   }
 
@@ -4135,8 +4157,8 @@ export default function MikrotikRouter() {
     <div className="space-y-6">
       <StatusHeader status={status} />
 
-      <Tabs value={tab} onValueChange={setTab}>
-        <TabsList className="border-slate-800 bg-slate-950">
+      <Tabs value={tab} onValueChange={setTab} className="min-w-0">
+        <TabsList className="h-auto w-full justify-start gap-1 border border-slate-800 bg-slate-950 p-1">
           <TabsTrigger
             value="system"
             className="data-[state=active]:bg-slate-800 data-[state=active]:text-white"

--- a/web/src/components/RouterSelector.tsx
+++ b/web/src/components/RouterSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Router } from "lucide-react";
+import { Network, Router, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 type ActiveRouter = "mikrotik" | "xiaomi" | "pfsense";
@@ -12,35 +12,20 @@ interface RouterSelectorProps {
 
 export function RouterSelector({ active }: RouterSelectorProps) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex min-w-0 flex-wrap gap-2">
       <Button
         variant={active === "mikrotik" ? "default" : "outline"}
         size="sm"
         asChild
         className={
           active === "mikrotik"
-            ? "bg-pink-600 text-white hover:bg-pink-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            ? "bg-cyan-600 text-white hover:bg-cyan-500"
+            : "border-slate-800 bg-slate-950 text-slate-400 hover:bg-slate-800 hover:text-white"
         }
       >
         <Link href="/router/mikrotik">
           <Router className="mr-1.5 h-3.5 w-3.5" />
           MikroTik
-        </Link>
-      </Button>
-      <Button
-        variant={active === "xiaomi" ? "default" : "outline"}
-        size="sm"
-        asChild
-        className={
-          active === "xiaomi"
-            ? "bg-orange-600 text-white hover:bg-orange-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
-        }
-      >
-        <Link href="/router/xiaomi">
-          <Router className="mr-1.5 h-3.5 w-3.5" />
-          Xiaomi
         </Link>
       </Button>
       <Button
@@ -50,12 +35,27 @@ export function RouterSelector({ active }: RouterSelectorProps) {
         className={
           active === "pfsense"
             ? "bg-blue-600 text-white hover:bg-blue-500"
-            : "border-slate-800 text-slate-400 hover:bg-slate-800 hover:text-white"
+            : "border-slate-800 bg-slate-950 text-slate-400 hover:bg-slate-800 hover:text-white"
         }
       >
         <Link href="/router/pfsense">
-          <Router className="mr-1.5 h-3.5 w-3.5" />
+          <Shield className="mr-1.5 h-3.5 w-3.5" />
           pfSense
+        </Link>
+      </Button>
+      <Button
+        variant={active === "xiaomi" ? "default" : "outline"}
+        size="sm"
+        asChild
+        className={
+          active === "xiaomi"
+            ? "bg-orange-600 text-white hover:bg-orange-500"
+            : "border-slate-800 bg-slate-950 text-slate-500 hover:bg-slate-800 hover:text-white"
+        }
+      >
+        <Link href="/router/xiaomi">
+          <Network className="mr-1.5 h-3.5 w-3.5" />
+          Xiaomi
         </Link>
       </Button>
     </div>

--- a/web/src/components/pfsense/PfSenseRouter.tsx
+++ b/web/src/components/pfsense/PfSenseRouter.tsx
@@ -25,13 +25,17 @@ import { DnsTab } from "./tabs/DnsTab";
 import { RoutingTab } from "./tabs/RoutingTab";
 import { ConfigTab } from "./tabs/ConfigTab";
 import { ServicesTab } from "./tabs/ServicesTab";
+import { RouterWorkspaceState } from "@/components/router/RouterWorkspace";
+
+const tabTriggerClass =
+  "gap-1.5 data-[state=active]:bg-slate-800 data-[state=active]:text-white";
 
 export default function PfSenseRouter() {
   const [tab, setTab] = useHashTab("system", ["system", "interfaces", "firewall", "dhcp", "dns", "services", "routing", "config"]);
   const fetcher = useCallback(() => fetchPfsenseStatus(), []);
-  const { data: status, loading } = useData(fetcher);
+  const { data: status, loading, error } = useData(fetcher);
 
-  if (loading || !status) {
+  if (loading) {
     return (
       <div className="space-y-6">
         <Skeleton className="h-10 w-80" />
@@ -41,41 +45,81 @@ export default function PfSenseRouter() {
     );
   }
 
+  if (!status) {
+    return (
+      <RouterWorkspaceState
+        title="pfSense status is unavailable"
+        description="The pfSense integration is enabled, but the status API did not return router data."
+        detail={error}
+        settingsHref="/settings/pfsense"
+        settingsLabel="Check Connection"
+        tone="rose"
+      />
+    );
+  }
+
+  if (!status.configured || !status.reachable) {
+    if (status.configured && !status.reachable) {
+      return (
+        <div className="space-y-5">
+          <PfSenseStatusHeader status={status} />
+          <RouterWorkspaceState
+            title="pfSense router is unreachable"
+            description="The integration is enabled, but the firewall did not respond. Last-known status fields remain visible below when available."
+            settingsHref="/settings/pfsense"
+            settingsLabel="Check Connection"
+            tone="rose"
+          />
+          <SystemTab status={status} />
+        </div>
+      );
+    }
+
+    return (
+      <RouterWorkspaceState
+        title="pfSense router is not configured"
+        description="Enable the pfSense integration and provide firewall connection settings before managing interfaces, services, DHCP, DNS, firewall, routing, and config backups."
+        settingsHref="/settings/pfsense"
+        settingsLabel="Configure pfSense"
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
       <PfSenseStatusHeader status={status} />
 
-      <Tabs value={tab} onValueChange={setTab} className="w-full">
-        <TabsList className="border-slate-800 bg-slate-900">
-          <TabsTrigger value="system" className="gap-1.5">
+      <Tabs value={tab} onValueChange={setTab} className="w-full min-w-0">
+        <TabsList className="h-auto w-full justify-start gap-1 border border-slate-800 bg-slate-950 p-1">
+          <TabsTrigger value="system" className={tabTriggerClass}>
             <Monitor className="h-3.5 w-3.5" />
             System
           </TabsTrigger>
-          <TabsTrigger value="interfaces" className="gap-1.5">
+          <TabsTrigger value="interfaces" className={tabTriggerClass}>
             <Network className="h-3.5 w-3.5" />
             Interfaces
           </TabsTrigger>
-          <TabsTrigger value="firewall" className="gap-1.5">
+          <TabsTrigger value="firewall" className={tabTriggerClass}>
             <Shield className="h-3.5 w-3.5" />
             Firewall
           </TabsTrigger>
-          <TabsTrigger value="dhcp" className="gap-1.5">
+          <TabsTrigger value="dhcp" className={tabTriggerClass}>
             <Server className="h-3.5 w-3.5" />
             DHCP
           </TabsTrigger>
-          <TabsTrigger value="dns" className="gap-1.5">
+          <TabsTrigger value="dns" className={tabTriggerClass}>
             <Globe className="h-3.5 w-3.5" />
             DNS
           </TabsTrigger>
-          <TabsTrigger value="services" className="gap-1.5">
+          <TabsTrigger value="services" className={tabTriggerClass}>
             <Cog className="h-3.5 w-3.5" />
             Services
           </TabsTrigger>
-          <TabsTrigger value="routing" className="gap-1.5">
+          <TabsTrigger value="routing" className={tabTriggerClass}>
             <GitFork className="h-3.5 w-3.5" />
             Routing
           </TabsTrigger>
-          <TabsTrigger value="config" className="gap-1.5">
+          <TabsTrigger value="config" className={tabTriggerClass}>
             <FileArchive className="h-3.5 w-3.5" />
             Config & Audit
           </TabsTrigger>

--- a/web/src/components/pfsense/PfSenseStatusHeader.tsx
+++ b/web/src/components/pfsense/PfSenseStatusHeader.tsx
@@ -6,42 +6,49 @@ import type { PfsenseStatus } from "@/lib/types";
 
 export function PfSenseStatusHeader({ status }: { status: PfsenseStatus }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4">
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
-          <Shield className="h-5 w-5 text-blue-400" />
+    <div className="rounded-md border border-slate-800 bg-slate-950/90 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-blue-500/20 bg-blue-500/10">
+            <Shield className="h-5 w-5 text-blue-300" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-blue-300/80">
+              firewall workspace
+            </p>
+            <h1 className="truncate text-2xl font-semibold tracking-tight text-white">
+              pfSense Router
+            </h1>
+            <p className="truncate text-xs text-slate-500">
+              {status.hostname ?? "pfSense"}{" "}
+              {status.version && (
+                <span className="text-slate-600">&middot; pfSense {status.version}</span>
+              )}
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-semibold text-white">pfSense Router</h1>
-          <p className="text-xs text-slate-500">
-            {status.hostname ?? "pfSense"}{" "}
-            {status.version && (
-              <span className="text-slate-600">&middot; pfSense {status.version}</span>
-            )}
-          </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {status.reachable ? (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+            >
+              &#9679; Connected
+            </Badge>
+          ) : (
+            <Badge
+              variant="outline"
+              className="border-rose-500/30 bg-rose-500/10 text-rose-400"
+            >
+              &#9679; Unreachable
+            </Badge>
+          )}
+          {status.uptime && (
+            <Badge variant="outline" className="border-slate-800 text-slate-400">
+              Uptime: {status.uptime}
+            </Badge>
+          )}
         </div>
-      </div>
-      <div className="flex items-center gap-2">
-        {status.reachable ? (
-          <Badge
-            variant="outline"
-            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
-          >
-            &#9679; Connected
-          </Badge>
-        ) : (
-          <Badge
-            variant="outline"
-            className="border-rose-500/30 bg-rose-500/10 text-rose-400"
-          >
-            &#9679; Unreachable
-          </Badge>
-        )}
-        {status.uptime && (
-          <Badge variant="outline" className="border-slate-800 text-slate-400">
-            Uptime: {status.uptime}
-          </Badge>
-        )}
       </div>
     </div>
   );

--- a/web/src/components/router/RouterWorkspace.tsx
+++ b/web/src/components/router/RouterWorkspace.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { AlertCircle, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RouterSelector } from "@/components/RouterSelector";
+
+type RouterWorkspaceProps = {
+  active: "mikrotik" | "pfsense" | "xiaomi";
+  children: ReactNode;
+};
+
+export function RouterWorkspace({ active, children }: RouterWorkspaceProps) {
+  return (
+    <div className="min-w-0 space-y-5">
+      <div className="rounded-md border border-slate-800/80 bg-slate-950/80 p-3">
+        <RouterSelector active={active} />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function RouterWorkspaceLoading() {
+  return (
+    <div className="space-y-5">
+      <div className="rounded-md border border-slate-800 bg-slate-950 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-56" />
+            <Skeleton className="h-4 w-72 max-w-full" />
+          </div>
+          <Skeleton className="h-8 w-28" />
+        </div>
+      </div>
+      <Skeleton className="h-12 w-full" />
+      <Skeleton className="h-80 w-full" />
+    </div>
+  );
+}
+
+type RouterWorkspaceStateProps = {
+  title: string;
+  description: string;
+  settingsHref: string;
+  settingsLabel: string;
+  tone?: "amber" | "rose";
+  detail?: string | null;
+};
+
+export function RouterWorkspaceState({
+  title,
+  description,
+  settingsHref,
+  settingsLabel,
+  tone = "amber",
+  detail,
+}: RouterWorkspaceStateProps) {
+  const toneClass =
+    tone === "rose"
+      ? "border-rose-500/30 bg-rose-500/10 text-rose-300"
+      : "border-amber-500/30 bg-amber-500/10 text-amber-300";
+
+  return (
+    <Card className="border-slate-800 bg-slate-950 shadow-none">
+      <CardContent className="grid gap-5 p-5 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0 space-y-3">
+          <div className={`inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs ${toneClass}`}>
+            <AlertCircle className="h-3.5 w-3.5" />
+            {tone === "rose" ? "Connection degraded" : "Action required"}
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight text-white">
+              {title}
+            </h1>
+            <p className="mt-1 max-w-2xl text-sm text-slate-400">
+              {description}
+            </p>
+            {detail && (
+              <p className="mt-2 font-mono text-xs text-slate-500">{detail}</p>
+            )}
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          asChild
+          className="w-full border-slate-700 text-slate-200 hover:bg-slate-800 sm:w-auto"
+        >
+          <Link href={settingsHref}>
+            <Settings className="mr-2 h-4 w-4" />
+            {settingsLabel}
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/ui/info-stat-card.tsx
+++ b/web/src/components/ui/info-stat-card.tsx
@@ -32,7 +32,7 @@ export function InfoStatCard({
   return (
     <Card
       className={cn(
-        "border-slate-800/50 bg-slate-900/60 shadow-none",
+        "col-span-1 border-slate-800/50 bg-slate-950/70 shadow-none",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- renews the production router workspace shell for MikroTik and pfSense
- adds shared router workspace loading/unconfigured/error state components
- keeps existing MikroTik/pfSense route tabs and real API-backed CRUD surfaces in place

Refs #745

## Verification
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run test`
- `cd web && bun run build`

Not run locally:
- Playwright route tests, because the worker environment did not have the app/API server listening on `localhost:8080`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renews the router workspace shell for MikroTik and pfSense by introducing three shared components — `RouterWorkspace`, `RouterWorkspaceLoading`, and `RouterWorkspaceState` — and migrating both pages to use them, replacing duplicated inline skeletons and ad-hoc unconfigured cards.

- `RouterWorkspace` wraps `RouterSelector` in a styled shell so each page no longer manages its own tab bar layout.
- `RouterWorkspaceLoading` and `RouterWorkspaceState` give MikroTik and pfSense pages consistent loading and empty/error states; `PfSenseRouter` also gains a `RouterWorkspaceState` for the null-status and unreachable paths.
- `xiaomi/page.tsx` adopts the new `RouterWorkspace` shell but retains the old inline skeleton and legacy Card-based unconfigured state rather than the new shared components, leaving it visually out of step with the other two workspaces.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all routing and API-backed surfaces remain intact and the new shared components are straightforward presentational wrappers.

The MikroTik and pfSense workspaces are cleanly migrated and the new shared components have no logic bugs. The Xiaomi page partially adopts the new shell but skips the new loading/unconfigured components — a visual inconsistency with no functional impact on routing or data fetching.

web/src/app/(app)/router/xiaomi/page.tsx — still uses old inline state patterns despite the PR introducing standardized replacements.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/router/RouterWorkspace.tsx | New shared workspace shell, loading skeleton, and state card components; well-structured and correctly typed. |
| web/src/app/(app)/router/xiaomi/page.tsx | Adopts RouterWorkspace shell but retains old inline loading skeletons and Card-based unconfigured state instead of the new shared components, leaving the Xiaomi workspace visually inconsistent. |
| web/src/app/(app)/router/page.tsx | Router redirect page rewritten; Xiaomi is no longer a redirect target (addressed in a prior thread), but the fallback logic is otherwise sound. |
| web/src/components/pfsense/PfSenseRouter.tsx | Adopts RouterWorkspaceState for null-status and unconfigured error states; unreachable-but-configured path shows last-known status alongside the error card, which is intentional. |
| web/src/components/ui/info-stat-card.tsx | New reusable stat card component; well-typed with em-dash tooltip guard and no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/app/(app)/router/xiaomi/page.tsx:39-81
**Xiaomi loading and unconfigured states not migrated to shared components**

The PR introduces `RouterWorkspaceLoading` and `RouterWorkspaceState` as the standard shared state components and uses them in both the MikroTik and pfSense pages, but `xiaomi/page.tsx` still uses the old inline `Skeleton` loading shimmer (lines 39–42) and the legacy `Card`/`CardContent` unconfigured block (lines 57–80). A user landing on the Xiaomi workspace will see a noticeably different loading and empty-state UI compared to the other two workspaces. The unused imports (`Link`, `Router`, `Settings`, `Card`, `CardContent`, `Skeleton`) are also left over from the pre-refactor version of this file.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/fea..."](https://github.com/befeast/panoptikon/commit/2e9d047d23103fa7d8c82e4a11083f2e891274bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32462190)</sub>

<!-- /greptile_comment -->