### PR TITLE
UX renewal: dashboard route signals retry

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -10,11 +10,13 @@ import {
   ExternalLink,
   Info,
   MonitorSmartphone,
+  Network,
   Pin,
   Radar,
   Rocket,
   Router,
   Shield,
+  Server,
   WifiOff,
 } from "lucide-react";
 import {
@@ -38,8 +40,18 @@ import {
   fetchTrafficHistory,
   fetchDevices,
   fetchCriticalDevices,
+  fetchTopDevices,
+  fetchTopologyGraph,
 } from "@/lib/api";
-import type { Alert, CriticalDevice, DashboardStats, TrafficHistoryPoint, Device } from "@/lib/types";
+import type {
+  Alert,
+  CriticalDevice,
+  DashboardStats,
+  TrafficHistoryPoint,
+  Device,
+  TopDevice,
+  TopologyGraph,
+} from "@/lib/types";
 import { formatBps, timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { StaggerContainer, StaggerItem } from "@/components/MotionStagger";
@@ -74,6 +86,44 @@ function severityDotColor(severity: Alert["severity"]): string {
     default:
       return "bg-blue-500";
   }
+}
+
+function panelClassName(extra?: string) {
+  return cn(
+    "border-slate-800/90 bg-slate-950/70 shadow-[inset_0_1px_0_rgba(148,163,184,0.04)]",
+    extra,
+  );
+}
+
+function SectionTitle({
+  icon,
+  title,
+  href,
+  action = "Details",
+}: {
+  icon?: React.ReactNode;
+  title: string;
+  href?: string;
+  action?: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-2">
+        {icon && <span className="shrink-0 text-cyan-400">{icon}</span>}
+        <CardTitle className="truncate text-[11px] font-medium uppercase tracking-wider text-slate-500">
+          {title}
+        </CardTitle>
+      </div>
+      {href && (
+        <Link
+          href={href}
+          className="flex shrink-0 items-center gap-1 text-xs text-cyan-400 transition-colors hover:text-cyan-300"
+        >
+          {action} <ArrowRight className="h-3 w-3" />
+        </Link>
+      )}
+    </div>
+  );
 }
 
 // ─── Critical Devices Dialog ──────────────────────────
@@ -212,9 +262,9 @@ function StatCard({
   const inner = (
     <Card
       className={cn(
-        "h-full min-h-[8.25rem] border-slate-700/50 bg-slate-900/55",
+        "h-full min-h-[8.25rem] border-slate-800/90 bg-slate-950/70",
         href &&
-          "transition-[border-color,background-color,box-shadow] hover:border-slate-700/90 hover:bg-slate-900/72 hover:shadow-[0_14px_32px_-22px_rgba(15,23,42,0.95)]",
+          "transition-[border-color,background-color,box-shadow] hover:border-cyan-700/50 hover:bg-slate-900/72 hover:shadow-[0_14px_32px_-22px_rgba(8,145,178,0.45)]",
       )}
     >
       <CardHeader className="flex flex-row items-start justify-between pb-3">
@@ -245,7 +295,7 @@ function StatCard({
 
 function StatCardSkeleton() {
   return (
-    <Card className="h-full min-h-[8.25rem] border-slate-700/50 bg-slate-900/55">
+    <Card className="h-full min-h-[8.25rem] border-slate-800/90 bg-slate-950/70">
       <CardHeader className="pb-3">
         <Skeleton className="h-3.5 w-24" />
       </CardHeader>
@@ -416,6 +466,263 @@ function QuickActions() {
   );
 }
 
+function routerDisplayName(type: string) {
+  if (type === "mikrotik") return "MikroTik";
+  if (type === "pfsense") return "pfSense";
+  return "Router";
+}
+
+function RouterHealthSection({
+  stats,
+  error,
+  onRetry,
+}: {
+  stats: DashboardStats | null;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  const activeType = stats?.router_type ?? "none";
+  const isConfigured = Boolean(stats && activeType !== "none" && stats.router_status !== "unconfigured");
+  const isOnline = stats?.router_status === "connected" || stats?.router_status === "online";
+  const cards = [
+    {
+      type: "mikrotik",
+      label: "MikroTik",
+      href: "/router/mikrotik",
+      primary: stats && activeType === "mikrotik",
+    },
+    {
+      type: "pfsense",
+      label: "pfSense",
+      href: "/router/pfsense",
+      primary: stats && activeType === "pfsense",
+    },
+  ];
+
+  return (
+    <Card className={panelClassName()}>
+      <CardHeader className="pb-4">
+        <SectionTitle
+          icon={<Router className="h-4 w-4" />}
+          title="Router Health"
+          href="/router"
+          action="Open"
+        />
+      </CardHeader>
+      <CardContent className="grid gap-3 sm:grid-cols-2">
+        {error ? (
+          <div className="sm:col-span-2">
+            <SectionError message="Failed to load router health" onRetry={onRetry} />
+          </div>
+        ) : stats === null ? (
+          <>
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </>
+        ) : (
+          cards.map((card) => {
+            const statusLabel = card.primary
+              ? isOnline
+                ? "Connected"
+                : isConfigured
+                  ? "Unreachable"
+                  : "Unconfigured"
+              : "Standby";
+            const statusClass = card.primary
+              ? isOnline
+                ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-300"
+                : isConfigured
+                  ? "border-rose-500/25 bg-rose-500/10 text-rose-300"
+                  : "border-amber-500/25 bg-amber-500/10 text-amber-300"
+              : "border-slate-700 bg-slate-900/60 text-slate-400";
+
+            return (
+              <Link
+                key={card.type}
+                href={card.href}
+                className="rounded-md border border-slate-800 bg-slate-900/35 p-3 transition-colors hover:border-cyan-700/50 hover:bg-slate-900/70"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-200">{card.label}</p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {card.primary ? "Primary router signal" : "Available router client"}
+                    </p>
+                  </div>
+                  <span className={cn("shrink-0 rounded-full border px-2 py-0.5 text-[11px]", statusClass)}>
+                    {statusLabel}
+                  </span>
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                  <div className="rounded border border-slate-800/80 bg-slate-950/50 px-2 py-1.5">
+                    <p className="text-slate-600">WAN RX</p>
+                    <p className="mt-0.5 truncate tabular-nums text-slate-300">
+                      {card.primary ? formatBps(stats.wan_rx_bps) : "—"}
+                    </p>
+                  </div>
+                  <div className="rounded border border-slate-800/80 bg-slate-950/50 px-2 py-1.5">
+                    <p className="text-slate-600">WAN TX</p>
+                    <p className="mt-0.5 truncate tabular-nums text-slate-300">
+                      {card.primary ? formatBps(stats.wan_tx_bps) : "—"}
+                    </p>
+                  </div>
+                </div>
+              </Link>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopologyPreview({
+  topology,
+  error,
+  onRetry,
+}: {
+  topology: TopologyGraph | null;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  const onlineDevices = topology?.devices.filter((d) => d.is_online).length ?? 0;
+  const offlineDevices = topology ? topology.devices.length - onlineDevices : 0;
+  const previewDevices = topology?.devices
+    .slice()
+    .sort((a, b) => Number(b.is_online) - Number(a.is_online))
+    .slice(0, 8) ?? [];
+
+  return (
+    <Card className={panelClassName("h-full")}>
+      <CardHeader className="pb-4">
+        <SectionTitle
+          icon={<Network className="h-4 w-4" />}
+          title="Topology Preview"
+          href="/topology"
+          action="Map"
+        />
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <SectionError message="Failed to load topology" onRetry={onRetry} />
+        ) : topology === null ? (
+          <Skeleton className="h-56 w-full" />
+        ) : topology.devices.length === 0 ? (
+          <div className="flex h-56 items-center justify-center rounded-md border border-dashed border-slate-800 text-sm text-slate-600">
+            No topology data yet
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="relative h-56 overflow-hidden rounded-md border border-slate-800 bg-[radial-gradient(circle_at_center,rgba(8,145,178,0.12),transparent_34%),linear-gradient(rgba(15,23,42,0.8)_1px,transparent_1px),linear-gradient(90deg,rgba(15,23,42,0.8)_1px,transparent_1px)] bg-[size:100%_100%,24px_24px,24px_24px]">
+              <div className="absolute left-1/2 top-1/2 z-10 flex h-14 w-14 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-cyan-400/30 bg-slate-950 text-cyan-300 shadow-[0_0_28px_rgba(8,145,178,0.18)]">
+                <Router className="h-6 w-6" />
+              </div>
+              {previewDevices.map((device, index) => {
+                const angle = (index / Math.max(previewDevices.length, 1)) * Math.PI * 2 - Math.PI / 2;
+                const radius = 34 + (index % 2) * 10;
+                const left = 50 + Math.cos(angle) * radius;
+                const top = 50 + Math.sin(angle) * radius;
+                return (
+                  <div
+                    key={device.id}
+                    className={cn(
+                      "absolute flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border bg-slate-950",
+                      device.is_online
+                        ? "border-emerald-400/35 text-emerald-300"
+                        : "border-rose-400/35 text-rose-300",
+                    )}
+                    style={{ left: `${left}%`, top: `${top}%` }}
+                    title={device.name || device.hostname || device.ips[0] || "Unknown device"}
+                  >
+                    <Server className="h-4 w-4" />
+                  </div>
+                );
+              })}
+            </div>
+            <div className="grid grid-cols-3 gap-2 text-xs">
+              <div className="rounded border border-slate-800 bg-slate-900/40 px-2 py-2">
+                <p className="text-slate-600">Router</p>
+                <p className="mt-1 truncate text-slate-300">{routerDisplayName(topology.router.router_type)}</p>
+              </div>
+              <div className="rounded border border-slate-800 bg-slate-900/40 px-2 py-2">
+                <p className="text-slate-600">Online</p>
+                <p className="mt-1 tabular-nums text-emerald-300">{onlineDevices}</p>
+              </div>
+              <div className="rounded border border-slate-800 bg-slate-900/40 px-2 py-2">
+                <p className="text-slate-600">Offline</p>
+                <p className="mt-1 tabular-nums text-rose-300">{offlineDevices}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopDevicesTable({
+  devices,
+  error,
+  onRetry,
+}: {
+  devices: TopDevice[] | null;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <Card className={panelClassName("h-full")}>
+      <CardHeader className="pb-4">
+        <SectionTitle
+          icon={<Activity className="h-4 w-4" />}
+          title="Top Devices"
+          href="/traffic"
+          action="Traffic"
+        />
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <SectionError message="Failed to load top devices" onRetry={onRetry} />
+        ) : devices === null ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-9 w-full" />
+            ))}
+          </div>
+        ) : devices.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-600">No device traffic recorded yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[420px] text-left text-xs">
+              <thead className="border-b border-slate-800 text-[10px] uppercase tracking-wider text-slate-600">
+                <tr>
+                  <th className="py-2 pr-3 font-medium">Device</th>
+                  <th className="px-3 py-2 font-medium">IP</th>
+                  <th className="px-3 py-2 text-right font-medium">Down</th>
+                  <th className="py-2 pl-3 text-right font-medium">Up</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800/80">
+                {devices.map((device) => (
+                  <tr key={device.id} className="hover:bg-slate-900/45">
+                    <td className="max-w-[13rem] py-2 pr-3">
+                      <Link href={`/devices?id=${device.id}`} className="block truncate text-slate-200 hover:text-cyan-300">
+                        {device.name || device.hostname || device.vendor || "Unknown"}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums text-slate-500">{device.ip || "—"}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-emerald-300">{formatBps(device.rx_bps)}</td>
+                    <td className="py-2 pl-3 text-right tabular-nums text-cyan-300">{formatBps(device.tx_bps)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── Page ───────────────────────────────────────────────
 
 export default function DashboardPage() {
@@ -443,6 +750,16 @@ export default function DashboardPage() {
     () => fetchDevices().then((d) => (Array.isArray(d) ? d : [])),
     swrOpts,
   );
+  const { data: topDevices, error: topDevicesError, mutate: mutateTopDevices } = useApiFetch<TopDevice[]>(
+    "/api/v1/dashboard/top-devices",
+    () => fetchTopDevices(6).then((d) => (Array.isArray(d) ? d : [])),
+    swrOpts,
+  );
+  const { data: topology, error: topologyError, mutate: mutateTopology } = useApiFetch<TopologyGraph>(
+    "/api/v1/topology/graph",
+    fetchTopologyGraph,
+    swrOpts,
+  );
 
   const devicesRef = useRef(devices);
   devicesRef.current = devices;
@@ -452,6 +769,8 @@ export default function DashboardPage() {
     mutateAlerts();
     mutateTraffic();
     mutateDevices();
+    mutateTopDevices();
+    mutateTopology();
   };
 
   useWsEvent(
@@ -492,12 +811,17 @@ export default function DashboardPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-semibold tracking-tight text-white">Dashboard</h1>
-        <p className="max-w-3xl text-sm leading-6 text-slate-400">
-          Network health, traffic, and alerts at a glance.
-        </p>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 border-b border-slate-800/80 pb-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-white">Dashboard</h1>
+          <p className="max-w-3xl text-sm leading-6 text-slate-400">
+            Network health, router status, traffic, and alerts at a glance.
+          </p>
+        </div>
+        <div className="text-xs uppercase tracking-wider text-slate-600">
+          Live refresh / 30s
+        </div>
       </div>
 
       {/* ── Quick Actions ──────────────────────────────── */}
@@ -507,16 +831,14 @@ export default function DashboardPage() {
       {stats && <WelcomeCard stats={stats} />}
 
       {/* ── Bento Grid ─────────────────────────────────── */}
-      <StaggerContainer className="grid grid-cols-1 gap-6 xl:grid-cols-5">
+      <StaggerContainer className="grid grid-cols-1 gap-4 xl:grid-cols-5">
         {/* ── Health Score Ring ─────────────────────────── */}
         <StaggerItem><Card
-          className="h-full border-slate-700/50 bg-slate-900/55 xl:col-span-1"
+          className={panelClassName("h-full xl:col-span-1")}
           data-testid="infra-health-card"
         >
           <CardHeader className="pb-4">
-            <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-              Infrastructure Health
-            </CardTitle>
+            <SectionTitle title="Infrastructure Health" icon={<Shield className="h-4 w-4" />} />
           </CardHeader>
           <CardContent className="flex items-center justify-center pb-5">
             {statsError ? (
@@ -544,7 +866,7 @@ export default function DashboardPage() {
         />
 
         {/* ── Stat Cards Row ───────────────────────────── */}
-        <StaggerItem className="xl:col-span-4"><div className="grid h-full grid-cols-2 gap-4 xl:grid-cols-4">
+        <StaggerItem className="xl:col-span-4"><div className="grid h-full grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
           {statsError ? (
             <>
               <StatCard
@@ -588,10 +910,10 @@ export default function DashboardPage() {
                 value={routerStatusLabel(stats).label}
                 subtitle={
                   stats.router_status === "connected" || stats.router_status === "online"
-                    ? `Connected to ${stats.router_type === "mikrotik" ? "MikroTik" : "router"}`
+                    ? `Connected to ${routerDisplayName(stats.router_type)}`
                     : stats.router_status === "unconfigured"
                       ? "Router not configured"
-                      : `Cannot reach ${stats.router_type === "mikrotik" ? "MikroTik" : "router"}`
+                      : `Cannot reach ${routerDisplayName(stats.router_type)}`
                 }
                 icon={<Router className="h-4 w-4" />}
                 status={routerStatusLabel(stats).status}
@@ -632,26 +954,13 @@ export default function DashboardPage() {
         </div></StaggerItem>
 
         {/* ── WAN Traffic Card with Sparkline ─────────── */}
-        <StaggerItem className="xl:col-span-3"><Card className="border-slate-700/50 bg-slate-900/55">
+        <StaggerItem className="xl:col-span-3"><Card className={panelClassName()}>
           <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Activity className="h-4 w-4 text-blue-400" />
-                <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                  WAN Traffic
-                </CardTitle>
-              </div>
-              <Link
-                href="/traffic"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                Details <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
+            <SectionTitle icon={<Activity className="h-4 w-4" />} title="WAN Traffic" href="/traffic" />
           </CardHeader>
           <CardContent>
             {/* Current aggregate speeds */}
-            <div className="mb-4 flex flex-wrap items-end gap-6 rounded-xl border border-slate-800/70 bg-slate-900/50 px-4 py-3">
+            <div className="mb-4 flex flex-wrap items-end gap-6 rounded-md border border-slate-800/70 bg-slate-900/35 px-4 py-3">
               <div className="min-w-[8rem]">
                 <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-emerald-400/85">Download</span>
                 <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
@@ -659,7 +968,7 @@ export default function DashboardPage() {
                 </p>
               </div>
               <div className="min-w-[8rem]">
-                <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-blue-400/90">Upload</span>
+                <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-cyan-400/90">Upload</span>
                 <p className="mt-1 text-2xl font-semibold leading-none tabular-nums text-white">
                   {statsError ? "—" : stats ? formatBps(stats.wan_tx_bps) : "—"}
                 </p>
@@ -683,8 +992,8 @@ export default function DashboardPage() {
                         <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
                       </linearGradient>
                       <linearGradient id="sparkTx" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                        <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                        <stop offset="5%" stopColor="#06b6d4" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#06b6d4" stopOpacity={0} />
                       </linearGradient>
                     </defs>
                     <Tooltip
@@ -713,7 +1022,7 @@ export default function DashboardPage() {
                     <Area
                       type="monotone"
                       dataKey="tx_bps"
-                      stroke="#3b82f6"
+                      stroke="#06b6d4"
                       strokeWidth={1.5}
                       fill="url(#sparkTx)"
                       dot={false}
@@ -731,19 +1040,9 @@ export default function DashboardPage() {
         </Card></StaggerItem>
 
         {/* ── Alert Feed ───────────────────────────────── */}
-        <StaggerItem className="xl:col-span-2"><Card className="border-slate-700/50 bg-slate-900/55">
+        <StaggerItem className="xl:col-span-2"><Card className={panelClassName("h-full")}>
           <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                Recent Alerts
-              </CardTitle>
-              <Link
-                href="/alerts"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                View all <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
+            <SectionTitle title="Recent Alerts" href="/alerts" action="View all" icon={<AlertTriangle className="h-4 w-4" />} />
           </CardHeader>
           <CardContent>
             {alertsError ? (
@@ -768,7 +1067,7 @@ export default function DashboardPage() {
                   <div
                     key={alert.id}
                     className={`flex items-center gap-2.5 rounded-lg border border-transparent px-3 py-2 ${
-                      !alert.is_read ? "border-blue-500/15 bg-blue-500/6" : "hover:border-slate-800/70"
+                      !alert.is_read ? "border-cyan-500/15 bg-cyan-500/10" : "hover:border-slate-800/70"
                     }`}
                   >
                     <span
@@ -787,20 +1086,22 @@ export default function DashboardPage() {
           </CardContent>
         </Card></StaggerItem>
 
+        <StaggerItem className="xl:col-span-2">
+          <RouterHealthSection stats={stats} error={statsError} onRetry={() => mutateStats()} />
+        </StaggerItem>
+
+        <StaggerItem className="xl:col-span-3">
+          <TopDevicesTable devices={topDevices} error={topDevicesError} onRetry={() => mutateTopDevices()} />
+        </StaggerItem>
+
+        <StaggerItem className="xl:col-span-2">
+          <TopologyPreview topology={topology} error={topologyError} onRetry={() => mutateTopology()} />
+        </StaggerItem>
+
         {/* ── Device Type Breakdown ────────────────────── */}
-        <StaggerItem className="xl:col-span-5"><Card className="border-slate-700/50 bg-slate-900/55">
+        <StaggerItem className="xl:col-span-3"><Card className={panelClassName("h-full")}>
           <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-                Device Breakdown
-              </CardTitle>
-              <Link
-                href="/devices"
-                className="flex items-center gap-1 text-xs text-blue-400 transition-colors hover:text-blue-300"
-              >
-                View all <ArrowRight className="h-3 w-3" />
-              </Link>
-            </div>
+            <SectionTitle title="Device Breakdown" href="/devices" action="View all" icon={<MonitorSmartphone className="h-4 w-4" />} />
           </CardHeader>
           <CardContent>
             {devicesError ? (

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -276,7 +276,7 @@ export interface TopDevice {
   id: string;
   name: string | null;
   hostname: string | null;
-  ip: string;
+  ip: string | null;
   vendor: string | null;
   rx_bps: number;
   tx_bps: number;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -246,7 +246,7 @@ export interface Alert {
 /** Shape returned by the /api/v1/dashboard/stats endpoint. */
 export interface DashboardStats {
   router_status: string;
-  router_type: string; // "mikrotik" | "none"
+  router_type: string; // "mikrotik" | "pfsense" | "none"
   devices_online: number;
   devices_total: number;
   alerts_unread: number;
@@ -340,7 +340,7 @@ export interface TopologyDevice {
 
 /** Router hub node in the topology graph. */
 export interface TopologyRouter {
-  router_type: string; // "mikrotik" | "unknown"
+  router_type: string; // "mikrotik" | "pfsense" | "unknown"
   is_online: boolean;
   wan_ip: string | null;
   hostname: string | null;

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -74,6 +74,9 @@ test.describe('Dashboard', () => {
     await expect(page.getByText('Recent Alerts')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Device Breakdown')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Router Health')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Top Devices')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Topology Preview')).toBeVisible({ timeout: 5000 });
 
     await page.screenshot({ path: 'tests/screenshots/dashboard-bento-grid.png', fullPage: true });
   });
@@ -118,7 +121,7 @@ test.describe('Dashboard', () => {
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
 
-    expect(['mikrotik', 'none']).toContain(data.router_type);
+    expect(['mikrotik', 'pfsense', 'none']).toContain(data.router_type);
     expect(['connected', 'disconnected', 'unconfigured']).toContain(data.router_status);
 
     await page.screenshot({ path: 'tests/screenshots/dashboard-router-type-api.png' });

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -1,4 +1,131 @@
 import { test, expect, login } from '../../e2e/fixtures';
+import type { Page } from '@playwright/test';
+
+async function mockDashboardData(page: Page) {
+  const now = new Date().toISOString();
+
+  await page.route('**/api/v1/dashboard/stats', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        router_status: 'connected',
+        router_type: 'mikrotik',
+        devices_online: 2,
+        devices_total: 2,
+        alerts_unread: 1,
+        wan_rx_bps: 1_250_000,
+        wan_tx_bps: 250_000,
+        critical_online: 1,
+        critical_total: 2,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/alerts?limit=5', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'alert-dashboard-render',
+          type: 'device_offline',
+          message: 'Core switch uplink saturated',
+          severity: 'WARNING',
+          is_read: false,
+          created_at: now,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/traffic/history?minutes=60', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { minute: now, rx_bps: 500_000, tx_bps: 100_000 },
+        { minute: now, rx_bps: 1_250_000, tx_bps: 250_000 },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/devices', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'dev-core-switch',
+          mac: '00:11:22:33:44:55',
+          name: 'Core Switch',
+          hostname: 'core-gateway',
+          vendor: 'MikroTik',
+          mdns_services: null,
+          is_online: true,
+        },
+        {
+          id: 'dev-nas',
+          mac: '00:11:22:33:44:66',
+          name: 'Storage NAS',
+          hostname: 'storage-nas',
+          vendor: 'Synology',
+          mdns_services: null,
+          is_online: true,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/dashboard/top-devices?limit=6', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'dev-core-switch',
+          name: 'Core Switch',
+          hostname: 'core-gateway',
+          ip: '10.0.0.2',
+          vendor: 'MikroTik',
+          rx_bps: 900_000,
+          tx_bps: 125_000,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/topology/graph', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        router: {
+          router_type: 'mikrotik',
+          is_online: true,
+          wan_ip: '198.51.100.10',
+          hostname: 'edge-mikrotik',
+          version: '7.16',
+        },
+        devices: [
+          {
+            id: 'dev-core-switch',
+            mac: '00:11:22:33:44:55',
+            name: 'Core Switch',
+            hostname: 'core-gateway',
+            vendor: 'MikroTik',
+            is_online: true,
+            ips: ['10.0.0.2'],
+          },
+          {
+            id: 'dev-nas',
+            mac: '00:11:22:33:44:66',
+            name: 'Storage NAS',
+            hostname: 'storage-nas',
+            vendor: 'Synology',
+            is_online: false,
+            ips: ['10.0.0.10'],
+          },
+        ],
+        positions: [],
+      }),
+    });
+  });
+}
 
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
@@ -14,10 +141,10 @@ test.describe('Dashboard', () => {
 
     // Should have stat cards (4 of them) — wait for stats to load
     // In error state titles: Router Status, Active Devices, WAN Bandwidth, Unread Alerts
-    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('Active Devices')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('WAN Bandwidth')).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText('Unread Alerts')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Router Status', { exact: true })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Active Devices', { exact: true })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('WAN Bandwidth', { exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Unread Alerts', { exact: true })).toBeVisible({ timeout: 5000 });
 
     await page.screenshot({ path: 'tests/screenshots/dashboard-stat-cards.png', fullPage: true });
   });
@@ -26,14 +153,14 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
     // Wait for stat cards to resolve from skeleton to real values
-    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Router Status', { exact: true })).toBeVisible({ timeout: 10000 });
 
     // "Active Devices" card shows a number and subtitle
     const devicesSubtitle = page.getByText(/total known/);
     await expect(devicesSubtitle.first()).toBeVisible({ timeout: 10000 });
 
     // "Unread Alerts" card shows status
-    await expect(page.getByText('Unread Alerts')).toBeVisible();
+    await expect(page.getByText('Unread Alerts', { exact: true })).toBeVisible();
     const alertsSubtitle = page.getByText(/All clear|Needs attention/);
     await expect(alertsSubtitle.first()).toBeVisible({ timeout: 10000 });
 
@@ -63,20 +190,37 @@ test.describe('Dashboard', () => {
     await page.screenshot({ path: 'tests/screenshots/dashboard-quick-actions.png', fullPage: true });
   });
 
-  test('bento grid layout has correct sections', async ({ page }) => {
+  test('bento grid layout renders section data', async ({ page }) => {
+    await mockDashboardData(page);
+    await page.goto('/dashboard');
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
     // Wait for API calls to settle before checking bento grid
     await page.waitForLoadState('networkidle');
 
-    // All bento grid sections should be visible
+    // All bento grid sections should be visible and resolved with API-backed data,
+    // not only their unconditional section titles.
     await expect(page.getByText('WAN Traffic').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('1.3 Mbps').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('250.0 Kbps').first()).toBeVisible();
     await expect(page.getByText('Recent Alerts')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Core switch uplink saturated')).toBeVisible();
     await expect(page.getByText('Infrastructure Health')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('50%')).toBeVisible();
+    await expect(page.getByText('1/2 critical online')).toBeVisible();
     await expect(page.getByText('Device Breakdown')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Router Health')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Connected', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Available router client').first()).toBeVisible();
     await expect(page.getByText('Top Devices')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Core Switch', { exact: true })).toBeVisible();
+    await expect(page.getByText('10.0.0.2')).toBeVisible();
     await expect(page.getByText('Topology Preview')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Offline', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Routers')).toBeVisible();
+    await expect(page.getByText('Servers')).toBeVisible();
+    await expect(page.getByText('Connected to MikroTik')).toBeVisible();
+    await expect(page.getByText('2 total known')).toBeVisible();
 
     await page.screenshot({ path: 'tests/screenshots/dashboard-bento-grid.png', fullPage: true });
   });
@@ -180,8 +324,8 @@ test.describe('Dashboard', () => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
 
     // All stat cards should still be visible
-    await expect(page.getByText('Router Status')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('Active Devices')).toBeVisible();
+    await expect(page.getByText('Router Status', { exact: true })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Active Devices', { exact: true })).toBeVisible();
 
     // Quick actions should be visible
     await expect(page.getByText('Scan Network')).toBeVisible();


### PR DESCRIPTION
Refs #746

## Summary
- Tighten dashboard E2E coverage so renewed sections prove API-backed data renders, not just section titles.
- Cover router health, top devices, topology preview, WAN traffic, alerts, infrastructure health, and device breakdown with mocked API data.
- Align TopDevice.ip with the backend nullable shape.

## Verification
- cd web && bun run test
- cd web && bun run build
- cd web && bun run test:e2e -- dashboard.spec.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renews the dashboard UX by adding three new bento-grid sections (Router Health, Top Devices by traffic, Topology Preview), extracting shared `SectionTitle`/`panelClassName` helpers, and rethemes accent colors from blue to cyan. It also aligns `TopDevice.ip` to nullable and widens `router_type` comments to include `"pfsense"`, backed by expanded Playwright E2E coverage that mocks six API endpoints.

- **New dashboard sections**: `RouterHealthSection`, `TopDevicesTable`, and `TopologyPreview` each consume dedicated SWR fetches and expose per-section retry callbacks; the bento grid layout remains balanced across `xl:col-span` values.
- **Type alignment**: `TopDevice.ip` changed from `string` to `string | null` to match the backend's nullable shape; all display sites already guard with `|| \"—\"`.
- **E2E upgrade**: The bento-grid test is rewritten from section-title-only assertions to API-data assertions using `mockDashboardData`, covering router health, WAN speeds, alert messages, topology counts, and top-device rows.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; all new sections degrade gracefully to error states and the grid layout is balanced.

The dashboard additions are well-structured and the type fix is straightforward. The two minor findings — a silent fallback in routerDisplayName for unknown router types, and the bento-grid test double-navigation causing unmocked API calls during beforeEach — don't affect production behavior or test correctness under normal conditions.

No files require special attention, though dashboard.spec.ts would benefit from isolating the mocked test into its own describe block to avoid the redundant first navigation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dashboard/page.tsx | Large UX overhaul: adds RouterHealthSection, TopologyPreview, TopDevicesTable components; extracts panelClassName/SectionTitle helpers; hooks up two new SWR fetches (top-devices, topology/graph); rethemes from blue to cyan. Logic is sound; router display name has a silent fallback for unknown types. |
| web/src/lib/types.ts | Aligns TopDevice.ip to string | null (backend nullable shape) and widens router_type comment to include "pfsense". Minimal, correct changes. |
| web/tests/e2e/dashboard.spec.ts | Upgrades bento grid test from title-only checks to full API-mocked data assertions; adds mockDashboardData helper covering 6 endpoints. Double-navigation pattern (beforeEach + test body goto) is functional but causes unmocked real API calls on the first load. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/tests/e2e/dashboard.spec.ts:193-197
**Double navigation makes unmocked API calls in beforeEach**

`beforeEach` navigates to `/dashboard` before mocks are registered, so that first load fires real API requests (stats, alerts, devices, etc.). The mocked second navigation in the test body then reloads correctly. In a CI environment without a running backend, those first requests will fail and may emit console errors or timeouts that delay the suite. The cleanest fix is to nest this test inside its own `describe` block that calls `mockDashboardData` inside its own `beforeEach` and does a single `goto`.

### Issue 2 of 2
web/src/app/(app)/dashboard/page.tsx:109-113
**`routerDisplayName` falls back silently for future router types**

The function returns the generic string `"Router"` for any type that is neither `"mikrotik"` nor `"pfsense"`. With `router_type` typed as `string`, adding a new router type on the backend (e.g., `"openwrt"`) would silently produce `"Cannot reach Router"` or `"Connected to Router"` in the stat card subtitle rather than the proper display name. Consider a narrower union type or a logged warning on the fallback branch to make future additions easier to catch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: assert dashboard section data rend..."](https://github.com/befeast/panoptikon/commit/cfbf57393cd33be54dea6a73dd2480464a37ece5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32472540)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->