### PR TITLE
feat(u3): port details.jsx drawer/sheet IA

### DIFF
--- a/web/src/components/mesh/details/DetailsDrawer.tsx
+++ b/web/src/components/mesh/details/DetailsDrawer.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { DetailsHeader, type DetailsHeaderProps } from "./DetailsHeader";
+import { DetailsTabs, type DetailsTabItem } from "./DetailsTabs";
+
+export type DetailsDrawerSide = "right" | "left" | "center";
+
+export interface DetailsDrawerProps {
+  /** Controls visibility — Radix-style controlled prop. */
+  open: boolean;
+  /** Called when the user dismisses the surface. */
+  onOpenChange: (open: boolean) => void;
+  /** Primary title — shown in the header and used as the a11y label. */
+  title: ReactNode;
+  /** Optional eyebrow above the title (e.g. "Device"). */
+  eyebrow?: ReactNode;
+  /**
+   * Surface placement.
+   *   - `right` (default) / `left` — slide-in side sheet
+   *   - `center` — modal dialog (used for "Edit asset"-style forms)
+   */
+  side?: DetailsDrawerSide;
+  /** Optional pre-built header props — when omitted callers can pass `children`. */
+  header?: Omit<DetailsHeaderProps, "onClose"> & { onClose?: () => void };
+  /** Optional tab strip rendered under the header. */
+  tabs?: DetailsTabItem[];
+  /** Controlled active tab value. */
+  tabValue?: string;
+  /** Tab change handler. */
+  onTabValueChange?: (value: string) => void;
+  /** Optional sticky footer (CTA row). */
+  footer?: ReactNode;
+  /** Body content rendered between header and footer. */
+  children?: ReactNode;
+  /** Plain-text description for a11y (sr-only). */
+  description?: string;
+  /** Override the panel width (only honoured for side variants). */
+  widthClassName?: string;
+  className?: string;
+}
+
+const FRAME_BASE =
+  "flex h-full flex-col overflow-hidden bg-mesh-surface-1 text-mesh-text";
+
+/**
+ * DetailsDrawer — shared mesh surface for entity detail UIs.
+ *
+ * Faithful port of the drawer shell pattern implied by
+ * `panopticon/project/details.jsx`. Wraps the shadcn `Sheet` primitive for
+ * side variants and the `Dialog` primitive for the centered "form modal"
+ * variant — both already consume mesh tokens after #771, so we only override
+ * width / padding here.
+ *
+ * Composes the rest of the U3 vocabulary (`DetailsHeader`, `DetailsTabs`)
+ * and exposes a `footer` slot for sticky CTAs. Pure presentational; callers
+ * decide what goes inside the body.
+ */
+export function DetailsDrawer({
+  open,
+  onOpenChange,
+  title,
+  eyebrow,
+  side = "right",
+  header,
+  tabs,
+  tabValue,
+  onTabValueChange,
+  footer,
+  children,
+  description,
+  widthClassName,
+  className,
+}: DetailsDrawerProps) {
+  const resolvedHeader: DetailsHeaderProps = {
+    title,
+    eyebrow,
+    ...header,
+    onClose: header?.onClose ?? (() => onOpenChange(false)),
+  };
+
+  const body = (
+    <>
+      <DetailsHeader {...resolvedHeader} />
+      {tabs && tabs.length > 0 ? (
+        <div data-slot="mesh-details-drawer-tabs" className="flex-shrink-0">
+          <DetailsTabs
+            items={tabs}
+            value={tabValue}
+            onValueChange={onTabValueChange}
+          />
+        </div>
+      ) : null}
+      <div
+        data-slot="mesh-details-drawer-body"
+        className="flex-1 overflow-y-auto"
+        style={{ padding: tabs?.length ? 0 : "0 20px 20px" }}
+      >
+        {children}
+      </div>
+      {footer ? footer : null}
+    </>
+  );
+
+  if (side === "center") {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          data-component="mesh-details-drawer"
+          data-side="center"
+          className={cn(
+            "p-0 gap-0 max-w-2xl w-[min(720px,calc(100vw-32px))]",
+            "max-h-[min(820px,calc(100vh-32px))]",
+            FRAME_BASE,
+            className,
+          )}
+        >
+          <DialogTitle className="sr-only">
+            {typeof title === "string" ? title : "Details"}
+          </DialogTitle>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side={side === "left" ? "left" : "right"}
+        data-component="mesh-details-drawer"
+        data-side={side}
+        className={cn(
+          "p-0 gap-0",
+          "w-[min(640px,100vw)] sm:max-w-[640px]",
+          widthClassName,
+          FRAME_BASE,
+          className,
+        )}
+      >
+        <SheetTitle className="sr-only">
+          {typeof title === "string" ? title : "Details"}
+        </SheetTitle>
+        {description ? (
+          <SheetDescription className="sr-only">{description}</SheetDescription>
+        ) : null}
+        {body}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/components/mesh/details/DetailsField.tsx
+++ b/web/src/components/mesh/details/DetailsField.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+
+export interface DetailsFieldProps {
+  /** Field key — rendered in dim mute text on the left. */
+  label: ReactNode;
+  /** Field value — rendered in primary text on the right. */
+  value: ReactNode;
+  /** Render the value in mono font (defaults to `true`). */
+  mono?: boolean;
+  /** Optional inline status colour override for the value text. */
+  valueColor?: string;
+  /** Stack label above value instead of side-by-side (default `false`). */
+  vertical?: boolean;
+  className?: string;
+}
+
+/**
+ * DetailsField — single key/value pair used inside detail drawers.
+ *
+ * Faithful port of the metadata pairs from `panopticon/project/details.jsx`
+ * (`endpoint · wss://core.lan/agent`, `session · 8a4f-3c92`, etc.). Compose
+ * many of these inside a `DetailsSection` to build a metadata grid.
+ */
+export function DetailsField({
+  label,
+  value,
+  mono = true,
+  valueColor,
+  vertical = false,
+  className,
+}: DetailsFieldProps) {
+  return (
+    <div
+      data-component="mesh-details-field"
+      data-orientation={vertical ? "vertical" : "horizontal"}
+      className={className}
+      style={
+        vertical
+          ? { display: "flex", flexDirection: "column", gap: 2 }
+          : {
+              display: "grid",
+              gridTemplateColumns: "minmax(80px, 0.4fr) 1fr",
+              gap: 10,
+              alignItems: "baseline",
+              font: "400 12px var(--font-sans, system-ui, sans-serif)",
+            }
+      }
+    >
+      <span
+        data-slot="mesh-details-field-label"
+        style={{
+          color: "#5d7799",
+          font: vertical
+            ? "600 10px var(--font-sans, system-ui, sans-serif)"
+            : "400 12px var(--font-sans, system-ui, sans-serif)",
+          letterSpacing: vertical ? "0.08em" : undefined,
+          textTransform: vertical ? "uppercase" : undefined,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        data-slot="mesh-details-field-value"
+        style={{
+          color: valueColor ?? "#e9f0fc",
+          font: mono
+            ? "400 12px var(--font-mono, monospace)"
+            : "400 12px var(--font-sans, system-ui, sans-serif)",
+          wordBreak: "break-word",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/mesh/details/DetailsFooter.tsx
+++ b/web/src/components/mesh/details/DetailsFooter.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+export interface DetailsFooterProps {
+  /** Footer body — typically a row of primary / secondary buttons. */
+  children: ReactNode;
+  /** Render the buttons centered instead of right-aligned. */
+  align?: "start" | "center" | "end";
+  className?: string;
+}
+
+/**
+ * DetailsFooter — sticky bottom action bar inside a detail drawer.
+ *
+ * Mirrors the implicit footer pattern from `panopticon/project/details.jsx`
+ * (primary actions sat in the header card there; for non-trivial forms we
+ * promote them into a dedicated sticky footer to keep the CTA in reach as
+ * the body scrolls).
+ */
+export function DetailsFooter({
+  children,
+  align = "end",
+  className,
+}: DetailsFooterProps) {
+  const justify =
+    align === "center" ? "center" : align === "start" ? "flex-start" : "flex-end";
+  return (
+    <footer
+      data-component="mesh-details-footer"
+      className={className}
+      style={{
+        position: "sticky",
+        bottom: 0,
+        zIndex: 2,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: justify,
+        gap: 8,
+        padding: "12px 20px",
+        background: "hsl(var(--card))",
+        borderTop: "1px solid hsl(var(--border))",
+        backdropFilter: "saturate(140%) blur(6px)",
+      }}
+    >
+      {children}
+    </footer>
+  );
+}

--- a/web/src/components/mesh/details/DetailsHeader.tsx
+++ b/web/src/components/mesh/details/DetailsHeader.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Icon, type IconName } from "@/components/mesh/Icon";
+
+export interface DetailsHeaderProps {
+  /** Primary title — appears as the H1 of the surface. */
+  title: ReactNode;
+  /** Small uppercase pre-title shown above the H1 (e.g. "Device"). */
+  eyebrow?: ReactNode;
+  /**
+   * Optional iconic mark rendered to the left of the title block — mirrors the
+   * 64×64 framed glyph from the source `DeviceDetail` / `AgentDetail` shells.
+   */
+  icon?: IconName;
+  /** Optional accent colour for the icon glyph (defaults to mesh accent). */
+  iconColor?: string;
+  /**
+   * Meta row beneath the title — typically a mono key/value strip
+   * (`10.0.1.12 · a4:bb:6d:42:18:90 · DSM 7.2.1`).
+   */
+  meta?: ReactNode;
+  /** Secondary actions slot (right side of the header). */
+  actions?: ReactNode;
+  /** Close handler — when provided we render the trailing close glyph. */
+  onClose?: () => void;
+  className?: string;
+}
+
+/**
+ * DetailsHeader — sticky identity bar at the top of a detail drawer.
+ *
+ * Faithful port of the identity card from `panopticon/project/details.jsx`
+ * (`DeviceDetail` / `AgentDetail` shells). Pure presentational; consumers
+ * compose actions via the `actions` slot and wire the close affordance via
+ * `onClose` so it lives inside drawer or dialog scopes equally well.
+ */
+export function DetailsHeader({
+  title,
+  eyebrow,
+  icon,
+  iconColor = "#38bdf8",
+  meta,
+  actions,
+  onClose,
+  className,
+}: DetailsHeaderProps) {
+  return (
+    <header
+      data-component="mesh-details-header"
+      className={className}
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 2,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 16,
+        padding: "18px 20px",
+        background: "hsl(var(--card))",
+        borderBottom: "1px solid hsl(var(--border))",
+        backdropFilter: "saturate(140%) blur(6px)",
+      }}
+    >
+      {icon ? (
+        <div
+          data-slot="mesh-details-header-icon"
+          style={{
+            width: 56,
+            height: 56,
+            background: "#0e2148",
+            border: "1px solid rgba(96,144,212,0.40)",
+            borderRadius: "var(--radius)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: iconColor,
+            flexShrink: 0,
+          }}
+        >
+          <Icon name={icon} size={26} stroke={1.4} color={iconColor} />
+        </div>
+      ) : null}
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {eyebrow ? (
+          <div
+            data-slot="mesh-details-header-eyebrow"
+            style={{
+              font: "600 10px var(--font-sans, system-ui, sans-serif)",
+              letterSpacing: "0.10em",
+              textTransform: "uppercase",
+              color: "#5d7799",
+              marginBottom: 4,
+            }}
+          >
+            {eyebrow}
+          </div>
+        ) : null}
+        <h1
+          style={{
+            font: "600 20px var(--font-sans, system-ui, sans-serif)",
+            color: "#e9f0fc",
+            margin: 0,
+            lineHeight: 1.15,
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexWrap: "wrap",
+          }}
+        >
+          {title}
+        </h1>
+        {meta ? (
+          <div
+            data-slot="mesh-details-header-meta"
+            style={{
+              marginTop: 6,
+              font: "500 12px var(--font-mono, monospace)",
+              color: "#98aecf",
+              display: "flex",
+              gap: 14,
+              flexWrap: "wrap",
+              alignItems: "center",
+            }}
+          >
+            {meta}
+          </div>
+        ) : null}
+      </div>
+
+      {actions ? (
+        <div
+          data-slot="mesh-details-header-actions"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            flexShrink: 0,
+          }}
+        >
+          {actions}
+        </div>
+      ) : null}
+
+      {onClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          data-slot="mesh-details-header-close"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 28,
+            height: 28,
+            borderRadius: "var(--radius-sm, 6px)",
+            background: "transparent",
+            border: "1px solid transparent",
+            color: "#98aecf",
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+        >
+          <Icon name="x" size={14} />
+        </button>
+      ) : null}
+    </header>
+  );
+}

--- a/web/src/components/mesh/details/DetailsSection.tsx
+++ b/web/src/components/mesh/details/DetailsSection.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+import { Icon, type IconName } from "@/components/mesh/Icon";
+
+export interface DetailsSectionProps {
+  /** Section heading rendered as a small uppercase tracked label. */
+  title?: ReactNode;
+  /** Optional mesh icon glyph rendered before the title. */
+  icon?: IconName;
+  /** Right-aligned slot for a single secondary action / chip. */
+  action?: ReactNode;
+  /** Optional second-line subtitle / hint below the title. */
+  subtitle?: ReactNode;
+  /** Body content (cards, grids, charts). */
+  children?: ReactNode;
+  /** Render the section as a bare card (default `true`). */
+  card?: boolean;
+  className?: string;
+}
+
+/**
+ * DetailsSection — labelled block inside a drawer body.
+ *
+ * Faithful port of the body section pattern from
+ * `panopticon/project/details.jsx` ("Traffic · 24h", "Path · WAN → device",
+ * "Listening · 4 ports", etc.). Provides the consistent uppercase-tracked
+ * label + optional action slot contract every detail surface relies on.
+ */
+export function DetailsSection({
+  title,
+  icon,
+  action,
+  subtitle,
+  children,
+  card = true,
+  className,
+}: DetailsSectionProps) {
+  const body = (
+    <>
+      {title || action ? (
+        <div
+          data-slot="mesh-details-section-head"
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 12,
+            marginBottom: 10,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+            {icon ? <Icon name={icon} size={12} color="#5d7799" /> : null}
+            {title ? (
+              <h3
+                style={{
+                  font: "600 10px var(--font-sans, system-ui, sans-serif)",
+                  letterSpacing: "0.10em",
+                  textTransform: "uppercase",
+                  color: "#5d7799",
+                  margin: 0,
+                }}
+              >
+                {title}
+              </h3>
+            ) : null}
+            {subtitle ? (
+              <span
+                style={{
+                  font: "500 11px var(--font-mono, monospace)",
+                  color: "#5d7799",
+                }}
+              >
+                {subtitle}
+              </span>
+            ) : null}
+          </div>
+          {action ? (
+            <div
+              data-slot="mesh-details-section-action"
+              style={{ display: "flex", alignItems: "center", gap: 6 }}
+            >
+              {action}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      <div data-slot="mesh-details-section-body">{children}</div>
+    </>
+  );
+
+  return (
+    <section
+      data-component="mesh-details-section"
+      data-variant={card ? "card" : "bare"}
+      className={className}
+      style={
+        card
+          ? {
+              background: "hsl(var(--card))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: "var(--radius)",
+              padding: 14,
+            }
+          : { padding: 0 }
+      }
+    >
+      {body}
+    </section>
+  );
+}

--- a/web/src/components/mesh/details/DetailsTabs.tsx
+++ b/web/src/components/mesh/details/DetailsTabs.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+export interface DetailsTabItem {
+  /** Stable identifier used as the Radix `value`. */
+  value: string;
+  /** Visible label of the tab. */
+  label: ReactNode;
+  /** Optional small badge — typically a count chip (e.g. unread alerts). */
+  badge?: ReactNode;
+  /** Body content rendered when the tab is active. */
+  content?: ReactNode;
+  /** Disable the tab trigger. */
+  disabled?: boolean;
+}
+
+export interface DetailsTabsProps {
+  /** Tab definitions; first item is used as the default active tab. */
+  items: DetailsTabItem[];
+  /** Controlled active tab value. */
+  value?: string;
+  /** Change handler for controlled mode. */
+  onValueChange?: (value: string) => void;
+  /** Optional default tab when used uncontrolled. */
+  defaultValue?: string;
+  className?: string;
+  /** Slot rendered to the right of the tab triggers (e.g. filter chips). */
+  trailing?: ReactNode;
+}
+
+/**
+ * DetailsTabs — mesh-styled tab strip inside a detail drawer.
+ *
+ * Faithful port of the tab nav row from `panopticon/project/details.jsx`.
+ * Wraps shadcn `Tabs` primitive (already on mesh tokens after #771) and
+ * overrides the trigger styling to match the source: underline accent on the
+ * active trigger, `text-mute` for inactive, optional badge chip after the
+ * label.
+ */
+export function DetailsTabs({
+  items,
+  value,
+  onValueChange,
+  defaultValue,
+  className,
+  trailing,
+}: DetailsTabsProps) {
+  if (items.length === 0) return null;
+  const resolvedDefault = defaultValue ?? items[0]?.value;
+
+  return (
+    <Tabs
+      value={value}
+      defaultValue={resolvedDefault}
+      onValueChange={onValueChange}
+      data-component="mesh-details-tabs"
+      className={cn("flex flex-col", className)}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "0 20px",
+          borderBottom: "1px solid hsl(var(--border))",
+          background: "hsl(var(--card))",
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
+        }}
+      >
+        <TabsList
+          className={cn(
+            "h-auto bg-transparent border-0 p-0 gap-0 rounded-none",
+            "items-end",
+          )}
+        >
+          {items.map((item) => (
+            <TabsTrigger
+              key={item.value}
+              value={item.value}
+              disabled={item.disabled}
+              data-slot="mesh-details-tab-trigger"
+              className={cn(
+                "rounded-none px-3.5 py-2 text-[12.5px] font-medium",
+                "bg-transparent text-mesh-text-mute",
+                "border-b-2 border-transparent mb-[-1px]",
+                "data-[state=active]:bg-transparent data-[state=active]:text-mesh-text",
+                "data-[state=active]:font-semibold data-[state=active]:shadow-none",
+                "data-[state=active]:border-mesh-accent",
+                "hover:text-mesh-text",
+              )}
+            >
+              <span>{item.label}</span>
+              {item.badge != null ? (
+                <span
+                  data-slot="mesh-details-tab-badge"
+                  style={{
+                    marginLeft: 6,
+                    padding: "1px 5px",
+                    background: "rgba(244,63,94,0.18)",
+                    color: "#f43f5e",
+                    borderRadius: 3,
+                    font: "500 9.5px var(--font-mono, monospace)",
+                  }}
+                >
+                  {item.badge}
+                </span>
+              ) : null}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {trailing ? (
+          <div
+            data-slot="mesh-details-tabs-trailing"
+            style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}
+          >
+            {trailing}
+          </div>
+        ) : null}
+      </div>
+
+      {items.map((item) =>
+        item.content != null ? (
+          <TabsContent
+            key={item.value}
+            value={item.value}
+            className="m-0 px-5 py-4 outline-none"
+          >
+            {item.content}
+          </TabsContent>
+        ) : null,
+      )}
+    </Tabs>
+  );
+}

--- a/web/src/components/mesh/details/index.ts
+++ b/web/src/components/mesh/details/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Mesh detail surfaces — faithful port of `panopticon/project/details.jsx`.
+ *
+ * Shared vocabulary for entity detail drawers across mesh-direction routes
+ * (devices, alerts, agents, assets, ssh-hosts). Wraps the shadcn `Sheet` /
+ * `Dialog` primitives (already on mesh tokens after #771) and the mesh atoms
+ * shipped in #772 so per-route ports stop re-inventing modal layouts and IA.
+ *
+ * Pure presentational; no router or data-fetching coupling. Route-level
+ * adoption happens in the upcoming U1 / U5 / U6 PRs.
+ */
+
+export { DetailsDrawer } from "./DetailsDrawer";
+export type {
+  DetailsDrawerProps,
+  DetailsDrawerSide,
+} from "./DetailsDrawer";
+
+export { DetailsHeader } from "./DetailsHeader";
+export type { DetailsHeaderProps } from "./DetailsHeader";
+
+export { DetailsTabs } from "./DetailsTabs";
+export type { DetailsTabsProps, DetailsTabItem } from "./DetailsTabs";
+
+export { DetailsSection } from "./DetailsSection";
+export type { DetailsSectionProps } from "./DetailsSection";
+
+export { DetailsField } from "./DetailsField";
+export type { DetailsFieldProps } from "./DetailsField";
+
+export { DetailsFooter } from "./DetailsFooter";
+export type { DetailsFooterProps } from "./DetailsFooter";

--- a/web/tests/unit/mesh/details/DetailsDrawer.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsDrawer.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { isValidElement } from "react";
+import {
+  DetailsDrawer,
+  type DetailsDrawerSide,
+} from "@/components/mesh/details/DetailsDrawer";
+
+// Sheet / Dialog content is rendered through a Radix Portal, which is not
+// emitted by `renderToStaticMarkup` in a node-only test environment. We
+// therefore verify the drawer's static contract: it produces a valid React
+// tree for each variant, stays empty when closed, and forwards header /
+// tab / footer composition to its children without throwing.
+
+describe("DetailsDrawer", () => {
+  it("renders to an empty string when closed (overlay/portal stays inert)", () => {
+    const html = renderToStaticMarkup(
+      <DetailsDrawer open={false} onOpenChange={vi.fn()} title="closed">
+        <p>hidden-body</p>
+      </DetailsDrawer>,
+    );
+    expect(html).not.toContain("hidden-body");
+  });
+
+  it.each<DetailsDrawerSide>(["right", "left", "center"])(
+    "constructs a valid element for side=%s",
+    (side) => {
+      const el = (
+        <DetailsDrawer
+          open
+          onOpenChange={vi.fn()}
+          title="nas-01"
+          side={side}
+          eyebrow="Device"
+          footer={<button type="button">Save</button>}
+        >
+          <p>body</p>
+        </DetailsDrawer>
+      );
+      expect(isValidElement(el)).toBe(true);
+      // Should not throw during render even if portal output is opaque to SSR
+      expect(() => renderToStaticMarkup(el)).not.toThrow();
+    },
+  );
+
+  it("accepts a tabs payload without throwing", () => {
+    const el = (
+      <DetailsDrawer
+        open
+        onOpenChange={vi.fn()}
+        title="agent"
+        tabs={[
+          { value: "overview", label: "Overview", content: <p>ov</p> },
+          { value: "logs", label: "Logs", content: <p>logs</p> },
+        ]}
+      >
+        <p>extra</p>
+      </DetailsDrawer>
+    );
+    expect(() => renderToStaticMarkup(el)).not.toThrow();
+  });
+
+  it("falls back to a generic title for non-string titles", () => {
+    const el = (
+      <DetailsDrawer
+        open
+        onOpenChange={vi.fn()}
+        title={<span>complex</span>}
+        side="center"
+      >
+        <p>body</p>
+      </DetailsDrawer>
+    );
+    expect(() => renderToStaticMarkup(el)).not.toThrow();
+  });
+});

--- a/web/tests/unit/mesh/details/DetailsField.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsField.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DetailsField } from "@/components/mesh/details/DetailsField";
+
+describe("DetailsField", () => {
+  it("renders label and value", () => {
+    const html = renderToStaticMarkup(
+      <DetailsField label="endpoint" value="wss://core.lan/agent" />,
+    );
+    expect(html).toContain("endpoint");
+    expect(html).toContain("wss://core.lan/agent");
+    expect(html).toContain('data-component="mesh-details-field"');
+    expect(html).toContain('data-orientation="horizontal"');
+  });
+
+  it("supports the vertical orientation", () => {
+    const html = renderToStaticMarkup(
+      <DetailsField label="session" value="8a4f-3c92" vertical />,
+    );
+    expect(html).toContain('data-orientation="vertical"');
+  });
+
+  it("respects mono=false for sans value rendering", () => {
+    const html = renderToStaticMarkup(
+      <DetailsField label="hint" value="text" mono={false} />,
+    );
+    // Sans font stack should be applied to the value slot
+    expect(html).toMatch(/data-slot="mesh-details-field-value"[^>]*font-sans/);
+  });
+
+  it("applies a custom value colour when supplied", () => {
+    const html = renderToStaticMarkup(
+      <DetailsField label="retries" value="3 / 5" valueColor="#f59e0b" />,
+    );
+    expect(html).toContain("#f59e0b");
+  });
+});

--- a/web/tests/unit/mesh/details/DetailsFooter.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsFooter.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DetailsFooter } from "@/components/mesh/details/DetailsFooter";
+
+describe("DetailsFooter", () => {
+  it("renders children right-aligned by default", () => {
+    const html = renderToStaticMarkup(
+      <DetailsFooter>
+        <button type="button">Save</button>
+      </DetailsFooter>,
+    );
+    expect(html).toContain('data-component="mesh-details-footer"');
+    expect(html).toContain("Save");
+    expect(html).toContain("justify-content:flex-end");
+  });
+
+  it("supports the centered alignment", () => {
+    const html = renderToStaticMarkup(
+      <DetailsFooter align="center">
+        <button type="button">OK</button>
+      </DetailsFooter>,
+    );
+    expect(html).toContain("justify-content:center");
+  });
+
+  it("supports the start alignment", () => {
+    const html = renderToStaticMarkup(
+      <DetailsFooter align="start">
+        <button type="button">Back</button>
+      </DetailsFooter>,
+    );
+    expect(html).toContain("justify-content:flex-start");
+  });
+});

--- a/web/tests/unit/mesh/details/DetailsHeader.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsHeader.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DetailsHeader } from "@/components/mesh/details/DetailsHeader";
+
+describe("DetailsHeader", () => {
+  it("renders title, eyebrow and meta", () => {
+    const html = renderToStaticMarkup(
+      <DetailsHeader
+        eyebrow="Device"
+        title="nas-01"
+        meta={<span>10.0.1.12</span>}
+      />,
+    );
+    expect(html).toContain("Device");
+    expect(html).toContain("nas-01");
+    expect(html).toContain("10.0.1.12");
+    expect(html).toContain('data-component="mesh-details-header"');
+  });
+
+  it("renders the icon glyph when an icon name is supplied", () => {
+    const html = renderToStaticMarkup(
+      <DetailsHeader title="nas-01" icon="plug" />,
+    );
+    expect(html).toContain('data-slot="mesh-details-header-icon"');
+    expect(html).toMatch(/lucide-plug/);
+  });
+
+  it("renders the close affordance when onClose is provided", () => {
+    const html = renderToStaticMarkup(
+      <DetailsHeader title="nas-01" onClose={vi.fn()} />,
+    );
+    expect(html).toContain('data-slot="mesh-details-header-close"');
+    expect(html).toMatch(/lucide-x/);
+  });
+
+  it("renders the actions slot", () => {
+    const html = renderToStaticMarkup(
+      <DetailsHeader
+        title="nas-01"
+        actions={<button type="button">Trace path</button>}
+      />,
+    );
+    expect(html).toContain('data-slot="mesh-details-header-actions"');
+    expect(html).toContain("Trace path");
+  });
+});

--- a/web/tests/unit/mesh/details/DetailsSection.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsSection.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DetailsSection } from "@/components/mesh/details/DetailsSection";
+
+describe("DetailsSection", () => {
+  it("renders a card with a title and body", () => {
+    const html = renderToStaticMarkup(
+      <DetailsSection title="Traffic">
+        <p>chart</p>
+      </DetailsSection>,
+    );
+    expect(html).toContain('data-component="mesh-details-section"');
+    expect(html).toContain('data-variant="card"');
+    expect(html).toContain("Traffic");
+    expect(html).toContain("chart");
+  });
+
+  it("renders an action slot and subtitle", () => {
+    const html = renderToStaticMarkup(
+      <DetailsSection
+        title="Recent"
+        subtitle="last 24h"
+        action={<button type="button">All</button>}
+      >
+        <p>rows</p>
+      </DetailsSection>,
+    );
+    expect(html).toContain('data-slot="mesh-details-section-action"');
+    expect(html).toContain("last 24h");
+    expect(html).toContain("All");
+  });
+
+  it("renders bare variant without card chrome", () => {
+    const html = renderToStaticMarkup(
+      <DetailsSection title="bare" card={false}>
+        <p>body</p>
+      </DetailsSection>,
+    );
+    expect(html).toContain('data-variant="bare"');
+  });
+
+  it("renders an icon when an icon name is supplied", () => {
+    const html = renderToStaticMarkup(
+      <DetailsSection title="Ports" icon="ethernet">
+        <p>x</p>
+      </DetailsSection>,
+    );
+    expect(html).toMatch(/lucide-cable/);
+  });
+});

--- a/web/tests/unit/mesh/details/DetailsTabs.test.tsx
+++ b/web/tests/unit/mesh/details/DetailsTabs.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DetailsTabs } from "@/components/mesh/details/DetailsTabs";
+
+describe("DetailsTabs", () => {
+  it("renders nothing for an empty list", () => {
+    const html = renderToStaticMarkup(<DetailsTabs items={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("renders each tab label and the body of the default tab", () => {
+    const html = renderToStaticMarkup(
+      <DetailsTabs
+        items={[
+          { value: "overview", label: "Overview", content: <p>OV</p> },
+          { value: "traffic", label: "Traffic", content: <p>TR</p> },
+        ]}
+      />,
+    );
+    expect(html).toContain("Overview");
+    expect(html).toContain("Traffic");
+    expect(html).toContain('data-component="mesh-details-tabs"');
+    // Default-active body is rendered
+    expect(html).toContain("OV");
+  });
+
+  it("renders an optional badge chip after a tab label", () => {
+    const html = renderToStaticMarkup(
+      <DetailsTabs
+        items={[
+          { value: "alerts", label: "Alerts", badge: 2 },
+        ]}
+      />,
+    );
+    expect(html).toContain('data-slot="mesh-details-tab-badge"');
+    expect(html).toContain(">2<");
+  });
+
+  it("renders a trailing slot for filter chips", () => {
+    const html = renderToStaticMarkup(
+      <DetailsTabs
+        items={[{ value: "a", label: "A" }]}
+        trailing={<span>filter</span>}
+      />,
+    );
+    expect(html).toContain('data-slot="mesh-details-tabs-trailing"');
+    expect(html).toContain("filter");
+  });
+});


### PR DESCRIPTION
Foundation #771 + atoms #772 + states #773 + dashboard #774. Adds shared mesh detail surface for upcoming per-route ports. Pure presentational, no call site changes.

## Summary
- New `@/components/mesh/details/*` vocabulary: `DetailsDrawer`, `DetailsHeader`, `DetailsTabs`, `DetailsSection`, `DetailsField`, `DetailsFooter`.
- `DetailsDrawer` wraps shadcn `Sheet` (right/left) or `Dialog` (center) primitives that already consume mesh tokens after #771, and composes header + tabs + footer slots so per-route detail surfaces (devices, alerts, agents, assets, ssh-hosts) stop re-inventing modal IA.
- Faithful port of `panopticon/project/details.jsx`: 56×56 framed icon mark, mono meta row, sticky header + footer, mesh-accent underline on active tabs with optional count badge, uppercase-tracked section labels with optional icon and action slot, key/value pairs (mono by default).

## Implementation notes
- Header / Tabs / Section / Field / Footer compose `Icon` from `@/components/mesh/Icon` and inherit mesh tokens from `tailwind.config.ts` (`mesh-*`, `hsl(var(--card))`, `hsl(var(--border))`).
- `DetailsDrawer` exposes `side="right" | "left" | "center"`, `tabs`, `footer`, `header`, controlled tab value, and a description slot — sr-only `SheetTitle` / `DialogTitle` keep Radix a11y warnings quiet without pulling in a new dep.
- Pure presentational — no router, no SWR, no call site changes in this PR.

## Test plan
- [x] `bun run test` — 20 files / 86 tests pass (6 new test specs covering each component, mirroring the `renderToStaticMarkup` pattern from A1/A2).
- [x] `bun run build` — green, no new pages affected.
- [x] `cargo check` — clean (no backend touched).
- [ ] Visual / interactive verification will land with the per-route U1/U5/U6 ports that consume these surfaces.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `@/components/mesh/details/*` vocabulary — `DetailsDrawer`, `DetailsHeader`, `DetailsTabs`, `DetailsSection`, `DetailsField`, and `DetailsFooter` — as a pure presentational foundation for per-route detail surfaces, faithfully porting the `panoptikon/project/details.jsx` drawer/sheet IA. No call sites are wired in this PR.

- `DetailsDrawer` wraps shadcn `Sheet` (side variants) and `Dialog` (center variant) and composes header, tabs, and footer slots; it has a layout bug where the tabs wrapper is `flex-shrink-0` instead of `flex-1 min-h-0`, causing tab content to be clipped by the frame's `overflow-hidden`, and the `description` prop is silently dropped in the `center` variant.
- Six new unit tests use `renderToStaticMarkup` and cover each component's rendering contract; no Playwright E2E test is included despite the mandatory policy in `CLAUDE.md`.

<h3>Confidence Score: 3/5</h3>

The leaf components are individually safe, but DetailsDrawer has a flex-layout bug that will clip tab content in any drawer using the tabs prop.

The tab-content clipping issue will silently manifest in every route that uses DetailsDrawer with the tabs prop and long content — exactly the downstream U1/U5/U6 ports this PR is meant to unblock. The missing Playwright E2E test compounds the risk since portal/overlay behavior is invisible to renderToStaticMarkup.

web/src/components/mesh/details/DetailsDrawer.tsx — the tabs wrapper class and the missing DialogDescription for the center variant both need fixes before downstream ports consume this API.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/mesh/details/DetailsDrawer.tsx | Composes Sheet/Dialog primitives into a details surface; has a layout bug where the tabs wrapper uses `flex-shrink-0` instead of `flex-1 min-h-0`, causing tab content to overflow and be clipped, and the `description` prop is silently dropped for the center/Dialog variant. |
| web/src/components/mesh/details/DetailsTabs.tsx | Mesh-styled tab strip wrapping shadcn Tabs; correctly renders triggers, badge chips, and trailing slot; no logic issues found. |
| web/src/components/mesh/details/DetailsHeader.tsx | Sticky identity bar with icon mark, eyebrow, meta row, actions slot, and close affordance; pure presentational, no logic issues. |
| web/src/components/mesh/details/DetailsSection.tsx | Labelled card block with uppercase-tracked heading, optional icon, action slot, and bare/card variants; no logic issues. |
| web/src/components/mesh/details/DetailsField.tsx | Key/value pair component with horizontal/vertical orientation and mono font toggle; straightforward and correct. |
| web/src/components/mesh/details/DetailsFooter.tsx | Sticky bottom action bar with start/center/end alignment; correct implementation, no issues. |
| web/src/components/mesh/details/index.ts | Clean barrel export for all six components and their types; missing an E2E test per CLAUDE.md policy. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/components/mesh/details/DetailsDrawer.tsx:93-101
**Tab content clipped by `overflow-hidden` frame**

The outer frame is `flex flex-col overflow-hidden h-full`. The tabs wrapper uses `flex-shrink-0`, which prevents it from shrinking but does not bound its maximum height — with long tab content it grows past the frame boundary and gets clipped by `overflow-hidden`. The `flex-1 overflow-y-auto` body div that follows only holds extra `children`, not the tab panels. Changing the wrapper to `flex-1 min-h-0 overflow-y-auto` makes it fill remaining space and scroll independently, matching the same pattern the body div uses in the tabs-less case.

```suggestion
      {tabs && tabs.length > 0 ? (
        <div data-slot="mesh-details-drawer-tabs" className="flex-1 min-h-0 overflow-y-auto">
          <DetailsTabs
            items={tabs}
            value={tabValue}
            onValueChange={onTabValueChange}
          />
        </div>
      ) : null}
```

### Issue 2 of 4
web/src/components/mesh/details/index.ts:1-10
**Missing required Playwright E2E test**

`CLAUDE.md` mandates that every feature PR includes a Playwright test under `web/tests/e2e/`, or documents why in a `## Why No E2E Test` section in the PR description. This PR ships six new components, all unit-tested via `renderToStaticMarkup`, but no E2E spec exercises the rendered surfaces in a real browser. The PR description also does not include the required exemption section. Even a smoke-level spec that opens the `Sheet`/`Dialog` overlay for one variant and asserts the `data-component="mesh-details-drawer"` node is visible would satisfy the rule and catch portal/overlay regressions that `renderToStaticMarkup` misses entirely.

### Issue 3 of 4
web/src/components/mesh/details/DetailsDrawer.tsx:10
**`description` prop silently dropped for the `center` / Dialog variant**

The prop is documented as "Plain-text description for a11y (sr-only)" with no note that it only applies to sheet variants, but the Dialog render path neither imports nor renders `DialogDescription`. A consumer passing `description` when `side="center"` will silently get no accessible description on the dialog, which can trigger Radix a11y warnings and leaves screen-reader users without context.

```suggestion
import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
```

### Issue 4 of 4
web/src/components/mesh/details/DetailsDrawer.tsx:126-129
With `DialogDescription` now imported, render it `sr-only` alongside `DialogTitle` in the center variant when a description string is provided, mirroring the Sheet branch.

```suggestion
          <DialogTitle className="sr-only">
            {typeof title === "string" ? title : "Details"}
          </DialogTitle>
          {description ? (
            <DialogDescription className="sr-only">{description}</DialogDescription>
          ) : null}
          {body}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(u3): port details.jsx drawer/sheet ..."](https://github.com/befeast/panoptikon/commit/bc2fba549bca86020886960ae31ca29bf23dc0a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32531166)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->