### PR TITLE
UX renewal: devices alerts topology routes

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Activity,
   AlertTriangle,
   Bell,
-  BellOff,
   Check,
   CheckCheck,
   ChevronDown,
-  Clock,
   Download,
   MonitorSmartphone,
   Shield,
@@ -142,6 +140,7 @@ export default function AlertsPage() {
   const [muteDropdownId, setMuteDropdownId] = useState<string | null>(null);
   const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(new Set());
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
 
   const status = statusFilter === "all" ? undefined : statusFilter;
   const alertType = typeFilter === "all" ? undefined : typeFilter;
@@ -277,6 +276,10 @@ export default function AlertsPage() {
   const criticalCount = (alerts ?? []).filter((a) => a.severity === "CRITICAL" && !a.acknowledged_at).length;
   const warningCount = (alerts ?? []).filter((a) => a.severity === "WARNING" && !a.acknowledged_at).length;
   const infoCount = (alerts ?? []).filter((a) => a.severity === "INFO" && !a.acknowledged_at).length;
+  const selectedAlert = useMemo(() => {
+    if (!alerts?.length) return null;
+    return alerts.find((a) => a.id === selectedAlertId) ?? alerts[0];
+  }, [alerts, selectedAlertId]);
 
   return (
     <PageTransition>
@@ -444,9 +447,10 @@ export default function AlertsPage() {
         </div>
       )}
 
-      {/* Alert list */}
+      {/* Alert triage */}
       {alerts === null ? (
-        <div className="space-y-3">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="space-y-2">
           {Array.from({ length: 6 }).map((_, i) => (
             <Card key={i} className="border-slate-800 bg-slate-900">
               <CardContent className="flex items-center gap-4 py-4">
@@ -459,6 +463,14 @@ export default function AlertsPage() {
               </CardContent>
             </Card>
           ))}
+          </div>
+          <Card className="hidden border-slate-800 bg-slate-900 lg:block">
+            <CardContent className="space-y-3 py-4">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-32 w-full" />
+            </CardContent>
+          </Card>
         </div>
       ) : alerts.length === 0 ? (
         <Card className="border-slate-800 bg-slate-900">
@@ -474,185 +486,177 @@ export default function AlertsPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-2">
-          {alerts.map((alert) => (
-            <Card
-              key={alert.id}
-              className={`rounded-l-none border-slate-800 transition-all hover:bg-slate-800/60 hover:border-blue-500/30 ${
-                acknowledgingIds.has(alert.id)
-                  ? "animate-ack-strike opacity-0"
-                  : alert.acknowledged_at
-                    ? "bg-[#12121a] opacity-70"
-                    : !alert.is_read
-                      ? "border-l-2 border-l-blue-500 bg-slate-900"
-                      : "bg-slate-900"
-              }`}
-            >
-              <CardContent className="flex items-center gap-4 py-4">
-                {/* Icon */}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="min-w-0 rounded-lg border border-slate-800 bg-slate-950/40">
+            <div className="grid grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] gap-3 border-b border-slate-800 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500 max-md:hidden">
+              <span>Type</span>
+              <span>Message</span>
+              <span>Age</span>
+              <span className="text-right">Actions</span>
+            </div>
+            <div className="divide-y divide-slate-800">
+              {alerts.map((alert) => (
                 <div
-                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
-                    alert.acknowledged_at
-                      ? "bg-gray-800/50"
-                      : !alert.is_read
-                        ? "bg-blue-500/10"
-                        : "bg-gray-800"
+                  key={alert.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSelectedAlertId(alert.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setSelectedAlertId(alert.id);
+                    }
+                  }}
+                  className={`grid w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-l-none border-slate-800 px-3 py-3 text-left transition-colors hover:bg-slate-900/75 lg:grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] ${
+                    acknowledgingIds.has(alert.id)
+                      ? "animate-ack-strike opacity-0"
+                      : selectedAlert?.id === alert.id
+                        ? "bg-slate-900/90 shadow-[inset_2px_0_0_rgba(34,211,238,0.75)]"
+                        : !alert.is_read && !alert.acknowledged_at
+                          ? "bg-slate-900/55 shadow-[inset_2px_0_0_rgba(59,130,246,0.7)]"
+                          : ""
                   }`}
                 >
-                  {alertIcon(alert.type)}
-                </div>
+                  <span className={`flex h-8 w-8 items-center justify-center rounded-md border ${
+                    alert.acknowledged_at
+                      ? "border-slate-800 bg-slate-900 text-slate-500"
+                      : "border-slate-700 bg-slate-900"
+                  }`}>
+                    {alertIcon(alert.type)}
+                  </span>
 
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
-                      {alertTypeLabel(alert.type)}
+                  <span className="min-w-0">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                        {alertTypeLabel(alert.type)}
+                      </span>
+                      {severityBadge(alert.severity)}
+                      {!alert.is_read && !alert.acknowledged_at && (
+                        <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+                      )}
+                      {alert.acknowledged_at && (
+                        <Badge variant="outline" className="border-emerald-700 px-1.5 py-0 text-[10px] text-emerald-500">
+                          ACK
+                        </Badge>
+                      )}
                     </span>
-                    {severityBadge(alert.severity)}
-                    {!alert.is_read && !alert.acknowledged_at && (
-                      <span className="h-2 w-2 rounded-full bg-blue-500" />
-                    )}
-                    {alert.acknowledged_at && (
-                      <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-700 text-emerald-500">
-                        <CheckCheck className="mr-0.5 h-3 w-3" />
-                        ACK
-                      </Badge>
-                    )}
-                  </div>
-                  <p
-                    className={`mt-0.5 line-clamp-2 text-sm ${
+                    <span className={`mt-0.5 block truncate text-sm ${
                       alert.acknowledged_at
                         ? "text-slate-500"
                         : !alert.is_read
-                          ? "text-gray-200"
+                          ? "text-slate-200"
                           : "text-slate-400"
-                    }`}
-                    title={alert.message}
-                  >
-                    {alert.message}
-                  </p>
-                  {alert.acknowledged_by && (
-                    <p className="mt-0.5 truncate text-xs italic text-slate-600" title={alert.acknowledged_by}>
-                      Note: {alert.acknowledged_by}
-                    </p>
-                  )}
-                </div>
+                    }`}>
+                      {alert.message}
+                    </span>
+                  </span>
 
-                {/* Time */}
-                <span className="shrink-0 text-xs text-slate-600">
-                  {timeAgo(alert.created_at)}
-                </span>
+                  <span className="shrink-0 font-mono text-[11px] text-slate-600 max-lg:hidden">
+                    {timeAgo(alert.created_at)}
+                  </span>
 
-                {/* Actions */}
-                <div className="flex items-center gap-1 shrink-0">
-                  {/* Mark read / unread toggle */}
-                  {!alert.acknowledged_at && (
-                    alert.is_read ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-blue-400"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMarkUnread(alert.id);
-                        }}
-                        title="Mark unread"
-                      >
-                        <Bell className="h-3.5 w-3.5" />
+                  <span className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+                    {!alert.acknowledged_at && (
+                      alert.is_read ? (
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-blue-400" onClick={() => handleMarkUnread(alert.id)} title="Mark unread">
+                          <Bell className="h-3.5 w-3.5" />
+                        </Button>
+                      ) : (
+                        <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-gray-200" onClick={() => handleMarkRead(alert.id)} title="Mark read">
+                          <Check className="h-3.5 w-3.5" />
+                        </Button>
+                      )
+                    )}
+                    {!alert.acknowledged_at && (
+                      <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-emerald-400" onClick={() => openAckDialog(alert.id)} title="Acknowledge">
+                        <CheckCheck className="h-3.5 w-3.5" />
                       </Button>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-gray-200"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleMarkRead(alert.id);
-                        }}
-                        title="Mark read"
-                      >
-                        <Check className="h-3.5 w-3.5" />
-                      </Button>
-                    )
-                  )}
-
-                  {/* Acknowledge */}
-                  {!alert.acknowledged_at && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 px-2 text-slate-500 hover:text-emerald-400"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openAckDialog(alert.id);
-                      }}
-                      title="Acknowledge"
-                    >
-                      <CheckCheck className="h-3.5 w-3.5" />
+                    )}
+                    <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-500 hover:text-rose-400" onClick={() => handleDeleteOne(alert.id)} title="Delete alert">
+                      <X className="h-3.5 w-3.5" />
                     </Button>
-                  )}
-
-                  {/* Mute device */}
-                  {alert.device_id && (
-                    <div className="relative">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-slate-500 hover:text-amber-400"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setMuteDropdownId(
-                            muteDropdownId === alert.id ? null : alert.id
-                          );
-                        }}
-                        title="Mute device"
-                      >
-                        <VolumeX className="h-3.5 w-3.5" />
-                      </Button>
-                      {muteDropdownId === alert.id && (
-                        <div className="absolute right-0 top-full z-50 mt-1 w-36 rounded-md border border-slate-800 bg-slate-800/50 py-1 shadow-lg">
-                          {[
-                            { label: "Mute 1h", hours: 1 },
-                            { label: "Mute 8h", hours: 8 },
-                            { label: "Mute 24h", hours: 24 },
-                            { label: "Unmute", hours: 0 },
-                          ].map((opt) => (
-                            <button
-                              key={opt.hours}
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-800 hover:text-white"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (alert.device_id) {
-                                  handleMute(alert.device_id, opt.hours);
-                                }
-                              }}
-                            >
-                              <Clock className="h-3 w-3" />
-                              {opt.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {/* Delete */}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 text-slate-500 hover:text-rose-400"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeleteOne(alert.id);
-                    }}
-                    title="Delete alert"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </Button>
+                  </span>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
+              ))}
+            </div>
+          </div>
+
+          {selectedAlert && (
+            <aside className="min-w-0 rounded-lg border border-slate-800 bg-slate-950/60 p-4 lg:sticky lg:top-4 lg:self-start">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                    {alertTypeLabel(selectedAlert.type)}
+                  </p>
+                  <h2 className="mt-1 text-base font-semibold text-slate-100">
+                    Alert detail
+                  </h2>
+                </div>
+                {severityBadge(selectedAlert.severity)}
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-300">
+                {selectedAlert.message}
+              </p>
+              {selectedAlert.details && (
+                <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-slate-800 bg-slate-900/70 p-3 text-xs leading-5 text-slate-400">
+                  {selectedAlert.details}
+                </pre>
+              )}
+
+              <div className="mt-4 space-y-2 border-t border-slate-800 pt-4 text-xs">
+                <TriageRow label="Created" value={new Date(selectedAlert.created_at).toLocaleString()} />
+                <TriageRow label="Status" value={selectedAlert.acknowledged_at ? "Acknowledged" : selectedAlert.is_read ? "Read" : "Unread"} />
+                {selectedAlert.device_id && <TriageRow label="Device" value={selectedAlert.device_id} mono />}
+                {selectedAlert.agent_id && <TriageRow label="Agent" value={selectedAlert.agent_id} mono />}
+                {selectedAlert.acknowledged_by && <TriageRow label="Note" value={selectedAlert.acknowledged_by} />}
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-2">
+                {!selectedAlert.acknowledged_at && (
+                  <Button size="sm" className="gap-1.5" onClick={() => openAckDialog(selectedAlert.id)}>
+                    <CheckCheck className="h-3.5 w-3.5" />
+                    Acknowledge
+                  </Button>
+                )}
+                {selectedAlert.is_read ? (
+                  <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white" onClick={() => handleMarkUnread(selectedAlert.id)}>
+                    <Bell className="h-3.5 w-3.5" />
+                    Mark unread
+                  </Button>
+                ) : (
+                  <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white" onClick={() => handleMarkRead(selectedAlert.id)}>
+                    <Check className="h-3.5 w-3.5" />
+                    Mark read
+                  </Button>
+                )}
+                {selectedAlert.device_id && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-white">
+                        <VolumeX className="h-3.5 w-3.5" />
+                        Mute
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {[1, 8, 24].map((hours) => (
+                        <DropdownMenuItem key={hours} onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, hours)}>
+                          Mute {hours}h
+                        </DropdownMenuItem>
+                      ))}
+                      <DropdownMenuItem onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, 0)}>
+                        Unmute
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+                <Button variant="outline" size="sm" className="gap-1.5 border-slate-700 text-slate-300 hover:text-rose-400" onClick={() => handleDeleteOne(selectedAlert.id)}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </Button>
+              </div>
+            </aside>
+          )}
         </div>
       )}
 
@@ -715,5 +719,24 @@ export default function AlertsPage() {
       </Dialog>
     </div>
     </PageTransition>
+  );
+}
+
+function TriageRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="shrink-0 font-semibold uppercase tracking-wider text-slate-600">{label}</span>
+      <span className={`min-w-0 truncate text-right text-slate-400 ${mono ? "font-mono tabular-nums" : ""}`} title={value}>
+        {value}
+      </span>
+    </div>
   );
 }

--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -137,7 +137,6 @@ export default function AlertsPage() {
   const [ackDialogOpen, setAckDialogOpen] = useState(false);
   const [ackAlertId, setAckAlertId] = useState<string | null>(null);
   const [ackNote, setAckNote] = useState("");
-  const [muteDropdownId, setMuteDropdownId] = useState<string | null>(null);
   const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(new Set());
   const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
@@ -152,6 +151,11 @@ export default function AlertsPage() {
     },
     { refreshInterval: 30_000 },
   );
+
+  const selectedAlert = useMemo(() => {
+    if (!alerts?.length) return null;
+    return alerts.find((a) => a.id === selectedAlertId) ?? alerts[0];
+  }, [alerts, selectedAlertId]);
 
   async function handleMarkRead(id: string) {
     try {
@@ -256,7 +260,6 @@ export default function AlertsPage() {
   async function handleMute(deviceId: string, hours: number) {
     try {
       await muteDevice(deviceId, hours);
-      setMuteDropdownId(null);
       if (hours > 0) {
         toast.success(`Device muted for ${hours}h`);
       } else {
@@ -276,10 +279,6 @@ export default function AlertsPage() {
   const criticalCount = (alerts ?? []).filter((a) => a.severity === "CRITICAL" && !a.acknowledged_at).length;
   const warningCount = (alerts ?? []).filter((a) => a.severity === "WARNING" && !a.acknowledged_at).length;
   const infoCount = (alerts ?? []).filter((a) => a.severity === "INFO" && !a.acknowledged_at).length;
-  const selectedAlert = useMemo(() => {
-    if (!alerts?.length) return null;
-    return alerts.find((a) => a.id === selectedAlertId) ?? alerts[0];
-  }, [alerts, selectedAlertId]);
 
   return (
     <PageTransition>
@@ -499,6 +498,7 @@ export default function AlertsPage() {
                 <div
                   key={alert.id}
                   role="button"
+                  data-testid="alert-row"
                   tabIndex={0}
                   onClick={() => setSelectedAlertId(alert.id)}
                   onKeyDown={(event) => {

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -81,9 +81,9 @@ export default function DevicesPage() {
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
   const [view, setView] = useState<ViewMode>(() => {
     if (typeof window !== "undefined") {
-      return (localStorage.getItem("devices-view-preference") as ViewMode) || "grid";
+      return (localStorage.getItem("devices-view-preference") as ViewMode) || "table";
     }
-    return "grid";
+    return "table";
   });
   const [sortField, setSortField] = useState<SortField>("last_seen_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -103,6 +103,15 @@ export default function DevicesPage() {
     const interval = setInterval(load, 15_000);
     return () => clearInterval(interval);
   }, [load]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const selectedId = params.get("selected") ?? params.get("id");
+    if (!selectedId || !devices?.length || selectedDevice?.id === selectedId) return;
+    const match = devices.find((d) => d.id === selectedId);
+    if (match) setSelectedDevice(match);
+  }, [devices, selectedDevice?.id]);
 
   // Fetch Xiaomi WiFi data for device list columns
   useEffect(() => {
@@ -300,18 +309,25 @@ export default function DevicesPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-8">
+    <div className="space-y-5">
       {/* Header */}
-      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/45 px-5 py-5 sm:px-6">
+      <div className="border-b border-slate-800/80 pb-4">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-semibold tracking-tight text-white">Devices</h1>
               <HelpTooltip text="All devices discovered on your network. Use Scan Now to discover new devices, Re-identify to fingerprint them, and Resolve Names to look up hostnames via DNS." />
             </div>
-            <p className="max-w-2xl text-sm leading-6 text-slate-300/80">
-              Discover, classify, and monitor every device on your network.
-            </p>
+            <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+              {counts && (
+                <>
+                  <span><span className="font-mono text-slate-300">{counts.all}</span> total</span>
+                  <span><span className="font-mono text-emerald-300">{counts.online}</span> online</span>
+                  <span><span className="font-mono text-slate-300">{counts.offline}</span> offline</span>
+                  <span><span className="font-mono text-amber-300">{counts.unknown}</span> new</span>
+                </>
+              )}
+            </div>
           </div>
           <div className="flex flex-wrap items-center gap-2.5 xl:justify-end">
             <Tooltip>
@@ -455,7 +471,7 @@ export default function DevicesPage() {
       </div>
 
       {/* Filter bar */}
-      <div className="rounded-2xl border border-slate-700/50 bg-slate-900/40 px-5 py-4 sm:px-6">
+      <div className="rounded-lg border border-slate-800 bg-slate-950/45 px-3 py-3 sm:px-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             {(["all", "online", "offline", "unknown"] as Filter[]).map((f) => (

--- a/web/src/app/(app)/devices/page.tsx
+++ b/web/src/app/(app)/devices/page.tsx
@@ -89,6 +89,7 @@ export default function DevicesPage() {
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [addAssetOpen, setAddAssetOpen] = useState(false);
   const [wifiMap, setWifiMap] = useState<Record<string, DeviceWifiInfo>>({});
+  const selectedUrlParamConsumed = useRef(false);
 
   const load = useCallback(async () => {
     try {
@@ -105,13 +106,17 @@ export default function DevicesPage() {
   }, [load]);
 
   useEffect(() => {
+    if (selectedUrlParamConsumed.current) return;
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     const selectedId = params.get("selected") ?? params.get("id");
-    if (!selectedId || !devices?.length || selectedDevice?.id === selectedId) return;
+    if (!selectedId || !devices?.length) return;
     const match = devices.find((d) => d.id === selectedId);
-    if (match) setSelectedDevice(match);
-  }, [devices, selectedDevice?.id]);
+    if (match) {
+      setSelectedDevice(match);
+      selectedUrlParamConsumed.current = true;
+    }
+  }, [devices]);
 
   // Fetch Xiaomi WiFi data for device list columns
   useEffect(() => {
@@ -811,6 +816,7 @@ function DeviceCard({
 
   return (
     <Card
+      data-device-row
       className="h-full min-h-[15.5rem] cursor-pointer border-slate-700/50 bg-slate-900/55 transition-[border-color,background-color,box-shadow] hover:border-slate-600/70 hover:bg-slate-900/72 hover:shadow-[0_14px_32px_-22px_rgba(15,23,42,0.95)]"
       onClick={onClick}
     >
@@ -1064,6 +1070,7 @@ function DevicesTable({
             return (
               <motion.tr
                 key={device.id}
+                data-device-row
                 initial={{ opacity: 0, y: 6 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{

--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -49,6 +49,8 @@ import {
 import type { TopologyDevice, TopologyRouter } from '@/lib/types'
 import { getDeviceIcon } from '@/lib/device-icons'
 import { PageTransition } from '@/components/PageTransition'
+import { EmptyState } from '@/components/EmptyState'
+import { ErrorState } from '@/components/ErrorState'
 import {
   Sheet,
   SheetContent,
@@ -256,6 +258,8 @@ function RouterNode({ data }: NodeProps<RouterNodeType>) {
   const routerLabel =
     data.routerType === 'mikrotik'
       ? 'MikroTik'
+      : data.routerType === 'pfsense'
+        ? 'pfSense'
       : 'Router'
 
   return (
@@ -924,7 +928,16 @@ function TopologyPageInner() {
   const onNodeDragStop = useCallback(
     (_event: React.MouseEvent, node: TopologyNode) => {
       if (node.type === 'subnetGroup') return
-      const pos = { x: node.position.x, y: node.position.y }
+      const pos =
+        node.type === 'routerNode'
+          ? {
+              x: node.position.x + ROUTER_WIDTH / 2,
+              y: node.position.y + ROUTER_HEIGHT / 2,
+            }
+          : {
+              x: node.position.x + DEVICE_WIDTH / 2,
+              y: node.position.y + DEVICE_HEIGHT / 2,
+            }
       pinnedRef.current.set(node.id, pos)
       saveTopologyPositions([
         { node_id: node.id, x: pos.x, y: pos.y, pinned: true },
@@ -1075,20 +1088,13 @@ function TopologyPageInner() {
   if (error) {
     return (
       <PageTransition>
-        <div className="flex h-[calc(100vh-64px)] items-center justify-center">
-          <div className="text-center">
-            <p className="text-sm text-rose-400">{error}</p>
-            <button
-              onClick={() => {
-                setLoading(true)
-                buildGraph(true)
-              }}
-              className="mt-3 text-xs text-blue-400 hover:underline"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
+        <ErrorState
+          message={error}
+          onRetry={() => {
+            setLoading(true)
+            buildGraph(true)
+          }}
+        />
       </PageTransition>
     )
   }
@@ -1133,12 +1139,21 @@ function TopologyPageInner() {
           />
 
           {/* Floating toolbar */}
-          <div className="absolute right-4 top-4 z-10 flex items-center gap-3 rounded-lg border border-slate-700/50 bg-slate-900/80 px-4 py-2 backdrop-blur-sm">
+          <div className="absolute left-4 top-4 z-10 max-w-[calc(100vw-2rem)] rounded-lg border border-slate-700/50 bg-slate-900/85 px-4 py-3 backdrop-blur-sm">
+            <div className="mb-2 flex items-center gap-2">
+              <Network className="h-4 w-4 text-cyan-400" />
+              <h1 className="text-sm font-semibold text-white">Topology</h1>
+              <span className="rounded border border-slate-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-slate-500">
+                {routerInfoRef.current?.router_type ?? 'router'}
+              </span>
+            </div>
             <span className="text-[11px] text-slate-400">
               {stats.total} devices · {stats.online} online · {stats.subnets}{' '}
               subnet{stats.subnets !== 1 ? 's' : ''}
             </span>
-            <div className="h-3 w-px bg-slate-700" />
+          </div>
+
+          <div className="absolute right-4 top-4 z-10 flex items-center gap-3 rounded-lg border border-slate-700/50 bg-slate-900/80 px-4 py-2 backdrop-blur-sm">
             <button
               onClick={autoLayout}
               className="text-slate-400 transition-colors hover:text-white"
@@ -1177,6 +1192,20 @@ function TopologyPageInner() {
               </span>
             )}
           </div>
+
+          {stats.total === 0 && (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-4">
+              <div className="pointer-events-auto rounded-lg border border-slate-800 bg-slate-950/90 px-8 py-4 shadow-2xl">
+                <EmptyState
+                  icon={Network}
+                  title="No topology devices"
+                  description="Discovered devices will appear here after a network scan returns inventory data."
+                  actionLabel="Open Devices"
+                  actionHref="/devices"
+                />
+              </div>
+            </div>
+          )}
         </ReactFlow>
       </div>
 

--- a/web/tests/e2e/device-detail.spec.ts
+++ b/web/tests/e2e/device-detail.spec.ts
@@ -44,7 +44,7 @@ test.describe('Device detail page — enrichment display', () => {
     await page.screenshot({ path: 'tests/screenshots/device-detail-sheet.png' });
 
     // The sheet should contain Info tab content
-    const sheetContent = await page.textContent('[role="dialog"], [data-state="open"]') ?? '';
+    const sheetContent = await page.getByRole('dialog').textContent() ?? '';
 
     // Verify key sections exist
     const hasInfoContent =

--- a/web/tests/e2e/operations-renewal.spec.ts
+++ b/web/tests/e2e/operations-renewal.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, login } from '../../e2e/fixtures';
+import type { Page } from '@playwright/test';
+
+const now = new Date('2026-05-17T03:00:00Z').toISOString();
+
+const devices = [
+  {
+    id: 'device-alpha',
+    mac: 'AA:BB:CC:DD:EE:01',
+    name: 'Core Switch',
+    hostname: 'core-switch',
+    vendor: 'MikroTik',
+    icon: 'router',
+    notes: null,
+    is_known: true,
+    is_favorite: false,
+    first_seen_at: now,
+    last_seen_at: now,
+    is_online: true,
+    ips: ['192.168.1.2'],
+    mdns_services: null,
+    agent: null,
+    muted_until: null,
+    os_family: 'RouterOS',
+    os_version: null,
+    device_type: 'router',
+    device_model: null,
+    device_brand: null,
+    enrichment_source: null,
+    enrichment_corrected: null,
+    is_randomized_mac: false,
+    custom_name: null,
+    custom_type: null,
+    custom_os: null,
+    custom_vendor: null,
+    custom_model: null,
+    icon_override: null,
+    is_manual: false,
+    location: 'Rack',
+    owner: 'NetOps',
+    tags: 'core,router',
+    status_timeline: [true, true, true, true],
+  },
+  {
+    id: 'device-beta',
+    mac: 'AA:BB:CC:DD:EE:02',
+    name: 'Desk Laptop',
+    hostname: 'desk-laptop',
+    vendor: 'Framework',
+    icon: 'laptop',
+    notes: null,
+    is_known: false,
+    is_favorite: false,
+    first_seen_at: now,
+    last_seen_at: now,
+    is_online: false,
+    ips: ['192.168.1.50'],
+    mdns_services: null,
+    agent: null,
+    muted_until: null,
+    os_family: 'Linux',
+    os_version: null,
+    device_type: 'laptop',
+    device_model: null,
+    device_brand: null,
+    enrichment_source: null,
+    enrichment_corrected: null,
+    is_randomized_mac: false,
+    custom_name: null,
+    custom_type: null,
+    custom_os: null,
+    custom_vendor: null,
+    custom_model: null,
+    icon_override: null,
+    is_manual: false,
+    location: null,
+    owner: null,
+    tags: 'new',
+    status_timeline: [true, false, false, false],
+  },
+];
+
+const alerts = [
+  {
+    id: 'alert-critical',
+    type: 'device_offline',
+    device_id: 'device-alpha',
+    agent_id: null,
+    message: 'Core switch offline',
+    details: 'No ARP activity for 5 minutes',
+    is_read: false,
+    severity: 'CRITICAL',
+    acknowledged_at: null,
+    acknowledged_by: null,
+    created_at: now,
+  },
+  {
+    id: 'alert-info',
+    type: 'device_online',
+    device_id: 'device-beta',
+    agent_id: null,
+    message: 'Desk laptop recovered',
+    details: null,
+    is_read: true,
+    severity: 'INFO',
+    acknowledged_at: null,
+    acknowledged_by: null,
+    created_at: now,
+  },
+];
+
+async function mockOperationsApis(page: Page) {
+  await page.route('**/api/v1/alerts?*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(alerts) }),
+  );
+  await page.route('**/api/v1/alerts/**', (route) =>
+    route.fulfill({ status: 204 }),
+  );
+  await page.route('**/api/v1/alerts/mark-all-read', (route) =>
+    route.fulfill({ status: 204 }),
+  );
+  await page.route('**/api/v1/devices', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(devices) }),
+  );
+  await page.route('**/api/v1/devices/*/sysinfo', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: 'null' }),
+  );
+  await page.route('**/api/v1/xiaomi/status', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ configured: false }) }),
+  );
+  await page.route('**/api/v1/topology/graph', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        router: {
+          router_type: 'mikrotik',
+          is_online: true,
+          wan_ip: '203.0.113.5',
+          hostname: 'edge-router',
+          version: '7.15',
+        },
+        devices: devices.map((device) => ({
+          id: device.id,
+          mac: device.mac,
+          name: device.name,
+          hostname: device.hostname,
+          vendor: device.vendor,
+          is_online: device.is_online,
+          ips: device.ips,
+          custom_name: device.custom_name,
+          custom_type: device.custom_type,
+          custom_vendor: device.custom_vendor,
+          device_type: device.device_type,
+          device_model: device.device_model,
+          device_brand: device.device_brand,
+          mdns_services: device.mdns_services,
+          icon: device.icon,
+          first_seen_at: device.first_seen_at,
+          last_seen_at: device.last_seen_at,
+          os_family: device.os_family,
+          os_version: device.os_version,
+          location: device.location,
+          owner: device.owner,
+          tags: device.tags,
+          rx_bps: 1200,
+          tx_bps: 800,
+        })),
+        positions: [],
+      }),
+    }),
+  );
+  await page.route('**/api/v1/topology/positions', (route) =>
+    route.fulfill({ status: route.request().method() === 'GET' ? 200 : 204, contentType: 'application/json', body: '[]' }),
+  );
+}
+
+test.describe('operations route renewal', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await mockOperationsApis(page);
+  });
+
+  test('alerts show two-pane triage and detail actions', async ({ page }) => {
+    await page.goto('/alerts/');
+
+    await expect(page.getByRole('heading', { name: 'Alerts', level: 1 })).toBeVisible();
+    await expect(page.getByText('Severity')).toBeVisible();
+    await expect(page.getByTestId('alert-row')).toHaveCount(2);
+
+    await page.getByTestId('alert-row').filter({ hasText: 'Desk laptop recovered' }).click();
+    const detail = page.locator('aside');
+    await expect(detail.getByText('Desk laptop recovered')).toBeVisible();
+    await expect(detail.getByRole('button', { name: 'Acknowledge' })).toBeVisible();
+    await expect(detail.getByRole('button', { name: 'Mute' })).toBeVisible();
+  });
+
+  test('devices support selected-device deep links without fake data', async ({ page }) => {
+    await page.goto('/devices/?selected=device-alpha');
+
+    await expect(page.getByRole('heading', { name: 'Devices', level: 1 })).toBeVisible();
+    await expect(page.locator('tbody').getByText('192.168.1.2')).toBeVisible();
+    await expect(page.getByText('1 new')).toBeVisible();
+    await expect(page.getByRole('dialog').getByRole('heading', { name: 'core-switch' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await page.locator('[data-device-row]').filter({ hasText: 'desk-laptop' }).click();
+    await expect(page.getByRole('dialog').getByRole('heading', { name: 'desk-laptop' })).toBeVisible();
+  });
+
+  test('topology renders renewed graph controls with persisted-position API', async ({ page }) => {
+    await page.goto('/topology/');
+
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('topology-auto-layout')).toBeVisible();
+    await expect(page.getByTestId('topology-fit-view')).toBeVisible();
+    await expect(page.getByText(/2 devices/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- renew `/devices`, `/alerts`, and `/topology` production routes from the prior slice
- fix alerts hook order and remove orphaned mute dropdown state
- consume `/devices?selected=` deep links once so manual selection is not overridden on refresh
- add Playwright coverage for the renewed operations routes and repair the device-detail sheet selector

Implements #747

## Verification
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run test` -> 16 passed
- `cd web && bun run build` -> passed
- started `cargo run -p panoptikon-server -- --listen 127.0.0.1:8080 --db /tmp/panoptikon-pan8-e2e.db` for local E2E
- `cd web && bun run test:e2e -- tests/e2e/operations-renewal.spec.ts` -> 3 passed
- `cd web && bun run test:e2e -- tests/e2e/operations-renewal.spec.ts tests/e2e/device-detail.spec.ts tests/e2e/alert-card-border.spec.ts tests/e2e/alerts-severity.spec.ts tests/e2e/topology.spec.ts` -> 15 passed, 2 skipped

## Playwright Evidence
- Focused route suite passed locally against the Rust server on `127.0.0.1:8080`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renews the `/devices`, `/alerts`, and `/topology` production routes with refreshed layouts, fixes a topology drag-position persistence bug (nodes now save center coordinates instead of top-left to match the backend's expected format), and adds a `useRef`-guarded deep-link consumer on the devices page so `?selected=` is applied once and not re-applied after manual interaction.

- **Alerts**: replaces the flat list with a two-pane triage layout; removes the orphaned `muteDropdownId` state and moves mute controls into a `DropdownMenu` inside the detail panel; auto-selects the first alert when none is explicitly chosen.
- **Devices**: adds `selectedUrlParamConsumed` ref to handle deep-link selection without overriding manual changes; switches default view to `\"table\"` and inlines live counts into the header.
- **Topology**: fixes drag-persist coordinate space, splits toolbar into an info card and an action card, adds a `pfSense` router label, and surfaces an `EmptyState` overlay when no devices are present.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are self-contained UI renewals with no data-mutation regressions and a correctly scoped topology coordinate fix.

The topology center-coordinate fix is a meaningful correctness change and the new two-pane alerts triage is well-structured. The only gap is that the new E2E spec file omits the required page.screenshot() calls called out in CLAUDE.md, leaving the test suite slightly short of the team's defined standard for valid coverage.

web/tests/e2e/operations-renewal.spec.ts — needs screenshot captures added to each test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/alerts/page.tsx | Replaces list-only view with a two-pane triage layout; adds selectedAlertId state with auto-select-first fallback, removes orphaned muteDropdownId state, and moves mute controls into a DropdownMenu in the detail panel. |
| web/src/app/(app)/devices/page.tsx | Adds a selectedUrlParamConsumed ref to consume ?selected= deep-link once without overriding manual selections; changes default view from "grid" to "table"; refreshes header layout with inline device counts. |
| web/src/app/(app)/topology/page.tsx | Fixes drag-position persistence to save center coordinates (matching the backend's expected format); splits toolbar into info panel (left) and controls (right); adds pfSense router label and an EmptyState overlay when no devices are present; uses shared ErrorState component. |
| web/tests/e2e/operations-renewal.spec.ts | New E2E spec covering alerts triage pane, device deep-link, and topology graph controls with mocked APIs; missing page.screenshot() calls required by CLAUDE.md. |
| web/tests/e2e/device-detail.spec.ts | Repairs sheet selector from a fragile compound CSS/ARIA selector to the cleaner getByRole('dialog') API. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/tests/e2e/operations-renewal.spec.ts`, line 861-897 ([link](https://github.com/befeast/panoptikon/blob/482f531a646ce79b6de3155d7aaab04885b0087c/web/tests/e2e/operations-renewal.spec.ts#L861-L897)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Missing screenshots on key assertions**

   The project's `CLAUDE.md` style guide lists `page.screenshot(...)` on key assertions as a required element for a valid E2E test. All three tests in this file perform meaningful UI assertions (triage pane, deep-link device sheet, topology graph controls) but none capture a screenshot, so the tests don't fully satisfy the defined criteria. Adding a screenshot after the primary `expect` in each test — e.g. `await page.screenshot({ path: 'tests/screenshots/alerts-triage.png' })` after the detail pane assertions — would bring the file into compliance.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/tests/e2e/operations-renewal.spec.ts
   Line: 861-897
   
   Comment:
   **Missing screenshots on key assertions**
   
   The project's `CLAUDE.md` style guide lists `page.screenshot(...)` on key assertions as a required element for a valid E2E test. All three tests in this file perform meaningful UI assertions (triage pane, deep-link device sheet, topology graph controls) but none capture a screenshot, so the tests don't fully satisfy the defined criteria. Adding a screenshot after the primary `expect` in each test — e.g. `await page.screenshot({ path: 'tests/screenshots/alerts-triage.png' })` after the detail pane assertions — would bring the file into compliance.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/operations-renewal.spec.ts:861-897
**Missing screenshots on key assertions**

The project's `CLAUDE.md` style guide lists `page.screenshot(...)` on key assertions as a required element for a valid E2E test. All three tests in this file perform meaningful UI assertions (triage pane, deep-link device sheet, topology graph controls) but none capture a screenshot, so the tests don't fully satisfy the defined criteria. Adding a screenshot after the primary `expect` in each test — e.g. `await page.screenshot({ path: 'tests/screenshots/alerts-triage.png' })` after the detail pane assertions — would bring the file into compliance.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address operations renewal review f..."](https://github.com/befeast/panoptikon/commit/482f531a646ce79b6de3155d7aaab04885b0087c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32480280)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->