### PR TITLE
test(smoke): align dashboard heading assertion with new core.lan h1

### DIFF
--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -14,7 +14,7 @@ test.describe("Smoke Tests", () => {
   test("dashboard loads without errors", async ({ page }) => {
     await page.goto("/dashboard/");
     await expect(
-      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+      page.locator('[data-testid="dashboard-title"]'),
     ).toBeVisible({ timeout: 15000 });
     await page.screenshot({ path: "tests/screenshots/smoke-dashboard.png" });
   });
@@ -73,7 +73,7 @@ test.describe("Smoke Tests", () => {
 
     await page.goto("/dashboard/");
     await expect(
-      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+      page.locator('[data-testid="dashboard-title"]'),
     ).toBeVisible({ timeout: 15000 });
 
     // Allow network errors (external services may be down) but no JS crashes


### PR DESCRIPTION
Quick follow-up to PR #774. Smoke pinned the old <h1>Dashboard</h1>; the port replaced it with the <h1>core.lan</h1> + Overview eyebrow per design source. Target data-testid that the port already exposes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates two smoke-test assertions that were pinned to the old `<h1>Dashboard</h1>` heading, replacing them with `data-testid="dashboard-title"` locators introduced in PR #774's design port.

- Both occurrences (`"dashboard loads without errors"` and `"no console errors on dashboard"`) are updated consistently.
- The `data-testid` approach is more resilient to hostname/content changes, but drops the implicit text assertion the `getByRole` name filter provided — the tests now only confirm the element is visible, not that it actually renders any content.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change correctly retargets both dashboard heading assertions to the new testid, and the rest of the smoke suite is untouched.

The only concern is that switching from a named getByRole assertion to a bare data-testid locator silently removes the text-content check in both affected tests. A blank or unrendered heading would no longer be caught. This is a minor reduction in test coverage rather than a functional breakage.

web/tests/e2e/smoke.spec.ts — specifically the two toBeVisible assertions that no longer verify heading content.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/tests/e2e/smoke.spec.ts | Replaces two `getByRole` heading assertions with `data-testid` locators to match the redesigned dashboard header; drops the implicit text-content check in the process. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/tests/e2e/smoke.spec.ts:17-19
The switch from `getByRole("heading", { name: "Dashboard", level: 1 })` to a bare `data-testid` locator removes the implicit text/content assertion entirely. The smoke test now passes as long as the element is present in the DOM and visible, regardless of whether it actually renders any text. If a regression blanks the heading or swaps it for an empty placeholder, this check would not catch it. Since the PR description notes the new static eyebrow text is "Overview", that string could be asserted; alternatively, `.not.toBeEmpty()` keeps the check env-agnostic while still catching blank-heading regressions.

```suggestion
      page.locator('[data-testid="dashboard-title"]'),
    ).toBeVisible({ timeout: 15000 });
    await expect(page.locator('[data-testid="dashboard-title"]')).not.toBeEmpty();
    await page.screenshot({ path: "tests/screenshots/smoke-dashboard.png" });
```

### Issue 2 of 2
web/tests/e2e/smoke.spec.ts:76-79
Same issue as the first dashboard assertion: the "no console errors" test also loses its content check. A blank or broken heading would go undetected here too.

```suggestion
      page.locator('[data-testid="dashboard-title"]'),
    ).toBeVisible({ timeout: 15000 });
    await expect(page.locator('[data-testid="dashboard-title"]')).not.toBeEmpty();

    // Allow network errors (external services may be down) but no JS crashes
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(smoke): align dashboard heading ass..."](https://github.com/befeast/panoptikon/commit/c6f0442ca546261961a3bfe7e0460740c4d2e240) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32530498)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->