### PR TITLE
fix: keep login redesign within desktop viewport

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { useEffect, useState } from "react";
@@ -10,29 +9,119 @@ function PanoptikonMark() {
     <svg
       aria-hidden="true"
       viewBox="0 0 96 96"
-      className="h-20 w-20 text-sky-300"
+      className="h-12 w-12 text-sky-300"
       fill="none"
     >
-      <path d="M48 48 24 24M48 48l27-30M48 48 20 28M48 48 20 72" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
-      <path d="M24 24h34l17-6M20 72h42l6 4" stroke="currentColor" strokeWidth="2" strokeDasharray="5 8" opacity="0.22" />
-      <circle cx="48" cy="48" r="11" stroke="#38bdf8" strokeWidth="4" fill="#2563eb" />
+      <path
+        d="M48 48 24 24M48 48l27-30M48 48 20 28M48 48 20 72"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M24 24h34l17-6M20 72h42l6 4"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeDasharray="5 8"
+        opacity="0.22"
+      />
+      <circle
+        cx="48"
+        cy="48"
+        r="11"
+        stroke="#38bdf8"
+        strokeWidth="4"
+        fill="#2563eb"
+      />
       <circle cx="48" cy="48" r="4" fill="#4ade80" />
-      <circle cx="24" cy="24" r="7" fill="#09172d" stroke="currentColor" strokeWidth="4" />
-      <circle cx="75" cy="18" r="6" fill="#09172d" stroke="currentColor" strokeWidth="4" />
-      <circle cx="68" cy="76" r="7" fill="#09172d" stroke="currentColor" strokeWidth="4" />
-      <circle cx="20" cy="72" r="6" fill="#09172d" stroke="currentColor" strokeWidth="4" />
+      <circle
+        cx="24"
+        cy="24"
+        r="7"
+        fill="#09172d"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <circle
+        cx="75"
+        cy="18"
+        r="6"
+        fill="#09172d"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <circle
+        cx="68"
+        cy="76"
+        r="7"
+        fill="#09172d"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <circle
+        cx="20"
+        cy="72"
+        r="6"
+        fill="#09172d"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
     </svg>
   );
 }
 
 function NetworkBackdrop() {
   return (
-    <svg aria-hidden="true" className="pointer-events-none absolute inset-0 h-full w-full text-[#203b67] opacity-35" preserveAspectRatio="none">
-      <line x1="0" y1="18%" x2="16%" y2="34%" stroke="currentColor" strokeWidth="1" opacity="0.28" />
-      <line x1="0" y1="92%" x2="20%" y2="94%" stroke="currentColor" strokeWidth="1" opacity="0.24" />
-      <line x1="100%" y1="76%" x2="82%" y2="86%" stroke="currentColor" strokeWidth="1" opacity="0.2" />
-      <line x1="86%" y1="34%" x2="100%" y2="57%" stroke="currentColor" strokeWidth="1" opacity="0.22" />
-      <line x1="13%" y1="34%" x2="3%" y2="92%" stroke="currentColor" strokeWidth="1" opacity="0.24" />
+    <svg
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 h-full w-full text-[#203b67] opacity-35"
+      preserveAspectRatio="none"
+    >
+      <line
+        x1="0"
+        y1="18%"
+        x2="16%"
+        y2="34%"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.28"
+      />
+      <line
+        x1="0"
+        y1="92%"
+        x2="20%"
+        y2="94%"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.24"
+      />
+      <line
+        x1="100%"
+        y1="76%"
+        x2="82%"
+        y2="86%"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.2"
+      />
+      <line
+        x1="86%"
+        y1="34%"
+        x2="100%"
+        y2="57%"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.22"
+      />
+      <line
+        x1="13%"
+        y1="34%"
+        x2="3%"
+        y2="92%"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.24"
+      />
       <circle cx="3%" cy="92%" r="5" fill="currentColor" opacity="0.42" />
       <circle cx="84%" cy="34%" r="4" fill="currentColor" opacity="0.28" />
     </svg>
@@ -85,52 +174,65 @@ export default function LoginPage() {
       window.location.href = "/dashboard";
     } catch (err) {
       const msg = err instanceof Error ? err.message : "";
-      setError(msg.startsWith("API error 429") ? "Too many login attempts. Please try again later." : "Invalid password");
+      setError(
+        msg.startsWith("API error 429")
+          ? "Too many login attempts. Please try again later."
+          : "Invalid password",
+      );
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <main className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-8 text-slate-100">
+    <main className="login-bg relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-4 text-slate-100">
       <NetworkBackdrop />
-      <section className="relative z-10 w-full max-w-[840px] rounded-[18px] border border-[#2c4d80] bg-[#091731]/96 px-16 py-16 shadow-[0_0_0_3px_rgba(55,91,145,0.34),0_0_42px_rgba(42,98,177,0.28),inset_0_1px_0_rgba(122,163,218,0.16)] max-md:max-w-[430px] max-md:px-8 max-md:py-10">
-        <div className="mb-12 flex flex-col items-center text-center">
+      <section className="relative z-10 w-full max-w-[720px] rounded-[18px] border border-[#2c4d80] bg-[#091731]/96 px-10 py-6 shadow-[0_0_0_3px_rgba(55,91,145,0.34),0_0_42px_rgba(42,98,177,0.28),inset_0_1px_0_rgba(122,163,218,0.16)] max-md:max-w-[430px] max-md:px-6 max-md:py-6">
+        <div className="mb-5 flex flex-col items-center text-center">
           <PanoptikonMark />
-          <h1 className="mt-8 font-display text-[40px] font-semibold leading-none tracking-[0.08em] text-slate-100 max-md:text-3xl">
+          <h1 className="mt-4 font-display text-[30px] font-semibold leading-none tracking-[0.08em] text-slate-100 max-md:text-3xl">
             Panoptikon
           </h1>
-          <p className="mt-5 font-mono text-[26px] leading-none tracking-[0.12em] text-[#6580a8] max-md:text-lg">
+          <p className="mt-3 font-mono text-[18px] leading-none tracking-[0.12em] text-[#6580a8] max-md:text-lg">
             core.lan <span className="px-3">·</span> v{version ?? "0.6.103"}
           </p>
         </div>
 
         {!ready ? (
-          <div className="space-y-7">
-            <div className="h-[66px] rounded-md border border-[#2b4c7e] bg-[#08142b]" />
-            <div className="h-[66px] rounded-md border border-[#2b4c7e] bg-[#08142b]" />
-            <div className="h-[78px] rounded-md bg-[#2f6af0]" />
+          <div className="space-y-4">
+            <div className="h-12 rounded-md border border-[#2b4c7e] bg-[#08142b]" />
+            <div className="h-12 rounded-md border border-[#2b4c7e] bg-[#08142b]" />
+            <div className="h-14 rounded-md bg-[#2f6af0]" />
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-7">
+          <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-3">
-              <label htmlFor="operator" className="block font-mono text-[24px] font-semibold uppercase tracking-[0.08em] text-[#6a83aa] max-md:text-sm">
+              <label
+                htmlFor="operator"
+                className="block font-mono text-[16px] font-semibold uppercase tracking-[0.08em] text-[#6a83aa] max-md:text-sm"
+              >
                 Operator
               </label>
               <input
                 id="operator"
                 value="operator"
                 readOnly
-                className="h-[66px] w-full rounded-[5px] border-2 border-[#2c5289] bg-[#091832] px-6 font-sans text-[28px] text-slate-100 outline-none shadow-[inset_0_0_0_1px_rgba(81,124,185,0.16)] max-md:h-12 max-md:text-lg"
+                className="h-12 w-full rounded-[5px] border-2 border-[#2c5289] bg-[#091832] px-5 font-sans text-[22px] text-slate-100 outline-none shadow-[inset_0_0_0_1px_rgba(81,124,185,0.16)] max-md:h-12 max-md:text-lg"
               />
             </div>
 
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-4">
-                <label htmlFor="password" className="block font-mono text-[24px] font-semibold uppercase tracking-[0.08em] text-[#6a83aa] max-md:text-sm">
+                <label
+                  htmlFor="password"
+                  className="block font-mono text-[16px] font-semibold uppercase tracking-[0.08em] text-[#6a83aa] max-md:text-sm"
+                >
                   Password
                 </label>
-                <button type="button" className="font-mono text-[21px] font-semibold text-[#2f73ff] transition-colors hover:text-[#6ea1ff] max-md:text-sm">
+                <button
+                  type="button"
+                  className="font-mono text-[16px] font-semibold text-[#2f73ff] transition-colors hover:text-[#6ea1ff] max-md:text-sm"
+                >
                   reset key
                 </button>
               </div>
@@ -140,7 +242,7 @@ export default function LoginPage() {
                   type={showPassword ? "text" : "password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="h-[66px] w-full rounded-[5px] border-2 border-[#2c5289] bg-[#091832] px-6 pr-16 font-mono text-[28px] tracking-[0.18em] text-slate-100 outline-none shadow-[inset_0_0_0_1px_rgba(81,124,185,0.16)] transition-colors focus:border-[#3c72bc] max-md:h-12 max-md:text-lg"
+                  className="h-12 w-full rounded-[5px] border-2 border-[#2c5289] bg-[#091832] px-5 pr-14 font-mono text-[22px] tracking-[0.18em] text-slate-100 outline-none shadow-[inset_0_0_0_1px_rgba(81,124,185,0.16)] transition-colors focus:border-[#3c72bc] max-md:h-12 max-md:text-lg"
                   placeholder="••••••••••"
                   autoFocus
                   required
@@ -148,11 +250,15 @@ export default function LoginPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-5 top-1/2 -translate-y-1/2 text-[#607aa2] transition-colors hover:text-slate-200"
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[#607aa2] transition-colors hover:text-slate-200"
                   tabIndex={-1}
                   aria-label={showPassword ? "Hide password" : "Show password"}
                 >
-                  {showPassword ? <EyeOff className="h-7 w-7 max-md:h-5 max-md:w-5" /> : <Eye className="h-7 w-7 max-md:h-5 max-md:w-5" />}
+                  {showPassword ? (
+                    <EyeOff className="h-5 w-5 max-md:h-5 max-md:w-5" />
+                  ) : (
+                    <Eye className="h-5 w-5 max-md:h-5 max-md:w-5" />
+                  )}
                 </button>
               </div>
             </div>
@@ -166,13 +272,13 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-10 flex h-[78px] w-full items-center justify-center gap-4 rounded-[5px] bg-[#316aec] text-[30px] font-semibold text-white shadow-[0_10px_24px_rgba(49,106,236,0.18)] transition-colors hover:bg-[#3f78ff] disabled:cursor-not-allowed disabled:opacity-70 max-md:h-14 max-md:text-xl"
+              className="mt-6 flex h-14 w-full items-center justify-center gap-3 rounded-[5px] bg-[#316aec] text-[23px] font-semibold text-white shadow-[0_10px_24px_rgba(49,106,236,0.18)] transition-colors hover:bg-[#3f78ff] disabled:cursor-not-allowed disabled:opacity-70 max-md:h-14 max-md:text-xl"
             >
-              <Lock className="h-7 w-7 stroke-[1.8] max-md:h-5 max-md:w-5" />
+              <Lock className="h-5 w-5 stroke-[1.8] max-md:h-5 max-md:w-5" />
               {loading ? "Signing in" : "Sign in"}
             </button>
 
-            <div className="flex items-center gap-5 py-5 font-mono text-[24px] font-semibold text-[#38537f] max-md:text-sm">
+            <div className="flex items-center gap-4 py-2 font-mono text-[16px] font-semibold text-[#38537f] max-md:text-sm">
               <div className="h-px flex-1 bg-[#1d3760]" />
               OR
               <div className="h-px flex-1 bg-[#1d3760]" />
@@ -180,18 +286,18 @@ export default function LoginPage() {
 
             <button
               type="button"
-              className="flex h-[70px] w-full items-center justify-center gap-4 rounded-[5px] border-2 border-[#2c5289] bg-[#102142]/45 text-[29px] font-medium text-slate-100 transition-colors hover:border-[#3c72bc] hover:bg-[#13284f] max-md:h-12 max-md:text-lg"
+              className="flex h-12 w-full items-center justify-center gap-3 rounded-[5px] border-2 border-[#2c5289] bg-[#102142]/45 text-[22px] font-medium text-slate-100 transition-colors hover:border-[#3c72bc] hover:bg-[#13284f] max-md:h-12 max-md:text-lg"
             >
-              <Command className="h-7 w-7 stroke-[1.8] max-md:h-5 max-md:w-5" />
+              <Command className="h-5 w-5 stroke-[1.8] max-md:h-5 max-md:w-5" />
               Continue with SSO
             </button>
           </form>
         )}
 
-        <div className="mt-12 border-t border-[#1d3760] pt-8 font-mono text-[24px] text-[#637ea8] max-md:mt-8 max-md:text-sm">
-          <div className="flex items-center justify-between gap-5">
-            <div className="flex items-center gap-4">
-              <span className="h-3.5 w-3.5 rounded-full bg-[#46e27f] shadow-[0_0_16px_rgba(70,226,127,0.55)]" />
+        <div className="mt-5 border-t border-[#1d3760] pt-4 font-mono text-[16px] text-[#637ea8] max-md:mt-6 max-md:text-sm">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <span className="h-3 w-3 rounded-full bg-[#46e27f] shadow-[0_0_16px_rgba(70,226,127,0.55)]" />
               <span>all systems healthy</span>
             </div>
             <span>14d 6h up</span>

--- a/web/tests/e2e/login-visual.spec.ts
+++ b/web/tests/e2e/login-visual.spec.ts
@@ -5,13 +5,17 @@ import { test, expect } from "../../e2e/fixtures";
  * large bordered operations card, operator/password controls, and health footer.
  */
 test.describe("Login page visual upgrade", () => {
-  test("login page has network background and reference card", async ({ page }) => {
+  test("login page has network background and reference card", async ({
+    page,
+  }) => {
     await page.goto("/login/");
 
     await expect(
       page.getByRole("heading", { name: "Panoptikon", level: 1 }),
     ).toBeVisible({ timeout: 15000 });
-    await expect(page.getByLabel("Operator")).toHaveValue("operator", { timeout: 15000 });
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
 
     const bgContainer = page.locator(".login-bg");
     await expect(bgContainer).toBeVisible();
@@ -25,6 +29,15 @@ test.describe("Login page visual upgrade", () => {
 
     const card = page.locator("main.login-bg section").first();
     await expect(card).toBeVisible();
+    const box = await card.boundingBox();
+    expect(box).toBeTruthy();
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(720);
+    const hasVerticalOverflow = await page.evaluate(
+      () => document.documentElement.scrollHeight > window.innerHeight,
+    );
+    expect(hasVerticalOverflow).toBe(false);
+
     const borderColor = await card.evaluate(
       (element) => getComputedStyle(element).borderColor,
     );
@@ -33,7 +46,9 @@ test.describe("Login page visual upgrade", () => {
     await expect(page.getByText(/core\.lan/)).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
     await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with SSO" }),
+    ).toBeVisible();
     await expect(page.getByText("all systems healthy")).toBeVisible();
 
     const eyeToggle = page.locator('button[aria-label="Show password"]');
@@ -52,7 +67,9 @@ test.describe("Login page visual upgrade", () => {
     await expect(
       page.getByRole("heading", { name: "Panoptikon", level: 1 }),
     ).toBeVisible({ timeout: 15000 });
-    await expect(page.getByLabel("Operator")).toHaveValue("operator", { timeout: 15000 });
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
 
     const card = page.locator("main.login-bg section").first();
     await expect(card).toBeVisible();
@@ -61,7 +78,9 @@ test.describe("Login page visual upgrade", () => {
     expect(box!.width).toBeLessThanOrEqual(375);
 
     await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with SSO" }),
+    ).toBeVisible();
 
     await page.screenshot({
       path: "tests/screenshots/login-visual-mobile.png",
@@ -72,7 +91,9 @@ test.describe("Login page visual upgrade", () => {
   test("password eye toggle switches icon", async ({ page }) => {
     await page.goto("/login/");
 
-    await expect(page.getByLabel("Operator")).toHaveValue("operator", { timeout: 15000 });
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
 
     const showBtn = page.locator('button[aria-label="Show password"]');
     await expect(showBtn).toBeVisible();


### PR DESCRIPTION
Fixes the live login card clipping on real desktop Chrome by compacting the reference layout and adding an E2E viewport-fit assertion. Verified on workshop against the rebuilt server: the login card now fits within the 1280x720 viewport with no vertical overflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR compacts the login card's sizing and spacing so it fits within a 1280×720 desktop viewport without vertical overflow, and adds an E2E assertion to guard against regressions.

- `login/page.tsx`: Reduces the logo, font sizes, padding, and card max-width (840px → 720px) across all elements — no logic changes, purely presentational.
- `login-visual.spec.ts`: Adds a viewport-fit assertion that checks the card's bottom edge is ≤ 720px and that `scrollHeight` doesn't exceed `innerHeight`; also reformats several long lines for readability.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are entirely presentational and the new E2E guard covers the intended fix.

The login page changes are mechanical size reductions with no logic impact. The new test assertion hard-codes `720` instead of reading from `page.viewportSize()`, so a future device-definition change in the Playwright config could make the guard meaningless without anyone noticing, but this doesn't affect current correctness.

web/tests/e2e/login-visual.spec.ts — the hard-coded viewport boundary.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/login/page.tsx | Compacts the login card for 1280×720 desktop viewport: logo shrunk to h-12/w-12, font sizes and padding reduced throughout, card max-width changed from 840px to 720px. Pure presentational change with no logic modifications. |
| web/tests/e2e/login-visual.spec.ts | Adds a viewport-fit assertion (card bottom ≤ 720px, no scrollHeight overflow) to the desktop test; reformats long lines. The 720px boundary is hard-coded rather than read from the actual viewport size, making the assertion fragile if the config's device definition changes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/login-visual.spec.ts:32-35
The desktop test hard-codes `720` as the expected viewport boundary, but the test never explicitly sets (or reads) the viewport size. The Playwright config inherits `devices["Desktop Chrome"]` (1280×720 today), but if that device definition changes or the config is updated, the assertion will silently validate against a wrong height. Using `page.viewportSize()` makes the intent explicit and keeps the assertion accurate without chasing magic numbers.

```suggestion
    const viewportHeight = page.viewportSize()?.height ?? 720;
    const box = await card.boundingBox();
    expect(box).toBeTruthy();
    expect(box!.y).toBeGreaterThanOrEqual(0);
    expect(box!.y + box!.height).toBeLessThanOrEqual(viewportHeight);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep login redesign within desktop ..."](https://github.com/befeast/panoptikon/commit/13163a7c7ef4ca51b212dc03882db2d88d3ab61a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32498553)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->