### PR TITLE
UX renewal: auth detail and state surfaces

### DIFF
--- a/web/src/app/(app)/agents/detail/content.tsx
+++ b/web/src/app/(app)/agents/detail/content.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
-import { ArrowLeft, CircuitBoard, Cpu, HardDrive, MemoryStick, Monitor, Timer } from "lucide-react";
+import { ArrowLeft, CircuitBoard, Cpu, HardDrive, MemoryStick, Monitor, Radio, Timer } from "lucide-react";
 import {
   LineChart,
   Line,
@@ -24,6 +24,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { fetchAgent, fetchAgentReports } from "@/lib/api";
+import { EmptyState } from "@/components/EmptyState";
+import { ErrorState } from "@/components/ErrorState";
 import type { Agent, AgentReport } from "@/lib/types";
 import { formatBytes, formatPercent, timeAgo } from "@/lib/format";
 import { useWsEvent } from "@/lib/ws";
@@ -66,11 +68,7 @@ export default function AgentDetailContent() {
   if (!id) return null;
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-rose-400">{error}</p>
-      </div>
-    );
+    return <ErrorState message={error} onRetry={load} />;
   }
 
   if (!agent || !reports) {
@@ -148,7 +146,7 @@ export default function AgentDetailContent() {
       {chartData.length > 0 ? (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
           {/* CPU Chart */}
-          <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+          <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
             <h2 className="text-sm font-medium text-slate-400 mb-3">CPU Usage %</h2>
             <div className="h-48">
               <ResponsiveContainer width="100%" height="100%">
@@ -179,7 +177,7 @@ export default function AgentDetailContent() {
                   <Line
                     type="monotone"
                     dataKey="cpu"
-                    stroke="#3b82f6"
+                    stroke="#22d3ee"
                     strokeWidth={2}
                     dot={false}
                     connectNulls
@@ -191,7 +189,7 @@ export default function AgentDetailContent() {
           </div>
 
           {/* RAM Chart */}
-          <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+          <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
             <h2 className="text-sm font-medium text-slate-400 mb-3">RAM Usage %</h2>
             <div className="h-48">
               <ResponsiveContainer width="100%" height="100%">
@@ -222,7 +220,7 @@ export default function AgentDetailContent() {
                   <Line
                     type="monotone"
                     dataKey="ram"
-                    stroke="#8b5cf6"
+                    stroke="#10b981"
                     strokeWidth={2}
                     dot={false}
                     connectNulls
@@ -234,20 +232,28 @@ export default function AgentDetailContent() {
           </div>
         </div>
       ) : (
-        <div className="rounded-lg border border-slate-800 bg-slate-900 p-8 text-center">
-          <p className="text-slate-500">No report data available yet.</p>
-        </div>
+        <EmptyState
+          icon={Radio}
+          title="No report data available yet"
+          description="This agent has not submitted enough telemetry to draw CPU or RAM history."
+        />
       )}
 
       {/* Reports table */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900">
+      <div className="overflow-hidden rounded-md border border-slate-800 bg-slate-950/60">
         <div className="px-4 py-3 border-b border-slate-800">
           <h2 className="text-sm font-medium text-slate-400">
             Recent Reports ({reports.length})
           </h2>
         </div>
         {reports.length === 0 ? (
-          <div className="p-8 text-center text-slate-500">No reports yet.</div>
+          <div className="p-4">
+            <EmptyState
+              icon={Radio}
+              title="No reports yet"
+              description="Reports will appear here after the agent checks in."
+            />
+          </div>
         ) : (
           <Table>
             <TableHeader>
@@ -383,11 +389,11 @@ function HardwareInfoCard({ agent }: { agent: Agent }) {
   }
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+    <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
       <h2 className="text-sm font-medium text-slate-400 mb-3">Hardware Info</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2">
         {items.map((item) => (
-          <div key={item.label} className="flex items-start gap-2 text-sm">
+          <div key={item.label} className="flex min-w-0 items-start gap-2 text-sm">
             <span className="mt-0.5 text-slate-500">{item.icon}</span>
             <span className="text-slate-500 shrink-0">{item.label}:</span>
             <span className="text-white truncate" title={item.value}>{item.value}</span>

--- a/web/src/app/(app)/agents/detail/page.tsx
+++ b/web/src/app/(app)/agents/detail/page.tsx
@@ -2,10 +2,11 @@
 
 import { Suspense } from "react";
 import AgentDetailContent from "./content";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function AgentDetailPage() {
   return (
-    <Suspense fallback={<div className="text-gray-500 py-20 text-center">Loading…</div>}>
+    <Suspense fallback={<Skeleton className="h-64 w-full" />}>
       <AgentDetailContent />
     </Suspense>
   );

--- a/web/src/app/(app)/assets/detail/content.tsx
+++ b/web/src/app/(app)/assets/detail/content.tsx
@@ -47,6 +47,7 @@ import { formatBytes, formatPercent, timeAgo } from "@/lib/format";
 import { useWsEvent } from "@/lib/ws";
 import { getDeviceIcon } from "@/lib/device-icons";
 import { getOsDisplay } from "@/lib/os-icons";
+import { ErrorState } from "@/components/ErrorState";
 import { toast } from "sonner";
 
 // ─── Types ────────────────────────────────────────────────
@@ -170,11 +171,7 @@ export default function AssetDetailContent() {
   if (!id) return null;
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-rose-400">{error}</p>
-      </div>
-    );
+    return <ErrorState message={error} onRetry={load} />;
   }
 
   if (!device) {
@@ -340,7 +337,7 @@ function AssetHeader({
           />
         ) : (
           <h1
-            className="text-2xl font-semibold text-white cursor-pointer hover:text-blue-400 transition-colors group flex items-center gap-2"
+            className="text-2xl font-semibold text-white cursor-pointer hover:text-cyan-300 transition-colors group flex items-center gap-2"
             onClick={() => setEdit({ field: "custom_name", value: device.custom_name || device.name || device.hostname || "" })}
           >
             {effectiveName}
@@ -399,7 +396,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-blue-400 transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-cyan-300 transition-colors group"
             onClick={() => setEdit({ field: "tags", value: device.tags || "" })}
           >
             <Tag size={14} className="text-slate-500" />
@@ -435,7 +432,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-blue-400 transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-cyan-300 transition-colors group"
             onClick={() => setEdit({ field: "location", value: device.location || "" })}
           >
             <MapPin size={14} className="text-slate-500" />
@@ -461,7 +458,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-blue-400 transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-cyan-300 transition-colors group"
             onClick={() => setEdit({ field: "owner", value: device.owner || "" })}
           >
             <User size={14} className="text-slate-500" />
@@ -540,7 +537,7 @@ function InfoGrid({
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
       {/* Hardware Column */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
         <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center gap-2">
           <HardDrive size={14} />
           Hardware
@@ -597,7 +594,7 @@ function InfoGrid({
       </div>
 
       {/* Software Column */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
         <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center gap-2">
           <Monitor size={14} />
           Software
@@ -655,7 +652,7 @@ function InfoGrid({
       </div>
 
       {/* Network Column */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
         <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center gap-2">
           <Cpu size={14} />
           Network
@@ -686,7 +683,7 @@ function InfoGrid({
 
       {/* Asset Management (extra row) */}
       {(device.purchase_date || device.warranty_expiry) && (
-        <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 md:col-span-2 lg:col-span-3">
+        <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4 md:col-span-2 lg:col-span-3">
           <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center gap-2">
             <Tag size={14} />
             Asset Management
@@ -731,7 +728,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
       {/* CPU Chart */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
         <h2 className="text-sm font-medium text-slate-400 mb-3">CPU Usage %</h2>
         <div className="h-48">
           <ResponsiveContainer width="100%" height="100%">
@@ -762,7 +759,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
               <Line
                 type="monotone"
                 dataKey="cpu"
-                stroke="#3b82f6"
+                stroke="#22d3ee"
                 strokeWidth={2}
                 dot={false}
                 connectNulls
@@ -774,7 +771,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
       </div>
 
       {/* RAM Chart */}
-      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+      <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
         <h2 className="text-sm font-medium text-slate-400 mb-3">RAM Usage %</h2>
         <div className="h-48">
           <ResponsiveContainer width="100%" height="100%">
@@ -805,7 +802,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
               <Line
                 type="monotone"
                 dataKey="ram"
-                stroke="#8b5cf6"
+                stroke="#10b981"
                 strokeWidth={2}
                 dot={false}
                 connectNulls
@@ -832,7 +829,7 @@ function LinkedSources({
   if (!hasAny) return null;
 
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+    <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
       <h3 className="text-sm font-medium text-slate-400 mb-3">Linked Sources</h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {/* Network Device */}
@@ -851,7 +848,7 @@ function LinkedSources({
           </div>
           <Link
             href={`/devices`}
-            className="mt-2 inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+            className="mt-2 inline-flex items-center gap-1 text-xs text-cyan-300 hover:text-cyan-200 transition-colors"
           >
             View in Devices <ExternalLink size={10} />
           </Link>
@@ -881,7 +878,7 @@ function LinkedSources({
             </div>
             <Link
               href={`/agents/detail?id=${device.agent.id}`}
-              className="mt-2 inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-cyan-300 hover:text-cyan-200 transition-colors"
             >
               Agent Detail <ExternalLink size={10} />
             </Link>
@@ -917,7 +914,7 @@ function LinkedSources({
             </div>
             <Link
               href="/ssh-hosts"
-              className="mt-2 inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-cyan-300 hover:text-cyan-200 transition-colors"
             >
               SSH Hosts <ExternalLink size={10} />
             </Link>
@@ -951,12 +948,12 @@ function NotesSection({
   cancelEdit: () => void;
 }) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+    <div className="rounded-md border border-slate-800 bg-slate-950/60 p-4">
       <h3 className="text-sm font-medium text-slate-400 mb-3">Notes</h3>
       {edit.field === "notes" ? (
         <div className="space-y-2">
           <textarea
-            className="w-full min-h-[80px] rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full min-h-[80px] rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-cyan-500"
             value={edit.value}
             onChange={(e) => setEdit({ ...edit, value: e.target.value })}
             placeholder="Add notes about this asset..."
@@ -985,7 +982,7 @@ function NotesSection({
         </div>
       ) : (
         <p
-          className="text-sm text-slate-300 cursor-pointer hover:text-blue-400 transition-colors group"
+          className="text-sm text-slate-300 cursor-pointer hover:text-cyan-300 transition-colors group"
           onClick={() => setEdit({ field: "notes", value: device.notes || "" })}
         >
           {device.notes || (

--- a/web/src/app/(app)/assets/detail/page.tsx
+++ b/web/src/app/(app)/assets/detail/page.tsx
@@ -2,10 +2,11 @@
 
 import { Suspense } from "react";
 import AssetDetailContent from "./content";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function AssetDetailPage() {
   return (
-    <Suspense fallback={<div className="text-gray-500 py-20 text-center">Loading...</div>}>
+    <Suspense fallback={<Skeleton className="h-64 w-full" />}>
       <AssetDetailContent />
     </Suspense>
   );

--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -62,6 +62,8 @@ import {
 } from "@/lib/api";
 import type { NpmCertificate, NpmConnectionStatus } from "@/lib/types";
 import { HelpTooltip } from "@/components/HelpTooltip";
+import { EmptyState } from "@/components/EmptyState";
+import { ErrorState } from "@/components/ErrorState";
 import {
   Tooltip,
   TooltipContent,
@@ -268,29 +270,22 @@ export default function CertificatesPage() {
 
   if (!npmStatus?.configured) {
     return (
-      <div className="flex flex-col items-center justify-center gap-4 py-20">
-        <Shield className="h-12 w-12 text-slate-600" />
-        <h2 className="text-lg font-medium text-white">
-          Caddy Not Configured
-        </h2>
-        <p className="max-w-md text-center text-sm text-slate-400">
-          Configure your Caddy connection in Settings to manage SSL
-          certificates.
-        </p>
-      </div>
+      <EmptyState
+        icon={Shield}
+        title="Caddy Not Configured"
+        description="Configure your Caddy connection in Settings to manage SSL certificates."
+        actionLabel="Open Settings"
+        actionHref="/settings"
+      />
     );
   }
 
   if (!npmStatus.reachable) {
     return (
-      <div className="flex flex-col items-center justify-center gap-4 py-20">
-        <AlertTriangle className="h-12 w-12 text-amber-500" />
-        <h2 className="text-lg font-medium text-white">Caddy Unreachable</h2>
-        <p className="max-w-md text-center text-sm text-slate-400">
-          Could not connect to your Caddy instance. Check your settings and
-          ensure the service is running.
-        </p>
-      </div>
+      <ErrorState
+        message="Could not connect to your Caddy instance. Check your settings and ensure the service is running."
+        onRetry={loadCerts}
+      />
     );
   }
 
@@ -362,8 +357,8 @@ export default function CertificatesPage() {
       <Card className="border-slate-800 bg-slate-900">
         <CardHeader>
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-orange-500/10">
-              <Shield className="h-4 w-4 text-orange-400" />
+            <div className="flex h-9 w-9 items-center justify-center rounded-md border border-cyan-500/20 bg-cyan-500/10">
+              <Shield className="h-4 w-4 text-cyan-300" />
             </div>
             <div>
               <CardTitle className="text-base text-white">
@@ -377,13 +372,11 @@ export default function CertificatesPage() {
         </CardHeader>
         <CardContent>
           {certs.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <Shield className="mb-4 h-12 w-12 text-slate-600" />
-              <p className="text-lg font-medium text-slate-400">No certificates yet</p>
-              <p className="mt-1 max-w-sm text-sm text-slate-600">
-                Request a free Let&apos;s Encrypt certificate or upload your own using the buttons above. Make sure Caddy is configured in Settings first.
-              </p>
-            </div>
+            <EmptyState
+              icon={Shield}
+              title="No certificates yet"
+              description="Request a free Let's Encrypt certificate or upload your own using the buttons above."
+            />
           ) : (
             <div className="overflow-x-auto">
               <Table>
@@ -539,7 +532,7 @@ export default function CertificatesPage() {
             <Button
               onClick={handleCreateLetsEncrypt}
               disabled={!leDomains.trim() || !leEmail.trim() || leSubmitting}
-              className="bg-blue-600 text-white hover:bg-blue-500"
+              className="bg-cyan-500 text-slate-950 hover:bg-cyan-400"
             >
               {leSubmitting && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -584,7 +577,7 @@ export default function CertificatesPage() {
                 >
                   Certificate (PEM)
                 </Label>
-                <label className="cursor-pointer text-xs text-blue-400 hover:text-blue-300">
+                <label className="cursor-pointer text-xs text-cyan-300 hover:text-cyan-200">
                   <input
                     type="file"
                     accept=".pem,.crt,.cer"
@@ -601,7 +594,7 @@ export default function CertificatesPage() {
                 value={customCert}
                 onChange={(e) => setCustomCert(e.target.value)}
                 rows={4}
-                className="w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-cyan-500"
                 placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
               />
             </div>
@@ -613,7 +606,7 @@ export default function CertificatesPage() {
                 >
                   Private Key (PEM)
                 </Label>
-                <label className="cursor-pointer text-xs text-blue-400 hover:text-blue-300">
+                <label className="cursor-pointer text-xs text-cyan-300 hover:text-cyan-200">
                   <input
                     type="file"
                     accept=".pem,.key"
@@ -630,7 +623,7 @@ export default function CertificatesPage() {
                 value={customKey}
                 onChange={(e) => setCustomKey(e.target.value)}
                 rows={4}
-                className="w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-slate-800 bg-slate-950 px-3 py-2 font-mono text-xs text-white placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-cyan-500"
                 placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
               />
             </div>
@@ -651,7 +644,7 @@ export default function CertificatesPage() {
                 !customKey.trim() ||
                 customSubmitting
               }
-              className="bg-blue-600 text-white hover:bg-blue-500"
+              className="bg-cyan-500 text-slate-950 hover:bg-cyan-400"
             >
               {customSubmitting && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -212,7 +212,7 @@
   text-decoration: inherit;
 }
 
-/* ── Login / Setup animated gradient mesh background ── */
+/* Login / setup operator console background */
 @keyframes gradient-shift {
   0% {
     background-position: 0% 50%;
@@ -268,30 +268,19 @@
 }
 
 .login-bg {
-  background: linear-gradient(
-    135deg,
-    #070B12 0%,
-    #0E1624 25%,
-    #070B12 50%,
-    #132033 75%,
-    #070B12 100%
-  );
-  background-size: 400% 400%;
-  animation: gradient-shift 15s ease infinite;
-}
-
-.login-orb {
-  animation: float-orb 12s ease-in-out infinite;
-}
-
-.login-orb-reverse {
-  animation: float-orb-reverse 14s ease-in-out infinite;
+  background-color: #070b12;
+  background-image:
+    linear-gradient(rgba(34, 211, 238, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.045) 1px, transparent 1px),
+    radial-gradient(circle at 50% 0%, rgba(34, 211, 238, 0.1), transparent 34%),
+    linear-gradient(180deg, #070b12 0%, #0b1220 100%);
+  background-size: 32px 32px, 32px 32px, auto, auto;
 }
 
 .login-card-glow {
   box-shadow:
-    0 0 80px 20px rgba(34, 211, 238, 0.06),
-    0 0 40px 10px rgba(34, 211, 238, 0.04),
+    0 0 0 1px rgba(34, 211, 238, 0.04),
+    0 24px 80px -54px rgba(34, 211, 238, 0.55),
     inset 0 1px 0 0 rgba(148, 163, 184, 0.08);
 }
 
@@ -301,10 +290,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .login-bg {
-    animation: none;
-  }
-  .login-orb,
-  .login-orb-reverse {
     animation: none;
   }
   .input-focus-glow:focus-within {

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -71,28 +71,17 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden">
-      {/* Animated gradient orbs */}
-      <div className="login-orb pointer-events-none absolute -left-32 -top-32 h-[500px] w-[500px] rounded-full bg-cyan-500/10 blur-3xl" />
-      <div className="login-orb-reverse pointer-events-none absolute -bottom-40 -right-40 h-[600px] w-[600px] rounded-full bg-slate-500/8 blur-3xl" />
-      <div className="login-orb pointer-events-none absolute left-1/2 top-1/3 h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-cyan-500/5 blur-3xl" />
-
+    <div className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-8">
       <div className="relative z-10 w-full max-w-sm px-4">
-        {/* Glow behind card */}
-        <div className="pointer-events-none absolute inset-0 -z-10 mx-auto flex items-center justify-center">
-          <div className="h-64 w-64 rounded-full bg-cyan-500/10 blur-3xl" />
-        </div>
-
-        <Card className="login-card-glow w-full border-slate-800 bg-slate-900/90 backdrop-blur-sm">
-          <CardHeader className="items-center pb-2">
-            {/* Logo */}
-            <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-cyan-500 shadow-lg shadow-cyan-500/20">
-              <span className="text-2xl font-bold text-slate-950">P</span>
+        <Card className="login-card-glow w-full rounded-md border-slate-800/90 bg-slate-950/95 backdrop-blur-sm">
+          <CardHeader className="items-center border-b border-slate-800/80 pb-4">
+            <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-md border border-cyan-400/50 bg-cyan-500 shadow-[0_0_28px_rgba(34,211,238,0.18)]">
+              <span className="font-display text-2xl font-bold text-slate-950">P</span>
             </div>
-            <h1 className="font-display bg-gradient-to-r from-cyan-400 via-cyan-300 to-teal-400 bg-clip-text text-2xl font-bold text-transparent">
+            <h1 className="font-display text-2xl font-bold text-white">
               Panoptikon
             </h1>
-            <p className="text-sm text-slate-500">
+            <p className="text-center text-xs uppercase tracking-[0.2em] text-cyan-300/80">
               Sign in to your network operations console
             </p>
           </CardHeader>
@@ -139,12 +128,12 @@ export default function LoginPage() {
                 </div>
 
                 {error && (
-                  <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
+                  <p className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
                     {error}
                   </p>
                 )}
 
-                <Button type="submit" className="w-full" disabled={loading}>
+                <Button type="submit" className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400" disabled={loading}>
                   {loading ? "Signing in..." : "Sign In"}
                 </Button>
               </form>

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Eye, EyeOff, Lock, Shield } from "lucide-react";
+import { Eye, EyeOff, Lock } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -71,26 +71,16 @@ export default function SetupPage() {
 
   return (
     <div className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden p-4">
-      {/* Animated gradient orbs */}
-      <div className="login-orb pointer-events-none absolute -left-32 -top-32 h-[500px] w-[500px] rounded-full bg-blue-500/10 blur-3xl" />
-      <div className="login-orb-reverse pointer-events-none absolute -bottom-40 -right-40 h-[600px] w-[600px] rounded-full bg-indigo-500/8 blur-3xl" />
-      <div className="login-orb pointer-events-none absolute left-1/2 top-1/3 h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-cyan-500/5 blur-3xl" />
-
       <div className="relative z-10 w-full max-w-md">
-        {/* Glow behind card */}
-        <div className="pointer-events-none absolute inset-0 -z-10 mx-auto flex items-center justify-center">
-          <div className="h-64 w-64 rounded-full bg-blue-500/10 blur-3xl" />
-        </div>
-
-        <Card className="login-card-glow w-full border-slate-800 bg-slate-900/90 backdrop-blur-sm">
-          <CardHeader className="items-center pb-2">
-            <div className="mb-2 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-500 shadow-lg shadow-blue-500/20">
-              <Shield className="h-7 w-7 text-white" />
+        <Card className="login-card-glow w-full rounded-md border-slate-800/90 bg-slate-950/95 backdrop-blur-sm">
+          <CardHeader className="items-center border-b border-slate-800/80 pb-4">
+            <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-md border border-cyan-400/50 bg-cyan-500 shadow-[0_0_28px_rgba(34,211,238,0.18)]">
+              <span className="font-display text-2xl font-bold text-slate-950">P</span>
             </div>
-            <h1 className="bg-gradient-to-r from-blue-400 via-blue-300 to-cyan-400 bg-clip-text text-2xl font-bold text-transparent">
+            <h1 className="font-display text-center text-2xl font-bold text-white">
               Welcome to Panoptikon
             </h1>
-            <p className="text-center text-sm text-slate-500">
+            <p className="text-center text-xs uppercase tracking-[0.2em] text-cyan-300/80">
               Set up your admin password to get started.
             </p>
           </CardHeader>
@@ -154,12 +144,12 @@ export default function SetupPage() {
                 </div>
 
                 {error && (
-                  <p className="rounded-md bg-rose-500/10 px-3 py-2 text-sm text-rose-400">
+                  <p className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
                     {error}
                   </p>
                 )}
 
-                <Button type="submit" className="w-full" disabled={loading}>
+                <Button type="submit" className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400" disabled={loading}>
                   {loading ? "Setting up..." : "Complete Setup"}
                 </Button>
               </form>

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -29,15 +29,17 @@ export function EmptyState({
   variant?: "default" | "success";
 }) {
   const iconColor =
-    variant === "success" ? "text-emerald-500/70" : "text-slate-600";
+    variant === "success" ? "text-emerald-400/80" : "text-cyan-300/70";
   const titleColor =
-    variant === "success" ? "text-emerald-400" : "text-slate-400";
+    variant === "success" ? "text-emerald-300" : "text-slate-200";
 
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
-      <Icon className={`mb-4 h-12 w-12 ${iconColor}`} />
-      <p className={`text-lg font-medium ${titleColor}`}>{title}</p>
-      <p className="mt-1 max-w-sm text-sm text-slate-600">{description}</p>
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-slate-800 bg-slate-950/45 px-5 py-12 text-center">
+      <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-md border border-slate-800 bg-slate-900/80">
+        <Icon className={`h-5 w-5 ${iconColor}`} />
+      </div>
+      <p className={`text-sm font-semibold uppercase tracking-[0.16em] ${titleColor}`}>{title}</p>
+      <p className="mt-2 max-w-sm text-sm text-slate-500">{description}</p>
       {actionLabel && (actionHref || onAction) && (
         actionHref ? (
           <a href={actionHref}>

--- a/web/src/components/ErrorState.tsx
+++ b/web/src/components/ErrorState.tsx
@@ -15,15 +15,17 @@ export function ErrorState({
   onRetry?: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
-      <AlertCircle className="mb-4 h-12 w-12 text-rose-500/60" />
-      <p className="text-lg font-medium text-slate-400">Something went wrong</p>
-      <p className="mt-1 max-w-sm text-sm text-rose-400/80">{message}</p>
+    <div className="flex flex-col items-center justify-center rounded-md border border-rose-500/20 bg-rose-500/5 px-5 py-12 text-center">
+      <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-md border border-rose-500/30 bg-slate-950">
+        <AlertCircle className="h-5 w-5 text-rose-300" />
+      </div>
+      <p className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-200">Something went wrong</p>
+      <p className="mt-2 max-w-sm text-sm text-rose-300/80">{message}</p>
       {onRetry && (
         <Button
           variant="outline"
           size="sm"
-          className="mt-5 border-slate-700 text-slate-400 hover:text-white"
+          className="mt-5 border-slate-700 bg-slate-950 text-slate-300 hover:bg-slate-900 hover:text-white"
           onClick={onRetry}
         >
           Try again


### PR DESCRIPTION
## Summary
- renew `/login` and `/setup` with the dense dark mesh console treatment while preserving auth/setup flow semantics
- refresh shared `EmptyState` and `ErrorState` presentation for the renewed operator console
- tighten agent detail, asset detail, and certificate states/detail surfaces without fake data

Closes #748.

## Verification
- `ssh workshop zsh -lic "cd /mnt/storage/worktrees/panoptikon/pan-10/web && bun run test"` -> 16 passed
- `ssh workshop zsh -lic "cd /mnt/storage/worktrees/panoptikon/pan-10/web && bun run build"` -> passed
- `ssh workshop "cd /mnt/storage/worktrees/panoptikon/pan-10 && git diff --check origin/main"` -> passed

## Notes
- This PR was salvaged from Maestro pan-10 after retry accounting exhausted before PR creation. I rebased the slice onto current `origin/main` and kept the diff scoped to #748 production surfaces.
- No deployment to `net.oklabs.uk` is included.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renews the visual presentation of auth pages (`/login`, `/setup`), shared state components (`EmptyState`, `ErrorState`), and detail surfaces for agents, assets, and certificates — replacing animated orbs with a static dark mesh grid, consolidating inline error/empty markup into the shared components, and shifting the accent palette from blue to cyan throughout.

- `/login` and `/setup` drop the orb divs and animated gradient, adopting a CSS grid background, darker card (`bg-slate-950/95`), and cyan submit buttons while leaving auth/setup flow logic intact.
- `EmptyState` gains a dashed-border container and boxed icon; `ErrorState` gets a rose-tinted bordered container — both are drop-in replacements used across agents, assets, and certificates detail surfaces, adding a retry path where only static text existed before.
- `globals.css` removes the `.login-orb`/`.login-orb-reverse` CSS classes, though the `@keyframes gradient-shift` and `float-orb` definitions remain in the file as unreferenced dead CSS.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are UI-only with no modifications to auth logic, data fetching, or API contracts.

All ten changed files are presentation-layer only — colour tokens, layout classes, and inline error/empty state consolidation. Auth and setup flows are structurally identical to before. The one gap is that the existing login-visual.spec.ts and empty-states.spec.ts suites haven't been updated to assert the new design tokens, and the PR verification step runs unit tests rather than the full Playwright suite, leaving the renewed surfaces without automated regression coverage.

No files require special attention for correctness. web/src/app/globals.css has leftover unreferenced @keyframes after the orb removal, but that is harmless dead CSS.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/login/page.tsx | Replaces animated orbs with a static grid background; adopts darker card, cyan submit button, and bordered error text — purely cosmetic, auth logic unchanged. |
| web/src/app/setup/page.tsx | Mirrors login redesign: removes orb divs, unifies card to bg-slate-950/95 with cyan CTA; setup flow semantics are untouched. |
| web/src/components/EmptyState.tsx | Wraps icon in a bordered box, switches title to uppercase/tracked style, adds dashed outer border — API and CTA logic unchanged; pre-existing use of native <a> instead of Next.js Link for actionHref not addressed (pre-existing). |
| web/src/components/ErrorState.tsx | Adds rose-tinted bordered container and icon box; retry button gets explicit bg and hover states — no logic changes. |
| web/src/app/(app)/certificates/page.tsx | Replaces inline 'Caddy Unreachable' and 'not configured' blocks with ErrorState/EmptyState; adds 'Open Settings' CTA for unconfigured state; introduces retry via loadCerts for unreachable state; AlertTriangle import is now unused. |
| web/src/app/(app)/agents/detail/content.tsx | Swaps raw error div for ErrorState with retry, inline empty panel for EmptyState; chart card borders and chart-line colours updated to cyan/emerald palette. |
| web/src/app/(app)/assets/detail/content.tsx | Same ErrorState swap as agents detail; blue-400 hover colours updated to cyan-300 throughout; card backgrounds tightened to slate-950/60. |
| web/src/app/globals.css | Removes orb animation classes and the animated gradient from .login-bg; replaces with static grid + radial-gradient. @keyframes gradient-shift and float-orb remain defined but are now unreferenced dead code. |
| web/src/app/(app)/agents/detail/page.tsx | Suspense fallback upgraded from plain text div to Skeleton component — cosmetic only. |
| web/src/app/(app)/assets/detail/page.tsx | Same Skeleton fallback upgrade as agents detail page. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/app/login/page.tsx`, line 1 ([link](https://github.com/befeast/panoptikon/blob/53f3dd74d62273dc22daee114da3e58aac87b517/web/src/app/login/page.tsx#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Missing E2E test coverage for changed surfaces**

   `CLAUDE.md` requires every feature/layout-fix PR to ship a Playwright test under `web/tests/e2e/`, and the PR description has no `## Why No E2E Test` section to justify the omission. The verification step in the PR description only runs `bun run test` (unit tests, 16 passed), not `bunx playwright test`. The changed surfaces — `/login`, `/setup`, the renewed `EmptyState`/`ErrorState` components, and the agent/asset/certificate detail pages — each fall under the "layout fix → screenshot comparison or element visibility check" category. The `login-visual.spec.ts` and `empty-states.spec.ts` suites exist but have not been updated to assert the new design tokens (dashed-border empty state, grid login background, cyan submit buttons).

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/login/page.tsx
   Line: 1
   
   Comment:
   **Missing E2E test coverage for changed surfaces**
   
   `CLAUDE.md` requires every feature/layout-fix PR to ship a Playwright test under `web/tests/e2e/`, and the PR description has no `## Why No E2E Test` section to justify the omission. The verification step in the PR description only runs `bun run test` (unit tests, 16 passed), not `bunx playwright test`. The changed surfaces — `/login`, `/setup`, the renewed `EmptyState`/`ErrorState` components, and the agent/asset/certificate detail pages — each fall under the "layout fix → screenshot comparison or element visibility check" category. The `login-visual.spec.ts` and `empty-states.spec.ts` suites exist but have not been updated to assert the new design tokens (dashed-border empty state, grid login background, cyan submit buttons).
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/app/login/page.tsx:1
**Missing E2E test coverage for changed surfaces**

`CLAUDE.md` requires every feature/layout-fix PR to ship a Playwright test under `web/tests/e2e/`, and the PR description has no `## Why No E2E Test` section to justify the omission. The verification step in the PR description only runs `bun run test` (unit tests, 16 passed), not `bunx playwright test`. The changed surfaces — `/login`, `/setup`, the renewed `EmptyState`/`ErrorState` components, and the agent/asset/certificate detail pages — each fall under the "layout fix → screenshot comparison or element visibility check" category. The `login-visual.spec.ts` and `empty-states.spec.ts` suites exist but have not been updated to assert the new design tokens (dashed-border empty state, grid login background, cyan submit buttons).


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: renew auth detail and state surfac..."](https://github.com/befeast/panoptikon/commit/53f3dd74d62273dc22daee114da3e58aac87b517) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32482805)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->