### PR TITLE
U6 alerts: strict mesh port (chips + drawer + state recipes)

### DIFF
--- a/web/src/app/(app)/alerts/page.tsx
+++ b/web/src/app/(app)/alerts/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import {
   Activity,
   AlertTriangle,
@@ -8,18 +9,16 @@ import {
   Check,
   CheckCheck,
   ChevronDown,
+  Clock,
   Download,
+  Filter as FilterIcon,
   MonitorSmartphone,
   Shield,
   Trash2,
   VolumeX,
   Wifi,
-  X,
 } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import {
   Dialog,
@@ -30,6 +29,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "sonner";
+
+import {
   fetchAlerts,
   markAlertRead,
   markAlertUnread,
@@ -39,41 +46,97 @@ import {
   deleteAllAlerts,
   markAllAlertsRead,
 } from "@/lib/api";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import type { Alert } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
 import { downloadExport } from "@/lib/export";
-import { toast } from "sonner";
 import { useApiFetch } from "@/hooks/useApiFetch";
+import { useWsEvent } from "@/lib/ws";
 import { PageTransition } from "@/components/PageTransition";
 import { HelpTooltip } from "@/components/HelpTooltip";
-import { EmptyState } from "@/components/EmptyState";
-import { ErrorState } from "@/components/ErrorState";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
-function alertIcon(type: Alert["type"]) {
+import { LoadingState } from "@/components/mesh/state/LoadingState";
+import { EmptyState } from "@/components/mesh/state/EmptyState";
+import { ErrorState } from "@/components/mesh/state/ErrorState";
+import {
+  DetailsDrawer,
+  DetailsHeader,
+  DetailsTabs,
+  DetailsSection,
+  DetailsField,
+  DetailsFooter,
+} from "@/components/mesh/details";
+
+// Severity helpers
+type SevKey = "critical" | "warning" | "info" | "resolved";
+
+function sevFromAlert(alert: Alert): SevKey {
+  if (alert.acknowledged_at) return "resolved";
+  switch (alert.severity) {
+    case "CRITICAL":
+      return "critical";
+    case "WARNING":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+const SEV_COLOR: Record<SevKey, string> = {
+  critical: "#fb7185",
+  warning: "#fbbf24",
+  info: "#38bdf8",
+  resolved: "#4ade80",
+};
+
+const SEV_LABEL: Record<SevKey, string> = {
+  critical: "CRITICAL",
+  warning: "WARNING",
+  info: "INFO",
+  resolved: "RESOLVED",
+};
+
+function SevPill({ sev }: { sev: SevKey }) {
+  const color = SEV_COLOR[sev];
+  return (
+    <span
+      className="inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[9.5px] font-semibold uppercase tracking-[0.08em]"
+      style={{
+        background: `${color}1a`,
+        color,
+        borderColor: `${color}4d`,
+      }}
+    >
+      {SEV_LABEL[sev]}
+    </span>
+  );
+}
+
+function SevRail({ sev }: { sev: SevKey }) {
+  return (
+    <span
+      aria-hidden
+      className="absolute left-0 top-0 bottom-0 w-[2px] rounded-r"
+      style={{ background: SEV_COLOR[sev] }}
+    />
+  );
+}
+
+function alertIcon(type: Alert["type"], sev: SevKey) {
+  const color = SEV_COLOR[sev];
+  const cls = "h-4 w-4 shrink-0";
   switch (type) {
     case "new_device":
-      return <MonitorSmartphone className="h-5 w-5 text-mesh-primary" />;
+      return <MonitorSmartphone className={cls} style={{ color }} />;
     case "device_offline":
-      return <Wifi className="h-5 w-5 text-[#fb7185]" />;
+      return <Wifi className={cls} style={{ color }} />;
     case "device_online":
-      return <Wifi className="h-5 w-5 text-[#4ade80]" />;
+      return <Wifi className={cls} style={{ color }} />;
     case "agent_offline":
-      return <Activity className="h-5 w-5 text-[#fb7185]" />;
+      return <Activity className={cls} style={{ color }} />;
     case "high_bandwidth":
-      return <AlertTriangle className="h-5 w-5 text-[#fbbf24]" />;
+      return <AlertTriangle className={cls} style={{ color }} />;
     default:
-      return <Shield className="h-5 w-5 text-mesh-text-dim" />;
+      return <Shield className={cls} style={{ color }} />;
   }
 }
 
@@ -94,68 +157,125 @@ function alertTypeLabel(type: Alert["type"]): string {
   }
 }
 
-function severityBadge(severity: Alert["severity"]) {
-  switch (severity) {
-    case "CRITICAL":
-      return (
-        <Badge className="bg-[#fb7185]/20 text-[#fb7185] border-[#fb7185]/30 text-[10px] px-1.5 py-0">
-          CRITICAL
-        </Badge>
-      );
-    case "WARNING":
-      return (
-        <Badge className="bg-[#fbbf24]/20 text-[#fbbf24] border-[#fbbf24]/30 text-[10px] px-1.5 py-0">
-          WARNING
-        </Badge>
-      );
-    case "INFO":
-      return (
-        <Badge className="bg-mesh-primary/20 text-mesh-primary border-mesh-primary/30 text-[10px] px-1.5 py-0">
-          INFO
-        </Badge>
-      );
+// Filter chips
+type ChipKey = "all" | "critical" | "warning" | "info" | "ack";
+
+const CHIPS: { key: ChipKey; label: string; testid: string }[] = [
+  { key: "all", label: "All", testid: "filter-chip-all" },
+  { key: "critical", label: "Critical", testid: "filter-chip-critical" },
+  { key: "warning", label: "Warning", testid: "filter-chip-warning" },
+  { key: "info", label: "Info", testid: "filter-chip-info" },
+  { key: "ack", label: "Acknowledged", testid: "filter-chip-ack" },
+];
+
+function filterAlerts(alerts: Alert[], chip: ChipKey): Alert[] {
+  switch (chip) {
+    case "critical":
+      return alerts.filter((a) => !a.acknowledged_at && a.severity === "CRITICAL");
+    case "warning":
+      return alerts.filter((a) => !a.acknowledged_at && a.severity === "WARNING");
+    case "info":
+      return alerts.filter((a) => !a.acknowledged_at && a.severity === "INFO");
+    case "ack":
+      return alerts.filter((a) => !!a.acknowledged_at);
     default:
-      return null;
+      return alerts;
   }
 }
 
-type StatusFilter = "all" | "active" | "acknowledged";
-type TypeFilter = "all" | Alert["type"];
-
-const ALERT_TYPES: { value: TypeFilter; label: string }[] = [
-  { value: "all", label: "All Types" },
-  { value: "new_device", label: "New Device" },
-  { value: "device_online", label: "Online" },
-  { value: "device_offline", label: "Offline" },
-  { value: "agent_offline", label: "Agent Offline" },
-  { value: "high_bandwidth", label: "High Bandwidth" },
-];
-
 export default function AlertsPage() {
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  return (
+    <Suspense
+      fallback={
+        <div className="space-y-5" data-testid="alerts-root">
+          <LoadingState title="Loading alerts" message="Pulling open alerts…" tiles={0} rows={6} />
+        </div>
+      }
+    >
+      <AlertsPageInner />
+    </Suspense>
+  );
+}
+
+function AlertsPageInner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialChip = (searchParams.get("filter") as ChipKey) ?? "all";
+  const [chip, setChip] = useState<ChipKey>(
+    CHIPS.some((c) => c.key === initialChip) ? initialChip : "all",
+  );
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<string>("overview");
+
   const [ackDialogOpen, setAckDialogOpen] = useState(false);
   const [ackAlertId, setAckAlertId] = useState<string | null>(null);
   const [ackNote, setAckNote] = useState("");
   const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(new Set());
-  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
 
-  const status = statusFilter === "all" ? undefined : statusFilter;
-  const alertType = typeFilter === "all" ? undefined : typeFilter;
-  const { data: alerts, error, mutate } = useApiFetch<Alert[]>(
-    `/api/v1/alerts?status=${statusFilter}&type=${typeFilter}`,
+  const { data: alerts, error, mutate, isLoading } = useApiFetch<Alert[]>(
+    `/api/v1/alerts?all`,
     async () => {
-      const data = await fetchAlerts(100, status, undefined, alertType);
+      const data = await fetchAlerts(200);
       return Array.isArray(data) ? data : [];
     },
     { refreshInterval: 30_000 },
   );
 
+  // WS refresh on alert-related events
+  useWsEvent(
+    ["device_online", "device_offline", "new_device", "agent_offline", "agent_online"],
+    () => {
+      mutate();
+    },
+  );
+
+  // Sync chip -> URL
+  useEffect(() => {
+    const sp = new URLSearchParams(searchParams.toString());
+    if (chip === "all") {
+      sp.delete("filter");
+    } else {
+      sp.set("filter", chip);
+    }
+    const qs = sp.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chip]);
+
+  const counts = useMemo(() => {
+    const list = alerts ?? [];
+    const active = list.filter((a) => !a.acknowledged_at);
+    return {
+      all: list.length,
+      critical: active.filter((a) => a.severity === "CRITICAL").length,
+      warning: active.filter((a) => a.severity === "WARNING").length,
+      info: active.filter((a) => a.severity === "INFO").length,
+      ack: list.filter((a) => !!a.acknowledged_at).length,
+      unread: list.filter((a) => !a.is_read).length,
+      active: active.length,
+    };
+  }, [alerts]);
+
+  const filtered = useMemo(
+    () => filterAlerts(alerts ?? [], chip),
+    [alerts, chip],
+  );
+
   const selectedAlert = useMemo(() => {
-    if (!alerts?.length) return null;
-    return alerts.find((a) => a.id === selectedAlertId) ?? alerts[0];
+    if (!alerts || !selectedAlertId) return null;
+    return alerts.find((a) => a.id === selectedAlertId) ?? null;
   }, [alerts, selectedAlertId]);
+
+  const openDrawer = useCallback((alertId: string) => {
+    setSelectedAlertId(alertId);
+    setActiveTab("overview");
+    setDrawerOpen(true);
+  }, []);
 
   async function handleMarkRead(id: string) {
     try {
@@ -165,7 +285,7 @@ export default function AlertsPage() {
         { revalidate: false },
       );
     } catch {
-      // silently ignore
+      /* noop */
     }
   }
 
@@ -177,7 +297,7 @@ export default function AlertsPage() {
         { revalidate: false },
       );
     } catch {
-      // silently ignore
+      /* noop */
     }
   }
 
@@ -193,9 +313,7 @@ export default function AlertsPage() {
     try {
       await acknowledgeAlert(id, ackNote || undefined);
       setAckDialogOpen(false);
-      // Start strike-through animation
       setAcknowledgingIds((prev) => new Set(prev).add(id));
-      // After animation completes, update the alert state
       setTimeout(() => {
         setAcknowledgingIds((prev) => {
           const next = new Set(prev);
@@ -212,25 +330,27 @@ export default function AlertsPage() {
                     acknowledged_by: ackNote || null,
                     is_read: true,
                   }
-                : a
+                : a,
             ),
           { revalidate: false },
         );
-      }, 600);
+      }, 400);
+      toast.success("Alert acknowledged");
     } catch {
-      // silently ignore
+      toast.error("Failed to acknowledge");
     }
   }
 
   async function handleDeleteOne(id: string) {
     try {
       await deleteAlert(id);
-      mutate(
-        (prev) => (prev ?? []).filter((a) => a.id !== id),
-        { revalidate: false },
-      );
+      mutate((prev) => (prev ?? []).filter((a) => a.id !== id), { revalidate: false });
+      if (selectedAlertId === id) {
+        setDrawerOpen(false);
+        setSelectedAlertId(null);
+      }
     } catch {
-      // silently ignore
+      /* noop */
     }
   }
 
@@ -239,76 +359,104 @@ export default function AlertsPage() {
       await deleteAllAlerts();
       mutate([], { revalidate: false });
       setClearAllDialogOpen(false);
+      setDrawerOpen(false);
+      setSelectedAlertId(null);
+      toast.success("All alerts cleared");
     } catch {
-      // silently ignore
+      toast.error("Failed to clear alerts");
     }
   }
 
   async function handleMarkAllRead() {
     try {
       await markAllAlertsRead();
-      mutate(
-        (prev) => (prev ?? []).map((a) => ({ ...a, is_read: true })),
-        { revalidate: false },
-      );
+      mutate((prev) => (prev ?? []).map((a) => ({ ...a, is_read: true })), {
+        revalidate: false,
+      });
       toast.success("All alerts marked as read");
     } catch {
       toast.error("Failed to mark all as read");
     }
   }
 
-  async function handleMute(deviceId: string, hours: number) {
-    try {
-      await muteDevice(deviceId, hours);
-      if (hours > 0) {
-        toast.success(`Device muted for ${hours}h`);
-      } else {
-        toast.success("Device unmuted");
+  async function handleSnooze(alertId: string, hours: number) {
+    // Snooze maps onto mute when alert has device_id; otherwise just acknowledge.
+    const alert = (alerts ?? []).find((a) => a.id === alertId);
+    if (alert?.device_id) {
+      try {
+        await muteDevice(alert.device_id, hours);
+        toast.success(`Snoozed ${hours}h`);
+      } catch {
+        toast.error("Failed to snooze");
       }
-    } catch {
-      toast.error("Failed to mute device");
+    } else {
+      toast.message("Snooze unavailable", {
+        description: "No device target — acknowledge instead.",
+      });
     }
   }
 
   if (error) {
-    return <ErrorState message={error} onRetry={() => mutate()} />;
+    return (
+      <PageTransition>
+        <div className="space-y-6" data-testid="alerts-root">
+          <PageHeader counts={counts} disabled />
+          <ErrorState
+            title="Couldn't reach the alerts service"
+            message={String(error)}
+            onRetry={() => mutate()}
+          />
+        </div>
+      </PageTransition>
+    );
   }
-
-  const activeCount = (alerts ?? []).filter((a) => !a.acknowledged_at).length;
-  const acknowledgedCount = (alerts ?? []).filter((a) => !!a.acknowledged_at).length;
-  const criticalCount = (alerts ?? []).filter((a) => a.severity === "CRITICAL" && !a.acknowledged_at).length;
-  const warningCount = (alerts ?? []).filter((a) => a.severity === "WARNING" && !a.acknowledged_at).length;
-  const infoCount = (alerts ?? []).filter((a) => a.severity === "INFO" && !a.acknowledged_at).length;
 
   return (
     <PageTransition>
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Alerts</h1>
-          <HelpTooltip text="Notifications about network events — new devices, devices going offline, and security alerts. Configure rules in Settings → Alert Rules." />
-          {activeCount > 0 && (
-            <Badge variant="secondary" className="gap-1">
-              <Bell className="h-3 w-3" />
-              {activeCount} active
-            </Badge>
-          )}
-          {acknowledgedCount > 0 && (
-            <Badge variant="outline" className="gap-1 text-mesh-text-dim border-mesh-border-strong">
-              <Check className="h-3 w-3" />
-              {acknowledgedCount} acknowledged
-            </Badge>
-          )}
-        </div>
-        {alerts && alerts.length > 0 && (
-          <div className="flex items-center gap-2">
+      <div className="space-y-5" data-testid="alerts-root">
+        <PageHeader
+          counts={counts}
+          onMarkAllRead={counts.unread > 0 ? handleMarkAllRead : undefined}
+          onClearAll={counts.all > 0 ? () => setClearAllDialogOpen(true) : undefined}
+        />
+
+        {/* Filter chip strip */}
+        <div className="flex flex-wrap items-center gap-2">
+          {CHIPS.map((c) => {
+            const count = counts[c.key];
+            const active = chip === c.key;
+            return (
+              <button
+                key={c.key}
+                type="button"
+                data-testid={c.testid}
+                aria-pressed={active}
+                onClick={() => setChip(c.key)}
+                className={
+                  "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors " +
+                  (active
+                    ? "border-mesh-accent bg-mesh-primary-soft text-mesh-text"
+                    : "border-mesh-border bg-mesh-surface-1 text-mesh-text-mute hover:bg-mesh-surface-2 hover:text-mesh-text")
+                }
+              >
+                <span>{c.label}</span>
+                <span
+                  className="rounded font-mono text-[10.5px]"
+                  style={{ color: active ? undefined : "var(--mesh-text-mute)" }}
+                >
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+
+          <div className="ms-auto flex items-center gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="outline"
                   size="sm"
-                  className="border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text gap-1.5"
+                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text-dim hover:text-mesh-text gap-1.5"
                 >
                   <Download className="h-3.5 w-3.5" />
                   Export
@@ -319,9 +467,14 @@ export default function AlertsPage() {
                 <DropdownMenuItem
                   onClick={async () => {
                     try {
-                      await downloadExport("/api/v1/alerts/export?format=csv", "panoptikon-alerts.csv");
+                      await downloadExport(
+                        "/api/v1/alerts/export?format=csv",
+                        "panoptikon-alerts.csv",
+                      );
                       toast.success("Alerts exported as CSV");
-                    } catch { toast.error("Export failed"); }
+                    } catch {
+                      toast.error("Export failed");
+                    }
                   }}
                 >
                   Export CSV
@@ -329,414 +482,599 @@ export default function AlertsPage() {
                 <DropdownMenuItem
                   onClick={async () => {
                     try {
-                      await downloadExport("/api/v1/alerts/export?format=json", "panoptikon-alerts.json");
+                      await downloadExport(
+                        "/api/v1/alerts/export?format=json",
+                        "panoptikon-alerts.json",
+                      );
                       toast.success("Alerts exported as JSON");
-                    } catch { toast.error("Export failed"); }
+                    } catch {
+                      toast.error("Export failed");
+                    }
                   }}
                 >
                   Export JSON
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            {(alerts ?? []).some((a) => !a.is_read) && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text gap-1.5"
-                    onClick={handleMarkAllRead}
-                  >
-                    <CheckCheck className="h-3.5 w-3.5" />
-                    Mark all read
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
-                  Mark every unread alert as read
-                </TooltipContent>
-              </Tooltip>
-            )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="border-mesh-border-strong text-mesh-text-dim hover:text-[#fb7185] gap-1.5"
-                  onClick={() => setClearAllDialogOpen(true)}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Clear all
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
-                Permanently delete all alerts
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
-      </div>
-
-      {/* Filter tabs */}
-      <div className="static space-y-2">
-        <div className="static flex gap-2">
-          {(["all", "active", "acknowledged"] as StatusFilter[]).map((f) => (
-            <Button
-              key={f}
-              variant={statusFilter === f ? "default" : "outline"}
-              size="sm"
-              onClick={() => setStatusFilter(f)}
-              className={
-                statusFilter === f
-                  ? ""
-                  : "border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text"
-              }
-            >
-              {f === "all" ? "All" : f === "active" ? "Active" : "Acknowledged"}
-            </Button>
-          ))}
-        </div>
-
-        {/* Type filter */}
-        <div className="static flex gap-2 flex-wrap">
-          {ALERT_TYPES.map((t) => (
-            <Button
-              key={t.value}
-              variant={typeFilter === t.value ? "default" : "outline"}
-              size="sm"
-              onClick={() => setTypeFilter(t.value)}
-              className={
-                typeFilter === t.value
-                  ? ""
-                  : "border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text"
-              }
-            >
-              {t.value !== "all" && (
-                <span className="mr-1.5">{alertIcon(t.value as Alert["type"])}</span>
-              )}
-              {t.label}
-            </Button>
-          ))}
-        </div>
-      </div>
-
-      {/* Severity Summary Bar */}
-      {alerts && alerts.length > 0 && (criticalCount > 0 || warningCount > 0 || infoCount > 0) && (
-        <div className="flex items-center gap-3 rounded-lg border border-mesh-border bg-mesh-surface-1/95 px-4 py-2.5">
-          <span className="text-xs font-medium text-mesh-text-mute uppercase tracking-wider">Severity</span>
-          <div className="flex items-center gap-3">
-            {criticalCount > 0 && (
-              <Badge className="bg-[#fb7185]/20 text-[#fb7185] border-[#fb7185]/30 gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#fb7185]" />
-                {criticalCount} critical
-              </Badge>
-            )}
-            {warningCount > 0 && (
-              <Badge className="bg-[#fbbf24]/20 text-[#fbbf24] border-[#fbbf24]/30 gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#fbbf24]" />
-                {warningCount} warning
-              </Badge>
-            )}
-            {infoCount > 0 && (
-              <Badge className="bg-mesh-primary/20 text-mesh-primary border-mesh-primary/30 gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-mesh-primary" />
-                {infoCount} info
-              </Badge>
-            )}
           </div>
         </div>
-      )}
 
-      {/* Alert triage */}
-      {alerts === null ? (
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-          <div className="space-y-2">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Card key={i} className="border-mesh-border bg-mesh-surface-1/95">
-              <CardContent className="flex items-center gap-4 py-4">
-                <Skeleton className="h-10 w-10 rounded-full" />
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-4 w-48" />
-                  <Skeleton className="h-3 w-32" />
-                </div>
-                <Skeleton className="h-3 w-16" />
-              </CardContent>
-            </Card>
-          ))}
-          </div>
-          <Card className="hidden border-mesh-border bg-mesh-surface-1/95 lg:block">
-            <CardContent className="space-y-3 py-4">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-16 w-full" />
-              <Skeleton className="h-32 w-full" />
-            </CardContent>
-          </Card>
-        </div>
-      ) : alerts.length === 0 ? (
-        <Card className="border-mesh-border bg-mesh-surface-1/95">
-          <CardContent>
+        {/* Alert list / states */}
+        {isLoading && !alerts ? (
+          <LoadingState
+            title="Loading alerts"
+            message="Pulling open alerts and their history…"
+            tiles={0}
+            rows={6}
+          />
+        ) : filtered.length === 0 ? (
+          chip === "all" && counts.all === 0 ? (
             <EmptyState
-              icon={Shield}
-              title="All clear!"
-              description="No alerts right now. Alerts appear when new devices join, devices go offline, or configured rules are triggered."
-              variant="success"
-              actionLabel="Configure Alert Rules"
-              actionHref="/settings/alert-rules"
+              title="All clear"
+              message="No active alerts. New events from devices, agents, or rules will show up here."
+              action={
+                <Button asChild variant="outline" size="sm">
+                  <a href="/settings/alert-rules">
+                    <FilterIcon className="h-3.5 w-3.5" />
+                    <span>Configure rules</span>
+                  </a>
+                </Button>
+              }
             />
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-          <div className="min-w-0 rounded-lg border border-mesh-border bg-mesh-surface-1/95">
-            <div className="grid grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] gap-3 border-b border-mesh-border px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-mesh-text-mute max-md:hidden">
-              <span>Type</span>
-              <span>Message</span>
+          ) : (
+            <EmptyState
+              title="No alerts in this filter"
+              message={`Nothing matches "${CHIPS.find((c) => c.key === chip)?.label ?? chip}" right now. Try a different filter or clear it.`}
+              action={
+                <Button variant="outline" size="sm" onClick={() => setChip("all")}>
+                  Show all
+                </Button>
+              }
+            />
+          )
+        ) : (
+          <div className="overflow-hidden rounded-md border border-mesh-border bg-mesh-surface-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+            <div className="grid grid-cols-[32px_72px_minmax(0,1fr)_120px_120px] items-center gap-3 border-b border-mesh-border bg-mesh-surface-1/80 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-mesh-text-mute max-md:hidden">
+              <span />
+              <span>Severity</span>
+              <span>Event</span>
               <span>Age</span>
               <span className="text-right">Actions</span>
             </div>
-            <div className="divide-y divide-mesh-border">
-              {alerts.map((alert) => (
-                <div
-                  key={alert.id}
-                  role="button"
-                  data-testid="alert-row"
-                  tabIndex={0}
-                  onClick={() => setSelectedAlertId(alert.id)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      setSelectedAlertId(alert.id);
+            <ul className="divide-y divide-mesh-border">
+              {filtered.map((alert) => {
+                const sev = sevFromAlert(alert);
+                const animating = acknowledgingIds.has(alert.id);
+                const isSelected = selectedAlertId === alert.id && drawerOpen;
+                return (
+                  <li
+                    key={alert.id}
+                    data-testid="alert-row"
+                    data-severity={sev}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => openDrawer(alert.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        openDrawer(alert.id);
+                      }
+                    }}
+                    className={
+                      "relative grid cursor-pointer grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-3 px-3 py-3 transition-colors md:grid-cols-[32px_72px_minmax(0,1fr)_120px_120px] " +
+                      (animating
+                        ? "opacity-30"
+                        : isSelected
+                          ? "bg-mesh-surface-2"
+                          : "hover:bg-mesh-surface-2/60")
                     }
-                  }}
-                  className={`grid w-full grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-l-none border-mesh-border px-3 py-3 text-left transition-colors hover:bg-mesh-surface-2/55 lg:grid-cols-[2.25rem_minmax(0,1fr)_6rem_7.25rem] ${
-                    acknowledgingIds.has(alert.id)
-                      ? "animate-ack-strike opacity-0"
-                      : selectedAlert?.id === alert.id
-                        ? "bg-mesh-surface-1 shadow-[inset_2px_0_0_rgba(34,211,238,0.75)]"
-                        : !alert.is_read && !alert.acknowledged_at
-                          ? "bg-mesh-surface-1 shadow-[inset_2px_0_0_rgba(59,130,246,0.7)]"
-                          : ""
-                  }`}
-                >
-                  <span className={`flex h-8 w-8 items-center justify-center rounded-md border ${
-                    alert.acknowledged_at
-                      ? "border-mesh-border bg-mesh-surface-1/95 text-mesh-text-mute"
-                      : "border-mesh-border bg-mesh-surface-1"
-                  }`}>
-                    {alertIcon(alert.type)}
-                  </span>
-
-                  <span className="min-w-0">
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-[11px] font-semibold uppercase tracking-wider text-mesh-text-mute">
-                        {alertTypeLabel(alert.type)}
+                  >
+                    <SevRail sev={sev} />
+                    <span className="flex items-center justify-center">
+                      {alertIcon(alert.type, sev)}
+                    </span>
+                    <span className="max-md:hidden">
+                      <SevPill sev={sev} />
+                    </span>
+                    <span className="min-w-0">
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="truncate text-[11px] font-semibold uppercase tracking-wider text-mesh-text-mute">
+                          {alertTypeLabel(alert.type)}
+                        </span>
+                        {!alert.is_read && !alert.acknowledged_at && (
+                          <span
+                            aria-label="unread"
+                            className="h-1.5 w-1.5 rounded-full"
+                            style={{ background: SEV_COLOR.info }}
+                          />
+                        )}
+                        <span className="md:hidden">
+                          <SevPill sev={sev} />
+                        </span>
                       </span>
-                      {severityBadge(alert.severity)}
-                      {!alert.is_read && !alert.acknowledged_at && (
-                        <span className="h-1.5 w-1.5 rounded-full bg-mesh-primary" />
-                      )}
-                      {alert.acknowledged_at && (
-                        <Badge variant="outline" className="border-[#4ade80] px-1.5 py-0 text-[10px] text-[#4ade80]">
-                          ACK
-                        </Badge>
+                      <span
+                        className={
+                          "mt-0.5 block truncate text-[13px] " +
+                          (alert.acknowledged_at
+                            ? "text-mesh-text-mute"
+                            : !alert.is_read
+                              ? "font-medium text-mesh-text"
+                              : "text-mesh-text-dim")
+                        }
+                      >
+                        {alert.message}
+                      </span>
+                      {(alert.device_id || alert.agent_id) && (
+                        <span className="mt-1 block truncate font-mono text-[11px] text-mesh-text-mute">
+                          {alert.device_id
+                            ? `device · ${alert.device_id}`
+                            : `agent · ${alert.agent_id}`}
+                        </span>
                       )}
                     </span>
-                    <span className={`mt-0.5 block truncate text-sm ${
-                      alert.acknowledged_at
-                        ? "text-mesh-text-mute"
-                        : !alert.is_read
-                          ? "text-mesh-text"
-                          : "text-mesh-text-dim"
-                    }`}>
-                      {alert.message}
+                    <span className="shrink-0 font-mono text-[11px] text-mesh-text-mute max-md:hidden">
+                      <Clock className="me-1 inline h-3 w-3 align-[-2px]" />
+                      {timeAgo(alert.created_at)}
                     </span>
-                  </span>
-
-                  <span className="shrink-0 font-mono text-[11px] text-mesh-text-mute max-lg:hidden">
-                    {timeAgo(alert.created_at)}
-                  </span>
-
-                  <span className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
-                    {!alert.acknowledged_at && (
-                      alert.is_read ? (
-                        <Button variant="ghost" size="sm" className="h-7 px-2 text-mesh-text-mute hover:text-mesh-primary" onClick={() => handleMarkUnread(alert.id)} title="Mark unread">
-                          <Bell className="h-3.5 w-3.5" />
+                    <span
+                      className="flex items-center justify-end gap-1"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {!alert.acknowledged_at &&
+                        (alert.is_read ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-mesh-text-mute hover:text-mesh-accent"
+                            onClick={() => handleMarkUnread(alert.id)}
+                            title="Mark unread"
+                          >
+                            <Bell className="h-3.5 w-3.5" />
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-mesh-text-mute hover:text-mesh-text"
+                            onClick={() => handleMarkRead(alert.id)}
+                            title="Mark read"
+                          >
+                            <Check className="h-3.5 w-3.5" />
+                          </Button>
+                        ))}
+                      {!alert.acknowledged_at && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 px-2 text-mesh-text-mute hover:text-[#4ade80]"
+                          onClick={() => openAckDialog(alert.id)}
+                          title="Acknowledge"
+                        >
+                          <CheckCheck className="h-3.5 w-3.5" />
                         </Button>
-                      ) : (
-                        <Button variant="ghost" size="sm" className="h-7 px-2 text-mesh-text-mute hover:text-mesh-text" onClick={() => handleMarkRead(alert.id)} title="Mark read">
-                          <Check className="h-3.5 w-3.5" />
-                        </Button>
-                      )
-                    )}
-                    {!alert.acknowledged_at && (
-                      <Button variant="ghost" size="sm" className="h-7 px-2 text-mesh-text-mute hover:text-[#4ade80]" onClick={() => openAckDialog(alert.id)} title="Acknowledge">
-                        <CheckCheck className="h-3.5 w-3.5" />
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-mesh-text-mute hover:text-[#fb7185]"
+                        onClick={() => handleDeleteOne(alert.id)}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
                       </Button>
-                    )}
-                    <Button variant="ghost" size="sm" className="h-7 px-2 text-mesh-text-mute hover:text-[#fb7185]" onClick={() => handleDeleteOne(alert.id)} title="Delete alert">
-                      <X className="h-3.5 w-3.5" />
-                    </Button>
-                  </span>
-                </div>
-              ))}
-            </div>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
+        )}
 
-          {selectedAlert && (
-            <aside className="min-w-0 rounded-lg border border-mesh-border bg-mesh-surface-1/95 p-4 lg:sticky lg:top-4 lg:self-start">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-[11px] font-semibold uppercase tracking-wider text-mesh-text-mute">
-                    {alertTypeLabel(selectedAlert.type)}
-                  </p>
-                  <h2 className="mt-1 text-base font-semibold text-mesh-text">
-                    Alert detail
-                  </h2>
-                </div>
-                {severityBadge(selectedAlert.severity)}
-              </div>
+        {/* Details Drawer */}
+        <DetailsDrawer
+          open={drawerOpen}
+          onOpenChange={(open) => {
+            setDrawerOpen(open);
+            if (!open) setSelectedAlertId(null);
+          }}
+          data-testid="alert-drawer"
+        >
+          {selectedAlert ? (
+            <AlertDrawerBody
+              alert={selectedAlert}
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              onAcknowledge={() => openAckDialog(selectedAlert.id)}
+              onSnooze={(hours) => handleSnooze(selectedAlert.id, hours)}
+              onDelete={() => handleDeleteOne(selectedAlert.id)}
+              onMarkRead={() => handleMarkRead(selectedAlert.id)}
+              onMarkUnread={() => handleMarkUnread(selectedAlert.id)}
+            />
+          ) : null}
+        </DetailsDrawer>
 
-              <p className="mt-4 text-sm leading-6 text-mesh-text">
-                {selectedAlert.message}
-              </p>
-              {selectedAlert.details && (
-                <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap rounded-md border border-mesh-border bg-mesh-surface-1/95 p-3 text-xs leading-5 text-mesh-text-dim">
-                  {selectedAlert.details}
-                </pre>
-              )}
+        {/* Acknowledge Dialog */}
+        <Dialog open={ackDialogOpen} onOpenChange={setAckDialogOpen}>
+          <DialogContent className="border-mesh-border bg-mesh-surface-1">
+            <DialogHeader>
+              <DialogTitle>Acknowledge Alert</DialogTitle>
+              <DialogDescription>
+                Optionally add a note about why this alert is being acknowledged.
+              </DialogDescription>
+            </DialogHeader>
+            <Input
+              placeholder="Add a note (optional)..."
+              value={ackNote}
+              onChange={(e) => setAckNote(e.target.value)}
+              className="border-mesh-border bg-mesh-surface-2"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAcknowledge();
+              }}
+            />
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setAckDialogOpen(false)}
+                className="border-mesh-border"
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleAcknowledge}>Acknowledge</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
-              <div className="mt-4 space-y-2 border-t border-mesh-border pt-4 text-xs">
-                <TriageRow label="Created" value={new Date(selectedAlert.created_at).toLocaleString()} />
-                <TriageRow label="Status" value={selectedAlert.acknowledged_at ? "Acknowledged" : selectedAlert.is_read ? "Read" : "Unread"} />
-                {selectedAlert.device_id && <TriageRow label="Device" value={selectedAlert.device_id} mono />}
-                {selectedAlert.agent_id && <TriageRow label="Agent" value={selectedAlert.agent_id} mono />}
-                {selectedAlert.acknowledged_by && <TriageRow label="Note" value={selectedAlert.acknowledged_by} />}
-              </div>
-
-              <div className="mt-4 grid grid-cols-2 gap-2">
-                {!selectedAlert.acknowledged_at && (
-                  <Button size="sm" className="gap-1.5" onClick={() => openAckDialog(selectedAlert.id)}>
-                    <CheckCheck className="h-3.5 w-3.5" />
-                    Acknowledge
-                  </Button>
-                )}
-                {selectedAlert.is_read ? (
-                  <Button variant="outline" size="sm" className="gap-1.5 border-mesh-border-strong text-mesh-text hover:text-white" onClick={() => handleMarkUnread(selectedAlert.id)}>
-                    <Bell className="h-3.5 w-3.5" />
-                    Mark unread
-                  </Button>
-                ) : (
-                  <Button variant="outline" size="sm" className="gap-1.5 border-mesh-border-strong text-mesh-text hover:text-white" onClick={() => handleMarkRead(selectedAlert.id)}>
-                    <Check className="h-3.5 w-3.5" />
-                    Mark read
-                  </Button>
-                )}
-                {selectedAlert.device_id && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="sm" className="gap-1.5 border-mesh-border-strong text-mesh-text hover:text-white">
-                        <VolumeX className="h-3.5 w-3.5" />
-                        Mute
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {[1, 8, 24].map((hours) => (
-                        <DropdownMenuItem key={hours} onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, hours)}>
-                          Mute {hours}h
-                        </DropdownMenuItem>
-                      ))}
-                      <DropdownMenuItem onClick={() => selectedAlert.device_id && handleMute(selectedAlert.device_id, 0)}>
-                        Unmute
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-                <Button variant="outline" size="sm" className="gap-1.5 border-mesh-border-strong text-mesh-text hover:text-[#fb7185]" onClick={() => handleDeleteOne(selectedAlert.id)}>
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Delete
-                </Button>
-              </div>
-            </aside>
-          )}
-        </div>
-      )}
-
-      {/* Acknowledge Dialog */}
-      <Dialog open={ackDialogOpen} onOpenChange={setAckDialogOpen}>
-        <DialogContent className="bg-mesh-surface-1/95 border-mesh-border">
-          <DialogHeader>
-            <DialogTitle>Acknowledge Alert</DialogTitle>
-            <DialogDescription>
-              Optionally add a note about why this alert is being acknowledged.
-            </DialogDescription>
-          </DialogHeader>
-          <Input
-            placeholder="Add a note (optional)..."
-            value={ackNote}
-            onChange={(e) => setAckNote(e.target.value)}
-            className="bg-[#12121a] border-mesh-border-strong"
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleAcknowledge();
-            }}
-          />
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setAckDialogOpen(false)}
-              className="border-mesh-border-strong"
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleAcknowledge}>Acknowledge</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Clear All Confirmation Dialog */}
-      <Dialog open={clearAllDialogOpen} onOpenChange={setClearAllDialogOpen}>
-        <DialogContent className="bg-mesh-surface-1/95 border-mesh-border">
-          <DialogHeader>
-            <DialogTitle>Delete All Alerts</DialogTitle>
-            <DialogDescription>
-              Delete all {alerts?.length ?? 0} alerts? This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setClearAllDialogOpen(false)}
-              className="border-mesh-border-strong"
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteAll}
-            >
-              Delete all
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+        {/* Clear-all Dialog */}
+        <Dialog open={clearAllDialogOpen} onOpenChange={setClearAllDialogOpen}>
+          <DialogContent className="border-mesh-border bg-mesh-surface-1">
+            <DialogHeader>
+              <DialogTitle>Delete All Alerts</DialogTitle>
+              <DialogDescription>
+                Delete all {counts.all} alerts? This cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setClearAllDialogOpen(false)}
+                className="border-mesh-border"
+              >
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={handleDeleteAll}>
+                Delete all
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
     </PageTransition>
   );
 }
 
-function TriageRow({
-  label,
-  value,
-  mono,
+// Header
+function PageHeader({
+  counts,
+  onMarkAllRead,
+  onClearAll,
+  disabled,
 }: {
-  label: string;
-  value: string;
-  mono?: boolean;
+  counts: {
+    all: number;
+    critical: number;
+    warning: number;
+    info: number;
+    ack: number;
+    unread: number;
+    active: number;
+  };
+  onMarkAllRead?: () => void;
+  onClearAll?: () => void;
+  disabled?: boolean;
 }) {
   return (
-    <div className="flex items-baseline justify-between gap-4">
-      <span className="shrink-0 font-semibold uppercase tracking-wider text-mesh-text-mute">{label}</span>
-      <span className={`min-w-0 truncate text-right text-mesh-text-dim ${mono ? "font-mono tabular-nums" : ""}`} title={value}>
-        {value}
-      </span>
-    </div>
+    <header className="flex flex-wrap items-end justify-between gap-3">
+      <div>
+        <div className="font-mono text-[10.5px] font-medium uppercase tracking-[0.16em] text-mesh-text-mute">
+          Operations
+        </div>
+        <div className="mt-1 flex items-center gap-2">
+          <h1 className="m-0 text-[24px] font-semibold tracking-tight text-mesh-text">
+            Alerts
+          </h1>
+          <HelpTooltip text="Network events that need attention — devices joining/leaving, agents going offline, and configured rule violations." />
+        </div>
+        <div className="mt-1 font-mono text-[12px] text-mesh-text-mute">
+          {counts.all} total
+          {" · "}
+          <span style={{ color: counts.critical > 0 ? SEV_COLOR.critical : undefined }}>
+            {counts.critical} critical
+          </span>
+          {" · "}
+          <span style={{ color: counts.warning > 0 ? SEV_COLOR.warning : undefined }}>
+            {counts.warning} warning
+          </span>
+          {" · "}
+          {counts.unread} unread
+          {" · "}
+          {counts.ack} acknowledged
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {onMarkAllRead && (
+          <Button
+            data-testid="alerts-mark-all-read"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            onClick={onMarkAllRead}
+            className="border-mesh-border bg-mesh-surface-1 text-mesh-text-dim hover:text-mesh-text gap-1.5"
+          >
+            <CheckCheck className="h-3.5 w-3.5" />
+            Mark all read
+          </Button>
+        )}
+        {onClearAll && (
+          <Button
+            data-testid="alerts-clear-all"
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            onClick={onClearAll}
+            className="border-mesh-border bg-mesh-surface-1 text-mesh-text-dim hover:text-[#fb7185] gap-1.5"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Clear all
+          </Button>
+        )}
+      </div>
+    </header>
+  );
+}
+
+// Drawer body
+function AlertDrawerBody({
+  alert,
+  activeTab,
+  onTabChange,
+  onAcknowledge,
+  onSnooze,
+  onDelete,
+  onMarkRead,
+  onMarkUnread,
+}: {
+  alert: Alert;
+  activeTab: string;
+  onTabChange: (id: string) => void;
+  onAcknowledge: () => void;
+  onSnooze: (hours: number) => void;
+  onDelete: () => void;
+  onMarkRead: () => void;
+  onMarkUnread: () => void;
+}) {
+  const sev = sevFromAlert(alert);
+  const iconName =
+    alert.type === "agent_offline"
+      ? ("agent" as const)
+      : alert.type === "high_bandwidth"
+        ? ("alert" as const)
+        : alert.type === "new_device"
+          ? ("device" as const)
+          : ("plug" as const);
+
+  return (
+    <>
+      <DetailsHeader
+        icon={iconName}
+        iconColor={SEV_COLOR[sev]}
+        title={alertTypeLabel(alert.type)}
+        pills={<SevPill sev={sev} />}
+        meta={
+          <span>
+            {alert.device_id ? `device · ${alert.device_id}` : null}
+            {alert.agent_id ? `agent · ${alert.agent_id}` : null}
+            {!alert.device_id && !alert.agent_id ? "system" : null}
+            {" · "}
+            {timeAgo(alert.created_at)}
+          </span>
+        }
+      />
+      <DetailsTabs
+        tabs={[
+          { id: "overview", label: "Overview" },
+          { id: "activity", label: "Activity" },
+          { id: "source", label: "Source" },
+        ]}
+        active={activeTab}
+        onChange={onTabChange}
+      />
+      <div className="flex-1 overflow-auto p-4">
+        {activeTab === "overview" && (
+          <div className="flex flex-col gap-4">
+            <DetailsSection title="Message">
+              <p className="text-[13px] leading-6 text-mesh-text">{alert.message}</p>
+              {alert.details ? (
+                <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap rounded-md border border-mesh-border bg-mesh-surface-2 p-3 font-mono text-[11.5px] leading-5 text-mesh-text-dim">
+                  {alert.details}
+                </pre>
+              ) : null}
+            </DetailsSection>
+            <DetailsSection title="Metadata">
+              <DetailsField label="created" value={new Date(alert.created_at).toLocaleString()} />
+              <DetailsField
+                label="status"
+                value={
+                  alert.acknowledged_at
+                    ? "acknowledged"
+                    : alert.is_read
+                      ? "read"
+                      : "unread"
+                }
+                valueColor={
+                  alert.acknowledged_at
+                    ? SEV_COLOR.resolved
+                    : alert.is_read
+                      ? undefined
+                      : SEV_COLOR.info
+                }
+              />
+              <DetailsField label="severity" value={alert.severity} />
+              <DetailsField label="type" value={alert.type} />
+              {alert.device_id ? (
+                <DetailsField label="device" value={alert.device_id} />
+              ) : null}
+              {alert.agent_id ? (
+                <DetailsField label="agent" value={alert.agent_id} />
+              ) : null}
+              {alert.acknowledged_by ? (
+                <DetailsField label="note" value={alert.acknowledged_by} />
+              ) : null}
+              {alert.acknowledged_at ? (
+                <DetailsField
+                  label="ack at"
+                  value={new Date(alert.acknowledged_at).toLocaleString()}
+                />
+              ) : null}
+            </DetailsSection>
+          </div>
+        )}
+        {activeTab === "activity" && (
+          <DetailsSection title="History">
+            <ul className="flex flex-col gap-2 font-mono text-[11.5px] text-mesh-text-dim">
+              <li>
+                <span className="text-mesh-text">{new Date(alert.created_at).toLocaleTimeString()}</span>{" "}
+                alert raised
+              </li>
+              {alert.is_read ? (
+                <li>
+                  <span className="text-mesh-text">—</span> marked read
+                </li>
+              ) : null}
+              {alert.acknowledged_at ? (
+                <li>
+                  <span className="text-mesh-text">
+                    {new Date(alert.acknowledged_at).toLocaleTimeString()}
+                  </span>{" "}
+                  acknowledged{alert.acknowledged_by ? ` · ${alert.acknowledged_by}` : ""}
+                </li>
+              ) : null}
+            </ul>
+          </DetailsSection>
+        )}
+        {activeTab === "source" && (
+          <DetailsSection title="Source">
+            <DetailsField label="origin" value={alert.type} />
+            {alert.device_id ? (
+              <DetailsField
+                label="device"
+                value={
+                  <a
+                    className="text-mesh-accent underline-offset-2 hover:underline"
+                    href={`/devices?focus=${alert.device_id}`}
+                  >
+                    {alert.device_id}
+                  </a>
+                }
+              />
+            ) : null}
+            {alert.agent_id ? (
+              <DetailsField
+                label="agent"
+                value={
+                  <a
+                    className="text-mesh-accent underline-offset-2 hover:underline"
+                    href={`/agents?focus=${alert.agent_id}`}
+                  >
+                    {alert.agent_id}
+                  </a>
+                }
+              />
+            ) : null}
+            <p className="mt-2 text-[11.5px] text-mesh-text-mute">
+              Related rules and dependent topology will appear here once the backend exposes a
+              dedicated source endpoint (TODO).
+            </p>
+          </DetailsSection>
+        )}
+      </div>
+      <DetailsFooter
+        hint={
+          alert.acknowledged_at
+            ? `acknowledged ${timeAgo(alert.acknowledged_at)}`
+            : alert.is_read
+              ? "read · awaiting ack"
+              : "unread"
+        }
+        actions={
+          <>
+            {!alert.acknowledged_at && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-mesh-border"
+                  onClick={() => onSnooze(1)}
+                >
+                  <VolumeX className="h-3.5 w-3.5" />
+                  1h
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-mesh-border"
+                  onClick={() => onSnooze(4)}
+                >
+                  4h
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-mesh-border"
+                  onClick={() => onSnooze(24)}
+                >
+                  24h
+                </Button>
+              </>
+            )}
+            {alert.acknowledged_at ? null : alert.is_read ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-mesh-border"
+                onClick={onMarkUnread}
+              >
+                <Bell className="h-3.5 w-3.5" />
+                Mark unread
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-mesh-border"
+                onClick={onMarkRead}
+              >
+                <Check className="h-3.5 w-3.5" />
+                Mark read
+              </Button>
+            )}
+            {!alert.acknowledged_at && (
+              <Button size="sm" onClick={onAcknowledge} className="gap-1.5">
+                <CheckCheck className="h-3.5 w-3.5" />
+                Acknowledge
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-mesh-border text-mesh-text-mute hover:text-[#fb7185]"
+              onClick={onDelete}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete
+            </Button>
+          </>
+        }
+      />
+    </>
   );
 }

--- a/web/tests/e2e/alerts-mesh-layout.spec.ts
+++ b/web/tests/e2e/alerts-mesh-layout.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, login } from '../../e2e/fixtures';
+
+test.describe('Alerts mesh layout (U6)', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('renders mesh header + filter chips + persists filter via URL', async ({ page }) => {
+    await page.goto('/alerts/');
+
+    // Root marker present
+    await expect(page.getByTestId('alerts-root')).toBeVisible({ timeout: 15000 });
+
+    // Operations eyebrow + heading
+    await expect(page.getByText('Operations', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Alerts', level: 1 })).toBeVisible();
+
+    // All five filter chips render
+    for (const id of [
+      'filter-chip-all',
+      'filter-chip-critical',
+      'filter-chip-warning',
+      'filter-chip-info',
+      'filter-chip-ack',
+    ]) {
+      await expect(page.getByTestId(id)).toBeVisible();
+    }
+
+    // Activate Critical chip -> URL gains ?filter=critical
+    await page.getByTestId('filter-chip-critical').click();
+    await page.waitForFunction(() => window.location.search.includes('filter=critical'), null, {
+      timeout: 5000,
+    });
+    expect(page.url()).toContain('filter=critical');
+
+    // Reload preserves the chip selection via URL deeplink
+    await page.reload();
+    await expect(page.getByTestId('alerts-root')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('filter-chip-critical')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    // Reset to All -> URL drops the param
+    await page.getByTestId('filter-chip-all').click();
+    await page.waitForFunction(() => !window.location.search.includes('filter='), null, {
+      timeout: 5000,
+    });
+
+    await page.screenshot({ path: 'tests/screenshots/alerts-mesh-layout.png', fullPage: true });
+  });
+
+  test('clicking an alert row opens the details drawer (when any present)', async ({ page }) => {
+    await page.goto('/alerts/');
+    await expect(page.getByTestId('alerts-root')).toBeVisible({ timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+
+    const rows = page.getByTestId('alert-row');
+    const count = await rows.count();
+    if (count === 0) {
+      // No alerts in this DB — assert empty state copy and bail.
+      await expect(page.getByText(/all clear|no alerts in this filter/i)).toBeVisible();
+      return;
+    }
+
+    await rows.first().click();
+    await expect(page.getByTestId('alert-drawer')).toBeVisible({ timeout: 5000 });
+    // Tabs render
+    await expect(page.getByTestId('details-tab-overview')).toBeVisible();
+    await expect(page.getByTestId('details-tab-activity')).toBeVisible();
+    await expect(page.getByTestId('details-tab-source')).toBeVisible();
+    // Tab switching works
+    await page.getByTestId('details-tab-activity').click();
+    await expect(page.getByTestId('details-tab-activity')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await page.screenshot({ path: 'tests/screenshots/alerts-drawer.png', fullPage: true });
+  });
+});

--- a/web/tests/e2e/alerts.spec.ts
+++ b/web/tests/e2e/alerts.spec.ts
@@ -47,24 +47,13 @@ test.describe('Alerts page', () => {
       }
     }
 
-    // Also check the UI: filter to Agent Offline type and verify no
-    // adjacent cards show the exact same message text.
-    await page.getByRole('button', { name: /Agent Offline/i }).click();
-    await page.waitForTimeout(500);
-
-    const cards = await page.locator('[class*="card"], [class*="Card"]').all();
-    const messages: string[] = [];
-    for (const card of cards) {
-      const text = await card.textContent();
-      if (text) messages.push(text.trim());
-    }
-
-    // Consecutive identical card text would indicate duplicates.
-    for (let i = 1; i < messages.length; i++) {
-      if (messages[i] === messages[i - 1]) {
-        // Allow if timestamps differ — same message with different times is OK.
-        // But exact duplicates (same card text) indicate a problem.
-        expect(messages[i]).not.toBe(messages[i - 1]);
+    // Also check the UI: there is no per-type filter chip in the renewed
+    // alerts layout (U6), so verify no two alert-row testids contain the
+    // exact same text (which would indicate a UI duplicate).
+    const rowTexts = await page.getByTestId('alert-row').allTextContents();
+    for (let i = 1; i < rowTexts.length; i++) {
+      if (rowTexts[i] === rowTexts[i - 1]) {
+        expect(rowTexts[i]).not.toBe(rowTexts[i - 1]);
       }
     }
 


### PR DESCRIPTION
## Summary

Strict port of `/alerts` to the mesh direction matching the source design
in `panopticon/project/alerts-login.jsx` and `states.jsx`.

- **Page header**: `OPERATIONS` eyebrow + `Alerts` h1 + mono status line
  (total, critical, warning, unread, ack counts) and `Mark all read` /
  `Clear all` action cluster.
- **Filter chip strip** with counts: All / Critical / Warning / Info /
  Acknowledged. Active chip persists via the `?filter=` URL param so the
  selection survives reloads.
- **Alert list** uses severity-coded left rail (`#fb7185` / `#fbbf24` /
  `#38bdf8` / `#4ade80` from tokens.css), mono age, message + source +
  target meta. Row click opens the details drawer; row-level Ack / Mark
  read / Delete buttons remain available.
- **DetailsDrawer** composes `DetailsHeader` + `DetailsTabs` (Overview /
  Activity / Source) + `DetailsSection` + `DetailsField` + `DetailsFooter`
  with Snooze 1h/4h/24h, Acknowledge, Mark read/unread, and Delete actions.
- **Empty / loading / error** states use `@/components/mesh/state` recipes
  with state-aware copy (`No alerts in this filter` vs `All clear`).

## Atoms / state / drawer used

- `mesh/state/{LoadingState, EmptyState, ErrorState}`
- `mesh/details/{DetailsDrawer, DetailsHeader, DetailsTabs, DetailsSection, DetailsField, DetailsFooter}`
- shadcn `Button`, `Input`, `Dialog`, `DropdownMenu` primitives only
- No new colors — only `mesh-*` aliases and literal hex from tokens.css

## Backend gaps / TODO

- `Snooze` for alerts without a `device_id` falls back to a toast hint —
  no general per-alert snooze endpoint exists yet.
- `Source` tab links to device / agent IDs but cannot yet show the rule
  that fired the alert — backend needs to expose `source_rule` on the
  Alert payload.
- `Activity` tab synthesises history from `is_read`/`acknowledged_at` —
  proper audit log endpoint is still missing.

## Test plan

- [x] Frontend Build (`bun run build`) green; static export rendered for
  `/alerts`.
- [x] `web/scripts/check-design-tokens.sh` clean — no raw Tailwind color
  literals.
- [x] `bun run test` (vitest) — 66/66.
- [x] `cargo check` — clean.
- [x] `bunx playwright test tests/e2e/alerts*.spec.ts` — 6 passed,
  1 skipped (pre-existing).
- [x] New `alerts-mesh-layout.spec.ts`: header + 5 filter chips visible,
  `Critical` chip persists across reload via URL, drawer + tabs open on
  row click.
- [x] Updated `alerts.spec.ts` to drop the now-removed `Agent Offline`
  type-filter button; duplicate detection now reads `alert-row` testids.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Strict mesh port of the `/alerts` page: replaces the old sidebar+badge layout with filter chips (URL-persisted via `?filter=`), a severity-coded left-rail list, and a `DetailsDrawer` with Overview / Activity / Source tabs. New E2E spec covers the header, all five chips, URL deeplink round-trip, and drawer interaction.

- `page.tsx` is a near-complete rewrite touching fetching strategy, state management, and all presentation components; two logic gaps need attention before merge.
- The fetch now retrieves a flat list of 200 alerts and filters client-side; all chip counts and the header status line derive from that slice, which can undercount in high-volume deployments.
- `handleMarkRead`, `handleMarkUnread`, and `handleDeleteOne` still swallow errors silently while the other handlers in the same PR were updated to emit `toast.error`.

<h3>Confidence Score: 3/5</h3>

The UI migration is well-structured but two logic issues in page.tsx should be resolved before this ships to production users.

The fetch-cap change means the header status line and filter chip counts can silently show wrong numbers for any deployment with more than 200 total alerts, and the Critical chip could display zero even when critical alerts exist outside the fetched window. Three row-level action handlers were not updated to emit error toasts, so failed API calls produce an optimistic UI update that silently reverts on the next 30-second poll with no user signal.

web/src/app/(app)/alerts/page.tsx — the fetch limit and silent error handling both live here.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/alerts/page.tsx | Major rewrite adding filter chips with URL persistence, DetailsDrawer, and mesh state components. Two logic issues: fetchAlerts(200) cap causes incorrect counts in high-volume deployments; handleMarkRead/handleMarkUnread/handleDeleteOne silently swallow errors inconsistently with other updated handlers. |
| web/tests/e2e/alerts-mesh-layout.spec.ts | New E2E spec covering header, all five filter chips, URL persistence across reload, and drawer open/tab-switch flow. Correctly uses login fixture with screenshots on key assertions. |
| web/tests/e2e/alerts.spec.ts | Updated to remove the deleted Agent Offline type-filter button and switches duplicate detection to alert-row testids. Straightforward adaptation to the new layout. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/app/(app)/alerts/page.tsx:280-302
**Silent failure on row-level mark-read/unread/delete** — `handleMarkRead`, `handleMarkUnread`, and `handleDeleteOne` still swallow errors with `/* noop */` and show no user feedback. In contrast, `handleAcknowledge`, `handleDeleteAll`, and `handleMarkAllRead` were updated in this PR to display a `toast.error(...)` on failure. A user who clicks "Mark read" or "Delete" on a row and the network request silently fails will see the optimistic UI change then silently revert on the next poll (30 s), which looks like a ghost action.

```suggestion
  async function handleMarkRead(id: string) {
    try {
      await markAlertRead(id);
      mutate(
        (prev) => (prev ?? []).map((a) => (a.id === id ? { ...a, is_read: true } : a)),
        { revalidate: false },
      );
    } catch {
      toast.error("Failed to mark as read");
    }
  }

  async function handleMarkUnread(id: string) {
    try {
      await markAlertUnread(id);
      mutate(
        (prev) => (prev ?? []).map((a) => (a.id === id ? { ...a, is_read: false } : a)),
        { revalidate: false },
      );
    } catch {
      toast.error("Failed to mark as unread");
    }
  }
```

### Issue 2 of 3
web/src/app/(app)/alerts/page.tsx:223
**Client-side filtering from a hard-capped fetch** — the page now fetches at most 200 alerts and derives all chip counts and the header status line from that local slice. If the deployment has more than 200 total alerts, the header can show "50 total · 0 critical" while critical alerts exist beyond the 200-record window. The old code applied server-side type and status filters before the 100-alert cap, so each filter view would see its own 100 most-recent matches; here every view competes for the same 200 slots. Consider raising the cap, paginating, or re-introducing server-side filter params.

```suggestion
      const data = await fetchAlerts(500); // TODO: paginate or apply server-side filter
```

### Issue 3 of 3
web/src/app/(app)/alerts/page.tsx:237-248
**`useEffect` omits `searchParams`, `pathname`, and `router` from deps** — the `eslint-disable-next-line` comment sidesteps the exhaustive-deps warning. If the URL ever carries other search parameters alongside `?filter=` (e.g., `?from=notification&filter=critical`), the mount-time fire will silently drop the extra params because `searchParams` is captured at render time and only the `filter` key is reconstituted. An equality guard before calling `router.replace` would eliminate the lint suppression and make the intent explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(alerts): U6 strict port of alerts s..."](https://github.com/befeast/panoptikon/commit/15938b748bba8d0727b8a5f0a2820cc648871e98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536637)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->