### PR TITLE
fix(ux): dynamic topbar breadcrumb + remove vendor nav items

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -84,9 +84,7 @@ export const navGroups: NavGroup[] = [
     key: "services",
     label: "Services",
     items: [
-      { href: "/router", label: "Router", icon: Router, exact: true },
-      { href: "/router/mikrotik", label: "MikroTik", icon: Router },
-      { href: "/router/pfsense", label: "pfSense", icon: Shield },
+      { href: "/router", label: "Router", icon: Router },
       { href: "/caddy", label: "Caddy", icon: Shield },
       { href: "/services", label: "Services", icon: Workflow },
       { href: "/vpn-status", label: "VPN Status", icon: Shield },

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { type ReactNode, useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { type ReactNode, useMemo, useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
 import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, deleteAllAlerts, logout } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
@@ -19,7 +19,9 @@ import {
 
 export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   const router = useRouter();
+  const pathname = usePathname();
   const wsConnected = useWsConnected();
+  const breadcrumb = useMemo(() => breadcrumbFromPath(pathname || ""), [pathname]);
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResponse | null>(null);
@@ -455,8 +457,20 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
       {/* Realm context + live status pill — mirrors the design source TopBar */}
       <div className="hidden lg:flex items-center gap-2 shrink-0 font-mono text-[11px] text-mesh-text-dim">
         <span className="text-mesh-text-mute">core.lan</span>
-        <span className="text-mesh-border-strong">›</span>
-        <span className="text-mesh-text">Overview</span>
+        {breadcrumb.map((label, i) => (
+          <span key={`${label}-${i}`} className="contents">
+            <span className="text-mesh-border-strong">›</span>
+            <span
+              className={
+                i === breadcrumb.length - 1
+                  ? "text-mesh-text"
+                  : "text-mesh-text-dim"
+              }
+            >
+              {label}
+            </span>
+          </span>
+        ))}
       </div>
       <div
         className="flex items-center gap-2 shrink-0 rounded-full border border-mesh-border bg-mesh-surface-1/80 px-2.5 py-1 font-mono text-[11px] text-mesh-text"
@@ -622,4 +636,57 @@ function SeverityBadge({ severity }: { severity: string }) {
       {severity}
     </span>
   );
+}
+
+// Mirrors design source shell.jsx breadcrumb pattern: realm root (core.lan) is
+// fixed by the wrapper, this function returns just the route-derived trail.
+const BREADCRUMB_LABELS: Record<string, string> = {
+  dashboard: "Dashboard",
+  alerts: "Alerts",
+  "audit-log": "Audit log",
+  devices: "Devices",
+  assets: "Assets",
+  topology: "Topology",
+  mesh: "Mesh",
+  traffic: "Traffic",
+  qos: "QoS",
+  nat: "NAT",
+  router: "Router",
+  mikrotik: "MikroTik",
+  pfsense: "pfSense",
+  xiaomi: "Xiaomi",
+  caddy: "Caddy",
+  services: "Services",
+  "vpn-status": "VPN status",
+  ddns: "DDNS",
+  "dns-logs": "DNS logs",
+  "dns-queries": "DNS queries",
+  certificates: "Certificates",
+  "cloudflare-tunnel": "Cloudflare tunnel",
+  agents: "Agents",
+  "ssh-hosts": "SSH hosts",
+  settings: "Settings",
+  "alert-rules": "Alert rules",
+  "config-backup": "Config backup",
+  "dns-blocklists": "DNS blocklists",
+  "dns-security": "DNS security",
+  email: "Email",
+  password: "Password",
+  retention: "Retention",
+  scanner: "Scanner",
+  snmp: "SNMP",
+  speedtest: "Speed test",
+  tailscale: "Tailscale",
+  users: "Users",
+  webhook: "Webhook",
+  "xiaomi-mesh": "Xiaomi mesh",
+  advanced: "Advanced",
+  detail: "Detail",
+  npm: "NPM",
+};
+
+function breadcrumbFromPath(pathname: string): string[] {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return ["Overview"];
+  return segments.map((seg) => BREADCRUMB_LABELS[seg] ?? seg);
 }


### PR DESCRIPTION
## Summary

User flagged `/router/mikrotik` showing hardcoded `core.lan > Overview` in topbar and `MikroTik`/`pfSense` as separate sidebar nav items under Services. Per design source `shell.jsx`:

- **TopBar breadcrumb** is dynamic, derived from current route — not pinned to "Overview".
- **Services group** has only Router / DNS / Certificates / Caddy / etc. Vendor (mikrotik/pfsense/xiaomi) is a tab switcher INSIDE the Router workspace, not separate nav items.

## Changes

- `TopBar.tsx`: `usePathname()` + `breadcrumbFromPath()` helper with a `BREADCRUMB_LABELS` mapping table. Render breadcrumb segments via map instead of static label.
- `Sidebar.tsx`: removed `MikroTik` and `pfSense` items from Services group; loosened Router exact match so vendor sub-routes still highlight Router.

## Test plan

- [x] `bun run build` clean
- [x] `bash scripts/check-design-tokens.sh` passes
- [ ] After deploy: visit `/router/mikrotik` and `/router/pfsense` — verify topbar shows `core.lan > Network > Router > MikroTik` (resp pfSense), sidebar shows Router highlighted (no separate vendor items)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two UX regressions: the TopBar breadcrumb was hardcoded to \"Overview\" instead of reflecting the current route, and vendor devices (MikroTik, pfSense) appeared as top-level sidebar nav items instead of being tabs inside the Router workspace.

- **`TopBar.tsx`**: replaces the static label with a `usePathname()`-driven `breadcrumbFromPath()` helper backed by a `BREADCRUMB_LABELS` map; unknown segments fall back to the raw slug.
- **`Sidebar.tsx`**: removes the `MikroTik` and `pfSense` nav items from the Services group and drops `exact: true` from the Router entry so `/router/*` sub-routes keep Router highlighted.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the sidebar fix; the breadcrumb change works correctly for known paths but lacks an automated test and has a mismatch between the stated expected output and what the implementation actually renders.

The breadcrumb helper produces Router › MikroTik for /router/mikrotik, but the PR's own test plan claims the output should be Network › Router › MikroTik. No Playwright E2E test was added despite CLAUDE.md making this mandatory for every bug fix.

web/src/components/layout/TopBar.tsx — breadcrumb output vs. test plan expectation, and missing E2E coverage

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/layout/TopBar.tsx | Adds dynamic breadcrumb via usePathname + breadcrumbFromPath helper; missing mandatory E2E test and test-plan breadcrumb doesn't match implementation output for vendor sub-routes |
| web/src/components/layout/Sidebar.tsx | Removes MikroTik and pfSense vendor nav items from Services group and drops exact:true from Router entry so sub-routes keep it highlighted — straightforward and correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/layout/TopBar.tsx:637-692
**Missing mandatory Playwright E2E test**

`CLAUDE.md` mandates a Playwright E2E test (`web/tests/e2e/*.spec.ts`) for every feature and bug fix, including layout changes, with a visible failure-before / passing-after assertion. This PR's test plan has only an unchecked manual step ("After deploy: visit `/router/mikrotik`…") and no `## Why No E2E Test` section justifying the omission. Existing specs like `topbar-polish.spec.ts` and `navigation.spec.ts` show the pattern; a test that navigates to `/router/mikrotik`, asserts the breadcrumb contains `MikroTik`, and confirms no "MikroTik" sidebar item is present would satisfy the requirement.

### Issue 2 of 2
web/src/components/layout/TopBar.tsx:686-692
**Test plan breadcrumb doesn't match implementation output**

The PR description says visiting `/router/mikrotik` should show `core.lan > Network > Router > MikroTik`, but `breadcrumbFromPath("/router/mikrotik")` produces `["Router", "MikroTik"]` — rendering `core.lan › Router › MikroTik`. `Network` is a sidebar group label, not a URL segment, so it never enters the breadcrumb trail. If the design source requires a group-level segment, the helper will need to inject it from a separate segment-to-group mapping; otherwise the test plan expectation should be corrected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): dynamic topbar breadcrumb + rem..."](https://github.com/befeast/panoptikon/commit/23e7089060bdd7d66094ebd7d44461738fceadc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32568153)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->