### PR TITLE
feat(mesh): port atoms.jsx atomic UX components

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -313,3 +313,20 @@
     animation: none;
   }
 }
+
+/* ── mesh selected rail ────────────────────────────────
+ * Ported from panopticon/project/base.css —
+ * [data-direction="mesh"] .selected-rail dashed underline,
+ * used to mark the active rail in mesh-direction navigation.
+ * The host shell sets `data-direction="mesh"` on a parent so
+ * the rule stays scoped to mesh surfaces. */
+[data-direction="mesh"] .selected-rail {
+  background-image: linear-gradient(
+    90deg,
+    hsl(var(--ring)) 50%,
+    transparent 50%
+  );
+  background-size: 6px 1px;
+  background-repeat: repeat-x;
+  background-position: bottom left;
+}

--- a/web/src/components/mesh/BandwidthBar.tsx
+++ b/web/src/components/mesh/BandwidthBar.tsx
@@ -1,0 +1,76 @@
+export interface BandwidthBarProps {
+  /** Receive rate in same unit as `max`. */
+  rx: number;
+  /** Transmit rate in same unit as `max`. */
+  tx: number;
+  /** Full-scale value (e.g. link capacity). */
+  max?: number;
+  /** Total pixel width of the chart. */
+  width?: number;
+  className?: string;
+}
+
+/**
+ * BandwidthBar — two-row RX/TX utilisation bar.
+ *
+ * Faithful port of `BandwidthBar` from `atoms.jsx`. Top row is RX (sky/info),
+ * bottom is TX (violet). Both scale to the same `max` so the visual reading
+ * is comparable.
+ *
+ * @example
+ * <BandwidthBar rx={420} tx={180} max={1000} />
+ */
+export function BandwidthBar({
+  rx,
+  tx,
+  max = 1000,
+  width = 100,
+  className,
+}: BandwidthBarProps) {
+  const clamp = (n: number) => Math.max(0, Math.min(n, max));
+  const rxW = (clamp(rx) / max) * width;
+  const txW = (clamp(tx) / max) * width;
+  const trackStyle: React.CSSProperties = {
+    position: "relative",
+    height: 4,
+    background: "hsl(var(--muted))",
+    borderRadius: 2,
+    overflow: "hidden",
+  };
+  return (
+    <div
+      className={className}
+      style={{
+        width,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+      }}
+      role="group"
+      aria-label="bandwidth"
+    >
+      <div data-channel="rx" style={trackStyle}>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: rxW,
+            background: "hsl(var(--status-info))",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+      <div data-channel="tx" style={trackStyle}>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: txW,
+            background: "#a78bfa",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/mesh/Icon.tsx
+++ b/web/src/components/mesh/Icon.tsx
@@ -1,0 +1,171 @@
+import {
+  type LucideIcon,
+  AlertTriangle,
+  ArrowDown,
+  ArrowRightLeft,
+  ArrowUp,
+  Bell,
+  Bot,
+  Cable,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Cog,
+  Command,
+  Container,
+  Cpu,
+  Eye,
+  FileText,
+  Filter,
+  Gauge,
+  Globe,
+  LayoutDashboard,
+  Lock,
+  Menu,
+  Network,
+  Pin,
+  Plus,
+  PlugZap,
+  RefreshCw,
+  Router,
+  Search,
+  Server,
+  Settings,
+  ShieldCheck,
+  SlidersHorizontal,
+  Tag,
+  Wifi,
+  X,
+} from "lucide-react";
+
+/**
+ * Canonical icon names used across mesh-direction surfaces.
+ *
+ * The source design (`atoms.jsx`) uses Symbols Nerd Font codepoints for some
+ * glyphs and hand-rolled SVGs for the rest. In production we lean on
+ * `lucide-react` — the closest semantic match is chosen for each name so the
+ * mapping stays a single source of truth and call sites stay short:
+ *
+ *     <Icon name="dashboard" />
+ */
+export type IconName =
+  | "dashboard"
+  | "alert"
+  | "log"
+  | "device"
+  | "tag"
+  | "mesh"
+  | "qos"
+  | "nat"
+  | "router"
+  | "dns"
+  | "globe"
+  | "cert"
+  | "caddy"
+  | "tunnel"
+  | "service"
+  | "agent"
+  | "search"
+  | "chevron-right"
+  | "chevron-down"
+  | "refresh"
+  | "bell"
+  | "settings"
+  | "filter"
+  | "plus"
+  | "cmd"
+  | "arrow-up"
+  | "arrow-down"
+  | "wifi"
+  | "ethernet"
+  | "lock"
+  | "eye"
+  | "pin"
+  | "menu"
+  | "check"
+  | "x"
+  | "sliders"
+  | "plug";
+
+const ICON_MAP: Record<IconName, LucideIcon> = {
+  dashboard: LayoutDashboard,
+  alert: AlertTriangle,
+  log: FileText,
+  device: Cpu,
+  tag: Tag,
+  mesh: Network,
+  qos: Gauge,
+  nat: ArrowRightLeft,
+  router: Router,
+  dns: Globe,
+  globe: Globe,
+  cert: ShieldCheck,
+  caddy: Server,
+  tunnel: Container,
+  service: Server,
+  agent: Bot,
+  search: Search,
+  "chevron-right": ChevronRight,
+  "chevron-down": ChevronDown,
+  refresh: RefreshCw,
+  bell: Bell,
+  settings: Settings,
+  filter: Filter,
+  plus: Plus,
+  cmd: Command,
+  "arrow-up": ArrowUp,
+  "arrow-down": ArrowDown,
+  wifi: Wifi,
+  ethernet: Cable,
+  lock: Lock,
+  eye: Eye,
+  pin: Pin,
+  menu: Menu,
+  check: Check,
+  x: X,
+  sliders: SlidersHorizontal,
+  plug: PlugZap,
+};
+
+export interface IconProps {
+  name: IconName;
+  size?: number;
+  /** Stroke colour. Defaults to `currentColor` so callers can drive it via CSS. */
+  color?: string;
+  /** Stroke width — matches the source default (1.5). */
+  stroke?: number;
+  className?: string;
+}
+
+/**
+ * Icon — central glyph mapping for mesh surfaces.
+ *
+ * Wraps a single `lucide-react` icon per canonical name. Use this instead of
+ * importing icons directly so the visual vocabulary stays consistent across
+ * routes (and is easy to swap if we ever change the icon set).
+ *
+ * @example
+ * <Icon name="dashboard" size={16} />
+ * <Icon name="alert" color="hsl(var(--status-warning))" />
+ */
+export function Icon({
+  name,
+  size = 14,
+  color = "currentColor",
+  stroke = 1.5,
+  className,
+}: IconProps) {
+  const Glyph = ICON_MAP[name];
+  return (
+    <Glyph
+      width={size}
+      height={size}
+      color={color}
+      strokeWidth={stroke}
+      className={className}
+      aria-hidden="true"
+    />
+  );
+}
+
+export { ICON_MAP };

--- a/web/src/components/mesh/KPI.tsx
+++ b/web/src/components/mesh/KPI.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from "react";
+
+export interface KPIProps {
+  /** Uppercase micro-label shown above the value. */
+  label: string;
+  /** Primary value — accepts strings/numbers so callers can pre-format. */
+  value: ReactNode;
+  /** Optional unit suffix rendered in muted mono next to the value. */
+  unit?: ReactNode;
+  /**
+   * Optional trend chip — pass a pre-formatted string starting with `+` or
+   * `-` to drive the colour (matches the source `KPI` semantics).
+   */
+  trend?: string;
+  /** Optional inline visualisation (Spark / MiniBars) below the value. */
+  spark?: ReactNode;
+  /** Override the value colour (e.g. tint for alerts). */
+  accent?: string;
+  className?: string;
+}
+
+/**
+ * KPI — single-metric card with label, value, unit, trend chip and sparkline.
+ *
+ * Faithful port of `KPI` from the design handoff (`atoms.jsx`). The card chrome
+ * uses mesh tokens (`--card`, `--border`) so it reads correctly inside the
+ * existing mesh shell without any extra wrapper.
+ *
+ * @example
+ * <KPI
+ *   label="Bandwidth"
+ *   value="420"
+ *   unit="Mbps"
+ *   trend="+12%"
+ *   spark={<Spark data={series} />}
+ * />
+ */
+export function KPI({
+  label,
+  value,
+  unit,
+  trend,
+  spark,
+  accent,
+  className,
+}: KPIProps) {
+  const trendPositive = trend?.startsWith("+");
+  const trendColor = trend
+    ? trendPositive
+      ? "hsl(var(--status-online))"
+      : "hsl(var(--status-offline))"
+    : undefined;
+
+  return (
+    <div
+      className={className}
+      style={{
+        background: "hsl(var(--card))",
+        border: "1px solid hsl(var(--border))",
+        borderRadius: "var(--radius)",
+        padding: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        minWidth: 0,
+      }}
+      data-component="mesh-kpi"
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            lineHeight: 1.3,
+            fontWeight: 500,
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          {label}
+        </span>
+        {trend ? (
+          <span
+            data-trend={trendPositive ? "up" : "down"}
+            style={{
+              fontFamily: "var(--font-sans)",
+              fontWeight: 500,
+              fontSize: 10,
+              lineHeight: 1,
+              color: trendColor,
+            }}
+          >
+            {trend}
+          </span>
+        ) : null}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 4,
+          minWidth: 0,
+        }}
+      >
+        <span
+          className="tabular-nums"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 24,
+            fontWeight: 600,
+            color: accent ?? "hsl(var(--foreground))",
+            letterSpacing: "-0.02em",
+            lineHeight: 1,
+          }}
+        >
+          {value}
+        </span>
+        {unit ? (
+          <span
+            className="tabular-nums"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              color: "hsl(var(--muted-foreground))",
+            }}
+          >
+            {unit}
+          </span>
+        ) : null}
+      </div>
+      {spark ? <div style={{ marginTop: 2 }}>{spark}</div> : null}
+    </div>
+  );
+}

--- a/web/src/components/mesh/MiniBars.tsx
+++ b/web/src/components/mesh/MiniBars.tsx
@@ -1,0 +1,55 @@
+export interface MiniBarsProps {
+  /** Numeric series — each value renders as one bar. */
+  data: number[];
+  width?: number;
+  height?: number;
+  /** Bar fill colour. Accepts any CSS color string. */
+  color?: string;
+  className?: string;
+}
+
+/**
+ * MiniBars — minimal inline bar chart (~80x22 by default).
+ *
+ * Faithful port of `MiniBars` from `atoms.jsx`. Used in dense tables and KPI
+ * tiles when discrete buckets are more informative than a continuous line.
+ *
+ * @example
+ * <MiniBars data={[2, 4, 3, 7, 5]} color="hsl(var(--ring))" />
+ */
+export function MiniBars({
+  data,
+  width = 80,
+  height = 22,
+  color = "hsl(var(--ring))",
+  className,
+}: MiniBarsProps) {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data, 1);
+  const bw = width / data.length;
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      {data.map((v, i) => {
+        const h = (v / max) * (height - 2);
+        return (
+          <rect
+            key={i}
+            x={i * bw + 0.5}
+            y={height - h}
+            width={Math.max(bw - 1, 1)}
+            height={h}
+            fill={color}
+            opacity={0.5 + (v / max) * 0.5}
+            rx="0.5"
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/web/src/components/mesh/SevDot.tsx
+++ b/web/src/components/mesh/SevDot.tsx
@@ -1,0 +1,51 @@
+export type Severity = "critical" | "high" | "medium" | "low" | "info";
+
+export interface SevDotProps {
+  severity?: Severity;
+  size?: number;
+  className?: string;
+}
+
+const SEV_COLOR: Record<Severity, string> = {
+  critical: "hsl(var(--status-offline))",
+  high: "hsl(var(--status-offline))",
+  medium: "hsl(var(--status-warning))",
+  low: "hsl(var(--status-info))",
+  info: "hsl(var(--muted-foreground))",
+};
+
+/**
+ * SevDot — severity indicator dot for alert rows / counts.
+ *
+ * Faithful port of the severity-dot pattern used in `atoms.jsx` (StatusDot
+ * specialised for alert lists). Colour ladder follows the mesh palette:
+ * critical/high -> rose, medium -> amber, low -> sky, info -> muted.
+ *
+ * @example
+ * <SevDot severity="critical" />
+ */
+export function SevDot({
+  severity = "info",
+  size = 8,
+  className,
+}: SevDotProps) {
+  const color = SEV_COLOR[severity] ?? SEV_COLOR.info;
+  return (
+    <span
+      data-severity={severity}
+      className={className}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: color,
+        boxShadow:
+          severity === "critical"
+            ? "0 0 0 2px rgba(244, 63, 94, 0.18)"
+            : "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/mesh/Spark.tsx
+++ b/web/src/components/mesh/Spark.tsx
@@ -1,0 +1,75 @@
+import { useId } from "react";
+
+export interface SparkProps {
+  /** Series of numeric values to plot, left-to-right. */
+  data: number[];
+  width?: number;
+  height?: number;
+  /** Stroke colour for the line + gradient seed. Accepts any CSS color string. */
+  color?: string;
+  /** Whether to draw the soft gradient fill below the line. */
+  fill?: boolean;
+  className?: string;
+}
+
+/**
+ * Spark — minimal inline sparkline SVG.
+ *
+ * Faithful port of `Spark` from the design handoff (`atoms.jsx`). Used inside
+ * KPI tiles and dense table rows to give a quick directional read on a metric.
+ *
+ * @example
+ * <Spark data={[3, 5, 4, 7, 9, 8]} color="hsl(var(--ring))" />
+ */
+export function Spark({
+  data,
+  width = 80,
+  height = 22,
+  color = "hsl(var(--ring))",
+  fill = true,
+  className,
+}: SparkProps) {
+  const gid = useId();
+  if (!data || data.length === 0) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const stepX = data.length > 1 ? width / (data.length - 1) : width;
+  const points: Array<[number, number]> = data.map((v, i) => [
+    i * stepX,
+    height - ((v - min) / range) * (height - 4) - 2,
+  ]);
+  const d = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`)
+    .join(" ");
+  const dFill = `${d} L${width},${height} L0,${height} Z`;
+  const last = points[points.length - 1];
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className ?? "spark"}
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={color} stopOpacity="0.35" />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {fill && <path d={dFill} fill={`url(#${gid})`} />}
+      <path
+        d={d}
+        stroke={color}
+        strokeWidth="1.4"
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r="1.8" fill={color} />
+    </svg>
+  );
+}

--- a/web/src/components/mesh/StatusDot.tsx
+++ b/web/src/components/mesh/StatusDot.tsx
@@ -1,0 +1,58 @@
+export type StatusKind =
+  | "online"
+  | "offline"
+  | "warning"
+  | "info"
+  | "inactive";
+
+export interface StatusDotProps {
+  status?: StatusKind;
+  /** Add the glow-pulse halo animation (only meaningful for live indicators). */
+  pulse?: boolean;
+  /** Pixel diameter of the dot. */
+  size?: number;
+  className?: string;
+}
+
+const COLOR_MAP: Record<StatusKind, string> = {
+  online: "hsl(var(--status-online))",
+  offline: "hsl(var(--status-offline))",
+  warning: "hsl(var(--status-warning))",
+  info: "hsl(var(--status-info))",
+  inactive: "hsl(var(--muted-foreground))",
+};
+
+/**
+ * StatusDot — small coloured dot with optional pulse halo.
+ *
+ * Faithful port of `StatusDot` from `atoms.jsx`. The pulse animation reuses
+ * the `glow-pulse` keyframes already defined in `globals.css`, so the timing
+ * stays consistent with the rest of the mesh shell.
+ *
+ * @example
+ * <StatusDot status="online" pulse />
+ */
+export function StatusDot({
+  status = "online",
+  pulse = false,
+  size = 8,
+  className,
+}: StatusDotProps) {
+  const color = COLOR_MAP[status] ?? COLOR_MAP.inactive;
+  return (
+    <span
+      data-status={status}
+      data-pulse={pulse ? "true" : "false"}
+      className={className}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: color,
+        animation: pulse ? "glow-pulse 2.4s ease-in-out infinite" : "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/mesh/Trend.tsx
+++ b/web/src/components/mesh/Trend.tsx
@@ -1,0 +1,44 @@
+import { Icon } from "./Icon";
+
+export interface TrendProps {
+  /** Display string, e.g. `"+12%"` or `"-3.4 ms"`. */
+  value: string;
+  /** Direction of the change — drives the colour and arrow. */
+  positive?: boolean;
+  className?: string;
+}
+
+/**
+ * Trend — small directional change chip (arrow + value).
+ *
+ * Faithful port of `Trend` from `atoms.jsx`. Pair with KPI tiles or table
+ * cells to show delta vs previous window.
+ *
+ * @example
+ * <Trend value="+12%" positive />
+ * <Trend value="-3.4 ms" positive={false} />
+ */
+export function Trend({ value, positive = true, className }: TrendProps) {
+  const color = positive
+    ? "hsl(var(--status-online))"
+    : "hsl(var(--status-offline))";
+  return (
+    <span
+      data-direction={positive ? "up" : "down"}
+      className={className}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 2,
+        color,
+        fontFamily: "var(--font-mono)",
+        fontWeight: 500,
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      <Icon name={positive ? "arrow-up" : "arrow-down"} size={10} stroke={2} />
+      {value}
+    </span>
+  );
+}

--- a/web/src/components/mesh/index.ts
+++ b/web/src/components/mesh/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Mesh atoms — faithful port of `panopticon/project/atoms.jsx`.
+ *
+ * Each module is a small, pure-presentational building block used by the
+ * mesh-direction route shells (dashboard, devices, alerts, etc.). They are
+ * intentionally dependency-free aside from `lucide-react` (icon glyph map)
+ * so they can be composed freely inside both server- and client-rendered
+ * trees without bringing in extra runtime weight.
+ */
+
+export { Spark } from "./Spark";
+export type { SparkProps } from "./Spark";
+
+export { MiniBars } from "./MiniBars";
+export type { MiniBarsProps } from "./MiniBars";
+
+export { Trend } from "./Trend";
+export type { TrendProps } from "./Trend";
+
+export { BandwidthBar } from "./BandwidthBar";
+export type { BandwidthBarProps } from "./BandwidthBar";
+
+export { StatusDot } from "./StatusDot";
+export type { StatusDotProps, StatusKind } from "./StatusDot";
+
+export { SevDot } from "./SevDot";
+export type { SevDotProps, Severity } from "./SevDot";
+
+export { Icon, ICON_MAP } from "./Icon";
+export type { IconProps, IconName } from "./Icon";
+
+export { KPI } from "./KPI";
+export type { KPIProps } from "./KPI";

--- a/web/tests/unit/mesh/BandwidthBar.test.tsx
+++ b/web/tests/unit/mesh/BandwidthBar.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BandwidthBar } from "@/components/mesh/BandwidthBar";
+
+describe("BandwidthBar", () => {
+  it("renders separate rx and tx channels", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={250} tx={500} max={1000} width={100} />,
+    );
+    expect(html).toContain('data-channel="rx"');
+    expect(html).toContain('data-channel="tx"');
+  });
+
+  it("scales bar widths against max", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={500} tx={250} max={1000} width={100} />,
+    );
+    // rx should be 50px, tx should be 25px (substring match)
+    expect(html).toMatch(/width:\s*50px/);
+    expect(html).toMatch(/width:\s*25px/);
+  });
+
+  it("clamps rx/tx to max so the bar never overflows", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={9000} tx={9000} max={1000} width={100} />,
+    );
+    expect(html).toMatch(/width:\s*100px/);
+  });
+});

--- a/web/tests/unit/mesh/Icon.test.tsx
+++ b/web/tests/unit/mesh/Icon.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Icon, ICON_MAP, type IconName } from "@/components/mesh/Icon";
+
+describe("Icon", () => {
+  it("renders an svg for a known name", () => {
+    const html = renderToStaticMarkup(<Icon name="dashboard" />);
+    expect(html).toContain("<svg");
+  });
+
+  it("applies the supplied size", () => {
+    const html = renderToStaticMarkup(<Icon name="alert" size={32} />);
+    expect(html).toMatch(/width="32"/);
+    expect(html).toMatch(/height="32"/);
+  });
+
+  it("covers every name required by the design handoff", () => {
+    const required: IconName[] = [
+      "dashboard",
+      "alert",
+      "log",
+      "device",
+      "tag",
+      "mesh",
+      "qos",
+      "nat",
+      "router",
+      "dns",
+      "globe",
+      "cert",
+      "caddy",
+      "tunnel",
+      "service",
+      "agent",
+      "search",
+      "chevron-right",
+      "chevron-down",
+      "refresh",
+      "bell",
+      "settings",
+      "filter",
+      "plus",
+      "cmd",
+    ];
+    for (const name of required) {
+      expect(ICON_MAP[name], `missing icon: ${name}`).toBeDefined();
+    }
+  });
+});

--- a/web/tests/unit/mesh/KPI.test.tsx
+++ b/web/tests/unit/mesh/KPI.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { KPI } from "@/components/mesh/KPI";
+import { Spark } from "@/components/mesh/Spark";
+
+describe("KPI", () => {
+  it("renders label, value and unit", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Bandwidth" value="420" unit="Mbps" />,
+    );
+    expect(html).toContain("Bandwidth");
+    expect(html).toContain("420");
+    expect(html).toContain("Mbps");
+  });
+
+  it("colours a positive trend chip green and exposes data-trend", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Latency" value="42" unit="ms" trend="+5%" />,
+    );
+    expect(html).toContain('data-trend="up"');
+    expect(html).toContain("status-online");
+    expect(html).toContain("+5%");
+  });
+
+  it("colours a negative trend chip red and exposes data-trend", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Errors" value="3" trend="-1" />,
+    );
+    expect(html).toContain('data-trend="down"');
+    expect(html).toContain("status-offline");
+  });
+
+  it("renders an embedded spark when supplied", () => {
+    const html = renderToStaticMarkup(
+      <KPI
+        label="Trend"
+        value="100"
+        spark={<Spark data={[1, 2, 3, 4]} />}
+      />,
+    );
+    expect(html).toContain("<svg");
+  });
+});

--- a/web/tests/unit/mesh/MiniBars.test.tsx
+++ b/web/tests/unit/mesh/MiniBars.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MiniBars } from "@/components/mesh/MiniBars";
+
+describe("MiniBars", () => {
+  it("renders one rect per data point", () => {
+    const html = renderToStaticMarkup(<MiniBars data={[1, 2, 3, 4]} />);
+    const rects = html.match(/<rect/g) ?? [];
+    expect(rects.length).toBe(4);
+  });
+
+  it("returns null for empty data", () => {
+    const html = renderToStaticMarkup(<MiniBars data={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("uses the supplied colour", () => {
+    const html = renderToStaticMarkup(
+      <MiniBars data={[1, 2]} color="#22d3ee" />,
+    );
+    expect(html).toContain("#22d3ee");
+  });
+});

--- a/web/tests/unit/mesh/SevDot.test.tsx
+++ b/web/tests/unit/mesh/SevDot.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SevDot } from "@/components/mesh/SevDot";
+
+describe("SevDot", () => {
+  it("defaults to severity=info", () => {
+    const html = renderToStaticMarkup(<SevDot />);
+    expect(html).toContain('data-severity="info"');
+  });
+
+  it.each(["critical", "high", "medium", "low", "info"] as const)(
+    "exposes data-severity=%s",
+    (severity) => {
+      const html = renderToStaticMarkup(<SevDot severity={severity} />);
+      expect(html).toContain(`data-severity="${severity}"`);
+    },
+  );
+
+  it("adds a halo for critical only", () => {
+    const critical = renderToStaticMarkup(<SevDot severity="critical" />);
+    const low = renderToStaticMarkup(<SevDot severity="low" />);
+    expect(critical).toContain("box-shadow");
+    expect(critical).toContain("244, 63, 94");
+    expect(low).not.toContain("244, 63, 94");
+  });
+});

--- a/web/tests/unit/mesh/Spark.test.tsx
+++ b/web/tests/unit/mesh/Spark.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Spark } from "@/components/mesh/Spark";
+
+describe("Spark", () => {
+  it("returns null for empty data", () => {
+    const html = renderToStaticMarkup(<Spark data={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("renders an svg with a stroked path and end-point circle", () => {
+    const html = renderToStaticMarkup(<Spark data={[1, 4, 2, 5, 3]} />);
+    expect(html).toContain("<svg");
+    // line path
+    expect(html).toMatch(/<path[^>]+stroke=/);
+    // end-point dot
+    expect(html).toContain("<circle");
+    // gradient defined for fill
+    expect(html).toContain("linearGradient");
+  });
+
+  it("respects custom color and disables fill when requested", () => {
+    const html = renderToStaticMarkup(
+      <Spark data={[1, 2, 3]} color="#ff0066" fill={false} />,
+    );
+    expect(html).toContain("#ff0066");
+    // when fill is false the gradient-fill path is omitted, only the line path
+    const pathCount = (html.match(/<path/g) ?? []).length;
+    expect(pathCount).toBe(1);
+  });
+});

--- a/web/tests/unit/mesh/StatusDot.test.tsx
+++ b/web/tests/unit/mesh/StatusDot.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StatusDot } from "@/components/mesh/StatusDot";
+
+describe("StatusDot", () => {
+  it("defaults to status=online without pulse", () => {
+    const html = renderToStaticMarkup(<StatusDot />);
+    expect(html).toContain('data-status="online"');
+    expect(html).toContain('data-pulse="false"');
+  });
+
+  it("renders pulse=true when requested and sets glow-pulse animation", () => {
+    const html = renderToStaticMarkup(<StatusDot status="online" pulse />);
+    expect(html).toContain('data-pulse="true"');
+    expect(html).toContain("glow-pulse");
+  });
+
+  it.each(["online", "offline", "warning", "info", "inactive"] as const)(
+    "exposes data-status=%s",
+    (status) => {
+      const html = renderToStaticMarkup(<StatusDot status={status} />);
+      expect(html).toContain(`data-status="${status}"`);
+    },
+  );
+});

--- a/web/tests/unit/mesh/Trend.test.tsx
+++ b/web/tests/unit/mesh/Trend.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Trend } from "@/components/mesh/Trend";
+
+describe("Trend", () => {
+  it("renders an up arrow for positive=true (default)", () => {
+    const html = renderToStaticMarkup(<Trend value="+12%" />);
+    expect(html).toContain('data-direction="up"');
+    expect(html).toContain("+12%");
+    expect(html).toContain("status-online");
+  });
+
+  it("renders a down arrow for positive=false", () => {
+    const html = renderToStaticMarkup(<Trend value="-3.4 ms" positive={false} />);
+    expect(html).toContain('data-direction="down"');
+    expect(html).toContain("-3.4 ms");
+    expect(html).toContain("status-offline");
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
-    include: ["tests/unit/**/*.test.ts"],
+    include: ["tests/unit/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Foundation #771 landed mesh design tokens and shadcn primitives on main. This PR adds the next foundation layer: faithful port of the design handoff atomic UX components from `panopticon/project/atoms.jsx` into `web/src/components/mesh/*.tsx`.

## Components

- `KPI` — KPI card with label / value / unit / trend chip / sparkline
- `Spark` — inline sparkline svg
- `MiniBars` — mini bar chart
- `Trend` — directional change chip (+/−)
- `BandwidthBar` — RX/TX bandwidth bar
- `StatusDot` — pulse-animated status dot
- `SevDot` — severity dot for alerts
- `Icon` — canonical glyph mapping (lucide-react) for `dashboard`, `alert`, `log`, `device`, `tag`, `mesh`, `qos`, `nat`, `router`, `dns`, `globe`, `cert`, `caddy`, `tunnel`, `service`, `agent`, `search`, `chevron-right`, `chevron-down`, `refresh`, `bell`, `settings`, `filter`, `plus`, `cmd` plus arrows, wifi, ethernet, lock, eye, pin, menu, check, x, sliders, plug.

Plus mesh `.selected-rail` decoration ported from `base.css` (`[data-direction=\"mesh\"]`) into `globals.css`.

## Why now, separate PR

These are reused across every upcoming route port (U2 dashboard, U1 devices, U6 alerts, U3 details, etc.). Landing them first means each route port stays small (compose existing data with these atoms) and the design language stays consistent.

## What this PR does not do

- Does not change any existing route or shadcn primitive call site. Migration happens per-route in U-series PRs.
- No backend or API changes.

## Verification

- `bun run build` — clean
- `bun run test` — vitest (11 files / 48 tests) green
- `cargo check` — clean

Live UX healthcheck doesn't regress (no consumed call sites yet).

## Test plan

- [x] Build passes
- [x] Vitest green
- [x] cargo check clean
- [ ] Visual smoke after U-series PRs migrate call sites

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Ports eight pure-presentational atomic UX components (`KPI`, `Spark`, `MiniBars`, `Trend`, `BandwidthBar`, `StatusDot`, `SevDot`, `Icon`) from the design-handoff `atoms.jsx` into typed TSX modules under `web/src/components/mesh/`, together with their vitest unit tests and a scoped CSS rule for the mesh selected-rail decoration.

- All components are intentionally dependency-free (only `lucide-react` for icons), use CSS design tokens for colours, and are covered by `renderToStaticMarkup`-based unit tests; `vitest.config.ts` is updated to pick up `.tsx` test files.
- `BandwidthBar` uses a hardcoded hex `#a78bfa` for the TX channel fill instead of a design token, unlike every other colour in the file.
- `Icon.tsx` contains an unused `Cog` import, and both `dns`/`globe` and `caddy`/`service` pairs resolve to the same lucide glyph.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-up items; no call sites are affected yet and all unit tests pass.

The components are self-contained with no existing call sites, so the hardcoded TX color and duplicate icon mappings won't surface in production until the U-series route PRs land. The missing CLAUDE.md Why No E2E Test section and the dead Cog import are the only other items worth addressing before or shortly after merge.

BandwidthBar.tsx (hardcoded TX color) and Icon.tsx (unused import, duplicate glyph mappings) deserve a quick look before the first route PR consumes them.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/mesh/BandwidthBar.tsx | New two-row RX/TX bar component; TX fill uses hardcoded hex `#a78bfa` instead of a CSS design token, unlike RX which uses `hsl(var(--status-info))`. |
| web/src/components/mesh/Icon.tsx | Canonical icon registry; unused `Cog` import and two pairs of duplicate glyph mappings (`dns`/`globe` to `Globe`, `caddy`/`service` to `Server`). |
| web/src/components/mesh/KPI.tsx | KPI card component; clean port with correct trend-colour logic and design token usage throughout. |
| web/src/components/mesh/Spark.tsx | Inline sparkline SVG with `useId` for stable gradient IDs; correctly handles empty data and single-point edge cases. |
| web/src/components/mesh/MiniBars.tsx | Mini bar chart SVG; guards division-by-zero with `Math.max(...data, 1)` and returns null for empty arrays. |
| web/src/components/mesh/Trend.tsx | Directional change chip; straightforward and uses design tokens correctly. |
| web/src/components/mesh/StatusDot.tsx | Status dot with optional pulse animation; references `glow-pulse` keyframe already defined in `globals.css`. |
| web/src/components/mesh/SevDot.tsx | Severity dot for alert rows; `critical` and `high` intentionally share the same rose colour per the design ladder. |
| web/src/components/mesh/index.ts | Barrel export for all mesh atoms; complete and consistent. |
| web/src/app/globals.css | Adds `[data-direction="mesh"] .selected-rail` dashed-underline rule scoped to mesh surfaces; no regressions expected. |
| web/vitest.config.ts | Adds `esbuild.jsx: "automatic"` and expands test glob to `.{ts,tsx}` to support the new component tests. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/src/components/mesh/BandwidthBar.tsx`, line 100 ([link](https://github.com/befeast/panoptikon/blob/49454dde01e08a19a660b9810bfba4758e047b4d/web/src/components/mesh/BandwidthBar.tsx#L100)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Hardcoded hex instead of design token for TX fill**

   The TX bar fill uses a raw hex `#a78bfa` while the RX bar correctly uses `hsl(var(--status-info))`. If the palette is ever updated via design tokens, the TX bar will silently stay violet regardless of theme changes, causing visual drift between the two channels.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/components/mesh/BandwidthBar.tsx
   Line: 100

   Comment:
   **Hardcoded hex instead of design token for TX fill**

   The TX bar fill uses a raw hex `#a78bfa` while the RX bar correctly uses `hsl(var(--status-info))`. If the palette is ever updated via design tokens, the TX bar will silently stay violet regardless of theme changes, causing visual drift between the two channels.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `web/src/components/mesh/Icon.tsx`, line 213-219 ([link](https://github.com/befeast/panoptikon/blob/49454dde01e08a19a660b9810bfba4758e047b4d/web/src/components/mesh/Icon.tsx#L213-L219)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **`dns` / `globe` and `caddy` / `service` map to the same glyph**

   `dns` and `globe` both resolve to `Globe`; `caddy` and `service` both resolve to `Server`. Consumers using `<Icon name="dns" />` and `<Icon name="globe" />` will see identical SVGs, which removes any semantic distinction in the UI. Intentional if the design handoff treats these as visual aliases, but worth confirming — otherwise `Globe` could be swapped for `Network` or `Dns` for the DNS entry.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/components/mesh/Icon.tsx
   Line: 213-219

   Comment:
   **`dns` / `globe` and `caddy` / `service` map to the same glyph**

   `dns` and `globe` both resolve to `Globe`; `caddy` and `service` both resolve to `Server`. Consumers using `<Icon name="dns" />` and `<Icon name="globe" />` will see identical SVGs, which removes any semantic distinction in the UI. Intentional if the design handoff treats these as visual aliases, but worth confirming — otherwise `Globe` could be swapped for `Network` or `Dns` for the DNS entry.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/components/mesh/BandwidthBar.tsx:100
**Hardcoded hex instead of design token for TX fill**

The TX bar fill uses a raw hex `#a78bfa` while the RX bar correctly uses `hsl(var(--status-info))`. If the palette is ever updated via design tokens, the TX bar will silently stay violet regardless of theme changes, causing visual drift between the two channels.

### Issue 2 of 4
web/src/components/mesh/Icon.tsx:25
**Unused `Cog` import**

`Cog` is imported from `lucide-react` but never referenced in `ICON_MAP` — `settings` maps to `Settings` instead. Dead imports add noise and may confuse future maintainers about whether `Cog` was intended as a fallback or an alternative.

### Issue 3 of 4
web/src/components/mesh/Icon.tsx:213-219
**`dns` / `globe` and `caddy` / `service` map to the same glyph**

`dns` and `globe` both resolve to `Globe`; `caddy` and `service` both resolve to `Server`. Consumers using `<Icon name="dns" />` and `<Icon name="globe" />` will see identical SVGs, which removes any semantic distinction in the UI. Intentional if the design handoff treats these as visual aliases, but worth confirming — otherwise `Globe` could be swapped for `Network` or `Dns` for the DNS entry.

### Issue 4 of 4
web/tests/unit/mesh/BandwidthBar.test.tsx:1
**Missing `## Why No E2E Test` section per CLAUDE.md**

CLAUDE.md requires every feature PR to include a Playwright E2E test in `web/tests/e2e/`, or—if a test is genuinely impossible—a `## Why No E2E Test` section in the PR description explaining why. The PR describes why visual smoke is deferred ("no consumed call sites yet"), but that reasoning lives under "What this PR does not do" rather than under the required heading. The existing rationale is reasonable; it just needs to be surfaced in the correct section so the rule is satisfied.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mesh): port atoms.jsx — KPI, Spark,..."](https://github.com/befeast/panoptikon/commit/49454dde01e08a19a660b9810bfba4758e047b4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529004)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->