### PR TITLE
Renew live UX shell fidelity

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -262,12 +262,12 @@ function StatCard({
   const inner = (
     <Card
       className={cn(
-        "h-full min-h-[8.25rem] border-cyan-900/45 bg-[#0b1220]/70",
+        "h-full min-h-[7.1rem] border-cyan-900/45 bg-[#0b1220]/70",
         href &&
           "transition-[border-color,background-color,box-shadow] hover:border-cyan-700/50 hover:bg-slate-900/72 hover:shadow-[0_14px_32px_-22px_rgba(8,145,178,0.45)]",
       )}
     >
-      <CardHeader className="flex flex-row items-start justify-between pb-3">
+      <CardHeader className="flex flex-row items-start justify-between pb-2">
         <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
           {title}
         </CardTitle>
@@ -276,8 +276,8 @@ function StatCard({
           <span className="text-slate-500">{icon}</span>
         </div>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <p className="truncate text-[1.65rem] font-semibold leading-none tabular-nums text-white">{value}</p>
+      <CardContent className="space-y-1.5">
+        <p className="truncate font-mono text-[1.45rem] font-semibold leading-none tabular-nums text-white">{value}</p>
         <p className="truncate text-xs leading-5 text-slate-400">{subtitle}</p>
       </CardContent>
     </Card>
@@ -295,7 +295,7 @@ function StatCard({
 
 function StatCardSkeleton() {
   return (
-    <Card className="h-full min-h-[8.25rem] border-cyan-900/45 bg-[#0b1220]/70">
+    <Card className="h-full min-h-[7.1rem] border-cyan-900/45 bg-[#0b1220]/70">
       <CardHeader className="pb-3">
         <Skeleton className="h-3.5 w-24" />
       </CardHeader>
@@ -485,7 +485,7 @@ function QuickActions() {
         <Link
           key={action.label}
           href={action.href}
-          className="inline-flex items-center gap-2 rounded-full border border-cyan-900/45 bg-[#0b1220]/70 px-4 py-2 text-sm text-slate-300 transition-all hover:border-cyan-700/50 hover:bg-cyan-950/80 hover:text-white"
+          className="inline-flex items-center gap-2 rounded-md border border-cyan-900/45 bg-[#0b1220]/70 px-3 py-1.5 text-xs text-slate-300 transition-all hover:border-cyan-700/50 hover:bg-cyan-950/80 hover:text-white"
         >
           {action.icon}
           {action.label}
@@ -834,16 +834,30 @@ export default function DashboardPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
-      <div className="flex flex-col gap-3 border-b border-cyan-900/35 pb-5 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Dashboard</h1>
-          <p className="max-w-3xl text-sm leading-6 text-slate-400">
-            Network health, router status, traffic, and alerts at a glance.
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 border-b border-cyan-900/35 pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-1.5">
+          <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-300">
+            core.lan <span className="text-slate-600">&gt;</span> Overview
+          </p>
+          <h1 className="font-mono text-xl font-semibold uppercase tracking-[0.12em] text-white">Dashboard</h1>
+          <p className="max-w-3xl text-xs leading-5 text-slate-400">
+            Router status, WAN traffic, topology, and recent events.
           </p>
         </div>
-        <div className="text-xs uppercase tracking-wider text-slate-600">
-          Live refresh / 30s
+        <div className="grid grid-cols-3 gap-2 text-[10px] uppercase tracking-[0.12em] text-slate-500">
+          <div className="rounded border border-cyan-900/35 bg-[#08111e]/70 px-3 py-2">
+            <p className="text-slate-600">Router</p>
+            <p className="mt-1 text-cyan-300">{stats ? routerDisplayName(stats.router_type) : "--"}</p>
+          </div>
+          <div className="rounded border border-cyan-900/35 bg-[#08111e]/70 px-3 py-2">
+            <p className="text-slate-600">Refresh</p>
+            <p className="mt-1 text-slate-300">30s</p>
+          </div>
+          <div className="rounded border border-cyan-900/35 bg-[#08111e]/70 px-3 py-2">
+            <p className="text-slate-600">Events</p>
+            <p className="mt-1 tabular-nums text-slate-300">{stats ? stats.alerts_unread : "--"}</p>
+          </div>
         </div>
       </div>
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,72 +3,7 @@
 import { useEffect, useState } from "react";
 import { Command, Eye, EyeOff, Lock } from "lucide-react";
 import { fetchAuthStatus, login } from "@/lib/api";
-
-function PanoptikonMark() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 96 96"
-      className="h-12 w-12 text-sky-300"
-      fill="none"
-    >
-      <path
-        d="M48 48 24 24M48 48l27-30M48 48 20 28M48 48 20 72"
-        stroke="currentColor"
-        strokeWidth="4"
-        strokeLinecap="round"
-      />
-      <path
-        d="M24 24h34l17-6M20 72h42l6 4"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeDasharray="5 8"
-        opacity="0.22"
-      />
-      <circle
-        cx="48"
-        cy="48"
-        r="11"
-        stroke="#38bdf8"
-        strokeWidth="4"
-        fill="#2563eb"
-      />
-      <circle cx="48" cy="48" r="4" fill="#4ade80" />
-      <circle
-        cx="24"
-        cy="24"
-        r="7"
-        fill="#09172d"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <circle
-        cx="75"
-        cy="18"
-        r="6"
-        fill="#09172d"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <circle
-        cx="68"
-        cy="76"
-        r="7"
-        fill="#09172d"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <circle
-        cx="20"
-        cy="72"
-        r="6"
-        fill="#09172d"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-    </svg>
-  );
-}
+import { BrandMark } from "@/components/brand/BrandMark";
 
 function NetworkBackdrop() {
   return (
@@ -189,7 +124,7 @@ export default function LoginPage() {
       <NetworkBackdrop />
       <section className="relative z-10 w-full max-w-[720px] rounded-[18px] border border-[#2c4d80] bg-[#091731]/96 px-10 py-6 shadow-[0_0_0_3px_rgba(55,91,145,0.34),0_0_42px_rgba(42,98,177,0.28),inset_0_1px_0_rgba(122,163,218,0.16)] max-md:max-w-[430px] max-md:px-6 max-md:py-6">
         <div className="mb-5 flex flex-col items-center text-center">
-          <PanoptikonMark />
+          <BrandMark size={52} className="text-sky-300 drop-shadow-[0_0_18px_rgba(56,189,248,0.24)]" />
           <h1 className="mt-4 font-display text-[30px] font-semibold leading-none tracking-[0.08em] text-slate-100 max-md:text-3xl">
             Panoptikon
           </h1>

--- a/web/src/components/brand/BrandMark.tsx
+++ b/web/src/components/brand/BrandMark.tsx
@@ -4,45 +4,40 @@ interface BrandMarkProps {
   /** Width and height in pixels. SVG scales proportionally. */
   size?: number;
   className?: string;
+  title?: string;
 }
 
-export function BrandMark({ size = 32, className }: BrandMarkProps) {
+export function BrandMark({ size = 32, className, title = "Panoptikon" }: BrandMarkProps) {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 256 256"
+      viewBox="0 0 96 96"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={cn("shrink-0", className)}
-      aria-label="Panoptikon"
+      aria-label={title}
       role="img"
+      data-testid="brand-mark"
     >
-      <g strokeLinecap="round" strokeLinejoin="round">
-        {/* Outer broken hex ring — signal cyan */}
+      <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
         <path
-          d="M57 87L128 46L199 87L199 169"
-          stroke="#22D3EE"
-          strokeWidth="14"
+          d="M48 48 24 24M48 48l27-30M48 48l20 28M48 48 20 24"
+          strokeWidth="2.25"
         />
         <path
-          d="M180 188L128 218L76 188"
-          stroke="#22D3EE"
-          strokeWidth="14"
+          d="M24 24h34l17-6M20 72h42l6 4"
+          strokeWidth="1.25"
+          strokeDasharray="4 7"
+          opacity="0.34"
         />
-        <path d="M57 169L57 87" stroke="#22D3EE" strokeWidth="14" />
-        {/* Inner hex — cloud white */}
-        <path
-          d="M87 104L128 80L169 104L169 152L128 176L87 152Z"
-          stroke="#E8EEF7"
-          strokeOpacity="0.92"
-          strokeWidth="10"
-        />
-        {/* Connector spoke — amber accent */}
-        <path d="M169 104L186 94" stroke="#F59E0B" strokeWidth="10" />
       </g>
-      {/* Central node — amber */}
-      <circle cx="128" cy="128" r="13" fill="#F59E0B" />
+      <circle cx="48" cy="48" r="8.5" fill="#0b1f3d" stroke="currentColor" strokeWidth="2.25" />
+      <circle cx="48" cy="48" r="2.75" fill="#67e8f9" />
+      <circle cx="24" cy="24" r="5.5" fill="#071326" stroke="currentColor" strokeWidth="2.25" />
+      <circle cx="75" cy="18" r="5" fill="#071326" stroke="currentColor" strokeWidth="2.25" />
+      <circle cx="68" cy="76" r="5.5" fill="#071326" stroke="currentColor" strokeWidth="2.25" />
+      <circle cx="20" cy="72" r="5" fill="#071326" stroke="currentColor" strokeWidth="2.25" />
     </svg>
   );
 }

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -12,6 +12,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
+import { BrandMark } from "@/components/brand/BrandMark";
 
 export function MobileSidebar() {
   const pathname = usePathname();
@@ -41,10 +42,10 @@ export function MobileSidebar() {
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           {/* Logo */}
           <div className="flex h-14 shrink-0 items-center border-b border-cyan-900/45 px-4">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/40 bg-cyan-400/12 text-sm font-bold text-cyan-200">
-              P
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/35 bg-cyan-400/10 text-cyan-200">
+              <BrandMark size={24} className="text-cyan-200" />
             </div>
-            <span className="ml-2 text-lg font-semibold text-white">
+            <span className="ml-2 font-mono text-[13px] font-semibold uppercase tracking-[0.12em] text-white">
               Panoptikon
             </span>
           </div>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { BrandMark } from "@/components/brand/BrandMark";
 import {
   Tooltip,
   TooltipContent,
@@ -271,11 +272,11 @@ export function Sidebar() {
             href="/dashboard"
             className="flex items-center min-w-0"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/40 bg-cyan-400/12 text-sm font-bold text-cyan-200">
-              P
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-cyan-300/35 bg-cyan-400/10 text-cyan-200">
+              <BrandMark size={24} className="text-cyan-200" />
             </div>
             {!sidebarCollapsed && (
-              <span className="ml-2 font-display text-base font-semibold text-white">
+              <span className="ml-2 font-mono text-[13px] font-semibold uppercase tracking-[0.12em] text-white">
                 Panoptikon
               </span>
             )}

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { type ReactNode, useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
 import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, deleteAllAlerts, logout } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
+import { BrandMark } from "@/components/brand/BrandMark";
+import { useWsStatus } from "@/components/providers/WebSocketProvider";
 import { timeAgo } from "@/lib/format";
 import type { SearchResponse, SearchDevice, SearchAgent, SearchAlert, SearchSshTarget, SearchAsset, Alert } from "@/lib/types";
 import {
@@ -18,6 +21,8 @@ import {
 
 export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   const router = useRouter();
+  const pathname = usePathname();
+  const { connected: wsConnected, latencyMs } = useWsStatus();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResponse | null>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -228,6 +233,23 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
       {/* Mobile menu button */}
       {mobileMenu}
 
+      <Link
+        href="/dashboard"
+        className="hidden min-w-[12rem] items-center gap-3 md:flex"
+        aria-label="Panoptikon dashboard"
+      >
+        <BrandMark size={30} className="text-cyan-200" />
+        <div className="min-w-0">
+          <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-100">
+            core.lan <span className="text-slate-600">&gt;</span>{" "}
+            <span className="text-cyan-300">{pathname === "/dashboard" ? "Overview" : "Console"}</span>
+          </div>
+          <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-slate-600">
+            Panoptikon
+          </div>
+        </div>
+      </Link>
+
       {/* Search */}
       <div className="relative max-w-lg flex-1" ref={containerRef}>
         <input
@@ -429,6 +451,23 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
 
       {/* Right side: alerts bell + user avatar */}
       <div className="flex items-center gap-2">
+        <div
+          className="hidden items-center gap-2 rounded-md border border-cyan-900/45 bg-[#08111e]/82 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-slate-400 sm:flex"
+          data-testid="ws-latency-pill"
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              wsConnected
+                ? "bg-emerald-400 ring-2 ring-emerald-400/25"
+                : "bg-rose-400 ring-2 ring-rose-400/20"
+            }`}
+          />
+          <span>{wsConnected ? "Live" : "Offline"}</span>
+          <span className="text-slate-600">/</span>
+          <span className="tabular-nums text-cyan-300">
+            ws {wsConnected && latencyMs ? `${latencyMs}ms` : "--"}
+          </span>
+        </div>
         {/* ── Notification Bell ── */}
         <div className="relative" ref={bellRef}>
           <button

--- a/web/src/components/providers/WebSocketProvider.tsx
+++ b/web/src/components/providers/WebSocketProvider.tsx
@@ -6,10 +6,13 @@ import { useWebSocket } from "@/lib/ws";
 interface WebSocketContextValue {
   /** Whether the WebSocket is currently connected to the server. */
   connected: boolean;
+  /** Time from socket construction to open, used as a lightweight live latency signal. */
+  latencyMs: number | null;
 }
 
 const WebSocketContext = createContext<WebSocketContextValue>({
   connected: false,
+  latencyMs: null,
 });
 
 /**
@@ -22,10 +25,10 @@ const WebSocketContext = createContext<WebSocketContextValue>({
  * 2. Subscribe to specific events via `useWsEvent()`
  */
 export function WebSocketProvider({ children }: { children: React.ReactNode }) {
-  const { connected } = useWebSocket();
+  const { connected, latencyMs } = useWebSocket();
 
   return (
-    <WebSocketContext.Provider value={{ connected }}>
+    <WebSocketContext.Provider value={{ connected, latencyMs }}>
       {children}
     </WebSocketContext.Provider>
   );
@@ -34,4 +37,9 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
 /** Returns whether the WebSocket is currently connected. */
 export function useWsConnected(): boolean {
   return useContext(WebSocketContext).connected;
+}
+
+/** Returns WebSocket status fields for compact shell status indicators. */
+export function useWsStatus(): WebSocketContextValue {
+  return useContext(WebSocketContext);
 }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -101,6 +101,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   } = options;
 
   const [connected, setConnected] = useState(false);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const delayRef = useRef(initialDelay);
@@ -118,11 +119,13 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     if (!mountedRef.current) return;
 
     try {
+      const startedAt = performance.now();
       const ws = new WebSocket(getUrl());
 
       ws.onopen = () => {
         if (!mountedRef.current) { ws.close(); return; }
         setConnected(true);
+        setLatencyMs(Math.max(1, Math.round(performance.now() - startedAt)));
         delayRef.current = initialDelay; // Reset backoff on successful connection
       };
 
@@ -138,6 +141,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       ws.onclose = () => {
         if (!mountedRef.current) return;
         setConnected(false);
+        setLatencyMs(null);
         wsRef.current = null;
 
         if (reconnect) {
@@ -175,5 +179,5 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     };
   }, [connect]);
 
-  return { connected };
+  return { connected, latencyMs };
 }

--- a/web/tests/e2e/brand-palette.spec.ts
+++ b/web/tests/e2e/brand-palette.spec.ts
@@ -15,9 +15,12 @@ test.describe("Brand palette migration", () => {
 
     // The renewed login surface should expose the reference-screen affordances.
     await expect(page.locator(".login-bg")).toBeVisible();
-    await expect(page.getByLabel("Operator")).toHaveValue("operator");
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
     await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
     await expect(page.getByText("all systems healthy")).toBeVisible();
+    await expect(page.getByTestId("brand-mark")).toBeVisible();
 
     await page.screenshot({
       path: "tests/screenshots/brand-palette-login.png",
@@ -32,6 +35,9 @@ test.describe("Brand palette migration", () => {
     await expect(
       page.getByRole("heading", { name: "Dashboard", level: 1 }),
     ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("main").getByText("core.lan > Overview")).toBeVisible();
+    await expect(page.getByTestId("brand-mark").first()).toBeVisible();
+    await expect(page.getByTestId("ws-latency-pill")).toBeVisible();
 
     await page.screenshot({
       path: "tests/screenshots/brand-palette-dashboard.png",

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -136,6 +136,8 @@ test.describe('Dashboard', () => {
   test('dashboard page loads with stat cards', async ({ page }) => {
     await openDashboard(page);
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+    await expect(page.getByRole('main').getByText('core.lan > Overview')).toBeVisible();
+    await expect(page.getByTestId('ws-latency-pill')).toBeVisible();
 
     // Wait for API calls to settle before checking stat cards
     await page.waitForLoadState('networkidle');

--- a/web/tests/e2e/login-visual.spec.ts
+++ b/web/tests/e2e/login-visual.spec.ts
@@ -26,6 +26,14 @@ test.describe("Login page visual upgrade", () => {
     expect(backgroundImage).toContain("radial-gradient");
 
     await expect(page.locator(".login-orb")).toHaveCount(0);
+    await expect(page.getByTestId("brand-mark")).toBeVisible();
+
+    const maxStrokeWidth = await page.getByTestId("brand-mark").evaluate((mark) => {
+      const widths = Array.from(mark.querySelectorAll("[stroke-width], [strokeWidth]"))
+        .map((node) => Number(node.getAttribute("stroke-width") ?? node.getAttribute("strokeWidth") ?? 0));
+      return Math.max(...widths);
+    });
+    expect(maxStrokeWidth).toBeLessThanOrEqual(2.25);
 
     const card = page.locator("main.login-bg section").first();
     await expect(card).toBeVisible();

--- a/web/tests/e2e/sidebar-rebrand.spec.ts
+++ b/web/tests/e2e/sidebar-rebrand.spec.ts
@@ -8,14 +8,14 @@ test.describe('Sidebar rebrand — cyan accents instead of blue', () => {
     await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible({ timeout: 30000 });
   });
 
-  test('sidebar is visible with branded logo tile', async ({ page }) => {
+  test('sidebar is visible with shared brand mark tile', async ({ page }) => {
     const sidebar = page.locator('aside');
     await expect(sidebar).toBeVisible({ timeout: 15000 });
 
-    // Logo tile should be visible with cyan background
+    // Logo tile should render the shared thin network glyph.
     const logoTile = sidebar.locator('div[class*="bg-cyan-400"]');
     await expect(logoTile).toBeVisible({ timeout: 10000 });
-    await expect(logoTile).toContainText('P');
+    await expect(logoTile.getByTestId('brand-mark')).toBeVisible();
 
     await page.screenshot({ path: 'tests/screenshots/sidebar-rebrand-logo.png', fullPage: true });
   });


### PR DESCRIPTION
Refs #767

## Summary
- Replaced the separate login/sidebar glyph treatments with one shared thin Panoptikon network mark.
- Added the authenticated shell context `core.lan > Overview` and a live WS latency pill in the production topbar.
- Tightened the dashboard first viewport density and updated visual regression tests to assert the accepted glyph, shell context, and live status affordance.

## Verification
- `cd web && bun run test -- --runInBand` failed before dependency install: `vitest: command not found`.
- `cd web && bun run build` failed before dependency install: `next: command not found`.
- `cd web && bun install --frozen-lockfile` passed.
- `cd web && bun run test` passed: 16 tests.
- `cd web && bun run build` passed.
- `cargo run -p panoptikon-server` used to serve production routes for Playwright QA.
- `cd web && bun run test:e2e -- login-visual.spec.ts dashboard.spec.ts brand-palette.spec.ts sidebar-rebrand.spec.ts` initially failed on an ambiguous `core.lan > Overview` locator, then the locator was fixed.
- `cd web && bun run test:e2e -- dashboard.spec.ts brand-palette.spec.ts` passed: 16 tests.
- `cd web && bun run test:e2e -- login-visual.spec.ts sidebar-rebrand.spec.ts` passed: 7 tests.
- `.maestro/verify.sh` failed after Rust unit tests passed because `server/tests/caddy_integration.rs` requires Caddy admin API at `http://localhost:2019`; local output says to start `docker run -d --name caddy-test -p 2019:2019 caddy:2-alpine`.

## Screenshot Evidence
Playwright generated screenshot evidence during the successful route QA runs, including:
- `web/tests/screenshots/login-visual-upgrade.png`
- `web/tests/screenshots/login-visual-mobile.png`
- `web/tests/screenshots/brand-palette-dashboard.png`
- `web/tests/screenshots/dashboard-stat-cards.png`
- `web/tests/screenshots/sidebar-rebrand-logo.png`

## Notes
No deploy or live `https://net.oklabs.uk` verification was performed from this branch. Per the issue definition, this is not complete until merge, deploy, and live visual healthcheck pass.