### PR TITLE
feat(topology): add Mesh tab — restores discoverability

### DIFF
--- a/web/src/app/(app)/topology/page.tsx
+++ b/web/src/app/(app)/topology/page.tsx
@@ -26,6 +26,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
+import XiaomiMeshTopology from "@/components/XiaomiMeshTopology";
 import {
   fetchTopologyGraph,
   deleteTopologyPositions,
@@ -404,6 +405,7 @@ export default function TopologyPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"subnets" | "mesh">("subnets");
   const pinnedRef = useRef<Map<string, { x: number; y: number }>>(new Map());
 
   // Animated flow offset for dashed links — verbatim from source.
@@ -578,6 +580,56 @@ export default function TopologyPage() {
           onTrace={tracePath}
         />
 
+        {/* Tab switcher — Subnets (literal port of topology.jsx) vs Mesh
+         * (XiaomiMeshTopology, restored from /mesh route per user request). */}
+        <div
+          role="tablist"
+          aria-label="Topology views"
+          data-testid="topology-tabs"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 24,
+            borderBottom: "1px solid rgba(96,144,212,0.20)",
+            paddingBottom: 8,
+          }}
+        >
+          {(["subnets", "mesh"] as const).map((key) => {
+            const active = activeTab === key;
+            const label = key === "subnets" ? "Subnets" : "Mesh";
+            return (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                data-testid={`topology-tab-${key}`}
+                onClick={() => setActiveTab(key)}
+                style={{
+                  background: "transparent",
+                  border: 0,
+                  padding: "4px 0",
+                  cursor: "pointer",
+                  font: `${active ? 500 : 400} 13px var(--font-sans)`,
+                  color: active ? "var(--text)" : "var(--text-mute)",
+                  borderBottom: active
+                    ? "2px solid var(--accent-cyan)"
+                    : "2px solid transparent",
+                  marginBottom: -9,
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
+        {activeTab === "mesh" ? (
+          <div style={{ flex: 1, minHeight: 0, overflow: "auto" }} data-testid="topology-mesh-pane">
+            <XiaomiMeshTopology />
+          </div>
+        ) : (
+        <>
         {/* Body grid — verbatim grid template from source */}
         <div
           style={{
@@ -906,6 +958,8 @@ export default function TopologyPage() {
             }
           />
         </div>
+        </>
+        )}
       </div>
     </PageTransition>
   );


### PR DESCRIPTION
## Summary

User flagged that the Xiaomi mesh visualization (4-node BE3600 topology) became unreachable from sidebar nav after the Wave A literal port of shell.jsx (which has only one Topology nav item in Network group, no separate Mesh). Per user choice, embed it as a tab inside the literal-ported /topology page.

## Changes

- Add 2-tab switcher (Subnets default, Mesh) between topology Header and body grid in `web/src/app/(app)/topology/page.tsx`.
- Subnets tab renders the existing literal port (graph card + side panel).
- Mesh tab renders `<XiaomiMeshTopology />` unchanged.
- `/mesh` standalone route preserved for backward compatibility.

Test-ids: `topology-tabs`, `topology-tab-subnets`, `topology-tab-mesh`, `topology-mesh-pane`.

## Verification

- [x] `bash scripts/check-design-tokens.sh` — all 3 guards pass
- [x] `bun run build` — clean (all 73 routes)
- [ ] After deploy: /topology shows Subnets + Mesh tabs; Mesh tab renders the BE3600 visualization.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR embeds the Xiaomi mesh visualization as a "Mesh" tab inside `/topology`, sitting alongside the existing "Subnets" view with a plain tab switcher, and preserves the standalone `/mesh` route for backward compatibility.

- The tab switcher is implemented with `role=\"tablist\"` / `role=\"tab\"` / `aria-selected`, but the corresponding tab panels lack `role=\"tabpanel\"`, `aria-labelledby`, and `id` attributes, and inactive tabs have no `tabIndex={-1}`, making the ARIA pattern incomplete for assistive technology users.
- No Playwright E2E test was added despite the PR listing four new test-ids and `CLAUDE.md` requiring a test for every feature PR; the PR description also contains no `## Why No E2E Test` justification section.

<h3>Confidence Score: 3/5</h3>

The functional change (tab-switching, embedding XiaomiMeshTopology) looks correct, but two issues need addressing before this lands.

The tab-switcher logic works and the Subnets/Mesh content is conditionally rendered correctly. However, the ARIA panel roles are missing — assistive technology users will see two tabs but no announced panels — and the mandatory Playwright test for the new tab UI is absent without justification, leaving the feature unverified in CI.

web/src/app/(app)/topology/page.tsx — needs the ARIA tabpanel roles completed and a companion E2E spec.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/topology/page.tsx | Adds a two-tab switcher (Subnets / Mesh) embedding XiaomiMeshTopology; missing mandatory E2E test and incomplete ARIA tab-panel pattern. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/app/(app)/topology/page.tsx:583-635
**Missing Playwright E2E test for tab switcher**

Per the mandatory rule in `CLAUDE.md`, every feature PR must ship a Playwright test in `web/tests/e2e/` that exercises the new UI (tab visibility, switching from Subnets to Mesh, `topology-mesh-pane` renders). The PR description lists test-ids (`topology-tabs`, `topology-tab-subnets`, `topology-tab-mesh`, `topology-mesh-pane`) but no test file was added, and there is no `## Why No E2E Test` section justifying the omission. The existing `topology.spec.ts` does not cover the new tab behaviour.

### Issue 2 of 2
web/src/app/(app)/topology/page.tsx:627-635
**Incomplete ARIA tab pattern — panels lack `role="tabpanel"`**

The `role="tablist"` / `role="tab"` / `aria-selected` triad is present, but neither the Mesh pane `<div>` nor the Subnets `<>` fragment carries `role="tabpanel"`. Without it, assistive technologies cannot associate the visible content with the selected tab. The full pattern also requires each tab to have a stable `id`, each panel a matching `aria-labelledby` pointing to its controlling tab, and inactive tabs to carry `tabIndex={-1}` (with only the active tab at `tabIndex={0}`). In the current form a screen reader announces two tabs but no panels, so keyboard-only users lose context when focus moves to the content area.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(topology): add Mesh tab — restores ..."](https://github.com/befeast/panoptikon/commit/d8f12c7c0ee45b478eb026346792cb00e888436e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32642249)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->