### PR TITLE
fix(ux): Wave B sweep — /dns-logs /dns-queries

### DIFF
--- a/web/src/app/(app)/dns-logs/page.tsx
+++ b/web/src/app/(app)/dns-logs/page.tsx
@@ -40,6 +40,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PageTransition } from "@/components/PageTransition";
+import { EmptyState } from "@/components/mesh/state";
 import { HelpTooltip } from "@/components/HelpTooltip";
 import {
   Tooltip,
@@ -150,12 +151,10 @@ export default function DnsLogsPage() {
         <div className="flex items-center justify-between">
           <div>
             <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-semibold tracking-tight text-white">
-                DNS Query Log
-              </h1>
+              <h1 className="t-h1 text-mesh-text">DNS Query Log</h1>
               <HelpTooltip text="Shows DNS queries made by devices on your network. Useful for spotting suspicious domains and debugging connectivity. Data is kept for 7 days." />
             </div>
-            <p className="text-muted-foreground">
+            <p className="text-mesh-text-mute">
               Per-device DNS query history and statistics (7-day retention)
             </p>
           </div>
@@ -167,7 +166,7 @@ export default function DnsLogsPage() {
                   Refresh
                 </Button>
               </TooltipTrigger>
-              <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
+              <TooltipContent className="max-w-xs">
                 Reload the query log with the latest entries
               </TooltipContent>
             </Tooltip>
@@ -333,6 +332,18 @@ export default function DnsLogsPage() {
             </div>
 
             {/* Query Log Table */}
+            {!loading && logData?.entries.length === 0 ? (
+              <EmptyState
+                icon={Globe}
+                title="No DNS queries recorded yet"
+                message="Configure Unbound log ingestion to start collecting per-device DNS history."
+                action={
+                  <a href="/settings/dns" className="btn btn-primary">
+                    DNS Settings
+                  </a>
+                }
+              />
+            ) : (
             <Card>
               <CardContent className="p-0">
                 <Table>
@@ -358,16 +369,6 @@ export default function DnsLogsPage() {
                           ))}
                         </TableRow>
                       ))
-                    ) : logData?.entries.length === 0 ? (
-                      <TableRow>
-                        <TableCell
-                          colSpan={7}
-                          className="h-24 text-center text-muted-foreground"
-                        >
-                          No DNS queries recorded yet. Configure Unbound log
-                          ingestion to start collecting data.
-                        </TableCell>
-                      </TableRow>
                     ) : (
                       logData?.entries.map((entry: DnsQueryLogEntry) => (
                         <TableRow key={entry.id}>
@@ -417,6 +418,7 @@ export default function DnsLogsPage() {
                 </Table>
               </CardContent>
             </Card>
+            )}
 
             {/* Pagination */}
             {totalPages > 1 && (
@@ -457,7 +459,7 @@ export default function DnsLogsPage() {
               {/* Top Queried Domains */}
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-lg">Top Queried Domains</CardTitle>
+                  <CardTitle className="t-h2">Top Queried Domains</CardTitle>
                 </CardHeader>
                 <CardContent>
                   {statsLoading ? (
@@ -498,7 +500,7 @@ export default function DnsLogsPage() {
               {/* Top Blocked Domains */}
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-lg">Top Blocked Domains</CardTitle>
+                  <CardTitle className="t-h2">Top Blocked Domains</CardTitle>
                 </CardHeader>
                 <CardContent>
                   {statsLoading ? (

--- a/web/src/app/(app)/dns-queries/page.tsx
+++ b/web/src/app/(app)/dns-queries/page.tsx
@@ -31,7 +31,7 @@ import type {
   DnsQueryStats,
 } from "@/lib/types";
 import { PageTransition } from "@/components/PageTransition";
-import { EmptyState } from "@/components/EmptyState";
+import { EmptyState } from "@/components/mesh/state";
 import { ErrorState } from "@/components/ErrorState";
 
 type TimeRange = "1h" | "6h" | "24h" | "48h" | "7d";
@@ -133,7 +133,7 @@ export default function DnsQueriesPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight text-white">DNS Query Log</h1>
+            <h1 className="t-h1 text-mesh-text">DNS Query Log</h1>
             {stats && (
               <Badge variant="secondary" className="gap-1">
                 <Globe className="h-3 w-3" />
@@ -308,11 +308,6 @@ export default function DnsQueriesPage() {
                 variant={timeRange === t.value ? "default" : "outline"}
                 size="sm"
                 onClick={() => setTimeRange(t.value)}
-                className={
-                  timeRange === t.value
-                    ? ""
-                    : "border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text"
-                }
               >
                 {t.label}
               </Button>
@@ -327,11 +322,6 @@ export default function DnsQueriesPage() {
                 variant={blockedFilter === f ? "default" : "outline"}
                 size="sm"
                 onClick={() => setBlockedFilter(f)}
-                className={
-                  blockedFilter === f
-                    ? ""
-                    : "border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text"
-                }
               >
                 {f === "all" ? "All" : f === "blocked" ? "Blocked" : "Allowed"}
               </Button>
@@ -345,7 +335,7 @@ export default function DnsQueriesPage() {
               placeholder="Filter by domain..."
               value={domainSearch}
               onChange={(e) => setDomainSearch(e.target.value)}
-              className="pl-9 bg-[#12121a] border-mesh-border-strong text-sm"
+              className="pl-9 text-sm"
             />
           </div>
         </div>
@@ -360,17 +350,16 @@ export default function DnsQueriesPage() {
             </CardContent>
           </Card>
         ) : logData.items.length === 0 ? (
-          <Card className="">
-            <CardContent>
-              <EmptyState
-                icon={Globe}
-                title="No DNS queries recorded"
-                description="No queries match the selected filters. Check that DNS logging is enabled in Settings → DNS."
-                actionLabel="DNS Settings"
-                actionHref="/settings/dns"
-              />
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={Globe}
+            title="No DNS queries recorded"
+            message="No queries match the selected filters. Check that DNS logging is enabled in Settings → DNS."
+            action={
+              <a href="/settings/dns" className="btn btn-primary">
+                DNS Settings
+              </a>
+            }
+          />
         ) : (
           <Card className="overflow-hidden">
             <div className="overflow-x-auto">
@@ -476,7 +465,6 @@ export default function DnsQueriesPage() {
                     size="sm"
                     disabled={page <= 1}
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    className="border-mesh-border-strong text-mesh-text-dim h-7 px-2"
                   >
                     <ChevronLeft className="h-4 w-4" />
                   </Button>
@@ -485,7 +473,6 @@ export default function DnsQueriesPage() {
                     size="sm"
                     disabled={page >= totalPages}
                     onClick={() => setPage((p) => p + 1)}
-                    className="border-mesh-border-strong text-mesh-text-dim h-7 px-2"
                   >
                     <ChevronRight className="h-4 w-4" />
                   </Button>


### PR DESCRIPTION
## Summary

Bring the two DNS routes (`/dns-logs`, `/dns-queries`) onto the mesh
design system so they match the rest of the shell. The screenshot the
user shared on `/dns-logs` flagged a prominent empty-state card with
very visible border chrome — that drift came from two places, both
addressed here.

### Per-route drift fixes

**`/dns-queries`**
- Legacy `@/components/EmptyState` was nesting `.mesh-card` inside an
  outer `<Card>` (which itself applies `.mesh-card`). That is exactly
  the "double border from nested recipes" anti-pattern from the runbook
  — and the chrome the user saw on the live route.
- Swapped to the existing `EmptyState` atom from
  `@/components/mesh/state/EmptyState.tsx` (a faithful port of
  `states.jsx`). The atom ships its own card chrome, so the wrapping
  `<Card>` is gone — one elevation tier only.
- CTA now uses the design-source `.btn .btn-primary` recipe.
- Header heading uses `.t-h1` typography recipe.
- Stripped ad-hoc filter button overrides
  (`border-mesh-border-strong text-mesh-text-dim hover:text-mesh-text`)
  that recomposed the `.btn` recipe at the consumer site.
- Dropped `bg-[#12121a]` on the search input (non-token literal) and
  the `border-mesh-border-strong h-7 px-2` overrides on pagination
  buttons. `Button variant="outline"` already matches the design.

**`/dns-logs`**
- Pulled the "No DNS queries recorded yet" branch out of the
  `<TableCell colSpan>` and rendered the mesh `EmptyState` above the
  table for parity with `/dns-queries`.
- Heading uses `.t-h1`; section card titles use `.t-h2` (was raw
  `text-lg`).
- Removed redundant `border-mesh-border bg-mesh-surface-1 text-mesh-text`
  override on `<TooltipContent>` — the primitive already ports the mesh
  recipe by default; overriding it was a downgrade.

### Why this is small

Both files only consume primitives; no new recipes are added to
`globals.css` and no shared atoms are modified. The mesh `EmptyState`
atom already exists at `web/src/components/mesh/state/EmptyState.tsx`
from the earlier `states.jsx` port — we're routing the two DNS pages
through it.

### Out of scope (deliberately)

- `ErrorState` still uses `@/components/ErrorState`. The mesh
  `ErrorState` has a different API (`title` required, `staleContent`,
  etc.); the legacy implementation already uses literal hex (no
  framework family violations) and only renders on a hard fetch failure.
  Out of scope for this targeted sweep — flagging for a future wave.
- Other consumers of the legacy `EmptyState` (traffic, ssh-hosts,
  agents, caddy, certificates, dashboard) are not touched. The brief
  scoped this to the two DNS routes.

## Test plan

- [x] `bash web/scripts/check-design-tokens.sh` — green
  (no raw color literals, no ad-hoc card recipe combos,
  no gradient-on-mesh-surface combos)
- [x] `bun run build` — succeeds; `/dns-logs` (11.1 kB) and
  `/dns-queries` (6.5 kB) prerender as static
- [ ] Visual check on staging: `/dns-queries` empty surface no
  longer shows a double border; `/dns-logs` empty surface renders
  the blueprint EmptyState atom with the same chrome as
  `/dns-queries`
- [ ] Existing Playwright suites for DNS routes still pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes `/dns-logs` and `/dns-queries` are migrated onto the mesh design system: the legacy double-nested `EmptyState`/`Card` combo is replaced by the existing `mesh/state/EmptyState` atom (which ships its own card chrome), ad-hoc className token overrides are stripped, and heading/section-title typography is updated to `.t-h1`/`.t-h2`.

- **`/dns-queries`**: legacy `EmptyState` inside a wrapping `<Card>` removed; mesh atom used directly; filter-button and pagination button `className` overrides dropped; `bg-[#12121a]` literal removed from the search input.
- **`/dns-logs`**: \"No DNS queries recorded yet\" branch lifted out of `<TableCell colSpan>` and rendered as the mesh `EmptyState` above the table; `TooltipContent` redundant token override removed; `CardTitle` updated to `.t-h2`.
- Both files only consume existing primitives; no new recipes or shared atoms are modified.

<h3>Confidence Score: 3/5</h3>

Safe to merge for dns-queries; dns-logs carries a misleading empty-state message shown to any user whose active filter yields zero results, plus no new Playwright coverage for the visual fix.

The dns-logs empty-state condition does not distinguish between no data ever recorded and current filter returning nothing. A user selecting the Blocked filter with zero results is told to configure Unbound ingestion even though the system is working correctly. Additionally the mandatory E2E test is absent with no exemption in the PR description.

web/src/app/(app)/dns-logs/page.tsx — the empty-state condition at line 335 and the missing test coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/dns-logs/page.tsx | Mesh EmptyState atom replaces inline table-row empty state and typography tokens are updated; empty-state condition does not distinguish filter-driven zero results from truly empty data, surfacing an incorrect "configure Unbound" message. |
| web/src/app/(app)/dns-queries/page.tsx | Legacy EmptyState swapped for mesh atom, double-card nesting removed, ad-hoc className overrides dropped; changes look correct and the filter-aware empty message was already appropriate here. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/app/(app)/dns-logs/page.tsx`, line 1-3 ([link](https://github.com/befeast/panoptikon/blob/d2388f0f539d36f6689f0ffa908b1b9da83570bf/web/src/app/(app)/dns-logs/page.tsx#L1-L3)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Missing Playwright E2E test for the visual fix**

   `CLAUDE.md` requires every bug-fix PR to ship a Playwright test that fails before the fix and passes after. The test plan's Playwright checkbox is unchecked and there is no `## Why No E2E Test` section in the PR description. The existing `dns-logs.spec.ts` pre-dates this PR and only asserts the heading and HTTP 200; it does not verify that the mesh `EmptyState` atom renders (e.g. checking `data-component="mesh-empty-state"`) or that no double-border card nesting is present. A minimal test checking `page.locator('[data-component="mesh-empty-state"]')` is visible when the page loads with an empty fixture would satisfy the requirement.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/dns-logs/page.tsx
   Line: 1-3
   
   Comment:
   **Missing Playwright E2E test for the visual fix**
   
   `CLAUDE.md` requires every bug-fix PR to ship a Playwright test that fails before the fix and passes after. The test plan's Playwright checkbox is unchecked and there is no `## Why No E2E Test` section in the PR description. The existing `dns-logs.spec.ts` pre-dates this PR and only asserts the heading and HTTP 200; it does not verify that the mesh `EmptyState` atom renders (e.g. checking `data-component="mesh-empty-state"`) or that no double-border card nesting is present. A minimal test checking `page.locator('[data-component="mesh-empty-state"]')` is visible when the page loads with an empty fixture would satisfy the requirement.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/app/(app)/dns-logs/page.tsx:335-345
**Misleading empty-state message when filters are active**

The condition `!loading && logData?.entries.length === 0` fires for both "no data ever ingested" and "no rows matched the current filter." When a user switches to the "Blocked" tab (or enters a domain/IP filter) and gets zero results, they see "No DNS queries recorded yet — Configure Unbound log ingestion" with a "DNS Settings" CTA. That's factually wrong: Unbound is already running and recording data; the empty result is a filter artifact. The fix is to check whether any filter is active and swap the message accordingly (same pattern used in `/dns-queries`).

### Issue 2 of 2
web/src/app/(app)/dns-logs/page.tsx:1-3
**Missing Playwright E2E test for the visual fix**

`CLAUDE.md` requires every bug-fix PR to ship a Playwright test that fails before the fix and passes after. The test plan's Playwright checkbox is unchecked and there is no `## Why No E2E Test` section in the PR description. The existing `dns-logs.spec.ts` pre-dates this PR and only asserts the heading and HTTP 200; it does not verify that the mesh `EmptyState` atom renders (e.g. checking `data-component="mesh-empty-state"`) or that no double-border card nesting is present. A minimal test checking `page.locator('[data-component="mesh-empty-state"]')` is visible when the page loads with an empty fixture would satisfy the requirement.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): mesh-design consistency sweep f..."](https://github.com/befeast/panoptikon/commit/d2388f0f539d36f6689f0ffa908b1b9da83570bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32650965)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->