### PR TITLE
Login: hide SSO action unless SSO is configured

### DIFF
--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -136,6 +136,8 @@ pub struct LoginResponse {
 pub struct AuthStatusResponse {
     pub authenticated: bool,
     pub needs_setup: bool,
+    pub sso_enabled: bool,
+    pub sso_login_url: Option<String>,
 }
 
 /// POST /api/v1/auth/login — authenticate and set session cookie.
@@ -398,9 +400,17 @@ pub async fn status(
         false
     };
 
+    let sso_enabled = state.config.auth.sso_enabled && state.config.auth.sso_login_url.is_some();
+
     Ok(Json(AuthStatusResponse {
         authenticated,
         needs_setup,
+        sso_enabled,
+        sso_login_url: if sso_enabled {
+            state.config.auth.sso_login_url.clone()
+        } else {
+            None
+        },
     }))
 }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -117,6 +117,14 @@ pub struct AuthConfig {
     /// Only add addresses you control. Defaults to loopback only.
     #[serde(default = "default_trusted_proxies")]
     pub trusted_proxies: Vec<String>,
+
+    /// Show the SSO login action when an external SSO endpoint is configured.
+    #[serde(default)]
+    pub sso_enabled: bool,
+
+    /// External SSO login URL. Used only when sso_enabled is true.
+    #[serde(default)]
+    pub sso_login_url: Option<String>,
 }
 
 fn default_session_expiry() -> u64 {
@@ -132,6 +140,8 @@ impl Default for AuthConfig {
         Self {
             session_expiry_seconds: default_session_expiry(),
             trusted_proxies: default_trusted_proxies(),
+            sso_enabled: false,
+            sso_login_url: None,
         }
     }
 }

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -365,6 +365,14 @@ async fn test_auth_status_needs_setup() {
         body["needs_setup"], true,
         "should need setup on fresh DB (no password set)"
     );
+    assert_eq!(
+        body["sso_enabled"], false,
+        "SSO should be disabled by default"
+    );
+    assert!(
+        body["sso_login_url"].is_null(),
+        "SSO login URL should be absent by default"
+    );
 }
 
 // ── Test 11: Auth status after setup ────────────────────────────────
@@ -400,6 +408,35 @@ async fn test_auth_status_after_setup() {
     assert_eq!(
         body["authenticated"], true,
         "should be authenticated after setup (auto-login)"
+    );
+    assert_eq!(
+        body["sso_enabled"], false,
+        "SSO should remain disabled without auth config"
+    );
+}
+
+#[tokio::test]
+async fn test_auth_status_reports_configured_sso() {
+    let mut app_config = config::AppConfig::default();
+    app_config.auth.sso_enabled = true;
+    app_config.auth.sso_login_url = Some("/api/v1/auth/sso".to_string());
+
+    let (base_url, _pool) = spawn_test_server_with_config(app_config).await;
+    let client = http_client();
+
+    let resp = client
+        .get(format!("{base_url}/api/v1/auth/status"))
+        .send()
+        .await
+        .expect("auth status request failed");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: Value = resp.json().await.expect("failed to parse JSON");
+    assert_eq!(body["sso_enabled"], true, "SSO should reflect config");
+    assert_eq!(
+        body["sso_login_url"], "/api/v1/auth/sso",
+        "SSO login URL should reflect config"
     );
 }
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -135,6 +135,7 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
   const [version, setVersion] = useState<string | null>(null);
+  const [ssoLoginUrl, setSsoLoginUrl] = useState<string | null>(null);
 
   useEffect(() => {
     fetchAuthStatus()
@@ -147,6 +148,7 @@ export default function LoginPage() {
           window.location.href = "/setup";
           return;
         }
+        setSsoLoginUrl(status.sso_enabled ? status.sso_login_url : null);
         setReady(true);
       })
       .catch(() => setReady(true));
@@ -278,19 +280,26 @@ export default function LoginPage() {
               {loading ? "Signing in" : "Sign in"}
             </button>
 
-            <div className="flex items-center gap-4 py-2 font-mono text-[16px] font-semibold text-[#38537f] max-md:text-sm">
-              <div className="h-px flex-1 bg-[#1d3760]" />
-              OR
-              <div className="h-px flex-1 bg-[#1d3760]" />
-            </div>
+            {ssoLoginUrl && (
+              <>
+                <div className="flex items-center gap-4 py-2 font-mono text-[16px] font-semibold text-[#38537f] max-md:text-sm">
+                  <div className="h-px flex-1 bg-[#1d3760]" />
+                  OR
+                  <div className="h-px flex-1 bg-[#1d3760]" />
+                </div>
 
-            <button
-              type="button"
-              className="flex h-12 w-full items-center justify-center gap-3 rounded-[5px] border-2 border-[#2c5289] bg-[#102142]/45 text-[22px] font-medium text-slate-100 transition-colors hover:border-[#3c72bc] hover:bg-[#13284f] max-md:h-12 max-md:text-lg"
-            >
-              <Command className="h-5 w-5 stroke-[1.8] max-md:h-5 max-md:w-5" />
-              Continue with SSO
-            </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.location.href = ssoLoginUrl;
+                  }}
+                  className="flex h-12 w-full items-center justify-center gap-3 rounded-[5px] border-2 border-[#2c5289] bg-[#102142]/45 text-[22px] font-medium text-slate-100 transition-colors hover:border-[#3c72bc] hover:bg-[#13284f] max-md:h-12 max-md:text-lg"
+                >
+                  <Command className="h-5 w-5 stroke-[1.8] max-md:h-5 max-md:w-5" />
+                  Continue with SSO
+                </button>
+              </>
+            )}
           </form>
         )}
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1008,6 +1008,8 @@ export interface SyslogResponse {
 export interface AuthStatus {
   authenticated: boolean;
   needs_setup: boolean;
+  sso_enabled: boolean;
+  sso_login_url: string | null;
 }
 
 export interface LoginResponse {

--- a/web/tests/e2e/auth.spec.ts
+++ b/web/tests/e2e/auth.spec.ts
@@ -7,7 +7,8 @@ test.describe('Authentication', () => {
     await expect(page.getByRole('heading', { name: 'Panoptikon', level: 1 })).toBeVisible();
     await expect(page.getByLabel('Operator')).toHaveValue('operator', { timeout: 15000 });
     await expect(page.getByRole('button', { name: 'reset key' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Continue with SSO' })).toBeVisible();
+    await expect(page.getByText(/^OR$/)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Continue with SSO' })).toHaveCount(0);
     await expect(page.getByText('all systems healthy')).toBeVisible();
     await expect(page.locator('#password')).toBeVisible();
     await expect(page.getByRole('button', { name: /Sign in/i })).toBeVisible();

--- a/web/tests/e2e/brand-palette.spec.ts
+++ b/web/tests/e2e/brand-palette.spec.ts
@@ -16,7 +16,8 @@ test.describe("Brand palette migration", () => {
     // The renewed login surface should expose the reference-screen affordances.
     await expect(page.locator(".login-bg")).toBeVisible();
     await expect(page.getByLabel("Operator")).toHaveValue("operator");
-    await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
+    await expect(page.getByText(/^OR$/)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Continue with SSO" })).toHaveCount(0);
     await expect(page.getByText("all systems healthy")).toBeVisible();
 
     await page.screenshot({

--- a/web/tests/e2e/login-rebrand.spec.ts
+++ b/web/tests/e2e/login-rebrand.spec.ts
@@ -15,12 +15,39 @@ test.describe("Login page rebrand", () => {
     await expect(page.locator("main.login-bg svg").first()).toBeVisible();
     await expect(page.getByLabel("Operator")).toHaveValue("operator");
     await expect(page.getByRole("button", { name: "reset key" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
+    await expect(page.getByText(/^OR$/)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Continue with SSO" })).toHaveCount(0);
     await expect(page.getByText("all systems healthy")).toBeVisible();
 
     await page.screenshot({
       path: "tests/screenshots/login-rebrand.png",
       fullPage: true,
     });
+  });
+
+  test("shows configured SSO action from auth status", async ({ page }) => {
+    await page.route("**/api/v1/auth/status", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          authenticated: false,
+          needs_setup: false,
+          sso_enabled: true,
+          sso_login_url: "/api/v1/auth/sso",
+        }),
+      });
+    });
+
+    await page.goto("/login/");
+
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
+    await expect(page.getByText(/^OR$/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with SSO" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Continue with SSO" }).click();
+    await page.waitForURL("**/api/v1/auth/sso", { timeout: 5000 });
   });
 });

--- a/web/tests/e2e/login-visual.spec.ts
+++ b/web/tests/e2e/login-visual.spec.ts
@@ -46,9 +46,10 @@ test.describe("Login page visual upgrade", () => {
     await expect(page.getByText(/core\.lan/)).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
     await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+    await expect(page.getByText(/^OR$/)).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Continue with SSO" }),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(page.getByText("all systems healthy")).toBeVisible();
 
     const eyeToggle = page.locator('button[aria-label="Show password"]');
@@ -78,9 +79,10 @@ test.describe("Login page visual upgrade", () => {
     expect(box!.width).toBeLessThanOrEqual(375);
 
     await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+    await expect(page.getByText(/^OR$/)).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Continue with SSO" }),
-    ).toBeVisible();
+    ).toHaveCount(0);
 
     await page.screenshot({
       path: "tests/screenshots/login-visual-mobile.png",


### PR DESCRIPTION
Implements #768.

## Summary
- Hide the login SSO divider and action unless `/api/v1/auth/status` reports SSO is configured.
- Add `sso_enabled` and `sso_login_url` auth status fields with default disabled config.
- Add E2E coverage for default no-SSO login and configured SSO redirect behavior.

## Verification
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run test`
- `cd web && bun run build`
- `cargo fmt --check`
- `cargo test -p panoptikon-server auth_status --test integration`
- `cd web && PANOPTIKON_URL=http://127.0.0.1:8080 bun run test:e2e -- auth.spec.ts login-rebrand.spec.ts login-visual.spec.ts auth-password-validation.spec.ts login-rate-limit.spec.ts`

## Note
Full `.maestro/verify.sh` is currently not a reliable signal for this change because it runs Caddy integration tests in a way that can conflict with shared local Caddy state. The CI-equivalent Caddy suite must be run sequentially with `--test-threads=1`.