### PR TITLE
UX renewal: devices alerts topology routes

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Activity,
   AlertTriangle,
   Bell,
-  BellOff,
   Check,
   CheckCheck,
   ChevronDown,
-  Clock,
   Download,
   MonitorSmartphone,
   Shield,
@@ -142,6 +140,7 @@ export default function AlertsPage() {
   const [muteDropdownId, setMuteDropdownId] = useState<string | null>(null);
   const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(new Set());
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
 
   const status = statusFilter === "all" ? undefined : statusFilter;
   const alertType = typeFilter === "all" ? undefined : typeFilter;
@@ -277,6 +276,10 @@ export default function AlertsPage() {
   const criticalCount = (alerts ?? []).filter((a) => a.severity === "CRITICAL" && !a.acknowledged_at).length;
   const warningCount = (alerts ?? []).filter((a) => a.severity === "WARNING" && !a.acknowledged_at).length;
   const infoCount = (alerts ?? []).filter((a) => a.severity === "INFO" && !a.acknowledged_at).length;
+  const selectedAlert = useMemo(() => {
+    if (!alerts?.length) return null;
+    return alerts.find((a) => a.id === selectedAlertId) ?? alerts[0];
+  }, [alerts, selectedAlertId]);
 
   return (
     <PageTransition>
@@ -444,9 +447,10 @@ export default function AlertsPage() {
         </div>
       )}
 
-      {/* Alert list */}
+      {/* Alert triage */}
       {alerts === null ? (
-        <div className="space-y-3">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="space-y-2">
           {Array.from({ length: 6 }).map((_, i) => (
             <Card key={i} className="border-slate-800 bg-slate-900">
               <CardContent className="flex items-center gap-4 py-4">
@@ -459,6 +463,14 @@ export default function AlertsPage() {
               </CardContent>
             </Card>
           ))}
+          </div>
+          <Card className="hidden border-slate-800 bg-slate-900 lg:block">
+            <CardContent className="space-y-3 py-4">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-32 w-full" />
+            </CardContent>
+          </Card>
         </div>
       ) : alerts.length === 0 ? (
         <Card className="border-slate-800 bg-slate-900">
@@ -474,185 +486,177 @@ export default function AlertsPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-2">
-          {alerts.map((alert) => (
-            <Card
-              key={alert.id}
-              className={`rounded-l-none border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${
-                acknowledgingIds.has(alert.id)
-                  ? "animate-ack-strike opacity-0"
-                  : alert.acknowledged_at
-                    ? "bg-[#12121a] opacity-70"
-                    : !alert.is_read
-                      ? "border-l-2 border-l-blue-500 bg-slate-900"
-                      : "bg-slate-900"
-              }`}
-            >
-              <CardContent className="flex items-center gap-4 py-4">
-                {/* Icon */}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="min-w-0 rounded-lg border border-slate-800 bg-slate-950/40">
+            <div className="grid grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] gap-3 border-b border-slate-800 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500 max-md:hidden">
+              <span>Type</span>
+              <span>Message</span>
+              <span>Age</span>
+              <span className="text-right">Actions</span>
+            </div>
+            <div className="divide-y divide-slate-800">
+              {alerts.map((alert) => (
                 <div
-                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
-                    alert.acknowledged_at
-                      ? "bg-gray-800/50"
-                      : !alert.is_read
-                        ? "bg-blue-500/10"
-                        : "bg-gray-800"
+                  key={alert.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSelectedAlertId(alert.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setSelectedAlertId(alert.id);
+                    }
+                  }}
+                  className={`grid w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-l-none border-slate-800 px-3 py-3 text-left transition-colors hover:bg-slate-900/75 lg:grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] ${
+                    acknowledgingIds.has(alert.id)
+                      ? "animate-ack-strike opacity-0"
+                      : selectedAlert?.id === alert.id
+                        ? "bg-slate-900/90 shadow-[inset_2px_0_0_rgba(34,211,238,0.75)]"
+                        : !alert.is_read && !alert.acknowledged_at
+                          ? "bg-slate-900/55 shadow-[inset_2px_0_0_rgba(59,130,246,0.7)]"
+                          : ""
                   }`}
                 >
-                  {alertIcon(alert.type)}
-                </div>
+                  <span className={`flex h-8 w-8 items-center justify-center rounded-md border ${
+                    alert.acknowledged_at
+                      ? "border-slate-800 bg-slate-900 text-slate-500"
+                      : "border-slate-700 bg-slate-900"
+                  }`}>
+                    {alertIcon(alert.type)}
+                  </span>
 
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
-                      {alertTypeLabel(alert.type)}
+                  <span className="min-w-0">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                        {alertTypeLabel(alert.type)}
+                      </span>
+                      {severityBadge(alert.severity)}
+                      {!alert.is_read && !alert.acknowledged_at && (
+                        <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+                      )}
+                      {alert.acknowledged_at && (
+                        <Badge variant="outline" className="border-emerald-700 px-1.5 py-0 text-[10px] text-emerald-500">
+                          ACK
+                        </Badge>
+                      )}
                     </span>
-                    {severityBadge(alert.severity)}
-                    {!alert.is_read && !alert.acknowledged_at && (
-                      <span className="h-2 w-2 rounded-full bg-blue-500" />
-                    )}
-                    {alert.acknowledged_at && (
-                      <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-700 text-emerald-500">
-                        <CheckCheck className="mr-0.5 h-3 w-3" />
-                        ACK
-                      </Badge>
-                    )}
-                  </div>
-                  <p
-                    className={`mt-0.5 line-clamp-2 text-sm ${
+                    <span className={`mt-0.5 block truncate text-sm ${
                       alert.acknowledged_at
                         ? "text-slate-500"
                         : !alert.is_read
-                          ? "text-gray-200"
+                          ? "text-slate-200"
                           : "text-slate-400"
-                    }`}
-                    title={alert.message}
-                  >
-                    {alert.message}
-                  </p>
-                  {alert.acknowledged_by && (
-                    <p className="mt-0.5 truncate text-xs italic text-slate-600" title={alert.acknowledged_by}>
-                      Note: {alert.acknowledged_by}
-                    </p>
-                  )}
-                </div>
+                    }`}>
+                      {alert.message}
+                    </span>
+                  </span>
 
-                {/* Time */}
-                <span className="shrink-0 text-xs text-slate-600">
-                  {timeAgo(alert.created_at)}
-                </span>
+                  <span className="shrink-0 font-mono text-[11px] text-slate-600 max-lg:hidden">
+                    {timeAgo(alert.created_at)}
+                  </span>
 
-                {/* Actions */}
-                <div className="flex items-center gap-1 shrink-0">
-                  {/* Mark read / unread toggle */}
-                  {!alert.acknowledged_at && (
-                    alert.is_read ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-blue-400"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMarkUnread(alert.id);
-                        }}
-                        title="Mark unread"
-                      >
-                        <Bell className="h-3.5 w-3.5" />
+                  <span className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+                    {!alert.acknowledged_at && (
+                      alert.is_read ? (
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-blue-400" onClick={() => handleMarkUnread(alert.id)} title="Mark unread">
+                          <Bell className="h-3.5 w-3.5" />
+                        </Button>
+                      ) : (
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-gray-200" onClick={() => handleMarkRead(alert.id)} title="Mark read">
+                          <Check className="h-3.5 w-3.5" />
+                        </Button>
+                      )
+                    )}
+                    {!alert.acknowledged_at && (
+                      <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-emerald-400" onClick={() => openAckDialog(alert.id)} title="Acknowledge">
+                        <CheckCheck className="h-3.5 w-3.5" />
                       </Button>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-gray-200"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMarkRead(alert.id);
-                        }}
-                        title="Mark read"
-                      >
-                        <Check className="h-3.5 w-3.5" />
-                      </Button>
-                    )
-                  )}
-
-                  {/* Acknowledge */}
-                  {!alert.acknowledged_at && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 px-2 text-slate-500 hover:text-emerald-400"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openAckDialog(alert.id);
-                      }}
-                      title="Acknowledge"
-                    >
-                      <CheckCheck className="h-3.5 w-3.5" />
+                    )}
+                    <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-rose-400" onClick={() => handleDeleteOne(alert.id)} title="Delete alert">
+                      <X className="h-3.5 w-3.5" />
                     </Button>
-                  )}
-
-                  {/* Mute device */}
-                  {alert.device_id && (
-                    <div className="relative">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-amber-400"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setMuteDropdownId(
-                            muteDropdownId === alert.id ? null : alert.id
-                          );
-                        }}
-                        title="Mute device"
-                      >
-                        <VolumeX className="h-3.5 w-3.5" />
-                      </Button>
-                      {muteDropdownId === alert.id && (
-                        <div className="absolute right-0 top-full z-50 mt-1 w-36 rounded-md border border-slate-800 bg-slate-800/50 py-1 shadow-lg">
-                          {[
-                            { label: "Mute 1h", hours: 1 },
-                            { label: "Mute 8h", hours: 8 },
-                            { label: "Mute 24h", hours: 24 },
-                            { label: "Unmute", hours: 0 },
-                          ].map((opt) => (
-                            <button
-                              key={opt.hours}
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-800 hover:text-white"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (alert.device_id) {
-                                  handleMute(alert.device_id, opt.hours);
-                                }
-                              }}
-                            >
-                              <Clock className="h-3 w-3" />
-                              {opt.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {/* Delete */}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 text-slate-500 hover:text-rose-400"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeleteOne(alert.id);
-                    }}
-                    title="Delete alert"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </Button>
+                  </span>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
+              ))}
+            </div>
+          </div>
+
+          {selectedAlert && (
+            <aside className="min-w-0 rounded-lg border border-slate-800 bg-slate-950/60 p-4 lg:sticky lg:top-4 lg:self-start">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                    {alertTypeLabel(selectedAlert.type)}
+                  </p>
+                  <h2 className="mt-1 text-base font-semibold text-slate-100">
+                    Alert detail
+                  </h2>
+                </div>
+                {severityBadge(selectedAlert.severity)}
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-300">
+                {selectedAlert.message}
+              </p>
+              {selectedAlert.details && (
+                <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-slate-800 bg-slate-900/70 p-3 text-xs leading-5 text-slate-400">
+                  {selectedAlert.details}
+                </pre>
+              )}
+
+              <div className="mt-4 space-y-2 border-t border-slate-800 pt-4 text-xs">
+                <TriageRow label="Created" value={new Date(selectedAlert.created_at).toLocaleString()} />
+                <TriageRow label="Status" value={selectedAlert.acknowledged_at ? "Acknowledged" : selectedAlert.is_read ? "Read" : "Unread"} />
+                {selectedAlert.device_id && <TriageRow label="Device" value={selectedAlert.device_id} mono />}
+                {selectedAlert.agent_id && <TriageRow label="Agent" value={selectedAlert.agent_id} mono />}
+                {selectedAlert.acknowledged_by && <TriageRow label="Note" value={selectedAlert.acknowledged_by} />}
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-2">
+                {!selectedAlert.acknowledged_at && (
+                  <Button size="sm" className="gap-1.5" onClick={() => openAckDialog(selectedAlert.id)}>
+                    <CheckCheck className="h-3.5 w-3.5" />
+                    Acknowledge
+                  </Button>
+                )}
+                {selectedAlert.is_read ? (
+                  <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white" onClick={() => handleMarkUnread(selectedAlert.id)}>
+                    <Bell className="h-3.5 w-3.5" />
+                    Mark unread
+                  </Button>
+                ) : (
+                  <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white" onClick={() => handleMarkRead(selectedAlert.id)}>
+                    <Check className="h-3.5 w-3.5" />
+                    Mark read
+                  </Button>
+                )}
+                {selectedAlert.device_id && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white">
+                        <VolumeX className="h-3.5 w-3.5" />
+                        Mute
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {[1, 8, 24].map((hours) => (
+                        <DropdownMenuItem key={hours} onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, hours)}>
+                          Mute {hours}h
+                        </DropdownMenuItem>
+                      ))}
+                      <DropdownMenuItem onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, 0)}>
+                        Unmute
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+                <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-rose-400" onClick={() => handleDeleteOne(selectedAlert.id)}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </Button>
+              </div>
+            </aside>
+          )}
         </div>
       )}
 
@@ -715,5 +719,24 @@ export default function AlertsPage() {
       </Dialog>
     </div>
     </PageTransition>
+  );
+}
+
+function TriageRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="shrink-0 font-semibold uppercase tracking-wider text-slate-600">{label}</span>
+      <span className={`min-w-0 truncate text-right text-slate-400 ${mono ? "font-mono tabular-nums" : ""}`} title={value}>
+        {value}
+      </span>
+    </div>
   );
 }

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -81,9 +81,9 @@ export default function DevicesPage() {
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
   const [view, setView] = useState<ViewMode>(() => {
     if (typeof window !== "undefined") {
-      return (localStorage.getItem("devices-view-preference") as ViewMode) || "grid";
+      return (localStorage.getItem("devices-view-preference") as ViewMode) || "table";
     }
-    return "grid";
+    return "table";
   });
   const [sortField, setSortField] = useState<SortField>("last_seen_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -103,6 +103,15 @@ export default function DevicesPage() {
     const interval = setInterval(load, 15_000);
     return () => clearInterval(interval);
   }, [load]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const selectedId = params.get("selected") ?? params.get("id");
+    if (!selectedId || !devices?.length || selectedDevice?.id === selectedId) return;
+    const match = devices.find((d) => d.id === selectedId);
+    if (match) setSelectedDevice(match);
+  }, [devices, selectedDevice?.id]);
 
   // Fetch Xiaomi WiFi data for device list columns
   useEffect(() => {
@@ -300,18 +309,25 @@ export default function DevicesPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-8">
+    <div className="space-y-5">
       {/* Header */}
-      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/45 px-5 py-5 sm:px-6">
+      <div className="border-b border-slate-800/80 pb-4">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-semibold tracking-tight text-white">Devices</h1>
               <HelpTooltip text="All devices discovered on your network. Use Scan Now to discover new devices, Re-identify to fingerprint them, and Resolve Names to look up hostnames via DNS." />
             </div>
-            <p className="max-w-2xl text-sm leading-6 text-slate-300/80">
-              Discover, classify, and monitor every device on your network.
-            </p>
+            <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+              {counts && (
+                <>
+                  <span><span className="font-mono text-slate-300">{counts.all}</span> total</span>
+                  <span><span className="font-mono text-emerald-300">{counts.online}</span> online</span>
+                  <span><span className="font-mono text-slate-300">{counts.offline}</span> offline</span>
+                  <span><span className="font-mono text-amber-300">{counts.unknown}</span> new</span>
+                </>
+              )}
+            </div>
           </div>
           <div className="flex flex-wrap items-center gap-2.5 xl:justify-end">
             <Tooltip>
@@ -455,7 +471,7 @@ export default function DevicesPage() {
       </div>
 
       {/* Filter bar */}
-      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/40 px-5 py-4 sm:px-6">
+      <div className="rounded-lg border border-slate-800 bg-slate-950/45 px-3 py-3 sm:px-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             {(["all", "online", "offline", "unknown"] as Filter[]).map((f) => (

--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -49,6 +49,8 @@ import {
 import type { TopologyDevice, TopologyRouter } from '@/lib/types'
 import { getDeviceIcon } from '@/lib/device-icons'
 import { PageTransition } from '@/components/PageTransition'
+import { EmptyState } from '@/components/EmptyState'
+import { ErrorState } from '@/components/ErrorState'
 import {
   Sheet,
   SheetContent,
@@ -256,6 +258,8 @@ function RouterNode({ data }: NodeProps<RouterNodeType>) {
   const routerLabel =
     data.routerType === 'mikrotik'
       ? 'MikroTik'
+      : data.routerType === 'pfsense'
+        ? 'pfSense'
       : 'Router'
 
   return (
@@ -924,7 +928,16 @@ function TopologyPageInner() {
   const onNodeDragStop = useCallback(
     (_event: React.MouseEvent, node: TopologyNode) => {
       if (node.type === 'subnetGroup') return
-      const pos = { x: node.position.x, y: node.position.y }
+      const pos =
+        node.type === 'routerNode'
+          ? {
+              x: node.position.x + ROUTER_WIDTH / 2,
+              y: node.position.y + ROUTER_HEIGHT / 2,
+            }
+          : {
+              x: node.position.x + DEVICE_WIDTH / 2,
+              y: node.position.y + DEVICE_HEIGHT / 2,
+            }
       pinnedRef.current.set(node.id, pos)
       saveTopologyPositions([
         { node_id: node.id, x: pos.x, y: pos.y, pinned: true },
@@ -1075,20 +1088,13 @@ function TopologyPageInner() {
   if (error) {
     return (
       <PageTransition>
-        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
-          <div className="text-center">
-            <p className="text-sm text-rose-400">{error}</p>
-            <button
-              onClick={() => {
-                setLoading(true)
-                buildGraph(true)
-              }}
-              className="mt-3 text-xs text-blue-400 hover:underline"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
+        <ErrorState
+          message={error}
+          onRetry={() => {
+            setLoading(true)
+            buildGraph(true)
+          }}
+        />
       </PageTransition>
     )
   }
@@ -1133,12 +1139,21 @@ function TopologyPageInner() {
           />
 
           {/* Floating toolbar */}
-          <div className="absolute right-4 top-4 z-10 flex items-center gap-3 rounded-lg border border-slate-700/50 bg-slate-900/80 px-4 py-2 backdrop-blur-sm">
+          <div className="absolute left-4 top-4 z-10 max-w-[calc(100vw-2rem)] rounded-lg border border-slate-700/50 bg-slate-900/85 px-4 py-3 backdrop-blur-sm">
+            <div className="mb-2 flex items-center gap-2">
+              <Network className="h-4 w-4 text-cyan-400" />
+              <h1 className="text-sm font-semibold text-white">Topology</h1>
+              <span className="rounded border border-slate-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-slate-500">
+                {routerInfoRef.current?.router_type ?? 'router'}
+              </span>
+            </div>
             <span className="text-[11px] text-slate-400">
               {stats.total} devices · {stats.online} online · {stats.subnets}{' '}
               subnet{stats.subnets !== 1 ? 's' : ''}
             </span>
-            <div className="h-3 w-px bg-slate-700" />
+          </div>
+
+          <div className="absolute right-4 top-4 z-10 flex items-center gap-3 rounded-lg border border-slate-700/50 bg-slate-900/80 px-4 py-2 backdrop-blur-sm">
             <button
               onClick={autoLayout}
               className="text-slate-400 transition-colors hover:text-white"
@@ -1177,6 +1192,20 @@ function TopologyPageInner() {
               </span>
             )}
           </div>
+
+          {stats.total === 0 && (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-4">
+              <div className="pointer-events-auto rounded-lg border border-slate-800 bg-slate-950/90 px-8 py-4 shadow-2xl">
+                <EmptyState
+                  icon={Network}
+                  title="No topology devices"
+                  description="Discovered devices will appear here after a network scan returns inventory data."
+                  actionLabel="Open Devices"
+                  actionHref="/devices"
+                />
+              </div>
+            </div>
+          )}
         </ReactFlow>
       </div>
 


### PR DESCRIPTION
## Summary
- renew `/devices` with a denser default table, compact inventory counts, and topology-selected device deep links
- renew `/alerts` as a two-pane triage workflow while preserving alert actions
- renew `/topology` with pfSense router labeling, corrected persisted drag positions, and improved error/empty states

Closes #747.

## Verification
- `ssh workshop zsh -lic "cd /mnt/storage/worktrees/panoptikon/pan-8/web && bun run test"` -> 16 passed
- `ssh workshop zsh -lic "cd /mnt/storage/worktrees/panoptikon/pan-8/web && bun run build"` -> passed

## Notes
- This PR was salvaged from Maestro pan-8 after retry accounting exhausted before PR creation. I rebased the slice onto current `origin/main` and kept the diff scoped to the three production route files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes three production routes: `/alerts` gains a two-pane triage layout with a sticky detail panel, `/devices` defaults to table view and adds URL-driven device deep-linking, and `/topology` adds pfSense router labeling, fixes persisted drag-position coordinates (top-left → center), and replaces inline error/empty state markup with shared components.

- **`/alerts`**: The new triage workflow is well-structured; `muteDropdownId` state is now orphaned after the per-row mute button was removed and should be cleaned up along with its `setMuteDropdownId(null)` call in `handleMute`.
- **`/devices`**: The URL-param auto-selection `useEffect` depends on the `devices` array that refreshes every 15 s — any manual device selection will be overridden on the next poll while the URL param remains in the address bar.
- **`/topology`**: The position-persistence fix (storing center coordinates rather than the React Flow top-left corner) is correct and aligns with how `computeForceLayout` consumes pinned positions.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the URL-param selection loop in the devices page; the alerts and topology changes are otherwise correct.

The devices page introduces a useEffect that re-runs on every 15-second poll and silently re-applies the URL selected param, overriding any device the user has manually clicked. This will surface immediately in normal use whenever someone navigates to a deep-linked device and then tries to switch to another.

web/src/app/(app)/devices/page.tsx — the URL-param selection effect needs a consumed-flag or a one-time run to avoid fighting with manual selection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/alerts/page.tsx | Refactors alert list into a two-pane triage layout with a persistent detail panel; mute dropdown is now dead state after per-row removal; no E2E test included. |
| web/src/app/(app)/devices/page.tsx | Changes default view to table and adds URL-param driven device selection; the selection effect re-runs on every 15s poll and will override manual selection when a URL param is present. |
| web/src/app/(app)/topology/page.tsx | Adds pfSense router label, corrects drag-position persistence (center vs top-left fix), and replaces inline error/empty states with shared components; logic looks correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/app/(app)/devices/page.tsx:107-114
**URL param selection overrides manual selection every poll cycle**

The `useEffect` depends on `devices`, which refreshes every 15 seconds. If the URL contains `?selected=A` and the user manually clicks device B, `selectedDevice?.id` (`B`) never equals `selectedId` (`A`), so the guard never short-circuits — device A is re-selected on every subsequent poll, permanently fighting the user's own clicks. A `useRef` consumed-flag (set to `true` after the first successful match) would prevent re-application once the URL param has been honored.

### Issue 2 of 3
web/src/app/(app)/alerts/page.tsx:140
**Dead state: `muteDropdownId` is never set to a non-null value**

The per-row mute dropdown was removed in this refactor; muting now lives in the detail pane. `setMuteDropdownId` is only called with `null` (inside `handleMute`), so this piece of state has no writer and can be deleted. The `null` call in `handleMute` is also a no-op and can be removed.

### Issue 3 of 3
web/src/app/(app)/alerts/page.tsx:1
**Missing Playwright E2E test**

Per `CLAUDE.md`, every feature or bug-fix PR must include a Playwright E2E test in `web/tests/e2e/` (or an explicit `## Why No E2E Test` section in the PR description). This PR introduces a new two-pane triage workflow on `/alerts`, URL-driven device deep-linking on `/devices`, and topology improvements — all exercisable in the browser — but ships no spec file and the description has no E2E exemption. The same gap applies to the other two changed routes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: renew devices alerts topology rout..."](https://github.com/befeast/panoptikon/commit/9d67aec6242ebe231ee27aecae965a7acb836558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32479352)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->