### PR TITLE
fix(ux): relocate user menu — TopBar dropdown → Sidebar footer pill

### DIFF
--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -10,8 +10,14 @@ use axum::{
     Json, Router,
 };
 use sqlx::SqlitePool;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+use std::time::Instant;
 use tower_http::cors::CorsLayer;
+
+/// Process start time, materialized on first access. Read once during router
+/// construction (see build_router) so the value reflects server boot, not the
+/// first /version request.
+static SERVER_START: LazyLock<Instant> = LazyLock::new(Instant::now);
 
 pub mod agents;
 pub mod alert_rules;
@@ -109,6 +115,10 @@ impl AppState {
 
 /// Build the main application router with all API routes.
 pub fn router(state: AppState) -> Router {
+    // Materialize SERVER_START so uptime is measured from router construction
+    // (server boot) rather than the first /version request.
+    let _ = *SERVER_START;
+
     let cors = CorsLayer::new()
         .allow_origin(tower_http::cors::AllowOrigin::mirror_request())
         .allow_methods([
@@ -703,7 +713,10 @@ async fn health() -> &'static str {
     "ok"
 }
 
-/// Returns the server binary version from Cargo.toml.
+/// Returns the server binary version from Cargo.toml and process uptime.
 async fn server_version() -> impl IntoResponse {
-    Json(serde_json::json!({ "version": env!("CARGO_PKG_VERSION") }))
+    Json(serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": SERVER_START.elapsed().as_secs(),
+    }))
 }

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -5,7 +5,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChevronDown, Menu, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { isNavItemActive, navGroups, useGroupCollapse, useServerVersion } from "./Sidebar";
+import { isNavItemActive, navGroups, useGroupCollapse, useServerStatus } from "./Sidebar";
+import { StatusDot } from "@/components/mesh/StatusDot";
 import {
   Sheet,
   SheetContent,
@@ -13,11 +14,21 @@ import {
 } from "@/components/ui/sheet";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
 
+function formatUptime(seconds: number | null): string {
+  if (seconds == null || seconds < 0) return "—";
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
 export function MobileSidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const wsConnected = useWsConnected();
-  const serverVersion = useServerVersion();
+  const serverStatus = useServerStatus();
   const { collapsed: groupCollapsed, toggle: toggleGroup } = useGroupCollapse(
     navGroups,
     pathname,
@@ -147,23 +158,21 @@ export function MobileSidebar() {
             </div>
           </nav>
 
-          {/* Status */}
-          <div className="shrink-0 border-t border-mesh-border p-3">
-            <div className="flex items-center gap-1.5 px-2">
-              <span
-                className={cn(
-                  "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
-                  wsConnected
-                    ? "bg-[#4ade80] ring-2 ring-[#4ade80]/30 status-glow-online"
-                    : "bg-mesh-text-mute"
-                )}
-              />
-              <span className="text-xs text-mesh-text-mute">
-                {wsConnected ? "Live" : "Disconnected"}
-              </span>
-              <p className="ml-auto text-[10px] text-mesh-border-strong">
-                Panoptikon {serverVersion ?? "..."}
-              </p>
+          {/* Footer — user pill (per shell.jsx 122-144). */}
+          <div className="flex shrink-0 items-center gap-2 border-t border-mesh-border-strong px-2.5 py-2">
+            <div
+              aria-hidden="true"
+              className="flex h-[26px] w-[26px] items-center justify-center rounded-full text-[11px] font-semibold text-white"
+              style={{ background: "linear-gradient(135deg, #2563eb, #8b5cf6)" }}
+            >
+              op
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-[12px] font-medium text-mesh-text">operator</div>
+              <div className="flex items-center gap-1.5 font-mono text-[10px] text-mesh-text-mute">
+                <StatusDot status={wsConnected ? "online" : "offline"} pulse={wsConnected} size={6} />
+                <span>core · {formatUptime(serverStatus.uptimeSeconds)}</span>
+              </div>
             </div>
           </div>
         </SheetContent>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -37,6 +37,15 @@ import {
 } from "@/components/ui/tooltip";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
 import { BrandMark } from "@/components/brand/BrandMark";
+import { StatusDot } from "@/components/mesh/StatusDot";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { logout } from "@/lib/api";
+import { LogOut } from "lucide-react";
 
 /* -------------------------------------------------------------------------- */
 /*  Navigation structure                                                      */
@@ -186,20 +195,57 @@ export function useGroupCollapse(groups: NavGroup[], pathname: string | null) {
   return { collapsed, toggle };
 }
 
-/** Fetches the server binary version from the backend. */
-export function useServerVersion(): string | null {
-  const [version, setVersion] = useState<string | null>(null);
+interface ServerStatus {
+  version: string | null;
+  uptimeSeconds: number | null;
+}
+
+/** Fetches the server binary version + uptime, polls every 60s. */
+export function useServerStatus(): ServerStatus {
+  const [state, setState] = useState<ServerStatus>({
+    version: null,
+    uptimeSeconds: null,
+  });
 
   useEffect(() => {
-    fetch("/api/v1/version", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data?.version) setVersion(`v${data.version}`);
-      })
-      .catch(() => {});
+    let cancelled = false;
+    async function tick() {
+      try {
+        const res = await fetch("/api/v1/version", { credentials: "include", cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setState({
+          version: data?.version ? `v${data.version}` : null,
+          uptimeSeconds: typeof data?.uptime_seconds === "number" ? data.uptime_seconds : null,
+        });
+      } catch {
+        /* swallow */
+      }
+    }
+    void tick();
+    const id = setInterval(tick, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
   }, []);
 
-  return version;
+  return state;
+}
+
+/**
+ * Formats uptime in seconds into the design's compact "14d 6h" / "6h 23m" /
+ * "42m" style. Per shell.jsx footer: "core · 14d 6h".
+ */
+function formatUptime(seconds: number | null): string {
+  if (seconds == null || seconds < 0) return "—";
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -210,7 +256,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const wsConnected = useWsConnected();
-  const serverVersion = useServerVersion();
+  const serverStatus = useServerStatus();
   const { collapsed: groupCollapsed, toggle: toggleGroup } = useGroupCollapse(
     navGroups,
     pathname,
@@ -364,55 +410,54 @@ export function Sidebar() {
           </div>
         </nav>
 
-        {/* Version + connection status */}
-        <div className="border-t border-mesh-border-strong p-2">
-          {!sidebarCollapsed ? (
-            <div className="flex items-center gap-1.5 px-3 py-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className={cn(
-                      "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
-                      wsConnected
-                        ? "bg-[#4ade80] ring-2 ring-[#4ade80]/30 status-glow-online"
-                        : "bg-mesh-text-mute",
-                    )}
-                  />
-                </TooltipTrigger>
-                <TooltipContent
-                  side="top"
-                  className="border-mesh-border bg-mesh-surface-1"
+        {/* Footer — user pill (per shell.jsx 122-144). Hidden when collapsed.
+         * Dropdown-wrapped for logout discoverability after removing TopBar
+         * user menu — pill visual is unchanged. */}
+        {!sidebarCollapsed && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 border-t border-mesh-border-strong px-2.5 py-2 text-left transition-colors hover:bg-mesh-surface-2/55 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-mesh-accent"
+              >
+                <span
+                  aria-hidden="true"
+                  className="flex h-[26px] w-[26px] items-center justify-center rounded-full text-[11px] font-semibold text-white"
+                  style={{ background: "linear-gradient(135deg, #2563eb, #8b5cf6)" }}
                 >
-                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
-                </TooltipContent>
-              </Tooltip>
-              <p className="text-[10px] text-mesh-border-strong">
-                Panoptikon {serverVersion ?? "..."}
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center gap-1 py-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className={cn(
-                      "inline-block h-1.5 w-1.5 rounded-full",
-                      wsConnected
-                        ? "bg-[#4ade80] ring-2 ring-[#4ade80]/30 status-glow-online"
-                        : "bg-mesh-text-mute",
-                    )}
-                  />
-                </TooltipTrigger>
-                <TooltipContent
-                  side="right"
-                  className="border-mesh-border bg-mesh-surface-1"
-                >
-                  <p>{wsConnected ? "Live — connected" : "Disconnected"}</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )}
-        </div>
+                  op
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[12px] font-medium text-mesh-text">operator</span>
+                  <span className="flex items-center gap-1.5 font-mono text-[10px] text-mesh-text-mute">
+                    <StatusDot status={wsConnected ? "online" : "offline"} pulse={wsConnected} size={6} />
+                    <span>core · {formatUptime(serverStatus.uptimeSeconds)}</span>
+                  </span>
+                </span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="top"
+              align="start"
+              className="w-40 border-mesh-border bg-mesh-surface-1"
+            >
+              <DropdownMenuItem
+                className="cursor-pointer text-mesh-text"
+                onClick={async () => {
+                  try {
+                    await logout();
+                  } catch {
+                    /* even if API fails, redirect to login */
+                  }
+                  window.location.href = "/login";
+                }}
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                Logout
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </aside>
     </TooltipProvider>
   );

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -2,20 +2,13 @@
 
 import { type ReactNode, useMemo, useState, useEffect, useRef, useCallback } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { Bell, Settings, Lock, LogOut, Monitor, Cpu, Terminal, Package } from "lucide-react";
-import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, deleteAllAlerts, logout } from "@/lib/api";
+import { Bell, Settings, Monitor, Cpu, Terminal, Package } from "lucide-react";
+import { searchAll, fetchRecentAlerts, fetchDashboardStats, markAllAlertsRead, deleteAllAlerts } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
 import { timeAgo } from "@/lib/format";
 import type { SearchResponse, SearchDevice, SearchAgent, SearchAlert, SearchSshTarget, SearchAsset, Alert } from "@/lib/types";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+
 
 export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
   const router = useRouter();
@@ -124,15 +117,6 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
     } catch {
       // ignore
     }
-  }
-
-  async function handleLogout() {
-    try {
-      await logout();
-    } catch {
-      // Even if the API call fails, redirect to login
-    }
-    window.location.href = "/login";
   }
 
   // ── Search logic (unchanged) ──
@@ -577,42 +561,6 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
           )}
         </div>
 
-        {/* ── User Avatar Menu ── */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="flex h-8 w-8 items-center justify-center rounded-md border border-[#67e8f9]/35 bg-mesh-accent/12 text-sm font-medium text-mesh-text transition-colors hover:bg-mesh-accent/18">
-              A
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuLabel className="text-xs text-mesh-text-dim font-normal">
-              Admin
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onClick={() => router.push("/settings")}
-            >
-              <Settings className="mr-2 h-4 w-4" />
-              Settings
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onClick={() => router.push("/settings/password")}
-            >
-              <Lock className="mr-2 h-4 w-4" />
-              Change password
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              className="cursor-pointer text-[#fb7185] focus:text-[#fb7185]"
-              onClick={handleLogout}
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              Logout
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
     </header>
   );

--- a/web/tests/e2e/display-font.spec.ts
+++ b/web/tests/e2e/display-font.spec.ts
@@ -31,8 +31,9 @@ test.describe("Display font (Space Grotesk)", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/dashboard");
 
-    // The sidebar "Panoptikon" text in the logo area
-    const logoText = page.locator("aside span.font-mono");
+    // The sidebar "Panoptikon" text in the logo area. Scope to the brand
+    // header so it doesn't match the user-pill mono text in the footer.
+    const logoText = page.locator("aside header span.font-mono");
     await expect(logoText).toBeVisible({ timeout: 15000 });
     await expect(logoText).toHaveText("Panoptikon");
 

--- a/web/tests/e2e/display-font.spec.ts
+++ b/web/tests/e2e/display-font.spec.ts
@@ -31,9 +31,9 @@ test.describe("Display font (Space Grotesk)", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/dashboard");
 
-    // The sidebar "Panoptikon" text in the logo area. Scope to the brand
-    // header so it doesn't match the user-pill mono text in the footer.
-    const logoText = page.locator("aside header span.font-mono");
+    // The sidebar "Panoptikon" wordmark. Scope to the brand link so we don't
+    // match the user-pill mono text in the footer.
+    const logoText = page.locator("aside a[aria-label='Panoptikon'] span.font-mono");
     await expect(logoText).toBeVisible({ timeout: 15000 });
     await expect(logoText).toHaveText("Panoptikon");
 

--- a/web/tests/e2e/sidebar-user-pill.spec.ts
+++ b/web/tests/e2e/sidebar-user-pill.spec.ts
@@ -35,13 +35,15 @@ test.describe("Sidebar user pill (P0 relocation)", () => {
   test("TopBar no longer has a user avatar dropdown", async ({
     authenticatedPage: page,
   }) => {
-    // Old contract: TopBar contained a 'A' avatar trigger opening Settings/
-    // Change password/Logout. New contract: no such trigger exists.
+    // Old contract: TopBar contained an 'A' avatar trigger opening Settings/
+    // Change password/Logout. New contract: no such trigger exists; user pill
+    // lives in the sidebar footer instead.
     const header = page.locator("header").first();
     await expect(header).toBeVisible();
-    // The old dropdown trigger was the only button with single-letter "A" label.
-    const oldAvatar = header.getByRole("button", { name: "A" });
-    await expect(oldAvatar).toHaveCount(0);
+    // The user pill — and any "operator" / "core · …" text — must not appear
+    // anywhere inside the topbar.
+    await expect(header.getByText("operator", { exact: true })).toHaveCount(0);
+    await expect(header.getByText(/core · /)).toHaveCount(0);
   });
 
   test("clicking the sidebar pill opens dropdown with Logout", async ({

--- a/web/tests/e2e/sidebar-user-pill.spec.ts
+++ b/web/tests/e2e/sidebar-user-pill.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../../e2e/fixtures";
+
+/**
+ * E2E coverage for the relocated user menu (P0 from structural audit).
+ *
+ * Per shell.jsx (122-144) the user pill belongs in the sidebar footer —
+ * avatar "op" + "operator" + StatusDot + "core · {uptime}". The TopBar
+ * loses its avatar dropdown and keeps only breadcrumb + live pill +
+ * icon-only refresh/bell/settings.
+ *
+ * The pill is dropdown-wrapped (small deviation from shell.jsx) so Logout
+ * stays discoverable after removing the TopBar user menu.
+ */
+test.describe("Sidebar user pill (P0 relocation)", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.goto("/dashboard/");
+  });
+
+  test("sidebar footer shows operator + core · {uptime} (per shell.jsx)", async ({
+    authenticatedPage: page,
+  }) => {
+    const pill = page.getByRole("button", { name: /operator/i });
+    await expect(pill).toBeVisible({ timeout: 10000 });
+
+    // "operator" + "op" avatar + status text in mono font with "core · …" uptime.
+    await expect(pill).toContainText("operator");
+    await expect(pill).toContainText(/core · /);
+
+    await page.screenshot({
+      path: "tests/screenshots/sidebar-user-pill.png",
+      fullPage: false,
+    });
+  });
+
+  test("TopBar no longer has a user avatar dropdown", async ({
+    authenticatedPage: page,
+  }) => {
+    // Old contract: TopBar contained a 'A' avatar trigger opening Settings/
+    // Change password/Logout. New contract: no such trigger exists.
+    const header = page.locator("header").first();
+    await expect(header).toBeVisible();
+    // The old dropdown trigger was the only button with single-letter "A" label.
+    const oldAvatar = header.getByRole("button", { name: "A" });
+    await expect(oldAvatar).toHaveCount(0);
+  });
+
+  test("clicking the sidebar pill opens dropdown with Logout", async ({
+    authenticatedPage: page,
+  }) => {
+    const pill = page.getByRole("button", { name: /operator/i });
+    await pill.click();
+    const logoutItem = page.getByRole("menuitem", { name: /logout/i });
+    await expect(logoutItem).toBeVisible({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Summary

Per shell.jsx (122-144) the user pill belongs in the **sidebar footer** — 26px gradient avatar + "operator" + StatusDot + "core · {uptime}". The **TopBar** loses its avatar dropdown and keeps only breadcrumb + live·ws·Nms pill + icon-only refresh/bell/settings (per shell.jsx 198-262).

This is P0 #1 from the structural-audit Wave 1.

## Changes

- **`server/src/api/mod.rs`** — `/api/v1/version` now returns `uptime_seconds` alongside `version`. `SERVER_START` is materialized during router construction so uptime reflects boot time, not the first `/version` request.
- **`web/src/components/layout/Sidebar.tsx`** — `useServerVersion` → `useServerStatus` polls `/version` every 60s for `{version, uptimeSeconds}`. Replaces the old version+connection footer with the literal port of `shell.jsx` footer recipe. Pill is wrapped in a `DropdownMenu` trigger with a single `Logout` item — small functional deviation from `shell.jsx` (display-only pill in design) so Logout stays discoverable after removing the TopBar user menu. Visual is identical to the design.
- **`web/src/components/layout/MobileSidebar.tsx`** — same footer port + local `formatUptime` helper.
- **`web/src/components/layout/TopBar.tsx`** — removed user `DropdownMenu` block + `handleLogout` helper + `Lock`, `LogOut`, `DropdownMenu*` imports that are no longer used.
- **`web/tests/e2e/sidebar-user-pill.spec.ts`** — E2E covers (a) pill visible with `operator` + `core · …`, (b) TopBar no longer has the avatar dropdown, (c) clicking pill opens dropdown with Logout.

## Forbidden substitutions checked

- No raw Tailwind color literals — `scripts/check-design-tokens.sh` passes.
- No ad-hoc card recipe combos — guard 2 passes.
- Pill avatar uses literal hex from design (`#2563eb` primary, `#8b5cf6` accent-violet).

## Test plan

- [x] `cargo check` clean
- [x] `cargo fmt --all` applied
- [x] `bun run build` clean
- [x] `bash scripts/check-design-tokens.sh` passes
- [ ] CI E2E green
- [ ] After deploy: visit any page on https://net.oklabs.uk — verify (a) sidebar footer shows operator + core · {uptime}, (b) TopBar right has only icons (no avatar), (c) clicking sidebar pill opens Logout dropdown

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relocates the user identity pill from the TopBar dropdown to the Sidebar footer, matching the `shell.jsx` spec. The backend gains `uptime_seconds` on `/api/v1/version` using a `LazyLock<Instant>` seeded at router construction.

- `server/src/api/mod.rs`: `SERVER_START` is forced at `router()` call-time so uptime reflects boot rather than the first request; implementation is correct.
- `Sidebar.tsx` / `MobileSidebar.tsx`: Desktop sidebar wraps the pill in a `DropdownMenu` for Logout discoverability; mobile sidebar renders the pill as a plain `div` with no interactive role or logout path (previously flagged in review thread, as is the collapsed-sidebar case).
- `display-font.spec.ts`: Selector narrowed to `a[aria-label='Panoptikon'] span.font-mono` — the fix is correct and addresses the earlier ambiguity with the new footer's mono text.

<h3>Confidence Score: 4/5</h3>

The structural move is coherent, but open threads about logout reachability (collapsed desktop sidebar and mobile viewport) have not been resolved before this review.

The user's only path to logout on desktop is now hidden when the sidebar is collapsed, and on mobile there is no logout affordance at all — the pill in `MobileSidebar` is an inert `div` with no dropdown. These gaps were introduced by removing the always-visible TopBar user menu without a complete replacement across all viewport/state combinations.

`web/src/components/layout/MobileSidebar.tsx` (no logout path on mobile) and `web/src/components/layout/Sidebar.tsx` (footer pill hidden when sidebar is collapsed) deserve attention before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/mod.rs | Adds `uptime_seconds` to `/api/v1/version` response; `SERVER_START` is a `LazyLock<Instant>` forced at router construction to capture boot time correctly. |
| web/src/components/layout/Sidebar.tsx | Replaces version/connection footer with design-spec user pill; wraps pill in DropdownMenu for Logout; pill is hidden when sidebar is collapsed (logout unreachable in that state — flagged in review thread). |
| web/src/components/layout/MobileSidebar.tsx | Ports the user pill to mobile sidebar footer as a plain `div` with no interactive role and no Logout dropdown — mobile logout path is absent after TopBar menu removal (flagged in review thread). |
| web/src/components/layout/TopBar.tsx | Removes the user avatar DropdownMenu block and related imports/handler; now shows only breadcrumb, live-pill, and icon-only actions as per spec. |
| web/tests/e2e/display-font.spec.ts | Selector narrowed from `aside span.font-mono` to `aside a[aria-label='Panoptikon'] span.font-mono` to avoid false matches against the new footer's mono text — fix looks correct. |
| web/tests/e2e/sidebar-user-pill.spec.ts | New E2E spec covers desktop pill visibility, TopBar regression, and Logout dropdown; does not set viewport explicitly, so coverage of the mobile pill (plain div, no button role) is absent. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/sidebar-user-pill.spec.ts:14-17
The test locates the pill via `getByRole("button", { name: /operator/i })`, which only exists in the desktop `Sidebar` component. The analogous pill in `MobileSidebar` is a plain `div` with no interactive role. Without an explicit viewport set here, the test passes only because Playwright's default is 1280px; at any narrower default (or if the config is changed) the `button` role won't be found and the test will time out. The sibling `display-font.spec.ts` sets `setViewportSize({ width: 1280, height: 800 })` explicitly — the same guard is worth adding to all three cases here.

```suggestion
test.describe("Sidebar user pill (P0 relocation)", () => {
  test.beforeEach(async ({ authenticatedPage: page }) => {
    await page.setViewportSize({ width: 1280, height: 800 });
    await page.goto("/dashboard/");
  });
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(e2e): scope display-font locator to..."](https://github.com/befeast/panoptikon/commit/b6db4addb50dd82d1783a786add2a9364b60dcf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32583013)</sub>

<!-- /greptile_comment -->