### PR TITLE
[codex] Renew production shell mesh foundation

### DIFF
--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -20,12 +20,12 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     <SWRProvider>
     <WebSocketProvider>
       <TooltipProvider delayDuration={300}>
-        <div className="flex h-screen overflow-clip">
+        <div className="flex h-screen overflow-clip bg-slate-950/35">
           <Sidebar />
           <div className="flex min-w-0 flex-1 flex-col overflow-clip">
             <TopBar mobileMenu={<MobileSidebar />} />
             <Breadcrumbs />
-            <main className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-8 pt-4 md:px-6 md:pb-10 md:pt-6">
+            <main className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-8 pt-4 md:px-5 md:pb-10 md:pt-5">
               <div className="mx-auto w-full max-w-[1700px]">{children}</div>
             </main>
           </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -38,13 +38,25 @@
 
   body {
     @apply text-foreground;
-    background-color: #070B12;
+    background-color: #05080d;
     background-image:
-      radial-gradient(circle at 14% -16%, rgba(34, 211, 238, 0.08) 0%, transparent 34%),
-      radial-gradient(circle at 88% -26%, rgba(30, 41, 59, 0.24) 0%, transparent 38%),
-      linear-gradient(180deg, #070B12 0%, #0E1624 100%);
+      linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+      linear-gradient(180deg, #05080d 0%, #0a111d 48%, #07101a 100%);
+    background-size: 32px 32px, 32px 32px, 100% 100%;
     background-attachment: fixed;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+
+  ::selection {
+    background: hsl(var(--primary) / 0.28);
+    color: hsl(var(--foreground));
+  }
+
+  h1,
+  h2,
+  h3 {
+    letter-spacing: 0;
   }
 }
 

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -13,10 +13,12 @@ import {
   MonitorSmartphone,
   Package,
   Plus,
+  RadioTower,
   Radar,
   Router,
   Search,
   Settings,
+  Shield,
   Terminal,
 } from 'lucide-react'
 import { searchAll } from '@/lib/api'
@@ -45,7 +47,9 @@ const PAGES: PageItem[] = [
   { label: 'Agents', href: '/agents', icon: Cpu },
   { label: 'Traffic', href: '/traffic', icon: Activity },
   { label: 'Alerts', href: '/alerts', icon: Bell },
-  { label: 'Router', href: '/router', icon: Router },
+  { label: 'Router Overview', href: '/router', icon: Router },
+  { label: 'MikroTik', href: '/router/mikrotik', icon: RadioTower },
+  { label: 'pfSense', href: '/router/pfsense', icon: Shield },
   { label: 'Settings', href: '/settings', icon: Settings },
 ]
 
@@ -127,7 +131,7 @@ export function CommandPalette() {
     '[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:pt-3 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-slate-500'
 
   const itemClass =
-    'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-slate-300 outline-none aria-selected:bg-blue-500/15 aria-selected:text-white cursor-pointer transition-colors'
+    'flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm text-slate-300 outline-none aria-selected:bg-cyan-400/10 aria-selected:text-white cursor-pointer transition-colors'
 
   const groupDividerClass = `border-t border-slate-800 mt-1 pt-1 ${groupHeadingClass}`
 
@@ -138,12 +142,12 @@ export function CommandPalette() {
       label="Command palette"
       className="flex flex-col flex-1 min-h-0"
       overlayClassName="fixed inset-0 z-[99] bg-black/70 backdrop-blur-sm"
-      contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 z-[100] w-[min(560px,calc(100vw-2rem))] max-h-[min(480px,60vh)] flex flex-col overflow-hidden rounded-2xl border border-slate-600/80 bg-slate-900 shadow-[0_24px_80px_-12px_rgba(0,0,0,0.8)]"
+      contentClassName="fixed left-1/2 top-[15vh] -translate-x-1/2 z-[100] w-[min(560px,calc(100vw-2rem))] max-h-[min(480px,60vh)] flex flex-col overflow-hidden rounded-lg border border-slate-700/80 bg-slate-950 shadow-[0_24px_80px_-12px_rgba(0,0,0,0.85)]"
       shouldFilter={!hasResults}
     >
       {/* Search input */}
-      <div className="flex items-center gap-3 border-b border-slate-700/80 px-4 py-3">
-        <Search className="h-5 w-5 shrink-0 text-slate-400" />
+      <div className="flex items-center gap-3 border-b border-slate-800/80 px-4 py-3">
+        <Search className="h-5 w-5 shrink-0 text-cyan-400/80" />
         <Command.Input
           value={query}
           onValueChange={setQuery}

--- a/web/src/components/layout/Breadcrumbs.tsx
+++ b/web/src/components/layout/Breadcrumbs.tsx
@@ -13,6 +13,8 @@ const segmentLabels: Record<string, string> = {
   mesh: "Mesh",
   traffic: "Traffic",
   router: "Router",
+  mikrotik: "MikroTik",
+  pfsense: "pfSense",
   caddy: "Caddy",
   services: "Services",
   nat: "NAT",

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -40,8 +40,8 @@ export function MobileSidebar() {
         >
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           {/* Logo */}
-          <div className="flex h-14 shrink-0 items-center border-b border-slate-800 px-4">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500 text-sm font-bold text-white">
+          <div className="flex h-14 shrink-0 items-center border-b border-slate-800/80 px-4">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/30 bg-cyan-400 text-sm font-bold text-slate-950">
               P
             </div>
             <span className="ml-2 text-lg font-semibold text-white">
@@ -81,7 +81,7 @@ export function MobileSidebar() {
                     <span
                       className={cn(
                         "cursor-default select-none text-[11px] font-semibold uppercase tracking-wider",
-                        hasActive ? "text-blue-400" : "text-slate-500",
+                        hasActive ? "text-cyan-400" : "text-slate-500",
                       )}
                     >
                       {group.label}
@@ -97,7 +97,11 @@ export function MobileSidebar() {
                   >
                     <div className="overflow-hidden">
                       {group.items.map((item) => {
-                        const active = pathname?.startsWith(item.href);
+                        const active =
+                          pathname === item.href ||
+                          (item.href !== "/router" &&
+                            item.href !== "/dashboard" &&
+                            pathname?.startsWith(`${item.href}/`));
                         const Icon = item.icon;
 
                         return (
@@ -106,14 +110,14 @@ export function MobileSidebar() {
                             href={item.href}
                             onClick={() => setOpen(false)}
                             className={cn(
-                              "group/nav relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
+                              "group/nav relative flex min-h-9 items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
                               active
-                                ? "bg-blue-500/10 text-blue-500"
-                                : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
+                                ? "bg-cyan-400/10 text-cyan-300"
+                                : "text-slate-400 hover:bg-slate-900/80 hover:text-white",
                             )}
                           >
                             {active && (
-                              <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-blue-400 to-blue-600" />
+                              <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-cyan-300 to-cyan-600" />
                             )}
                             <Icon className="h-[18px] w-[18px] shrink-0 transition-transform duration-150 group-hover/nav:scale-105" />
                             <span>{item.label}</span>
@@ -134,12 +138,12 @@ export function MobileSidebar() {
                 className={cn(
                   "group/nav relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
                   pathname?.startsWith("/settings")
-                    ? "bg-blue-500/10 text-blue-500"
+                    ? "bg-cyan-400/10 text-cyan-300"
                     : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
                 )}
               >
                 {pathname?.startsWith("/settings") && (
-                  <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-blue-400 to-blue-600" />
+                  <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full bg-gradient-to-b from-cyan-300 to-cyan-600" />
                 )}
                 <Settings className="h-[18px] w-[18px] shrink-0 transition-transform duration-150 group-hover/nav:scale-105" />
                 <span>Settings</span>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   LayoutDashboard,
   MonitorSmartphone,
   Network,
+  RadioTower,
   Router,
   Search,
   Server,
@@ -71,7 +72,9 @@ export const navGroups: NavGroup[] = [
     key: "routing",
     label: "Routing & Proxy",
     items: [
-      { href: "/router", label: "Router", icon: Router },
+      { href: "/router", label: "Router Overview", icon: Router },
+      { href: "/router/mikrotik", label: "MikroTik", icon: RadioTower },
+      { href: "/router/pfsense", label: "pfSense", icon: Shield },
       { href: "/caddy", label: "Caddy", icon: Shield },
       { href: "/services", label: "Services", icon: Workflow },
       { href: "/nat", label: "NAT", icon: ArrowRightLeft },
@@ -208,17 +211,21 @@ export function Sidebar() {
 
   /** Render a single navigation link. */
   function renderNavLink(item: NavItem) {
-    const active = pathname?.startsWith(item.href);
+    const active =
+      pathname === item.href ||
+      (item.href !== "/router" &&
+        item.href !== "/dashboard" &&
+        pathname?.startsWith(`${item.href}/`));
     const Icon = item.icon;
 
     const linkContent = (
       <Link
         href={item.href}
         className={cn(
-          "group/nav relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150",
+          "group/nav relative flex h-9 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors duration-150",
           active
-            ? "bg-cyan-500/10 text-cyan-500"
-            : "text-slate-400 hover:bg-slate-800/60 hover:text-white",
+            ? "bg-cyan-400/10 text-cyan-300"
+            : "text-slate-400 hover:bg-slate-900/80 hover:text-slate-100",
           sidebarCollapsed && "justify-center px-0",
         )}
       >
@@ -252,17 +259,17 @@ export function Sidebar() {
     <TooltipProvider delayDuration={0}>
       <aside
         className={cn(
-          "hidden md:flex flex-col border-r border-slate-800 bg-slate-950 transition-all duration-200",
+          "hidden md:flex flex-col border-r border-slate-800/80 bg-[#060a11]/95 transition-all duration-200",
           sidebarCollapsed ? "w-16" : "w-60",
         )}
       >
         {/* Logo + collapse toggle */}
-        <div className="flex h-[3.75rem] items-center justify-between border-b border-slate-800/75 px-3">
+        <div className="flex h-[3.75rem] items-center justify-between border-b border-slate-800/80 px-3">
           <Link
             href="/dashboard"
             className="flex items-center min-w-0"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-cyan-500 text-sm font-bold text-slate-950">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/30 bg-cyan-400 text-sm font-bold text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.18)]">
               P
             </div>
             {!sidebarCollapsed && (
@@ -273,7 +280,7 @@ export function Sidebar() {
           </Link>
           <button
             onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-800/60 hover:text-slate-300"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-900 hover:text-slate-200"
             aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             {sidebarCollapsed ? (
@@ -347,7 +354,7 @@ export function Sidebar() {
           {/* Settings — always visible, pinned after groups */}
           <div
             className={cn(
-              "mt-1 border-t border-slate-800/50 pt-1",
+              "mt-1 border-t border-slate-800/70 pt-1",
               sidebarCollapsed && "border-t-0",
             )}
           >
@@ -356,7 +363,7 @@ export function Sidebar() {
         </nav>
 
         {/* Version + connection status */}
-        <div className="border-t border-slate-800/50 p-2">
+        <div className="border-t border-slate-800/70 p-2">
           {!sidebarCollapsed ? (
             <div className="flex items-center gap-1.5 px-3 py-1">
               <Tooltip>

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -224,7 +224,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   let runningIndex = 0;
 
   return (
-    <header className="sticky top-0 z-40 flex h-[3.75rem] items-center justify-between gap-3 border-b border-slate-800/75 bg-slate-950/70 px-3 backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/60 md:px-6">
+    <header className="sticky top-0 z-40 flex h-[3.75rem] items-center justify-between gap-3 border-b border-slate-800/80 bg-[#060a11]/85 px-3 backdrop-blur-xl supports-[backdrop-filter]:bg-[#060a11]/75 md:px-5">
       {/* Mobile menu button */}
       {mobileMenu}
 
@@ -240,12 +240,12 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
             if (results && query.length >= 2) setIsOpen(true);
           }}
           placeholder="Search devices, IPs, MACs...  ⌘K"
-          className="h-8 w-full rounded-lg border border-slate-800/80 bg-slate-900 px-3 text-sm text-white placeholder-slate-500 transition-all duration-300 focus:border-blue-500/40 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:shadow-[0_0_15px_rgba(59,130,246,0.15)]"
+          className="h-8 w-full rounded-md border border-slate-800/90 bg-slate-950/85 px-3 text-sm text-white placeholder-slate-500 transition-all duration-200 focus:border-cyan-400/45 focus:outline-none focus:ring-2 focus:ring-cyan-400/15 focus:shadow-[0_0_16px_rgba(34,211,238,0.12)]"
         />
 
         {/* Search Results Dropdown */}
         {isOpen && (
-          <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
+          <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-lg border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
             {noResults && (
               <div className="px-4 py-3 text-sm text-slate-500">
                 No results for &ldquo;{query}&rdquo;
@@ -433,7 +433,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
         <div className="relative" ref={bellRef}>
           <button
             onClick={() => setBellOpen((v) => !v)}
-            className="relative flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800/85 hover:text-white"
+            className="relative flex h-9 w-9 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-900/90 hover:text-white"
             aria-label="Notifications"
           >
             <Bell className="h-5 w-5" />
@@ -445,14 +445,14 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
           </button>
 
           {bellOpen && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-80 rounded-xl border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
+            <div className="absolute right-0 top-full z-50 mt-1 w-80 max-w-[calc(100vw-1rem)] rounded-lg border border-slate-800/80 bg-slate-950/95 shadow-2xl backdrop-blur-md">
               <div className="flex items-center justify-between border-b border-slate-800 px-4 py-2.5">
                 <span className="text-sm font-semibold text-white">Notifications</span>
                 <div className="flex items-center gap-3">
                   {unreadCount > 0 && (
                     <button
                       onClick={handleMarkAllRead}
-                      className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                      className="text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
                     >
                       Mark all read
                     </button>
@@ -508,7 +508,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
                     setBellOpen(false);
                     router.push("/alerts");
                   }}
-                  className="flex w-full items-center justify-center px-4 py-2.5 text-sm text-blue-400 hover:text-blue-300 hover:bg-slate-800/60 transition-colors"
+                  className="flex w-full items-center justify-center px-4 py-2.5 text-sm text-cyan-400 hover:text-cyan-300 hover:bg-slate-800/60 transition-colors"
                 >
                   View all alerts
                 </button>
@@ -520,7 +520,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
         {/* ── User Avatar Menu ── */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-500 text-sm font-medium text-white hover:bg-blue-600 transition-colors">
+            <button className="flex h-8 w-8 items-center justify-center rounded-md border border-cyan-300/30 bg-cyan-400 text-sm font-semibold text-slate-950 transition-colors hover:bg-cyan-300">
               A
             </button>
           </DropdownMenuTrigger>
@@ -562,7 +562,7 @@ function SeverityBadge({ severity }: { severity: string }) {
   const colors: Record<string, string> = {
     CRITICAL: "bg-rose-500/20 text-rose-400 border-rose-500/30",
     WARNING: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
-    INFO: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+    INFO: "bg-cyan-500/15 text-cyan-300 border-cyan-500/30",
   };
   const cls = colors[severity] || colors.WARNING;
   return (

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -9,9 +9,9 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative overflow-hidden rounded-xl border border-slate-800 bg-slate-900/60 text-card-foreground shadow-[0_8px_26px_-18px_rgba(15,23,42,0.95)] backdrop-blur-xl supports-[backdrop-filter]:bg-slate-900/55",
-      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent",
-      "transition-[border-color] duration-200 ease-out hover:border-blue-500/20",
+      "relative overflow-hidden rounded-lg border border-slate-800/80 bg-slate-950/70 text-card-foreground shadow-[0_10px_30px_-24px_rgba(0,0,0,0.95)] backdrop-blur-xl supports-[backdrop-filter]:bg-slate-950/65",
+      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-cyan-300/10",
+      "transition-[border-color,background-color] duration-150 ease-out hover:border-cyan-400/25",
       selected && "card-selected",
       className
     )}
@@ -26,7 +26,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col gap-1.5 p-5", className)}
+    className={cn("flex flex-col gap-1.5 p-4", className)}
     {...props}
   />
 ))
@@ -39,7 +39,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-base font-semibold leading-tight tracking-tight",
+      "text-base font-semibold leading-tight tracking-normal",
       className
     )}
     {...props}
@@ -53,7 +53,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+    className={cn("text-sm leading-relaxed text-slate-400", className)}
     {...props}
   />
 ))
@@ -63,7 +63,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -73,7 +73,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-5 pt-0", className)}
+    className={cn("flex items-center p-4 pt-0", className)}
     {...props}
   />
 ))

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn("w-full caption-bottom border-collapse text-sm tabular-nums", className)}
       {...props}
     />
   </div>
@@ -20,7 +20,11 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn("bg-slate-950/80 [&_tr]:border-b [&_tr]:border-slate-800/80", className)}
+    {...props}
+  />
 ))
 TableHeader.displayName = "TableHeader"
 
@@ -28,11 +32,7 @@ const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
 ))
 TableBody.displayName = "TableBody"
 
@@ -58,7 +58,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-b border-slate-800/60 transition-colors hover:bg-cyan-400/[0.035] data-[state=selected]:bg-cyan-400/10",
       className
     )}
     {...props}
@@ -73,7 +73,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-9 px-3 text-left align-middle text-[11px] font-semibold uppercase tracking-wider text-slate-500 [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
@@ -87,7 +87,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("px-3 py-2.5 align-middle text-slate-300 [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))

--- a/web/src/lib/settings-nav.ts
+++ b/web/src/lib/settings-nav.ts
@@ -22,18 +22,18 @@ export const settingsNav: SettingsNavGroup[] = [
     items: [
       {
         href: "/settings/router",
-        title: "Router",
+        title: "MikroTik",
         description: "Configure MikroTik router integration.",
-      },
-      {
-        href: "/settings/xiaomi-mesh",
-        title: "Xiaomi Mesh",
-        description: "Configure Xiaomi mesh router integration.",
       },
       {
         href: "/settings/pfsense",
         title: "pfSense",
         description: "Configure pfSense router integration via SSH.",
+      },
+      {
+        href: "/settings/xiaomi-mesh",
+        title: "Xiaomi Mesh",
+        description: "Configure Xiaomi mesh router integration.",
       },
       {
         href: "/settings/dns",

--- a/web/tests/unit/settings-nav.test.ts
+++ b/web/tests/unit/settings-nav.test.ts
@@ -30,13 +30,18 @@ describe("settingsNav visibility gating", () => {
     expect(cfItem!.title).toBe("Cloudflare Tunnel");
   });
 
-  it("Router integration is in the primary Integrations section", () => {
-    const routerItem = integrationsGroup!.items.find(
+  it("MikroTik and pfSense integrations are in the primary Integrations section", () => {
+    const mikrotikItem = integrationsGroup!.items.find(
       (i) => i.href === "/settings/router",
     );
-    expect(routerItem).toBeDefined();
-    expect(routerItem!.title).toBe("Router");
-    expect(routerItem!.description).toMatch(/MikroTik/);
+    const pfsenseItem = integrationsGroup!.items.find(
+      (i) => i.href === "/settings/pfsense",
+    );
+    expect(mikrotikItem).toBeDefined();
+    expect(mikrotikItem!.title).toBe("MikroTik");
+    expect(mikrotikItem!.description).toMatch(/MikroTik/);
+    expect(pfsenseItem).toBeDefined();
+    expect(pfsenseItem!.title).toBe("pfSense");
   });
 
   it("VyOS does not appear anywhere in settings nav", () => {


### PR DESCRIPTION
## Summary

Refs #743

- Renews the authenticated app chrome with a dense mesh/operator-console treatment: darker shell surfaces, hairline borders, restrained cyan accents, compact spacing, and tabular table defaults.
- Promotes MikroTik and pfSense as direct router destinations in the sidebar and command palette while keeping `/dashboard` as the authenticated landing route and using production routes in place.
- Updates settings navigation and the matching unit test so MikroTik and pfSense are primary integrations, with Xiaomi remaining secondary.

## Verification

- `cd web && bun install --frozen-lockfile`
- `cd web && bun run test`
- `cd web && bun run build`
- `cargo build -q -p panoptikon-server`
- `cargo test -q -p panoptikon-server --lib`
- `cd web && bun run test:e2e -- tests/e2e/navigation.spec.ts tests/e2e/sidebar-ux.spec.ts tests/e2e/topbar-polish.spec.ts` (passed; one setup-race retry in `navigation.spec.ts` passed on retry)

## Notes

- Full `cargo test` was also attempted after building `web/out`; server unit/lib tests passed, then `server/tests/caddy_integration.rs` failed because no Caddy admin API was running at `http://localhost:2019` in this local environment.
