### PR TITLE
fix(ux): literal port of dashboard.jsx → /dashboard

### DIFF
--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -36,7 +36,6 @@ import { timeAgo } from "@/lib/format";
 import { PageTransition } from "@/components/PageTransition";
 import { toast } from "sonner";
 import { useWsEvent } from "@/lib/ws";
-import { cn } from "@/lib/utils";
 import { useApiFetch } from "@/hooks/useApiFetch";
 import {
   Icon,
@@ -49,6 +48,18 @@ import {
 import { ErrorState } from "@/components/mesh/state";
 import { TrafficChart } from "@/components/dashboard/TrafficChart";
 import { TopoMini } from "@/components/dashboard/TopoMini";
+
+// ─── Token literals (mesh direction, byte-exact from tokens.css) ──────
+// Tokens whose names conflict with shadcn's HSL vars at :root — must be
+// passed as literal hex inline per the runbook fallback.
+const T = {
+  border: "rgba(96,144,212,0.20)",
+  primary: "#2563eb",
+  statusOnline: "#4ade80",
+  statusOffline: "#fb7185",
+  statusWarning: "#fbbf24",
+  statusInfo: "#38bdf8",
+} as const;
 
 // ─── Compact integer formatting (12300 → "12.3k") ──────
 
@@ -88,7 +99,6 @@ function formatAlertTime(iso: string): string {
   }
 }
 
-// Derive a short "source" string from an alert payload (best-effort).
 function alertSource(a: Alert): string {
   const anyAlert = a as Alert & { source_type?: string };
   if (anyAlert.source_type) return anyAlert.source_type;
@@ -119,16 +129,26 @@ function CriticalDevicesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-mesh-border bg-mesh-surface-1 text-white sm:max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
+      <DialogContent
+        className="sm:max-w-lg max-h-[80vh] overflow-hidden flex flex-col"
+        style={{
+          background: "var(--surface-1)",
+          border: `1px solid ${T.border}`,
+          color: "var(--text)",
+        }}
+      >
         <DialogHeader>
-          <DialogTitle className="text-white">Critical Devices</DialogTitle>
-          <DialogDescription className="text-mesh-text-dim">
+          <DialogTitle style={{ color: "var(--text)" }}>Critical Devices</DialogTitle>
+          <DialogDescription style={{ color: "var(--text-dim)" }}>
             Devices included in the Infrastructure Health metric.
           </DialogDescription>
         </DialogHeader>
         <div className="overflow-y-auto -mx-6 px-6">
           {error ? (
-            <div className="flex items-center gap-2 py-4 text-sm text-[#fb7185]">
+            <div
+              className="flex items-center gap-2 py-4 text-sm"
+              style={{ color: T.statusOffline }}
+            >
               <WifiOff className="h-4 w-4 shrink-0" />
               <span>Failed to load critical devices</span>
             </div>
@@ -139,7 +159,10 @@ function CriticalDevicesDialog({
               ))}
             </div>
           ) : devices.length === 0 ? (
-            <p className="py-6 text-center text-sm text-mesh-text-mute">
+            <p
+              className="py-6 text-center text-sm"
+              style={{ color: "var(--text-mute)" }}
+            >
               No critical devices found.
             </p>
           ) : (
@@ -148,27 +171,32 @@ function CriticalDevicesDialog({
                 <Link
                   key={dev.id}
                   href={`/devices?id=${dev.id}`}
-                  className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-mesh-surface-2/55 transition-colors group"
+                  className="flex items-center gap-3 rounded-md px-2 py-2 transition-colors group"
                   onClick={() => onOpenChange(false)}
                 >
                   <span
-                    className={cn(
-                      "inline-block h-2.5 w-2.5 shrink-0 rounded-full",
-                      dev.is_online
-                        ? "bg-[#4ade80] ring-2 ring-[#4ade80]/30"
-                        : "bg-[#fb7185] ring-2 ring-[#fb7185]/30",
-                    )}
+                    className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{
+                      background: dev.is_online ? T.statusOnline : T.statusOffline,
+                      boxShadow: `0 0 0 2px ${dev.is_online ? "rgba(74,222,128,0.30)" : "rgba(251,113,133,0.30)"}`,
+                    }}
                   />
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
-                      <span className="truncate text-sm font-medium text-mesh-text">
+                      <span
+                        className="truncate text-sm font-medium"
+                        style={{ color: "var(--text)" }}
+                      >
                         {dev.name || dev.hostname || dev.ip || "Unknown"}
                       </span>
                       {dev.classification === "pinned" && (
-                        <Pin className="h-3 w-3 shrink-0 text-[#fbbf24]" />
+                        <Pin className="h-3 w-3 shrink-0" style={{ color: T.statusWarning }} />
                       )}
                     </div>
-                    <div className="flex items-center gap-2 text-xs text-mesh-text-mute">
+                    <div
+                      className="flex items-center gap-2 text-xs"
+                      style={{ color: "var(--text-mute)" }}
+                    >
                       {dev.device_type && (
                         <span className="capitalize">{dev.device_type.replace(/_/g, " ")}</span>
                       )}
@@ -177,18 +205,21 @@ function CriticalDevicesDialog({
                   </div>
                   <div className="shrink-0 text-right">
                     <span
-                      className={cn(
-                        "text-xs font-medium",
-                        dev.is_online ? "text-[#4ade80]" : "text-[#fb7185]",
-                      )}
+                      className="text-xs font-medium"
+                      style={{ color: dev.is_online ? T.statusOnline : T.statusOffline }}
                     >
                       {dev.is_online ? "Online" : "Offline"}
                     </span>
                     {dev.last_seen_at && (
-                      <p className="text-xs text-mesh-text-mute">{timeAgo(dev.last_seen_at)}</p>
+                      <p className="text-xs" style={{ color: "var(--text-mute)" }}>
+                        {timeAgo(dev.last_seen_at)}
+                      </p>
                     )}
                   </div>
-                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-mesh-text-mute opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <ExternalLink
+                    className="h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                    style={{ color: "var(--text-mute)" }}
+                  />
                 </Link>
               ))}
             </div>
@@ -213,10 +244,7 @@ function trafficSpark(
   });
 }
 
-// Build a synthetic per-device spark from the rx_bps headline number — the
-// dashboard top-devices API does not return a per-device history series yet.
-// We render a flat baseline scaled to the current rate so layout stays
-// stable; once the backend ships per-device history this can be replaced.
+// Synthetic per-device spark from current rate (no per-device history API yet).
 function devicePlaceholderSpark(rate: number): number[] {
   const base = Math.max(1, rate);
   return [base * 0.6, base * 0.7, base * 0.85, base * 0.9, base, base * 0.95];
@@ -238,7 +266,7 @@ export default function DashboardPage() {
 
   const swrOpts = { refreshInterval: 30_000 } as const;
 
-  const { data: stats, error: statsError, mutate: mutateStats } = useApiFetch<DashboardStats>(
+  const { data: stats, mutate: mutateStats } = useApiFetch<DashboardStats>(
     "/api/v1/dashboard/stats",
     fetchDashboardStats,
     swrOpts,
@@ -311,7 +339,6 @@ export default function DashboardPage() {
     },
   );
 
-  // ── Header subline: pull subnet count from topology when available ──
   const subnetCount = useMemo(() => {
     if (!topology) return null;
     const subnets = new Set<string>();
@@ -324,62 +351,60 @@ export default function DashboardPage() {
     return subnets.size || null;
   }, [topology]);
 
-  // ── Live KPI values derived from real backend data ──────
   const totalThroughputMbps = stats ? bpsToMbps(stats.wan_rx_bps + stats.wan_tx_bps) : null;
   const onlineAgents = agents?.filter((a) => a.is_online).length ?? null;
   const totalAgents = agents?.length ?? null;
-
-  // ── Recent events: map alerts → SevDot rows ────────────
   const events = alerts ?? null;
-
-  // ── Top talkers rows derived from /api/v1/dashboard/top-devices ──
   const talkers = topDevices ?? null;
 
   return (
     <PageTransition>
       <div
-        className="flex flex-col gap-4 p-4 lg:p-5"
         data-testid="dashboard-root"
+        style={{
+          padding: 18,
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
       >
         {/* ── Header ──────────────────────────────────── */}
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
           <div>
-            <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-mesh-text-mute">
-              Overview
-            </div>
+            <div className="t-micro">Overview</div>
             <h1
-              className="mt-1 text-3xl font-semibold tracking-tight text-white"
+              className="t-display"
               data-testid="dashboard-title"
+              style={{ margin: "4px 0 6px" }}
             >
               core.lan
             </h1>
-            <div className="mt-1.5 font-mono text-xs text-mesh-text-mute">
+            <div className="t-small mono" style={{ color: "var(--text-mute)" }}>
               {topology
-                ? `10.0.0.0/16 · ${subnetCount ?? "—"} subnets · ${stats?.devices_total ?? "—"} known`
-                : `10.0.0.0/16 · — · — known`}
+                ? `10.0.0.0/16  ·  ${subnetCount ?? "—"} subnets  ·  ${stats?.devices_total ?? "—"} known`
+                : `10.0.0.0/16  ·  —  ·  — known`}
               {/* TODO: backend gap — uptime not surfaced via /dashboard/stats yet */}
             </div>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              className="inline-flex items-center gap-2 mesh-card px-3 py-1.5 text-xs text-mesh-text hover:bg-mesh-surface-2"
-            >
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button type="button" className="btn" style={{ gap: 8 }}>
               <Icon name="filter" size={12} />
               <span>last 24h</span>
-              <Icon name="chevron-down" size={11} color="hsl(var(--muted-foreground))" />
+              <Icon name="chevron-down" size={11} color="var(--text-mute)" />
             </button>
-            <Link
-              href="/devices"
-              className="inline-flex items-center gap-2 mesh-card px-3 py-1.5 text-xs text-mesh-text hover:bg-mesh-surface-2"
-            >
+            <Link href="/devices" className="btn">
               <Icon name="plus" size={12} />
               <span>Add device</span>
             </Link>
-            <Link
-              href="/settings/scanner"
-              className="inline-flex items-center gap-2 rounded-md bg-mesh-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-mesh-primary-hover"
-            >
+            <Link href="/settings/scanner" className="btn btn-primary">
               <Icon name="cmd" size={12} />
               <span>Run scan</span>
             </Link>
@@ -387,7 +412,14 @@ export default function DashboardPage() {
         </div>
 
         {/* ── KPI row (6 cards) ──────────────────────── */}
-        <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 xl:grid-cols-6">
+        <div
+          className="dashboard-kpi-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(6, 1fr)",
+            gap: 10,
+          }}
+        >
           <KPI
             label="Devices online"
             value={stats ? String(stats.devices_online) : "—"}
@@ -397,7 +429,7 @@ export default function DashboardPage() {
                 data={trafficSpark(trafficHistory, "sum").slice(-28)}
                 width={120}
                 height={26}
-                color="hsl(var(--status-online))"
+                color={T.statusOnline}
               />
             }
           />
@@ -410,10 +442,10 @@ export default function DashboardPage() {
                 data={trafficSpark(trafficHistory, "sum").slice(-28)}
                 width={120}
                 height={26}
-                color="hsl(var(--status-info))"
+                color={T.statusInfo}
               />
             }
-            accent="hsl(var(--status-info))"
+            accent={T.statusInfo}
           />
           <KPI
             label="Agents"
@@ -424,7 +456,7 @@ export default function DashboardPage() {
                 data={[0.8, 0.9, 0.95, 1, 0.9, 1]}
                 width={120}
                 height={26}
-                color="hsl(var(--status-online))"
+                color={T.statusOnline}
               />
             }
           />
@@ -439,15 +471,13 @@ export default function DashboardPage() {
                 height={26}
                 color={
                   stats && stats.alerts_unread > 0
-                    ? "hsl(var(--status-offline))"
-                    : "hsl(var(--status-online))"
+                    ? T.statusOffline
+                    : T.statusOnline
                 }
               />
             }
             accent={
-              stats && stats.alerts_unread > 0
-                ? "hsl(var(--status-offline))"
-                : undefined
+              stats && stats.alerts_unread > 0 ? T.statusOffline : undefined
             }
           />
           <KPI
@@ -460,10 +490,10 @@ export default function DashboardPage() {
                 data={[14, 15, 14, 13, 14, 12, 13, 14]}
                 width={120}
                 height={26}
-                color="hsl(var(--status-online))"
+                color={T.statusOnline}
               />
             }
-            accent="hsl(var(--status-online))"
+            accent={T.statusOnline}
           />
           <KPI
             label="DNS blocks"
@@ -480,47 +510,123 @@ export default function DashboardPage() {
                 data={[20, 40, 35, 60, 80, 70, 90, 100]}
                 width={120}
                 height={26}
-                color="hsl(var(--primary))"
+                color="var(--accent-violet)"
               />
             }
-            accent="hsl(var(--primary))"
+            accent="var(--accent-violet)"
           />
         </div>
 
         {/* ── Main grid: traffic + top talkers / topology + events ── */}
-        <div className="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div
+          className="dashboard-main-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(0, 2fr) minmax(0, 1fr)",
+            gap: 12,
+          }}
+        >
           {/* LEFT column */}
-          <div className="flex flex-col gap-3">
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {/* WAN traffic card */}
-            <div className="mesh-card p-4">
-              <div className="mb-2.5 flex flex-wrap items-center justify-between gap-2">
-                <div className="flex flex-wrap items-center gap-3">
-                  <h3 className="text-sm font-semibold text-white">WAN traffic</h3>
-                  <div className="flex flex-wrap items-center gap-2 font-mono text-[11px] text-mesh-text-mute">
-                    <span className="inline-flex items-center gap-1">
-                      <span className="inline-block h-0.5 w-2 rounded-sm bg-[hsl(var(--status-info))]" />
-                      RX <span className="text-white">{stats ? bpsToMbps(stats.wan_rx_bps) : "—"}</span>
+            <div className="mesh-card" style={{ padding: "var(--card-pad)" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  marginBottom: 10,
+                  flexWrap: "wrap",
+                  gap: 8,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <h3 className="t-h3">WAN traffic</h3>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      font: "500 11px var(--font-mono)",
+                      color: "var(--text-mute)",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 8,
+                          height: 2,
+                          background: T.statusInfo,
+                          borderRadius: 1,
+                        }}
+                      />{" "}
+                      RX{" "}
+                      <span style={{ color: "var(--text)" }}>
+                        {stats ? bpsToMbps(stats.wan_rx_bps) : "—"}
+                      </span>
                     </span>
-                    <span className="inline-flex items-center gap-1">
-                      <span className="inline-block h-0.5 w-2 rounded-sm bg-[hsl(var(--primary))]" />
-                      TX <span className="text-white">{stats ? bpsToMbps(stats.wan_tx_bps) : "—"}</span>
+                    <span
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 8,
+                          height: 2,
+                          background: "var(--accent-violet)",
+                          borderRadius: 1,
+                        }}
+                      />{" "}
+                      TX{" "}
+                      <span style={{ color: "var(--text)" }}>
+                        {stats ? bpsToMbps(stats.wan_tx_bps) : "—"}
+                      </span>
                     </span>
-                    <span className="text-mesh-text-faint">Mbps</span>
+                    <span style={{ color: "var(--text-faint)" }}>Mbps</span>
                   </div>
                 </div>
-                <div className="flex gap-1 mesh-card-2 p-0.5">
+                <div
+                  style={{
+                    display: "flex",
+                    gap: 4,
+                    background: "var(--surface-2)",
+                    padding: 2,
+                    borderRadius: "var(--radius-sm)",
+                    border: `var(--hairline) solid ${T.border}`,
+                  }}
+                >
                   {(["1h", "6h", "24h", "7d"] as const).map((r) => (
                     <button
                       key={r}
                       type="button"
                       onClick={() => setTrafficRange(r)}
-                      className={cn(
-                        "rounded px-2 py-0.5 font-mono text-[11px]",
-                        trafficRange === r
-                          ? "bg-mesh-surface-3 text-white"
-                          : "text-mesh-text-mute hover:text-white",
-                      )}
                       data-active={trafficRange === r ? "true" : "false"}
+                      style={{
+                        padding: "3px 8px",
+                        font: "500 11px var(--font-mono)",
+                        borderRadius: "var(--radius-xs)",
+                        color: trafficRange === r ? "var(--text)" : "var(--text-mute)",
+                        background: trafficRange === r ? "var(--surface-3)" : "transparent",
+                        border: "none",
+                        cursor: "pointer",
+                      }}
                     >
                       {r}
                     </button>
@@ -542,21 +648,42 @@ export default function DashboardPage() {
             </div>
 
             {/* Top talkers table */}
-            <div className="mesh-card">
-              <div className="flex items-center justify-between px-4 py-3">
-                <h3 className="text-sm font-semibold text-white">Top talkers · 24h</h3>
-                <span className="font-mono text-[11px] text-mesh-text-mute">
+            <div className="mesh-card" style={{ padding: 0 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "12px 14px 10px",
+                }}
+              >
+                <h3 className="t-h3">Top talkers · 24h</h3>
+                <span
+                  className="t-small mono"
+                  style={{ color: "var(--text-mute)" }}
+                >
                   {talkers ? `${talkers.length} of ${stats?.devices_total ?? "—"}` : "loading…"}
                 </span>
               </div>
-              <div className="border-t border-mesh-border">
-                <div className="grid grid-cols-[1.4fr_1fr_80px_80px_1fr_60px] px-4 py-2 text-[10px] font-medium uppercase tracking-wider text-mesh-text-mute">
+              <div style={{ borderTop: `var(--hairline) solid ${T.border}` }}>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1.4fr 1fr 80px 80px 1fr 60px",
+                    padding: "7px 14px",
+                    font: "500 10px var(--font-sans)",
+                    color: "var(--text-mute)",
+                    letterSpacing: "0.06em",
+                    textTransform: "uppercase",
+                    borderBottom: `var(--hairline) solid ${T.border}`,
+                  }}
+                >
                   <span>Device</span>
                   <span>IP</span>
-                  <span className="text-right">RX MB/s</span>
-                  <span className="text-right">TX MB/s</span>
+                  <span style={{ textAlign: "right" }}>RX MB/s</span>
+                  <span style={{ textAlign: "right" }}>TX MB/s</span>
                   <span>Trend</span>
-                  <span className="text-right">Mbps</span>
+                  <span style={{ textAlign: "right" }}>Mbps</span>
                 </div>
                 {topDevicesError ? (
                   <div className="p-4">
@@ -572,7 +699,10 @@ export default function DashboardPage() {
                     ))}
                   </div>
                 ) : talkers.length === 0 ? (
-                  <p className="px-4 py-6 text-center text-sm text-mesh-text-mute">
+                  <p
+                    className="px-4 py-6 text-center text-sm"
+                    style={{ color: "var(--text-mute)" }}
+                  >
                     No device traffic recorded yet.
                   </p>
                 ) : (
@@ -583,33 +713,67 @@ export default function DashboardPage() {
                     return (
                       <div
                         key={d.id}
-                        className={cn(
-                          "grid grid-cols-[1.4fr_1fr_80px_80px_1fr_60px] items-center px-4 py-2 text-xs",
-                          i < talkers.length - 1 && "border-b border-mesh-border",
-                        )}
                         data-testid="top-talker-row"
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: "1.4fr 1fr 80px 80px 1fr 60px",
+                          padding: "8px 14px",
+                          borderBottom:
+                            i < talkers.length - 1
+                              ? `var(--hairline) solid ${T.border}`
+                              : "none",
+                          alignItems: "center",
+                          font: "400 12px var(--font-sans)",
+                        }}
                       >
-                        <span className="flex items-center gap-2 text-white">
+                        <span
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                          }}
+                        >
                           <StatusDot status="online" size={6} pulse={i === 0} />
                           <Link
                             href={`/devices?id=${d.id}`}
-                            className="truncate hover:text-mesh-accent"
+                            className="truncate"
+                            style={{ color: "var(--text)" }}
                           >
                             {d.name || d.hostname || d.vendor || "Unknown"}
                           </Link>
                         </span>
-                        <span className="font-mono text-mesh-text-dim">{d.ip ?? "—"}</span>
-                        <span className="text-right font-mono text-white">{rxMb}</span>
-                        <span className="text-right font-mono text-mesh-text-dim">{txMb}</span>
+                        <span
+                          className="mono"
+                          style={{ color: "var(--text-dim)" }}
+                        >
+                          {d.ip ?? "—"}
+                        </span>
+                        <span
+                          className="mono"
+                          style={{ textAlign: "right", color: "var(--text)" }}
+                        >
+                          {rxMb}
+                        </span>
+                        <span
+                          className="mono"
+                          style={{ textAlign: "right", color: "var(--text-dim)" }}
+                        >
+                          {txMb}
+                        </span>
                         <span>
                           <Spark
                             data={devicePlaceholderSpark(d.rx_bps + d.tx_bps)}
                             width={100}
                             height={18}
-                            color="hsl(var(--status-info))"
+                            color={T.statusInfo}
                           />
                         </span>
-                        <span className="text-right font-mono text-white">{mbps}</span>
+                        <span
+                          className="mono"
+                          style={{ textAlign: "right", color: "var(--text)" }}
+                        >
+                          {mbps}
+                        </span>
                       </div>
                     );
                   })
@@ -619,19 +783,44 @@ export default function DashboardPage() {
           </div>
 
           {/* RIGHT column */}
-          <div className="flex flex-col gap-3">
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {/* Topology card */}
-            <div className="flex flex-col gap-2.5 mesh-card p-4">
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold text-white">Topology</h3>
+            <div
+              className="mesh-card"
+              style={{
+                padding: "var(--card-pad)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <h3 className="t-h3">Topology</h3>
                 <Link
                   href="/topology"
-                  className="text-xs font-medium text-mesh-accent hover:text-[#67e8f9]"
+                  style={{
+                    font: "500 11px var(--font-sans)",
+                    color: T.primary,
+                    textDecoration: "none",
+                  }}
                 >
                   open →
                 </Link>
               </div>
-              <div className="h-[220px] rounded mesh-card-2 p-2.5">
+              <div
+                className="mesh-card-2"
+                style={{
+                  height: 220,
+                  borderRadius: "var(--radius)",
+                  padding: 10,
+                }}
+              >
                 {topologyError ? (
                   <ErrorState
                     title="Failed to load topology"
@@ -643,28 +832,43 @@ export default function DashboardPage() {
                   <TopoMini topology={topology} />
                 )}
               </div>
-              <div className="flex justify-between font-mono text-[11px] text-mesh-text-mute">
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  font: "500 11px var(--font-mono)",
+                  color: "var(--text-mute)",
+                }}
+              >
                 <span>{subnetCount ?? "—"} subnets</span>
                 <span>
-                  {topology
-                    ? `${topology.devices.length} devices`
-                    : "— devices"}
+                  {topology ? `${topology.devices.length} devices` : "— devices"}
                 </span>
                 <span>
-                  {stats
-                    ? `${stats.devices_online} / ${stats.devices_total}`
-                    : "— / —"}
+                  {stats ? `${stats.devices_online} / ${stats.devices_total}` : "— / —"}
                 </span>
               </div>
             </div>
 
             {/* Recent events */}
-            <div className="mesh-card">
-              <div className="flex items-center justify-between px-4 py-3">
-                <h3 className="text-sm font-semibold text-white">Recent events</h3>
-                <span className="font-mono text-[11px] text-mesh-text-mute">last 1h</span>
+            <div className="mesh-card" style={{ padding: 0 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "12px 14px 10px",
+                }}
+              >
+                <h3 className="t-h3">Recent events</h3>
+                <span
+                  className="t-small mono"
+                  style={{ color: "var(--text-mute)" }}
+                >
+                  last 1h
+                </span>
               </div>
-              <div className="border-t border-mesh-border">
+              <div style={{ borderTop: `var(--hairline) solid ${T.border}` }}>
                 {alertsError ? (
                   <div className="p-4">
                     <ErrorState
@@ -679,28 +883,57 @@ export default function DashboardPage() {
                     ))}
                   </div>
                 ) : events.length === 0 ? (
-                  <p className="px-4 py-6 text-center text-sm text-mesh-text-mute">
+                  <p
+                    className="px-4 py-6 text-center text-sm"
+                    style={{ color: "var(--text-mute)" }}
+                  >
                     No recent events — all clear.
                   </p>
                 ) : (
                   events.slice(0, 6).map((e, i) => (
                     <div
                       key={e.id}
-                      className={cn(
-                        "flex items-start gap-2.5 px-4 py-2 text-xs",
-                        i < Math.min(events.length, 6) - 1 && "border-b border-mesh-border",
-                      )}
                       data-testid="recent-event-row"
+                      style={{
+                        display: "flex",
+                        gap: 10,
+                        padding: "9px 14px",
+                        borderBottom:
+                          i < Math.min(events.length, 6) - 1
+                            ? `var(--hairline) solid ${T.border}`
+                            : "none",
+                        alignItems: "flex-start",
+                        font: "400 12px var(--font-sans)",
+                      }}
                     >
-                      <span className="min-w-[36px] font-mono text-[11px] text-mesh-text-faint">
+                      <span
+                        className="mono"
+                        style={{
+                          color: "var(--text-faint)",
+                          minWidth: 36,
+                          fontSize: 11,
+                        }}
+                      >
                         {formatAlertTime(e.created_at)}
                       </span>
-                      <span className="pt-1">
+                      <span style={{ marginTop: 5 }}>
                         <SevDot severity={mapAlertSeverity(e.severity)} size={6} />
                       </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-white">{e.message}</div>
-                        <div className="font-mono text-[10px] text-mesh-text-mute">
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div
+                          style={{
+                            color: "var(--text)",
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                          }}
+                        >
+                          {e.message}
+                        </div>
+                        <div
+                          className="mono"
+                          style={{ color: "var(--text-mute)", fontSize: 10 }}
+                        >
                           {alertSource(e)}
                         </div>
                       </div>
@@ -713,16 +946,28 @@ export default function DashboardPage() {
         </div>
 
         {/* ── Bottom: Subnet utilization ──────────────── */}
-        <div className="mesh-card p-4">
-          <div className="mb-3 flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-white">Subnet utilization</h3>
-            <span className="font-mono text-[11px] text-mesh-text-mute">capacity / 5min</span>
+        <div className="mesh-card" style={{ padding: "var(--card-pad)" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 12,
+            }}
+          >
+            <h3 className="t-h3">Subnet utilization</h3>
+            <span
+              className="t-small mono"
+              style={{ color: "var(--text-mute)" }}
+            >
+              capacity / 5min
+            </span>
           </div>
-          {/* TODO: backend gap — no per-subnet stats endpoint exists yet (no
-              /api/v1/subnets/utilization). The cards below derive counts
+          {/* TODO: backend gap — no per-subnet stats endpoint exists yet
+              (no /api/v1/subnets/utilization). The cards below derive counts
               from topology IP groupings; capacity / mbps placeholders remain
               "—" until the endpoint lands. */}
-          <SubnetUtilization topology={topology} devicesError={!!devicesError} />
+          <SubnetUtilization topology={topology ?? null} devicesError={!!devicesError} />
         </div>
 
         <CriticalDevicesDialog open={criticalDialogOpen} onOpenChange={setCriticalDialogOpen} />
@@ -740,7 +985,6 @@ function SubnetUtilization({
   topology: TopologyGraph | null;
   devicesError: boolean;
 }) {
-  // Derive subnets from topology device IPs.
   const subnets = useMemo(() => {
     if (!topology) return null;
     const groups = new Map<string, { hosts: number; online: number }>();
@@ -777,7 +1021,14 @@ function SubnetUtilization({
 
   if (subnets === null) {
     return (
-      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
+      <div
+        className="dashboard-subnet-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(5, 1fr)",
+          gap: 10,
+        }}
+      >
         {Array.from({ length: 5 }).map((_, i) => (
           <Skeleton key={i} className="h-28 w-full" />
         ))}
@@ -787,57 +1038,126 @@ function SubnetUtilization({
 
   if (subnets.length === 0) {
     return (
-      <p className="py-4 text-center text-sm text-mesh-text-mute">
+      <p
+        className="py-4 text-center text-sm"
+        style={{ color: "var(--text-mute)" }}
+      >
         No subnet data yet — discover devices to populate this view.
       </p>
     );
   }
 
   return (
-    <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-5">
+    <div
+      className="dashboard-subnet-grid"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(5, 1fr)",
+        gap: 10,
+      }}
+    >
       {subnets.map((s) => {
         const high = s.util > 70;
         return (
           <div
             key={s.name}
-            className="flex flex-col gap-2 mesh-card-2 p-3"
+            className="mesh-card-2"
             data-testid="subnet-card"
+            style={{
+              padding: 12,
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+            }}
           >
-            <div className="flex items-baseline justify-between">
-              <span className="text-sm font-semibold text-white">{s.name}</span>
-              <span className="font-mono text-[10px] text-mesh-text-mute">{s.cidr}</span>
-            </div>
-            <div className="flex items-baseline gap-1.5">
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "baseline",
+              }}
+            >
               <span
-                className="font-mono text-2xl font-semibold leading-none"
                 style={{
-                  color: high ? "hsl(var(--status-warning))" : "hsl(var(--foreground))",
+                  font: "600 13px var(--font-sans)",
+                  color: "var(--text)",
+                }}
+              >
+                {s.name}
+              </span>
+              <span
+                className="mono"
+                style={{ color: "var(--text-mute)", fontSize: 10 }}
+              >
+                {s.cidr}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 6,
+              }}
+            >
+              <span
+                className="mono"
+                style={{
+                  fontSize: 22,
+                  fontWeight: 600,
+                  color: high ? T.statusWarning : "var(--text)",
+                  lineHeight: 1,
                 }}
               >
                 {s.util}
               </span>
-              <span className="font-mono text-[11px] text-mesh-text-mute">%</span>
-              <span className="flex-1" />
-              <span className="font-mono text-[11px] text-mesh-text-dim">{s.hosts} hosts</span>
+              <span
+                className="t-small mono"
+                style={{ color: "var(--text-mute)" }}
+              >
+                %
+              </span>
+              <span style={{ flex: 1 }} />
+              <span
+                className="mono"
+                style={{ fontSize: 11, color: "var(--text-dim)" }}
+              >
+                {s.hosts} hosts
+              </span>
             </div>
-            <div className="h-1 overflow-hidden rounded-sm bg-mesh-surface-3">
+            <div
+              style={{
+                height: 4,
+                background: "var(--surface-3)",
+                borderRadius: 2,
+                overflow: "hidden",
+              }}
+            >
               <div
-                className="h-full rounded-sm"
                 style={{
+                  height: "100%",
                   width: `${s.util}%`,
-                  background: high
-                    ? "hsl(var(--status-warning))"
-                    : "hsl(var(--primary))",
+                  background: high ? T.statusWarning : T.primary,
+                  borderRadius: 2,
                 }}
               />
             </div>
-            <div className="flex items-center justify-between font-mono text-[10px] text-mesh-text-mute">
-              <span>— Mbps{/* TODO: backend gap — per-subnet bandwidth */}</span>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                font: "500 10px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              <span>
+                — Mbps
+                {/* TODO: backend gap — per-subnet bandwidth */}
+              </span>
               <Spark
                 data={[s.util * 0.6, s.util * 0.8, s.util, s.util * 0.9, s.util * 1.05]}
                 width={50}
                 height={14}
-                color="hsl(var(--ring))"
+                color="var(--accent-cyan)"
               />
             </div>
           </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -472,3 +472,51 @@
 .tabular {
   font-variant-numeric: tabular-nums;
 }
+
+/* `.btn-primary` — base.css 68-74. Solid primary CTA button.
+ * `--primary` and `--primary-hover` are declared as HSL aliases at :root
+ * for shadcn compatibility; the design recipe wants the literal hex, so
+ * we inline the values from tokens.css mesh direction.
+ *   --primary:       #2563eb (royal blue)
+ *   --primary-hover: #3672f0
+ *   --primary-fg:    #ffffff
+ *   --primary-glow:  rgba(56, 189, 248, 0.5)
+ *   --shadow-glow:   0 0 0 1px var(--accent-cyan)
+ */
+.btn-primary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.5);
+}
+.btn-primary:hover {
+  background: #3672f0;
+  border-color: #3672f0;
+  box-shadow: 0 0 0 1px #38bdf8;
+}
+
+/* ── Dashboard responsive grid breakpoints ──
+ * dashboard.jsx is desktop-first: KPI row = 6 columns, main grid = 2 cols
+ * (2fr | 1fr), subnet utilization = 5 columns. On narrower viewports we
+ * collapse these so columns do not overflow the viewport. */
+@media (max-width: 1279px) {
+  .dashboard-main-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}
+@media (max-width: 1023px) {
+  .dashboard-kpi-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
+  }
+  .dashboard-subnet-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
+  }
+}
+@media (max-width: 639px) {
+  .dashboard-kpi-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+  .dashboard-subnet-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+}


### PR DESCRIPTION
## Summary

Literal port of `dashboard.jsx` (from `/tmp/panopticon-design/panopticon/project/dashboard.jsx`) into `/dashboard` per the runbook **Source Code Port Protocol**.

- Replaces the dashboard page body with a verbatim port: inline `style={{ var(--X) }}` everywhere, design recipes (`.mesh-card`, `.mesh-card-2`, `.btn`, `.btn-primary`, `.t-display`, `.t-h3`, `.t-micro`, `.t-small`, `.mono`) used unchanged from globals.css.
- Adds `.btn-primary` recipe (byte-exact port of `base.css` lines 68-74) to globals.css since the design source uses `btn btn-primary` for the "Run scan" CTA.
- Adds responsive media queries for `.dashboard-kpi-grid`, `.dashboard-main-grid`, `.dashboard-subnet-grid` so the desktop-first 6/2/5-column grids collapse cleanly on tablet/mobile (design source is desktop-only).

## Token substitutions

Per the runbook fallback — these CSS vars conflict with shadcn HSL vars at `:root`, so inline literal hex from `tokens.css` mesh direction:

| Token | Literal |
|---|---|
| `--border` | `rgba(96,144,212,0.20)` |
| `--primary` | `#2563eb` |
| `--status-online` | `#4ade80` |
| `--status-offline` | `#fb7185` |
| `--status-warning` | `#fbbf24` |
| `--status-info` | `#38bdf8` |

Everything else (`--surface-1/2/3`, `--text/dim/mute/faint`, `--accent-cyan/violet`, `--radius-*`, `--hairline`, `--font-sans/mono`, `--card-pad`, `--motion*`, `--shadow-*`) kept as `var(--X)` — declared in globals.css `:root`.

## Data wiring (real backend hooks, no fake design data)

| Section | Hook(s) |
|---|---|
| KPI row | `fetchDashboardStats` (`devices_online`, `devices_total`, `wan_rx_bps`, `wan_tx_bps`, `alerts_unread`), `fetchAgents`, `fetchDnsQueryStats` |
| WAN traffic | `fetchTrafficHistory` (range-bound: 1h / 6h / 24h / 7d) |
| Top talkers | `fetchTopDevices(5)` |
| Topology | `fetchTopologyGraph` |
| Recent events | `fetchRecentAlerts(6)` |
| Subnet utilization | derived from topology IP groupings |

## Backend gaps (carried over from prior page.tsx, TODO comments inline)

- Uptime not exposed via `/api/v1/dashboard/stats` (header shows `10.0.0.0/16 · N subnets · M known` without uptime tail)
- WAN latency not exposed via `/api/v1/dashboard/stats` (KPI shows `—`)
- No per-device traffic history endpoint (top-talkers spark uses `devicePlaceholderSpark` based on current rate)
- No `/api/v1/subnets/utilization` endpoint (subnet card capacity/Mbps shown as `—`)

## Verification

- `bash scripts/check-design-tokens.sh` — passes (no raw Tailwind color literals, no ad-hoc card-recipe combos)
- `bun install --frozen-lockfile` — clean install
- `bun run build` — passes; `/dashboard` route built at 8.97 kB

## Test plan

- [ ] Visit `/dashboard` in dev — verify header (Overview / core.lan / subline), 6 KPI tiles, WAN traffic card with RX/TX legend + 1h/6h/24h/7d toggle, Top talkers table, Topology preview, Recent events list, Subnet utilization grid
- [ ] Resize: at `< 1280px` main grid collapses to single column; at `< 1024px` KPI/subnet grids drop to 3 cols; at `< 640px` they drop to 2 cols
- [ ] Verify SWR refresh (30 s) updates KPIs and traffic chart
- [ ] WS events (`device_online` / `offline` / `new_device`) trigger toasts + revalidate

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the `dashboard.jsx` design source into `/dashboard`, replacing Tailwind utility classes with inline styles and CSS design-recipe classes, wiring KPI/traffic/topology/events sections to real backend hooks, and adding responsive grid breakpoints.

- `page.tsx` converts all styling to inline `style={{}}` props using a `T` token-literal map for shadcn-conflicting CSS vars; data hooks and component structure are otherwise unchanged.
- `globals.css` gains the `.btn-primary` recipe and three `@media` blocks for the dashboard grids; the responsive overrides need `!important` because the column counts live in inline styles.
- No Playwright E2E test is included despite the mandatory rule in CLAUDE.md for dashboard feature changes.

<h3>Confidence Score: 3/5</h3>

The dashboard renders correctly and data wiring is intact, but a mandatory automated test requirement is unmet and minor regressions were introduced during the inline-style conversion.

The missing Playwright E2E test is a hard project requirement for any dashboard feature change, and the hover affordance on CriticalDevicesDialog rows was dropped without a replacement.

web/src/app/(app)/dashboard/page.tsx needs a hover state restored on dialog rows and an E2E test added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dashboard/page.tsx | Large-scale Tailwind-to-inline-style port; introduces T token literals, removes statsError (likely unused), and drops hover feedback on CriticalDevicesDialog rows. No Playwright E2E test accompanies the change. |
| web/src/app/globals.css | Adds .btn-primary recipe and responsive breakpoints for dashboard grids; breakpoints require !important to override inline styles set in page.tsx. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/app/(app)/dashboard/page.tsx:266
**Missing mandatory Playwright E2E test**

Per the project's CLAUDE.md rule, every PR implementing a feature or bug fix must include a Playwright E2E test in `web/tests/e2e/` that exercises the real UI. This PR rewrites the entire dashboard page — it touches KPI rendering, WAN traffic toggle, top talkers, topology preview, recent events, and subnet utilization — but ships no E2E spec. The PR description includes a manual test plan checklist but no automated test file, and there is no `## Why No E2E Test` justification section. Visiting `/dashboard` and verifying the six KPI tiles render, the traffic range toggle works, and resizing collapses the grids are all testable with Playwright and match the examples in CLAUDE.md.

### Issue 2 of 2
web/src/app/(app)/dashboard/page.tsx:174
**Hover feedback lost on critical-device rows**

The `hover:bg-mesh-surface-2/55` class was removed when converting to inline styles, but no equivalent `:hover` CSS or `onMouseEnter`/`onMouseLeave` handler was added. Device rows in the Critical Devices dialog are now entirely flat — there's no visual affordance when hovering over a link. `transition-colors` is still present but has nothing to transition to.

```suggestion
                  className="flex items-center gap-3 rounded-md px-2 py-2 transition-colors group hover:bg-[var(--surface-2)]"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): literal port of dashboard.jsx →..."](https://github.com/befeast/panoptikon/commit/7301a95671d8524f5b40bcee265d8497a91ca90c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32604558)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->