### PR TITLE
feat(mesh): port states.jsx empty/loading/error patterns

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -313,3 +313,20 @@
     animation: none;
   }
 }
+
+/* ── mesh selected rail ────────────────────────────────
+ * Ported from panopticon/project/base.css —
+ * [data-direction="mesh"] .selected-rail dashed underline,
+ * used to mark the active rail in mesh-direction navigation.
+ * The host shell sets `data-direction="mesh"` on a parent so
+ * the rule stays scoped to mesh surfaces. */
+[data-direction="mesh"] .selected-rail {
+  background-image: linear-gradient(
+    90deg,
+    hsl(var(--ring)) 50%,
+    transparent 50%
+  );
+  background-size: 6px 1px;
+  background-repeat: repeat-x;
+  background-position: bottom left;
+}

--- a/web/src/components/mesh/BandwidthBar.tsx
+++ b/web/src/components/mesh/BandwidthBar.tsx
@@ -1,0 +1,76 @@
+export interface BandwidthBarProps {
+  /** Receive rate in same unit as `max`. */
+  rx: number;
+  /** Transmit rate in same unit as `max`. */
+  tx: number;
+  /** Full-scale value (e.g. link capacity). */
+  max?: number;
+  /** Total pixel width of the chart. */
+  width?: number;
+  className?: string;
+}
+
+/**
+ * BandwidthBar — two-row RX/TX utilisation bar.
+ *
+ * Faithful port of `BandwidthBar` from `atoms.jsx`. Top row is RX (sky/info),
+ * bottom is TX (violet). Both scale to the same `max` so the visual reading
+ * is comparable.
+ *
+ * @example
+ * <BandwidthBar rx={420} tx={180} max={1000} />
+ */
+export function BandwidthBar({
+  rx,
+  tx,
+  max = 1000,
+  width = 100,
+  className,
+}: BandwidthBarProps) {
+  const clamp = (n: number) => Math.max(0, Math.min(n, max));
+  const rxW = (clamp(rx) / max) * width;
+  const txW = (clamp(tx) / max) * width;
+  const trackStyle: React.CSSProperties = {
+    position: "relative",
+    height: 4,
+    background: "hsl(var(--muted))",
+    borderRadius: 2,
+    overflow: "hidden",
+  };
+  return (
+    <div
+      className={className}
+      style={{
+        width,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+      }}
+      role="group"
+      aria-label="bandwidth"
+    >
+      <div data-channel="rx" style={trackStyle}>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: rxW,
+            background: "hsl(var(--status-info))",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+      <div data-channel="tx" style={trackStyle}>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: txW,
+            background: "#a78bfa",
+            borderRadius: 2,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/mesh/Icon.tsx
+++ b/web/src/components/mesh/Icon.tsx
@@ -1,0 +1,171 @@
+import {
+  type LucideIcon,
+  AlertTriangle,
+  ArrowDown,
+  ArrowRightLeft,
+  ArrowUp,
+  Bell,
+  Bot,
+  Cable,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Cog,
+  Command,
+  Container,
+  Cpu,
+  Eye,
+  FileText,
+  Filter,
+  Gauge,
+  Globe,
+  LayoutDashboard,
+  Lock,
+  Menu,
+  Network,
+  Pin,
+  Plus,
+  PlugZap,
+  RefreshCw,
+  Router,
+  Search,
+  Server,
+  Settings,
+  ShieldCheck,
+  SlidersHorizontal,
+  Tag,
+  Wifi,
+  X,
+} from "lucide-react";
+
+/**
+ * Canonical icon names used across mesh-direction surfaces.
+ *
+ * The source design (`atoms.jsx`) uses Symbols Nerd Font codepoints for some
+ * glyphs and hand-rolled SVGs for the rest. In production we lean on
+ * `lucide-react` — the closest semantic match is chosen for each name so the
+ * mapping stays a single source of truth and call sites stay short:
+ *
+ *     <Icon name="dashboard" />
+ */
+export type IconName =
+  | "dashboard"
+  | "alert"
+  | "log"
+  | "device"
+  | "tag"
+  | "mesh"
+  | "qos"
+  | "nat"
+  | "router"
+  | "dns"
+  | "globe"
+  | "cert"
+  | "caddy"
+  | "tunnel"
+  | "service"
+  | "agent"
+  | "search"
+  | "chevron-right"
+  | "chevron-down"
+  | "refresh"
+  | "bell"
+  | "settings"
+  | "filter"
+  | "plus"
+  | "cmd"
+  | "arrow-up"
+  | "arrow-down"
+  | "wifi"
+  | "ethernet"
+  | "lock"
+  | "eye"
+  | "pin"
+  | "menu"
+  | "check"
+  | "x"
+  | "sliders"
+  | "plug";
+
+const ICON_MAP: Record<IconName, LucideIcon> = {
+  dashboard: LayoutDashboard,
+  alert: AlertTriangle,
+  log: FileText,
+  device: Cpu,
+  tag: Tag,
+  mesh: Network,
+  qos: Gauge,
+  nat: ArrowRightLeft,
+  router: Router,
+  dns: Globe,
+  globe: Globe,
+  cert: ShieldCheck,
+  caddy: Server,
+  tunnel: Container,
+  service: Server,
+  agent: Bot,
+  search: Search,
+  "chevron-right": ChevronRight,
+  "chevron-down": ChevronDown,
+  refresh: RefreshCw,
+  bell: Bell,
+  settings: Settings,
+  filter: Filter,
+  plus: Plus,
+  cmd: Command,
+  "arrow-up": ArrowUp,
+  "arrow-down": ArrowDown,
+  wifi: Wifi,
+  ethernet: Cable,
+  lock: Lock,
+  eye: Eye,
+  pin: Pin,
+  menu: Menu,
+  check: Check,
+  x: X,
+  sliders: SlidersHorizontal,
+  plug: PlugZap,
+};
+
+export interface IconProps {
+  name: IconName;
+  size?: number;
+  /** Stroke colour. Defaults to `currentColor` so callers can drive it via CSS. */
+  color?: string;
+  /** Stroke width — matches the source default (1.5). */
+  stroke?: number;
+  className?: string;
+}
+
+/**
+ * Icon — central glyph mapping for mesh surfaces.
+ *
+ * Wraps a single `lucide-react` icon per canonical name. Use this instead of
+ * importing icons directly so the visual vocabulary stays consistent across
+ * routes (and is easy to swap if we ever change the icon set).
+ *
+ * @example
+ * <Icon name="dashboard" size={16} />
+ * <Icon name="alert" color="hsl(var(--status-warning))" />
+ */
+export function Icon({
+  name,
+  size = 14,
+  color = "currentColor",
+  stroke = 1.5,
+  className,
+}: IconProps) {
+  const Glyph = ICON_MAP[name];
+  return (
+    <Glyph
+      width={size}
+      height={size}
+      color={color}
+      strokeWidth={stroke}
+      className={className}
+      aria-hidden="true"
+    />
+  );
+}
+
+export { ICON_MAP };

--- a/web/src/components/mesh/KPI.tsx
+++ b/web/src/components/mesh/KPI.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from "react";
+
+export interface KPIProps {
+  /** Uppercase micro-label shown above the value. */
+  label: string;
+  /** Primary value — accepts strings/numbers so callers can pre-format. */
+  value: ReactNode;
+  /** Optional unit suffix rendered in muted mono next to the value. */
+  unit?: ReactNode;
+  /**
+   * Optional trend chip — pass a pre-formatted string starting with `+` or
+   * `-` to drive the colour (matches the source `KPI` semantics).
+   */
+  trend?: string;
+  /** Optional inline visualisation (Spark / MiniBars) below the value. */
+  spark?: ReactNode;
+  /** Override the value colour (e.g. tint for alerts). */
+  accent?: string;
+  className?: string;
+}
+
+/**
+ * KPI — single-metric card with label, value, unit, trend chip and sparkline.
+ *
+ * Faithful port of `KPI` from the design handoff (`atoms.jsx`). The card chrome
+ * uses mesh tokens (`--card`, `--border`) so it reads correctly inside the
+ * existing mesh shell without any extra wrapper.
+ *
+ * @example
+ * <KPI
+ *   label="Bandwidth"
+ *   value="420"
+ *   unit="Mbps"
+ *   trend="+12%"
+ *   spark={<Spark data={series} />}
+ * />
+ */
+export function KPI({
+  label,
+  value,
+  unit,
+  trend,
+  spark,
+  accent,
+  className,
+}: KPIProps) {
+  const trendPositive = trend?.startsWith("+");
+  const trendColor = trend
+    ? trendPositive
+      ? "hsl(var(--status-online))"
+      : "hsl(var(--status-offline))"
+    : undefined;
+
+  return (
+    <div
+      className={className}
+      style={{
+        background: "hsl(var(--card))",
+        border: "1px solid hsl(var(--border))",
+        borderRadius: "var(--radius)",
+        padding: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        minWidth: 0,
+      }}
+      data-component="mesh-kpi"
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            lineHeight: 1.3,
+            fontWeight: 500,
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+            color: "hsl(var(--muted-foreground))",
+          }}
+        >
+          {label}
+        </span>
+        {trend ? (
+          <span
+            data-trend={trendPositive ? "up" : "down"}
+            style={{
+              fontFamily: "var(--font-sans)",
+              fontWeight: 500,
+              fontSize: 10,
+              lineHeight: 1,
+              color: trendColor,
+            }}
+          >
+            {trend}
+          </span>
+        ) : null}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 4,
+          minWidth: 0,
+        }}
+      >
+        <span
+          className="tabular-nums"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 24,
+            fontWeight: 600,
+            color: accent ?? "hsl(var(--foreground))",
+            letterSpacing: "-0.02em",
+            lineHeight: 1,
+          }}
+        >
+          {value}
+        </span>
+        {unit ? (
+          <span
+            className="tabular-nums"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              color: "hsl(var(--muted-foreground))",
+            }}
+          >
+            {unit}
+          </span>
+        ) : null}
+      </div>
+      {spark ? <div style={{ marginTop: 2 }}>{spark}</div> : null}
+    </div>
+  );
+}

--- a/web/src/components/mesh/MiniBars.tsx
+++ b/web/src/components/mesh/MiniBars.tsx
@@ -1,0 +1,55 @@
+export interface MiniBarsProps {
+  /** Numeric series — each value renders as one bar. */
+  data: number[];
+  width?: number;
+  height?: number;
+  /** Bar fill colour. Accepts any CSS color string. */
+  color?: string;
+  className?: string;
+}
+
+/**
+ * MiniBars — minimal inline bar chart (~80x22 by default).
+ *
+ * Faithful port of `MiniBars` from `atoms.jsx`. Used in dense tables and KPI
+ * tiles when discrete buckets are more informative than a continuous line.
+ *
+ * @example
+ * <MiniBars data={[2, 4, 3, 7, 5]} color="hsl(var(--ring))" />
+ */
+export function MiniBars({
+  data,
+  width = 80,
+  height = 22,
+  color = "hsl(var(--ring))",
+  className,
+}: MiniBarsProps) {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data, 1);
+  const bw = width / data.length;
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      {data.map((v, i) => {
+        const h = (v / max) * (height - 2);
+        return (
+          <rect
+            key={i}
+            x={i * bw + 0.5}
+            y={height - h}
+            width={Math.max(bw - 1, 1)}
+            height={h}
+            fill={color}
+            opacity={0.5 + (v / max) * 0.5}
+            rx="0.5"
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/web/src/components/mesh/SevDot.tsx
+++ b/web/src/components/mesh/SevDot.tsx
@@ -1,0 +1,51 @@
+export type Severity = "critical" | "high" | "medium" | "low" | "info";
+
+export interface SevDotProps {
+  severity?: Severity;
+  size?: number;
+  className?: string;
+}
+
+const SEV_COLOR: Record<Severity, string> = {
+  critical: "hsl(var(--status-offline))",
+  high: "hsl(var(--status-offline))",
+  medium: "hsl(var(--status-warning))",
+  low: "hsl(var(--status-info))",
+  info: "hsl(var(--muted-foreground))",
+};
+
+/**
+ * SevDot — severity indicator dot for alert rows / counts.
+ *
+ * Faithful port of the severity-dot pattern used in `atoms.jsx` (StatusDot
+ * specialised for alert lists). Colour ladder follows the mesh palette:
+ * critical/high -> rose, medium -> amber, low -> sky, info -> muted.
+ *
+ * @example
+ * <SevDot severity="critical" />
+ */
+export function SevDot({
+  severity = "info",
+  size = 8,
+  className,
+}: SevDotProps) {
+  const color = SEV_COLOR[severity] ?? SEV_COLOR.info;
+  return (
+    <span
+      data-severity={severity}
+      className={className}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: color,
+        boxShadow:
+          severity === "critical"
+            ? "0 0 0 2px rgba(244, 63, 94, 0.18)"
+            : "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/mesh/Spark.tsx
+++ b/web/src/components/mesh/Spark.tsx
@@ -1,0 +1,75 @@
+import { useId } from "react";
+
+export interface SparkProps {
+  /** Series of numeric values to plot, left-to-right. */
+  data: number[];
+  width?: number;
+  height?: number;
+  /** Stroke colour for the line + gradient seed. Accepts any CSS color string. */
+  color?: string;
+  /** Whether to draw the soft gradient fill below the line. */
+  fill?: boolean;
+  className?: string;
+}
+
+/**
+ * Spark — minimal inline sparkline SVG.
+ *
+ * Faithful port of `Spark` from the design handoff (`atoms.jsx`). Used inside
+ * KPI tiles and dense table rows to give a quick directional read on a metric.
+ *
+ * @example
+ * <Spark data={[3, 5, 4, 7, 9, 8]} color="hsl(var(--ring))" />
+ */
+export function Spark({
+  data,
+  width = 80,
+  height = 22,
+  color = "hsl(var(--ring))",
+  fill = true,
+  className,
+}: SparkProps) {
+  const gid = useId();
+  if (!data || data.length === 0) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const stepX = data.length > 1 ? width / (data.length - 1) : width;
+  const points: Array<[number, number]> = data.map((v, i) => [
+    i * stepX,
+    height - ((v - min) / range) * (height - 4) - 2,
+  ]);
+  const d = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`)
+    .join(" ");
+  const dFill = `${d} L${width},${height} L0,${height} Z`;
+  const last = points[points.length - 1];
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className ?? "spark"}
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={color} stopOpacity="0.35" />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {fill && <path d={dFill} fill={`url(#${gid})`} />}
+      <path
+        d={d}
+        stroke={color}
+        strokeWidth="1.4"
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r="1.8" fill={color} />
+    </svg>
+  );
+}

--- a/web/src/components/mesh/StatusDot.tsx
+++ b/web/src/components/mesh/StatusDot.tsx
@@ -1,0 +1,58 @@
+export type StatusKind =
+  | "online"
+  | "offline"
+  | "warning"
+  | "info"
+  | "inactive";
+
+export interface StatusDotProps {
+  status?: StatusKind;
+  /** Add the glow-pulse halo animation (only meaningful for live indicators). */
+  pulse?: boolean;
+  /** Pixel diameter of the dot. */
+  size?: number;
+  className?: string;
+}
+
+const COLOR_MAP: Record<StatusKind, string> = {
+  online: "hsl(var(--status-online))",
+  offline: "hsl(var(--status-offline))",
+  warning: "hsl(var(--status-warning))",
+  info: "hsl(var(--status-info))",
+  inactive: "hsl(var(--muted-foreground))",
+};
+
+/**
+ * StatusDot — small coloured dot with optional pulse halo.
+ *
+ * Faithful port of `StatusDot` from `atoms.jsx`. The pulse animation reuses
+ * the `glow-pulse` keyframes already defined in `globals.css`, so the timing
+ * stays consistent with the rest of the mesh shell.
+ *
+ * @example
+ * <StatusDot status="online" pulse />
+ */
+export function StatusDot({
+  status = "online",
+  pulse = false,
+  size = 8,
+  className,
+}: StatusDotProps) {
+  const color = COLOR_MAP[status] ?? COLOR_MAP.inactive;
+  return (
+    <span
+      data-status={status}
+      data-pulse={pulse ? "true" : "false"}
+      className={className}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: color,
+        animation: pulse ? "glow-pulse 2.4s ease-in-out infinite" : "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/mesh/Trend.tsx
+++ b/web/src/components/mesh/Trend.tsx
@@ -1,0 +1,44 @@
+import { Icon } from "./Icon";
+
+export interface TrendProps {
+  /** Display string, e.g. `"+12%"` or `"-3.4 ms"`. */
+  value: string;
+  /** Direction of the change — drives the colour and arrow. */
+  positive?: boolean;
+  className?: string;
+}
+
+/**
+ * Trend — small directional change chip (arrow + value).
+ *
+ * Faithful port of `Trend` from `atoms.jsx`. Pair with KPI tiles or table
+ * cells to show delta vs previous window.
+ *
+ * @example
+ * <Trend value="+12%" positive />
+ * <Trend value="-3.4 ms" positive={false} />
+ */
+export function Trend({ value, positive = true, className }: TrendProps) {
+  const color = positive
+    ? "hsl(var(--status-online))"
+    : "hsl(var(--status-offline))";
+  return (
+    <span
+      data-direction={positive ? "up" : "down"}
+      className={className}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 2,
+        color,
+        fontFamily: "var(--font-mono)",
+        fontWeight: 500,
+        fontSize: 11,
+        lineHeight: 1,
+      }}
+    >
+      <Icon name={positive ? "arrow-up" : "arrow-down"} size={10} stroke={2} />
+      {value}
+    </span>
+  );
+}

--- a/web/src/components/mesh/index.ts
+++ b/web/src/components/mesh/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Mesh atoms — faithful port of `panopticon/project/atoms.jsx`.
+ *
+ * Each module is a small, pure-presentational building block used by the
+ * mesh-direction route shells (dashboard, devices, alerts, etc.). They are
+ * intentionally dependency-free aside from `lucide-react` (icon glyph map)
+ * so they can be composed freely inside both server- and client-rendered
+ * trees without bringing in extra runtime weight.
+ */
+
+export { Spark } from "./Spark";
+export type { SparkProps } from "./Spark";
+
+export { MiniBars } from "./MiniBars";
+export type { MiniBarsProps } from "./MiniBars";
+
+export { Trend } from "./Trend";
+export type { TrendProps } from "./Trend";
+
+export { BandwidthBar } from "./BandwidthBar";
+export type { BandwidthBarProps } from "./BandwidthBar";
+
+export { StatusDot } from "./StatusDot";
+export type { StatusDotProps, StatusKind } from "./StatusDot";
+
+export { SevDot } from "./SevDot";
+export type { SevDotProps, Severity } from "./SevDot";
+
+export { Icon, ICON_MAP } from "./Icon";
+export type { IconProps, IconName } from "./Icon";
+
+export { KPI } from "./KPI";
+export type { KPIProps } from "./KPI";

--- a/web/src/components/mesh/state/EmptyState.tsx
+++ b/web/src/components/mesh/state/EmptyState.tsx
@@ -1,0 +1,174 @@
+import type { ReactNode } from "react";
+import { PlugZap, type LucideIcon } from "lucide-react";
+
+export interface EmptyStateProps {
+  /** Bold headline answering "why is this empty?". */
+  title: string;
+  /** 1–2 sentence explanation shown below the title in dim text. */
+  message: string;
+  /** Optional inline command / snippet shown in faint mono under the action row. */
+  hint?: ReactNode;
+  /** Optional CTA node (primary + optional secondary button(s)). */
+  action?: ReactNode;
+  /**
+   * Optional icon override for the decorative target — by default the source
+   * blueprint mark (dashed circle + center dot over a faint grid) is rendered.
+   * Pass a Lucide icon to replace the entire decorative element with a single
+   * accent glyph (used by tighter inline variants).
+   */
+  icon?: LucideIcon;
+  /** Render the tight `inline` variant — no decorative mark, smaller padding. */
+  inline?: boolean;
+  className?: string;
+}
+
+/**
+ * EmptyState — central, "explain the why" empty surface.
+ *
+ * Faithful port of `StateEmpty` from `panopticon/project/states.jsx`. The
+ * decorative blueprint mark (faint grid + dashed circle + accent dot) reads
+ * as a target / scope, reinforcing that the page is waiting for first data
+ * rather than being broken.
+ *
+ * @example
+ * <EmptyState
+ *   title="No agents connected yet"
+ *   message="Agents stream live metrics back to Panoptikon. Install one on any host to get started."
+ *   hint={<code>curl -sSL https://core.lan/install.sh | sh</code>}
+ *   action={
+ *     <>
+ *       <Button>Generate agent token</Button>
+ *       <Button variant="outline">Installation docs</Button>
+ *     </>
+ *   }
+ * />
+ */
+export function EmptyState({
+  title,
+  message,
+  hint,
+  action,
+  icon: IconOverride,
+  inline = false,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      data-component="mesh-empty-state"
+      data-variant={inline ? "inline" : "default"}
+      className={className}
+      style={{
+        background: "hsl(var(--card))",
+        border: "1px solid hsl(var(--border))",
+        borderRadius: "var(--radius)",
+        padding: inline ? 20 : 36,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        textAlign: "center",
+        gap: 12,
+      }}
+    >
+      {IconOverride ? (
+        <IconOverride
+          aria-hidden="true"
+          size={inline ? 22 : 28}
+          color="#38bdf8"
+          strokeWidth={1.5}
+        />
+      ) : inline ? (
+        <PlugZap
+          aria-hidden="true"
+          size={22}
+          color="#38bdf8"
+          strokeWidth={1.5}
+        />
+      ) : (
+        <EmptyBlueprint />
+      )}
+      <div>
+        <h3
+          style={{
+            font: "600 16px var(--font-sans, system-ui, sans-serif)",
+            color: "#e9f0fc",
+            margin: 0,
+          }}
+        >
+          {title}
+        </h3>
+        <p
+          style={{
+            font: "400 12.5px var(--font-sans, system-ui, sans-serif)",
+            color: "#98aecf",
+            margin: "6px 0 0",
+            maxWidth: 340,
+            lineHeight: 1.5,
+          }}
+        >
+          {message}
+        </p>
+      </div>
+      {action ? (
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "center" }}>
+          {action}
+        </div>
+      ) : null}
+      {hint ? (
+        <div
+          style={{
+            font: "400 10.5px var(--font-mono, monospace)",
+            color: "#3a5278",
+            marginTop: 6,
+          }}
+        >
+          {hint}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Decorative target/blueprint mark used as the default EmptyState illustration.
+ * Renders a faint 12px grid pattern with a dashed accent circle and a solid
+ * accent dot in the center, matching the source SVG verbatim.
+ */
+function EmptyBlueprint() {
+  return (
+    <svg
+      width="120"
+      height="80"
+      viewBox="0 0 120 80"
+      aria-hidden="true"
+      focusable="false"
+      data-component="mesh-empty-blueprint"
+    >
+      <defs>
+        <pattern
+          id="mesh-empty-grid"
+          width="12"
+          height="12"
+          patternUnits="userSpaceOnUse"
+        >
+          <path
+            d="M12 0 L0 0 0 12"
+            fill="none"
+            stroke="rgba(96,144,212,0.20)"
+            strokeWidth="0.5"
+          />
+        </pattern>
+      </defs>
+      <rect width="120" height="80" fill="url(#mesh-empty-grid)" />
+      <circle
+        cx="60"
+        cy="40"
+        r="14"
+        fill="#091633"
+        stroke="#38bdf8"
+        strokeWidth="1"
+        strokeDasharray="2 3"
+      />
+      <circle cx="60" cy="40" r="3" fill="#38bdf8" />
+    </svg>
+  );
+}

--- a/web/src/components/mesh/state/ErrorState.tsx
+++ b/web/src/components/mesh/state/ErrorState.tsx
@@ -1,0 +1,191 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, RefreshCw, type LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export interface ErrorStateProps {
+  /** Bold headline naming the failure (e.g. "Couldn't reach MikroTik"). */
+  title: string;
+  /** Supporting mono detail — usually the upstream error / next retry. */
+  message?: ReactNode;
+  /** Optional small hint rendered below the message in faint mono. */
+  hint?: ReactNode;
+  /** Custom action node — overrides the default "Try again" button. */
+  action?: ReactNode;
+  /**
+   * Retry handler — when provided (and `action` is not), a `Try again`
+   * outline button is rendered on the right of the banner.
+   */
+  onRetry?: () => void;
+  /** Override the default `AlertTriangle` icon glyph. */
+  icon?: LucideIcon;
+  /**
+   * Optional stale/cached content to keep visible below the banner —
+   * matches the source rule "errors never blank the screen — keep the last
+   * known data with a diagonal stripe overlay to mark it stale".
+   */
+  staleContent?: ReactNode;
+  /** Render the tight `inline` variant — single banner, no card chrome. */
+  inline?: boolean;
+  className?: string;
+}
+
+/**
+ * ErrorState — failure banner that keeps last-known data visible.
+ *
+ * Faithful port of `StateError` from `panopticon/project/states.jsx`. Two
+ * rules from the source:
+ *
+ *   1. NEVER blank the screen on error — keep stale data with a diagonal
+ *      stripe overlay above it.
+ *   2. Banner above the data with cause + retry action.
+ *
+ * @example
+ * <ErrorState
+ *   title="Couldn't reach MikroTik · cached 38s ago"
+ *   message="RouterOS REST returned 502 — likely transient. Auto-retry in 4s."
+ *   onRetry={refetch}
+ *   staleContent={<DeviceMetricsGrid data={cached} />}
+ * />
+ */
+export function ErrorState({
+  title,
+  message,
+  hint,
+  action,
+  onRetry,
+  icon,
+  staleContent,
+  inline = false,
+  className,
+}: ErrorStateProps) {
+  const Glyph = icon ?? AlertTriangle;
+  const retryNode =
+    action ??
+    (onRetry ? (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        data-action="retry"
+      >
+        <RefreshCw aria-hidden="true" />
+        <span>Try again</span>
+      </Button>
+    ) : null);
+
+  const banner = (
+    <div
+      style={{
+        padding: inline ? "8px 12px" : "10px 14px",
+        background: "rgba(244,63,94,0.06)",
+        borderBottom: staleContent
+          ? "1px solid rgba(244,63,94,0.25)"
+          : "none",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+      }}
+    >
+      <div
+        style={{
+          width: 26,
+          height: 26,
+          background: "rgba(244,63,94,0.12)",
+          border: "1px solid rgba(244,63,94,0.30)",
+          borderRadius: "calc(var(--radius) - 4px)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#fb7185",
+          flexShrink: 0,
+        }}
+      >
+        <Glyph size={14} aria-hidden="true" strokeWidth={2} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            font: "600 12.5px var(--font-sans, system-ui, sans-serif)",
+            color: "#e9f0fc",
+          }}
+        >
+          {title}
+        </div>
+        {message ? (
+          <div
+            style={{
+              font: "400 11px var(--font-mono, monospace)",
+              color: "#98aecf",
+              marginTop: 2,
+            }}
+          >
+            {message}
+          </div>
+        ) : null}
+        {hint ? (
+          <div
+            style={{
+              font: "400 10.5px var(--font-mono, monospace)",
+              color: "#3a5278",
+              marginTop: 2,
+            }}
+          >
+            {hint}
+          </div>
+        ) : null}
+      </div>
+      {retryNode}
+    </div>
+  );
+
+  if (inline) {
+    return (
+      <div
+        data-component="mesh-error-state"
+        data-variant="inline"
+        className={className}
+        style={{
+          background: "hsl(var(--card))",
+          border: "1px solid hsl(var(--border))",
+          borderRadius: "var(--radius)",
+          overflow: "hidden",
+        }}
+      >
+        {banner}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-component="mesh-error-state"
+      data-variant="default"
+      className={className}
+      style={{
+        background: "hsl(var(--card))",
+        border: "1px solid hsl(var(--border))",
+        borderRadius: "var(--radius)",
+        overflow: "hidden",
+      }}
+    >
+      {banner}
+      {staleContent ? (
+        <div style={{ padding: 14, position: "relative" }}>
+          <div style={{ opacity: 0.6 }}>{staleContent}</div>
+          <div
+            aria-hidden="true"
+            data-component="mesh-error-stale-overlay"
+            style={{
+              position: "absolute",
+              inset: 14,
+              backgroundImage:
+                "repeating-linear-gradient(135deg, transparent 0, transparent 18px, rgba(245,158,11,0.04) 18px, rgba(245,158,11,0.04) 19px)",
+              pointerEvents: "none",
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/mesh/state/LoadingState.tsx
+++ b/web/src/components/mesh/state/LoadingState.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export interface LoadingStateProps {
+  /** Optional title rendered above the skeleton ridges (e.g. "Loading agents"). */
+  title?: string;
+  /** Optional supporting line shown under the title in muted text. */
+  message?: ReactNode;
+  /**
+   * Number of grid placeholder tiles to render above the row stack (matches
+   * the source `StateLoading` top-row count). Set to `0` to omit the row.
+   */
+  tiles?: number;
+  /**
+   * Number of skeleton rows in the bottom list. Set to `0` to omit.
+   */
+  rows?: number;
+  /** Render the tight `inline` variant — single bar, no card chrome. */
+  inline?: boolean;
+  className?: string;
+}
+
+/**
+ * LoadingState — skeleton placeholder that matches the real surface layout.
+ *
+ * Faithful port of `StateLoading` from `panopticon/project/states.jsx`. The
+ * design rule from the source is explicit: skeletons MUST match the real
+ * layout — same column widths, same row heights, same count. Generic blocks
+ * are forbidden, so the component lets the caller tune `tiles` / `rows` to
+ * mirror the real surface.
+ *
+ * Internally we reuse the shared `Skeleton` from `@/components/ui/skeleton`
+ * which already provides the mesh-accent shimmer, so this component stays a
+ * pure layout wrapper.
+ *
+ * @example
+ * <LoadingState
+ *   title="Devices"
+ *   message="Pulling live inventory…"
+ *   tiles={4}
+ *   rows={5}
+ * />
+ */
+export function LoadingState({
+  title,
+  message,
+  tiles = 4,
+  rows = 5,
+  inline = false,
+  className,
+}: LoadingStateProps) {
+  if (inline) {
+    return (
+      <div
+        data-component="mesh-loading-state"
+        data-variant="inline"
+        className={className}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "8px 12px",
+        }}
+      >
+        <Skeleton style={{ width: 14, height: 14, borderRadius: 3 }} />
+        <Skeleton style={{ flex: 1, height: 10, borderRadius: 3 }} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-component="mesh-loading-state"
+      data-variant="default"
+      className={className}
+      style={{
+        background: "hsl(var(--card))",
+        border: "1px solid hsl(var(--border))",
+        borderRadius: "var(--radius)",
+        padding: 14,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {title ? (
+        <div
+          style={{
+            font: "600 13px var(--font-sans, system-ui, sans-serif)",
+            color: "#e9f0fc",
+            marginBottom: message ? 4 : 12,
+          }}
+        >
+          {title}
+        </div>
+      ) : (
+        <Skeleton style={{ width: 120, height: 11, borderRadius: 3 }} />
+      )}
+      {message ? (
+        <div
+          style={{
+            font: "400 11.5px var(--font-sans, system-ui, sans-serif)",
+            color: "#98aecf",
+            marginBottom: 12,
+          }}
+        >
+          {message}
+        </div>
+      ) : (
+        <div style={{ marginTop: 8 }}>
+          <Skeleton style={{ width: 180, height: 20, borderRadius: 3 }} />
+        </div>
+      )}
+      {tiles > 0 ? (
+        <div
+          style={{
+            marginTop: 14,
+            display: "grid",
+            gridTemplateColumns: `repeat(${tiles}, 1fr)`,
+            gap: 8,
+          }}
+        >
+          {Array.from({ length: tiles }, (_, i) => (
+            <Skeleton
+              key={`tile-${i}`}
+              style={{ width: "100%", height: 56, borderRadius: 3 }}
+            />
+          ))}
+        </div>
+      ) : null}
+      {rows > 0 ? (
+        <div style={{ marginTop: 14 }}>
+          {Array.from({ length: rows }, (_, i) => (
+            <div
+              key={`row-${i}`}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "60px 1fr 80px 60px",
+                gap: 10,
+                padding: "7px 0",
+                borderBottom:
+                  i < rows - 1
+                    ? "1px solid hsl(var(--border))"
+                    : "none",
+              }}
+            >
+              <Skeleton style={{ width: "100%", height: 10, borderRadius: 3 }} />
+              <Skeleton style={{ width: "80%", height: 10, borderRadius: 3 }} />
+              <Skeleton style={{ width: "100%", height: 10, borderRadius: 3 }} />
+              <Skeleton style={{ width: "100%", height: 10, borderRadius: 3 }} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/mesh/state/index.ts
+++ b/web/src/components/mesh/state/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Mesh state surfaces — faithful port of `panopticon/project/states.jsx`.
+ *
+ * The three non-success states every route ships with:
+ *
+ *   - `EmptyState`   — central "explain the why" placeholder with optional CTA
+ *   - `LoadingState` — skeleton ridges that mirror the real layout
+ *   - `ErrorState`   — failure banner that keeps last-known data visible
+ *
+ * These are pure presentational primitives — no data fetching, no router
+ * coupling — so route shells can compose them without dragging extra runtime
+ * into the leaf. Route-level adoption happens in the upcoming U-series PRs.
+ */
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";
+
+export { LoadingState } from "./LoadingState";
+export type { LoadingStateProps } from "./LoadingState";
+
+export { ErrorState } from "./ErrorState";
+export type { ErrorStateProps } from "./ErrorState";

--- a/web/tests/unit/mesh/BandwidthBar.test.tsx
+++ b/web/tests/unit/mesh/BandwidthBar.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BandwidthBar } from "@/components/mesh/BandwidthBar";
+
+describe("BandwidthBar", () => {
+  it("renders separate rx and tx channels", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={250} tx={500} max={1000} width={100} />,
+    );
+    expect(html).toContain('data-channel="rx"');
+    expect(html).toContain('data-channel="tx"');
+  });
+
+  it("scales bar widths against max", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={500} tx={250} max={1000} width={100} />,
+    );
+    // rx should be 50px, tx should be 25px (substring match)
+    expect(html).toMatch(/width:\s*50px/);
+    expect(html).toMatch(/width:\s*25px/);
+  });
+
+  it("clamps rx/tx to max so the bar never overflows", () => {
+    const html = renderToStaticMarkup(
+      <BandwidthBar rx={9000} tx={9000} max={1000} width={100} />,
+    );
+    expect(html).toMatch(/width:\s*100px/);
+  });
+});

--- a/web/tests/unit/mesh/Icon.test.tsx
+++ b/web/tests/unit/mesh/Icon.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Icon, ICON_MAP, type IconName } from "@/components/mesh/Icon";
+
+describe("Icon", () => {
+  it("renders an svg for a known name", () => {
+    const html = renderToStaticMarkup(<Icon name="dashboard" />);
+    expect(html).toContain("<svg");
+  });
+
+  it("applies the supplied size", () => {
+    const html = renderToStaticMarkup(<Icon name="alert" size={32} />);
+    expect(html).toMatch(/width="32"/);
+    expect(html).toMatch(/height="32"/);
+  });
+
+  it("covers every name required by the design handoff", () => {
+    const required: IconName[] = [
+      "dashboard",
+      "alert",
+      "log",
+      "device",
+      "tag",
+      "mesh",
+      "qos",
+      "nat",
+      "router",
+      "dns",
+      "globe",
+      "cert",
+      "caddy",
+      "tunnel",
+      "service",
+      "agent",
+      "search",
+      "chevron-right",
+      "chevron-down",
+      "refresh",
+      "bell",
+      "settings",
+      "filter",
+      "plus",
+      "cmd",
+    ];
+    for (const name of required) {
+      expect(ICON_MAP[name], `missing icon: ${name}`).toBeDefined();
+    }
+  });
+});

--- a/web/tests/unit/mesh/KPI.test.tsx
+++ b/web/tests/unit/mesh/KPI.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { KPI } from "@/components/mesh/KPI";
+import { Spark } from "@/components/mesh/Spark";
+
+describe("KPI", () => {
+  it("renders label, value and unit", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Bandwidth" value="420" unit="Mbps" />,
+    );
+    expect(html).toContain("Bandwidth");
+    expect(html).toContain("420");
+    expect(html).toContain("Mbps");
+  });
+
+  it("colours a positive trend chip green and exposes data-trend", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Latency" value="42" unit="ms" trend="+5%" />,
+    );
+    expect(html).toContain('data-trend="up"');
+    expect(html).toContain("status-online");
+    expect(html).toContain("+5%");
+  });
+
+  it("colours a negative trend chip red and exposes data-trend", () => {
+    const html = renderToStaticMarkup(
+      <KPI label="Errors" value="3" trend="-1" />,
+    );
+    expect(html).toContain('data-trend="down"');
+    expect(html).toContain("status-offline");
+  });
+
+  it("renders an embedded spark when supplied", () => {
+    const html = renderToStaticMarkup(
+      <KPI
+        label="Trend"
+        value="100"
+        spark={<Spark data={[1, 2, 3, 4]} />}
+      />,
+    );
+    expect(html).toContain("<svg");
+  });
+});

--- a/web/tests/unit/mesh/MiniBars.test.tsx
+++ b/web/tests/unit/mesh/MiniBars.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MiniBars } from "@/components/mesh/MiniBars";
+
+describe("MiniBars", () => {
+  it("renders one rect per data point", () => {
+    const html = renderToStaticMarkup(<MiniBars data={[1, 2, 3, 4]} />);
+    const rects = html.match(/<rect/g) ?? [];
+    expect(rects.length).toBe(4);
+  });
+
+  it("returns null for empty data", () => {
+    const html = renderToStaticMarkup(<MiniBars data={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("uses the supplied colour", () => {
+    const html = renderToStaticMarkup(
+      <MiniBars data={[1, 2]} color="#22d3ee" />,
+    );
+    expect(html).toContain("#22d3ee");
+  });
+});

--- a/web/tests/unit/mesh/SevDot.test.tsx
+++ b/web/tests/unit/mesh/SevDot.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SevDot } from "@/components/mesh/SevDot";
+
+describe("SevDot", () => {
+  it("defaults to severity=info", () => {
+    const html = renderToStaticMarkup(<SevDot />);
+    expect(html).toContain('data-severity="info"');
+  });
+
+  it.each(["critical", "high", "medium", "low", "info"] as const)(
+    "exposes data-severity=%s",
+    (severity) => {
+      const html = renderToStaticMarkup(<SevDot severity={severity} />);
+      expect(html).toContain(`data-severity="${severity}"`);
+    },
+  );
+
+  it("adds a halo for critical only", () => {
+    const critical = renderToStaticMarkup(<SevDot severity="critical" />);
+    const low = renderToStaticMarkup(<SevDot severity="low" />);
+    expect(critical).toContain("box-shadow");
+    expect(critical).toContain("244, 63, 94");
+    expect(low).not.toContain("244, 63, 94");
+  });
+});

--- a/web/tests/unit/mesh/Spark.test.tsx
+++ b/web/tests/unit/mesh/Spark.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Spark } from "@/components/mesh/Spark";
+
+describe("Spark", () => {
+  it("returns null for empty data", () => {
+    const html = renderToStaticMarkup(<Spark data={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("renders an svg with a stroked path and end-point circle", () => {
+    const html = renderToStaticMarkup(<Spark data={[1, 4, 2, 5, 3]} />);
+    expect(html).toContain("<svg");
+    // line path
+    expect(html).toMatch(/<path[^>]+stroke=/);
+    // end-point dot
+    expect(html).toContain("<circle");
+    // gradient defined for fill
+    expect(html).toContain("linearGradient");
+  });
+
+  it("respects custom color and disables fill when requested", () => {
+    const html = renderToStaticMarkup(
+      <Spark data={[1, 2, 3]} color="#ff0066" fill={false} />,
+    );
+    expect(html).toContain("#ff0066");
+    // when fill is false the gradient-fill path is omitted, only the line path
+    const pathCount = (html.match(/<path/g) ?? []).length;
+    expect(pathCount).toBe(1);
+  });
+});

--- a/web/tests/unit/mesh/StatusDot.test.tsx
+++ b/web/tests/unit/mesh/StatusDot.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StatusDot } from "@/components/mesh/StatusDot";
+
+describe("StatusDot", () => {
+  it("defaults to status=online without pulse", () => {
+    const html = renderToStaticMarkup(<StatusDot />);
+    expect(html).toContain('data-status="online"');
+    expect(html).toContain('data-pulse="false"');
+  });
+
+  it("renders pulse=true when requested and sets glow-pulse animation", () => {
+    const html = renderToStaticMarkup(<StatusDot status="online" pulse />);
+    expect(html).toContain('data-pulse="true"');
+    expect(html).toContain("glow-pulse");
+  });
+
+  it.each(["online", "offline", "warning", "info", "inactive"] as const)(
+    "exposes data-status=%s",
+    (status) => {
+      const html = renderToStaticMarkup(<StatusDot status={status} />);
+      expect(html).toContain(`data-status="${status}"`);
+    },
+  );
+});

--- a/web/tests/unit/mesh/Trend.test.tsx
+++ b/web/tests/unit/mesh/Trend.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Trend } from "@/components/mesh/Trend";
+
+describe("Trend", () => {
+  it("renders an up arrow for positive=true (default)", () => {
+    const html = renderToStaticMarkup(<Trend value="+12%" />);
+    expect(html).toContain('data-direction="up"');
+    expect(html).toContain("+12%");
+    expect(html).toContain("status-online");
+  });
+
+  it("renders a down arrow for positive=false", () => {
+    const html = renderToStaticMarkup(<Trend value="-3.4 ms" positive={false} />);
+    expect(html).toContain('data-direction="down"');
+    expect(html).toContain("-3.4 ms");
+    expect(html).toContain("status-offline");
+  });
+});

--- a/web/tests/unit/mesh/state/EmptyState.test.tsx
+++ b/web/tests/unit/mesh/state/EmptyState.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Plus } from "lucide-react";
+import { EmptyState } from "@/components/mesh/state/EmptyState";
+
+describe("EmptyState", () => {
+  it("renders title, message, hint and action", () => {
+    const html = renderToStaticMarkup(
+      <EmptyState
+        title="No agents connected yet"
+        message="Install one on any host to get started."
+        hint={<code>curl -sSL https://core.lan/install.sh | sh</code>}
+        action={<button type="button">Generate token</button>}
+      />,
+    );
+    expect(html).toContain("No agents connected yet");
+    expect(html).toContain("Install one on any host");
+    expect(html).toContain("curl -sSL");
+    expect(html).toContain("Generate token");
+  });
+
+  it("renders the decorative blueprint SVG by default", () => {
+    const html = renderToStaticMarkup(
+      <EmptyState title="Empty" message="…" />,
+    );
+    expect(html).toContain('data-component="mesh-empty-blueprint"');
+    expect(html).toContain("mesh-empty-grid");
+  });
+
+  it("swaps the decoration for a Lucide icon when one is supplied", () => {
+    const html = renderToStaticMarkup(
+      <EmptyState title="Empty" message="…" icon={Plus} />,
+    );
+    expect(html).not.toContain('data-component="mesh-empty-blueprint"');
+    // Lucide renders an <svg> with a lucide class
+    expect(html).toMatch(/lucide-plus/);
+  });
+
+  it("uses the inline variant attribute when inline=true", () => {
+    const html = renderToStaticMarkup(
+      <EmptyState title="No rows" message="Try adjusting filters." inline />,
+    );
+    expect(html).toContain('data-variant="inline"');
+    expect(html).not.toContain('data-component="mesh-empty-blueprint"');
+  });
+});

--- a/web/tests/unit/mesh/state/ErrorState.test.tsx
+++ b/web/tests/unit/mesh/state/ErrorState.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ErrorState } from "@/components/mesh/state/ErrorState";
+
+describe("ErrorState", () => {
+  it("renders title and message", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState
+        title="Couldn't reach MikroTik"
+        message="RouterOS REST returned 502 — auto-retry in 4s."
+      />,
+    );
+    expect(html).toContain("Couldn&#x27;t reach MikroTik");
+    expect(html).toContain("RouterOS REST returned 502");
+  });
+
+  it("renders a Try again button when onRetry is provided", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState
+        title="Failed"
+        message="…"
+        onRetry={() => {
+          /* noop */
+        }}
+      />,
+    );
+    expect(html).toContain('data-action="retry"');
+    expect(html).toContain("Try again");
+  });
+
+  it("does not render a retry button when neither onRetry nor action is set", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState title="Failed" message="…" />,
+    );
+    expect(html).not.toContain('data-action="retry"');
+  });
+
+  it("renders the stale-content overlay when staleContent is supplied", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState
+        title="Stale"
+        message="…"
+        staleContent={<div data-testid="last-good">Last good data</div>}
+      />,
+    );
+    expect(html).toContain("Last good data");
+    expect(html).toContain('data-component="mesh-error-stale-overlay"');
+  });
+
+  it("renders inline variant without stale overlay slot", () => {
+    const html = renderToStaticMarkup(
+      <ErrorState title="Stale" message="…" inline />,
+    );
+    expect(html).toContain('data-variant="inline"');
+    expect(html).not.toContain('data-component="mesh-error-stale-overlay"');
+  });
+});

--- a/web/tests/unit/mesh/state/LoadingState.test.tsx
+++ b/web/tests/unit/mesh/state/LoadingState.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LoadingState } from "@/components/mesh/state/LoadingState";
+
+describe("LoadingState", () => {
+  it("renders the requested tile and row counts", () => {
+    const html = renderToStaticMarkup(
+      <LoadingState tiles={3} rows={4} />,
+    );
+    // 3 tiles + 4 rows × 4 cells = 16 row skeletons + 1 default header skeleton + 1 default subhead skeleton
+    const skeletonCount = (html.match(/animate-shimmer/g) ?? []).length;
+    expect(skeletonCount).toBeGreaterThanOrEqual(3 + 4 * 4);
+    // grid template echoes tile count
+    expect(html).toContain("repeat(3, 1fr)");
+  });
+
+  it("renders title + message when supplied", () => {
+    const html = renderToStaticMarkup(
+      <LoadingState title="Devices" message="Pulling live inventory" tiles={0} rows={0} />,
+    );
+    expect(html).toContain("Devices");
+    expect(html).toContain("Pulling live inventory");
+  });
+
+  it("omits tile / row blocks when set to 0", () => {
+    const html = renderToStaticMarkup(
+      <LoadingState tiles={0} rows={0} />,
+    );
+    expect(html).not.toContain("repeat(0");
+  });
+
+  it("renders the inline variant as a single bar", () => {
+    const html = renderToStaticMarkup(<LoadingState inline />);
+    expect(html).toContain('data-variant="inline"');
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
-    include: ["tests/unit/**/*.test.ts"],
+    include: ["tests/unit/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Foundation #771 + atoms #772 (stacked). Adds shared mesh EmptyState/LoadingState/ErrorState ported from states.jsx. Pure presentational; no call site changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the `EmptyState`, `LoadingState`, and `ErrorState` presentational components from the original `states.jsx`, plus the full set of mesh atoms (`Spark`, `MiniBars`, `BandwidthBar`, `StatusDot`, `SevDot`, `Icon`, `KPI`, `Trend`) from `atoms.jsx`. No call sites are wired up yet; the components are pure layout primitives.

- `EmptyBlueprint` in `EmptyState.tsx` uses a hardcoded `id=\"mesh-empty-grid\"` for its SVG `<pattern>`, which will produce duplicate IDs and undefined rendering when two default `EmptyState` instances appear in the same document. `Spark` correctly avoids this with `useId()` and `EmptyBlueprint` should do the same.
- No Playwright E2E test is included, and the PR description does not contain the `## Why No E2E Test` section required by `CLAUDE.md` for feature PRs without tests.
- The TX fill in `BandwidthBar` and text colours in the state components use hardcoded hex values instead of CSS variables, inconsistent with the rest of the mesh atoms.

<h3>Confidence Score: 3/5</h3>

The new state components are safe in isolation but EmptyState has a real rendering defect waiting to surface as soon as two default instances share a page.

The SVG pattern-ID collision in EmptyBlueprint is a concrete rendering bug: any route that mounts two or more default EmptyState panels simultaneously will produce duplicate id=mesh-empty-grid nodes, and the second SVG may lose its fill pattern entirely. The missing E2E test and PR-description exemption section mean the team required CI gate is unmet.

web/src/components/mesh/state/EmptyState.tsx needs the pattern ID fixed with useId() before this ships to call sites.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/components/mesh/state/EmptyState.tsx | Ports StateEmpty from states.jsx; hardcoded id=mesh-empty-grid in EmptyBlueprint will collide when multiple default instances are rendered simultaneously. |
| web/src/components/mesh/state/ErrorState.tsx | Ports StateError with stale-content overlay pattern; logic is correct. Uses hardcoded hex colours in text/hint styles. |
| web/src/components/mesh/state/LoadingState.tsx | Ports StateLoading skeleton layout; correctly reuses shared Skeleton component, tile/row counts are tunable. No logic issues found. |
| web/src/components/mesh/BandwidthBar.tsx | RX/TX utilisation bar with correct clamping. TX fill uses a hardcoded hex #a78bfa instead of a CSS variable. |
| web/src/components/mesh/Spark.tsx | Sparkline SVG with gradient fill; correctly uses useId() for the gradient element ID to prevent DOM collisions. |
| web/src/components/mesh/Icon.tsx | Centralised Lucide icon map; typed IconName union and ICON_MAP record are exhaustive and correct. |
| web/vitest.config.ts | Adds esbuild.jsx automatic and widens the test glob to include .tsx files. |
| web/src/components/mesh/index.ts | Barrel export for all mesh atoms; exports are complete and correctly typed. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/src/components/mesh/state/EmptyState.tsx`, line 925-962 ([link](https://github.com/befeast/panoptikon/blob/16c7c4a81611d24d871695194a1cd3b57158f88d/web/src/components/mesh/state/EmptyState.tsx#L925-L962)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **SVG pattern ID collision on multiple mounts**

   `EmptyBlueprint` uses a hardcoded `id="mesh-empty-grid"` for the `<pattern>` element. SVG `fill="url(#id)"` references are resolved against the entire document, not the local SVG. When two default `EmptyState` components are in the same tree at once (e.g., dashboard with two empty panels), both `<pattern>` elements share the same ID — which is invalid HTML and causes undefined browser behaviour. The `Spark` component in this same PR correctly solves this with `useId()`. `EmptyBlueprint` should do the same.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/components/mesh/state/EmptyState.tsx
   Line: 925-962

   Comment:
   **SVG pattern ID collision on multiple mounts**

   `EmptyBlueprint` uses a hardcoded `id="mesh-empty-grid"` for the `<pattern>` element. SVG `fill="url(#id)"` references are resolved against the entire document, not the local SVG. When two default `EmptyState` components are in the same tree at once (e.g., dashboard with two empty panels), both `<pattern>` elements share the same ID — which is invalid HTML and causes undefined browser behaviour. The `Spark` component in this same PR correctly solves this with `useId()`. `EmptyBlueprint` should do the same.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `web/src/components/mesh/state/EmptyState.tsx`, line 835 ([link](https://github.com/befeast/panoptikon/blob/16c7c4a81611d24d871695194a1cd3b57158f88d/web/src/components/mesh/state/EmptyState.tsx#L835)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Missing Playwright E2E test (CLAUDE.md requirement)**

   Per `CLAUDE.md`, every feature PR must ship a Playwright E2E test in `web/tests/e2e/`, or include a `## Why No E2E Test` section in the PR description justifying why a test is impossible. This PR adds three new state-surface components that will be rendered inside route shells — the PR description marks them as "no call site changes yet," but that same note is the justification that belongs in the description. Neither an E2E test nor the required exemption section is present.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/components/mesh/state/EmptyState.tsx
   Line: 835
   
   Comment:
   **Missing Playwright E2E test (CLAUDE.md requirement)**
   
   Per `CLAUDE.md`, every feature PR must ship a Playwright E2E test in `web/tests/e2e/`, or include a `## Why No E2E Test` section in the PR description justifying why a test is impossible. This PR adds three new state-surface components that will be rendered inside route shells — the PR description marks them as "no call site changes yet," but that same note is the justification that belongs in the description. Neither an E2E test nor the required exemption section is present.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/mesh/state/EmptyState.tsx:925-962
**SVG pattern ID collision on multiple mounts**

`EmptyBlueprint` uses a hardcoded `id="mesh-empty-grid"` for the `<pattern>` element. SVG `fill="url(#id)"` references are resolved against the entire document, not the local SVG. When two default `EmptyState` components are in the same tree at once (e.g., dashboard with two empty panels), both `<pattern>` elements share the same ID — which is invalid HTML and causes undefined browser behaviour. The `Spark` component in this same PR correctly solves this with `useId()`. `EmptyBlueprint` should do the same.

### Issue 2 of 3
web/src/components/mesh/state/EmptyState.tsx:835
**Missing Playwright E2E test (CLAUDE.md requirement)**

Per `CLAUDE.md`, every feature PR must ship a Playwright E2E test in `web/tests/e2e/`, or include a `## Why No E2E Test` section in the PR description justifying why a test is impossible. This PR adds three new state-surface components that will be rendered inside route shells — the PR description marks them as "no call site changes yet," but that same note is the justification that belongs in the description. Neither an E2E test nor the required exemption section is present.

### Issue 3 of 3
web/src/components/mesh/BandwidthBar.tsx:69
The TX fill uses a hardcoded hex value while every other colour in this file (and the rest of the mesh atoms) uses CSS variables. Using a raw hex here means the colour won't respond to theme changes and is inconsistent with `hsl(var(--status-info))` used for RX.

```suggestion
            background: "hsl(var(--status-warning))",
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mesh): port states.jsx — EmptyState..."](https://github.com/befeast/panoptikon/commit/16c7c4a81611d24d871695194a1cd3b57158f88d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529148)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->