### PR TITLE
fix(ux): Wave B sweep — /audit-log /certificates /ddns

### DIFF
--- a/web/src/app/(app)/audit-log/page.tsx
+++ b/web/src/app/(app)/audit-log/page.tsx
@@ -8,11 +8,11 @@ export default function AuditLogPage() {
     <div className="space-y-4">
       <div className="flex items-center gap-3">
         <ScrollText className="h-5 w-5 text-mesh-accent" />
-        <h1 className="text-xl font-semibold tracking-tight text-mesh-text">
+        <h1 className="t-h1" style={{ margin: 0 }}>
           Audit log
         </h1>
       </div>
-      <Card className="">
+      <Card>
         <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center">
           <ScrollText className="h-10 w-10 text-mesh-text-faint/80" />
           <p className="text-sm text-mesh-text-dim">

--- a/web/src/app/(app)/certificates/page.tsx
+++ b/web/src/app/(app)/certificates/page.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import {
   Dialog,
@@ -299,7 +300,7 @@ export default function CertificatesPage() {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-semibold tracking-tight text-white">
+            <h1 className="t-display" style={{ margin: 0 }}>
               SSL Certificates
             </h1>
             <HelpTooltip text="View and manage SSL/TLS certificates provisioned through Caddy. Request free Let's Encrypt certs or upload your own." />
@@ -311,31 +312,23 @@ export default function CertificatesPage() {
         <div className="flex gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                onClick={() => setLeDialogOpen(true)}
-                className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
-              >
+              <Button variant="outline" onClick={() => setLeDialogOpen(true)}>
                 <Plus className="mr-1.5 h-3.5 w-3.5" />
                 Let&apos;s Encrypt
               </Button>
             </TooltipTrigger>
-            <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
+            <TooltipContent className="max-w-xs">
               Request a free SSL certificate from Let&apos;s Encrypt via DNS challenge
             </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                onClick={() => setCustomDialogOpen(true)}
-                className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
-              >
+              <Button variant="outline" onClick={() => setCustomDialogOpen(true)}>
                 <Upload className="mr-1.5 h-3.5 w-3.5" />
                 Upload Custom
               </Button>
             </TooltipTrigger>
-            <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
+            <TooltipContent className="max-w-xs">
               Upload your own SSL certificate and private key
             </TooltipContent>
           </Tooltip>
@@ -354,14 +347,14 @@ export default function CertificatesPage() {
       )}
 
       {/* Certificates table */}
-      <Card className="">
+      <Card>
         <CardHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-9 w-9 items-center justify-center rounded-md border border-mesh-accent/20 bg-mesh-accent/10">
-              <Shield className="h-4 w-4 text-[#67e8f9]" />
+              <Shield className="h-4 w-4 text-mesh-accent" />
             </div>
             <div>
-              <CardTitle className="text-base text-white">
+              <CardTitle className="text-base text-mesh-text">
                 Certificates ({certs.length})
               </CardTitle>
               <CardDescription className="text-xs text-mesh-text-mute">
@@ -381,7 +374,7 @@ export default function CertificatesPage() {
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
-                  <TableRow className="border-mesh-border-strong hover:bg-transparent">
+                  <TableRow className="hover:bg-transparent">
                     <TableHead className="text-mesh-text-dim">Name</TableHead>
                     <TableHead className="text-mesh-text-dim">Domains</TableHead>
                     <TableHead className="text-mesh-text-dim">Provider</TableHead>
@@ -394,21 +387,14 @@ export default function CertificatesPage() {
                 </TableHeader>
                 <TableBody>
                   {certs.map((cert) => (
-                    <TableRow
-                      key={cert.id}
-                      className="border-mesh-border-strong hover:bg-mesh-surface-2/55"
-                    >
-                      <TableCell className="font-medium text-white">
+                    <TableRow key={cert.id}>
+                      <TableCell className="font-medium text-mesh-text">
                         {cert.nice_name}
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-1">
                           {cert.domain_names.map((d) => (
-                            <Badge
-                              key={d}
-                              variant="outline"
-                              className="border-mesh-border-strong text-xs text-mesh-text"
-                            >
+                            <Badge key={d} variant="outline" className="text-xs">
                               {d}
                             </Badge>
                           ))}
@@ -445,7 +431,7 @@ export default function CertificatesPage() {
                               size="sm"
                               onClick={() => handleRenew(cert)}
                               disabled={renewingId === cert.id}
-                              className="h-8 px-2 text-mesh-text-dim hover:text-white"
+                              className="h-8 px-2 text-mesh-text-dim hover:text-mesh-text"
                               title="Renew"
                             >
                               {renewingId === cert.id ? (
@@ -477,10 +463,10 @@ export default function CertificatesPage() {
 
       {/* Let's Encrypt Dialog */}
       <Dialog open={leDialogOpen} onOpenChange={setLeDialogOpen}>
-        <DialogContent className="border-mesh-border bg-mesh-surface-1/95 text-white sm:max-w-md">
+        <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Request Let&apos;s Encrypt Certificate</DialogTitle>
-            <DialogDescription className="text-mesh-text-dim">
+            <DialogDescription>
               Provide domain names and an email for Let&apos;s Encrypt
               validation.
             </DialogDescription>
@@ -494,7 +480,6 @@ export default function CertificatesPage() {
                 id="le-domains"
                 value={leDomains}
                 onChange={(e) => setLeDomains(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="example.com, *.example.com"
               />
             </div>
@@ -507,7 +492,6 @@ export default function CertificatesPage() {
                 type="email"
                 value={leEmail}
                 onChange={(e) => setLeEmail(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="admin@example.com"
               />
             </div>
@@ -522,17 +506,12 @@ export default function CertificatesPage() {
             </label>
           </div>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setLeDialogOpen(false)}
-              className="border-mesh-border-strong text-mesh-text"
-            >
+            <Button variant="outline" onClick={() => setLeDialogOpen(false)}>
               Cancel
             </Button>
             <Button
               onClick={handleCreateLetsEncrypt}
               disabled={!leDomains.trim() || !leEmail.trim() || leSubmitting}
-              className="bg-mesh-accent text-mesh-surface-1 hover:bg-mesh-accent"
             >
               {leSubmitting && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -545,10 +524,10 @@ export default function CertificatesPage() {
 
       {/* Upload Custom Certificate Dialog */}
       <Dialog open={customDialogOpen} onOpenChange={setCustomDialogOpen}>
-        <DialogContent className="border-mesh-border bg-mesh-surface-1/95 text-white sm:max-w-lg">
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Upload Custom Certificate</DialogTitle>
-            <DialogDescription className="text-mesh-text-dim">
+            <DialogDescription>
               Upload PEM-encoded certificate and private key files, or paste
               them directly.
             </DialogDescription>
@@ -565,7 +544,6 @@ export default function CertificatesPage() {
                 id="custom-name"
                 value={customName}
                 onChange={(e) => setCustomName(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="My Certificate"
               />
             </div>
@@ -577,7 +555,7 @@ export default function CertificatesPage() {
                 >
                   Certificate (PEM)
                 </Label>
-                <label className="cursor-pointer text-xs text-[#67e8f9] hover:text-mesh-text">
+                <label className="cursor-pointer text-xs text-mesh-accent hover:text-mesh-text">
                   <input
                     type="file"
                     accept=".pem,.crt,.cer"
@@ -589,12 +567,12 @@ export default function CertificatesPage() {
                   Choose file
                 </label>
               </div>
-              <textarea
+              <Textarea
                 id="custom-cert"
                 value={customCert}
                 onChange={(e) => setCustomCert(e.target.value)}
                 rows={4}
-                className="w-full mesh-card px-3 py-2 font-mono text-xs text-white placeholder:text-mesh-text-mute focus:outline-none focus:ring-1 focus:ring-mesh-accent"
+                className="font-mono text-xs"
                 placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
               />
             </div>
@@ -606,7 +584,7 @@ export default function CertificatesPage() {
                 >
                   Private Key (PEM)
                 </Label>
-                <label className="cursor-pointer text-xs text-[#67e8f9] hover:text-mesh-text">
+                <label className="cursor-pointer text-xs text-mesh-accent hover:text-mesh-text">
                   <input
                     type="file"
                     accept=".pem,.key"
@@ -618,22 +596,18 @@ export default function CertificatesPage() {
                   Choose file
                 </label>
               </div>
-              <textarea
+              <Textarea
                 id="custom-key"
                 value={customKey}
                 onChange={(e) => setCustomKey(e.target.value)}
                 rows={4}
-                className="w-full mesh-card px-3 py-2 font-mono text-xs text-white placeholder:text-mesh-text-mute focus:outline-none focus:ring-1 focus:ring-mesh-accent"
+                className="font-mono text-xs"
                 placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
               />
             </div>
           </div>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setCustomDialogOpen(false)}
-              className="border-mesh-border-strong text-mesh-text"
-            >
+            <Button variant="outline" onClick={() => setCustomDialogOpen(false)}>
               Cancel
             </Button>
             <Button
@@ -644,7 +618,6 @@ export default function CertificatesPage() {
                 !customKey.trim() ||
                 customSubmitting
               }
-              className="bg-mesh-accent text-mesh-surface-1 hover:bg-mesh-accent"
             >
               {customSubmitting && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -660,24 +633,20 @@ export default function CertificatesPage() {
         open={!!deleteTarget}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
       >
-        <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+        <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle className="text-white">
-              Delete Certificate
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-mesh-text-dim">
+            <AlertDialogTitle>Delete Certificate</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete &ldquo;{deleteTarget?.nice_name}
               &rdquo;? This action cannot be undone. Any proxy hosts using this
               certificate will lose their SSL configuration.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel className="border-mesh-border-strong text-mesh-text">
-              Cancel
-            </AlertDialogCancel>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               Delete
             </AlertDialogAction>

--- a/web/src/app/(app)/ddns/page.tsx
+++ b/web/src/app/(app)/ddns/page.tsx
@@ -47,6 +47,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { PageTransition } from "@/components/PageTransition";
 import {
   fetchDdnsEntries,
@@ -193,7 +200,7 @@ function DdnsFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-lg bg-mesh-surface-1 border-mesh-border text-mesh-text max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {initial ? "Edit DDNS Entry" : "Add DDNS Entry"}
@@ -203,32 +210,34 @@ function DdnsFormDialog({
           <div className="grid grid-cols-2 gap-5">
             <div className="space-y-2">
               <Label>Provider</Label>
-              <select
-                className="w-full mesh-card px-3 py-2 text-sm text-mesh-text"
-                value={provider}
-                onChange={(e) => setProvider(e.target.value)}
-              >
-                {PROVIDERS.map((p) => (
-                  <option key={p} value={p}>
-                    {p.charAt(0).toUpperCase() + p.slice(1)}
-                  </option>
-                ))}
-              </select>
+              <Select value={provider} onValueChange={setProvider}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROVIDERS.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {p.charAt(0).toUpperCase() + p.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             {routerTypes.length > 1 && (
               <div className="space-y-2">
                 <Label>Router Type</Label>
-                <select
-                  className="w-full mesh-card px-3 py-2 text-sm text-mesh-text"
-                  value={routerType}
-                  onChange={(e) => setRouterType(e.target.value)}
-                >
-                  {routerTypes.map((t) => (
-                    <option key={t} value={t}>
-                      MikroTik
-                    </option>
-                  ))}
-                </select>
+                <Select value={routerType} onValueChange={setRouterType}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {routerTypes.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        MikroTik
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             )}
           </div>
@@ -236,7 +245,6 @@ function DdnsFormDialog({
           <div className="space-y-2">
             <Label>Hostname *</Label>
             <Input
-              className="bg-mesh-surface-1 border-mesh-border"
               placeholder="home.example.com"
               value={hostname}
               onChange={(e) => setHostname(e.target.value)}
@@ -246,7 +254,6 @@ function DdnsFormDialog({
           <div className="space-y-2">
             <Label>Zone</Label>
             <Input
-              className="bg-mesh-surface-1 border-mesh-border"
               placeholder="example.com (for Cloudflare)"
               value={zone}
               onChange={(e) => setZone(e.target.value)}
@@ -257,7 +264,6 @@ function DdnsFormDialog({
             <div className="space-y-2">
               <Label>Username</Label>
               <Input
-                className="bg-mesh-surface-1 border-mesh-border"
                 placeholder="Username or email"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -271,7 +277,6 @@ function DdnsFormDialog({
                 )}
               </Label>
               <Input
-                className="bg-mesh-surface-1 border-mesh-border"
                 type="password"
                 placeholder={initial?.has_password ? "Leave blank to keep" : "Password"}
                 value={password}
@@ -288,7 +293,6 @@ function DdnsFormDialog({
               )}
             </Label>
             <Input
-              className="bg-mesh-surface-1 border-mesh-border"
               type="password"
               placeholder={
                 initial?.has_api_token
@@ -303,36 +307,37 @@ function DdnsFormDialog({
           <div className="grid grid-cols-3 gap-5">
             <div className="space-y-2">
               <Label>IP Source</Label>
-              <select
-                className="w-full mesh-card px-3 py-2 text-sm text-mesh-text"
-                value={ipSource}
-                onChange={(e) => setIpSource(e.target.value)}
-              >
-                {IP_SOURCES.map((s) => (
-                  <option key={s} value={s}>
-                    {s.charAt(0).toUpperCase() + s.slice(1)}
-                  </option>
-                ))}
-              </select>
+              <Select value={ipSource} onValueChange={setIpSource}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {IP_SOURCES.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s.charAt(0).toUpperCase() + s.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label>Protocol</Label>
-              <select
-                className="w-full mesh-card px-3 py-2 text-sm text-mesh-text"
-                value={protocol}
-                onChange={(e) => setProtocol(e.target.value)}
-              >
-                {PROTOCOLS.map((p) => (
-                  <option key={p} value={p}>
-                    {p.toUpperCase()}
-                  </option>
-                ))}
-              </select>
+              <Select value={protocol} onValueChange={setProtocol}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROTOCOLS.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {p.toUpperCase()}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label>Interface</Label>
               <Input
-                className="bg-mesh-surface-1 border-mesh-border"
                 placeholder="eth0"
                 value={interfaceName}
                 onChange={(e) => setInterfaceName(e.target.value)}
@@ -463,7 +468,9 @@ export default function DdnsPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight text-white">Dynamic DNS</h1>
+            <h1 className="t-display" style={{ margin: 0 }}>
+              Dynamic DNS
+            </h1>
             <p className="text-sm text-mesh-text-dim">
               Manage DDNS client configurations for automatic DNS updates
             </p>
@@ -487,24 +494,24 @@ export default function DdnsPage() {
         {statusData === null ? (
           <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
             {[...Array(4)].map((_, i) => (
-              <Skeleton key={i} className="h-24 bg-mesh-surface-1" />
+              <Skeleton key={i} className="h-24" />
             ))}
           </div>
         ) : (
           <div className="grid grid-cols-2 gap-5 md:grid-cols-4">
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-mesh-text-mute">
                   Total Entries
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-2xl font-semibold tabular-nums text-white">
+                <p className="text-2xl font-semibold tabular-nums text-mesh-text">
                   {statusData.total}
                 </p>
               </CardContent>
             </Card>
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-mesh-text-mute">
                   Enabled
@@ -516,7 +523,7 @@ export default function DdnsPage() {
                 </p>
               </CardContent>
             </Card>
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-mesh-text-mute">
                   Healthy
@@ -528,7 +535,7 @@ export default function DdnsPage() {
                 </p>
               </CardContent>
             </Card>
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardTitle className="text-[11px] font-medium uppercase tracking-wider text-mesh-text-mute">
                   Failing
@@ -546,7 +553,7 @@ export default function DdnsPage() {
         {/* Search */}
         <div className="flex items-center gap-2">
           <Input
-            className="max-w-sm bg-mesh-surface-1 border-mesh-border"
+            className="max-w-sm"
             placeholder="Search by hostname, provider, or IP..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -554,11 +561,11 @@ export default function DdnsPage() {
         </div>
 
         {/* Table */}
-        <Card className="">
+        <Card>
           {entries === null ? (
             <div className="p-6 space-y-3">
               {[...Array(3)].map((_, i) => (
-                <Skeleton key={i} className="h-12 bg-mesh-border-strong" />
+                <Skeleton key={i} className="h-12" />
               ))}
             </div>
           ) : filtered.length === 0 ? (
@@ -581,7 +588,7 @@ export default function DdnsPage() {
           ) : (
             <Table>
               <TableHeader>
-                <TableRow className="border-mesh-border-strong">
+                <TableRow>
                   <TableHead className="text-mesh-text-dim">Provider</TableHead>
                   <TableHead className="text-mesh-text-dim">Hostname</TableHead>
                   <TableHead className="text-mesh-text-dim">Current IP</TableHead>
@@ -595,15 +602,10 @@ export default function DdnsPage() {
               </TableHeader>
               <TableBody>
                 {filtered.map((entry) => (
-                  <TableRow key={entry.id} className="border-mesh-border-strong">
+                  <TableRow key={entry.id}>
                     <TableCell>
                       <div className="flex items-center gap-2">
-                        <Badge
-                          variant="outline"
-                          className="border-mesh-text-mute text-mesh-text"
-                        >
-                          {entry.provider}
-                        </Badge>
+                        <Badge variant="outline">{entry.provider}</Badge>
                       </div>
                     </TableCell>
                     <TableCell>
@@ -646,10 +648,7 @@ export default function DdnsPage() {
                       )}
                     </TableCell>
                     <TableCell>
-                      <Badge
-                        variant="outline"
-                        className="border-mesh-text-mute text-mesh-text-dim text-xs"
-                      >
+                      <Badge variant="outline" className="text-xs">
                         MikroTik
                       </Badge>
                     </TableCell>
@@ -709,10 +708,10 @@ export default function DdnsPage() {
         open={!!pendingDelete}
         onOpenChange={(v) => !v && setPendingDelete(null)}
       >
-        <AlertDialogContent className="bg-mesh-surface-1 border-mesh-border text-mesh-text">
+        <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete DDNS Entry</AlertDialogTitle>
-            <AlertDialogDescription className="text-mesh-text-dim">
+            <AlertDialogDescription>
               Are you sure you want to delete the DDNS entry for{" "}
               <strong className="text-mesh-text">
                 {pendingDelete?.hostname}
@@ -721,12 +720,10 @@ export default function DdnsPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel className="border-mesh-text-mute text-mesh-text">
-              Cancel
-            </AlertDialogCancel>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
-              className="bg-[#fb7185] hover:bg-[#fb7185]"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               Delete
             </AlertDialogAction>

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Textarea primitive — mesh-design counterpart of <Input> for multi-line
+ * input. Mirrors the Input recipe (border-mesh-border-strong, bg-mesh-surface-1,
+ * mesh-accent focus ring) so consumer files can't drift into ad-hoc
+ * "border border-mesh-border-strong bg-mesh-surface-1" combos.
+ *
+ * Use this anywhere PEM blobs, JSON payloads, multi-line notes, etc. are
+ * collected. Never paste the recipe inline at the consumer.
+ */
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex w-full rounded-md border border-mesh-border-strong bg-mesh-surface-1 px-3 py-2 text-sm text-mesh-text placeholder:text-mesh-text-mute ring-offset-background focus-visible:border-mesh-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mesh-accent/30 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }


### PR DESCRIPTION
## Summary

Wave B mesh-design consistency sweep for three routes that have **no** design source file: `/audit-log`, `/certificates`, `/ddns`. Goal — uniform application of the existing mesh primitives, with all CI guards (raw literals, ad-hoc card combos, gradient combos) still green. No new recipes added to `globals.css`.

## Per-route drift removed

### `/audit-log`
- Header → `.t-h1` typescale recipe (was raw `text-xl font-semibold tracking-tight`).
- `<Card className="">` → `<Card>` (no empty override).

### `/certificates`
- Header → `.t-display` (was `text-2xl ... text-white`).
- `<Card className="">`, `TableRow`, `Badge variant="outline"`, `Dialog`, `AlertDialog`, `Input`, `TooltipContent` — all consumer-side border/bg overrides stripped.
- Outline buttons: dropped `border-mesh-border + bg-mesh-surface-2/55` overrides → `variant="outline"` only.
- Forbidden substitution removed: literal `#67e8f9` ("cyan-300" lookalike) → `mesh-accent` (`#38bdf8`).
- `text-white` → `text-mesh-text` everywhere on this route.
- PEM textareas were composing the Input recipe ad-hoc (`border + mesh-border-strong + bg-mesh-surface-1` — CI guard #2 hit). Introduced **new `<Textarea>` primitive** in `components/ui/textarea.tsx` mirroring `<Input>`, then consumed naked.
- Destructive `AlertDialogAction` → `bg-destructive` semantic token.

### `/ddns`
- Header → `.t-display`.
- `<Card className="">` → `<Card>` across four KPI cards and table card.
- Native `<select>` with `.mesh-card` recipe inside a `DialogContent` surface → nested-recipe violation. Swapped for the project `<Select>` primitive (already in `components/ui`).
- `Input` overrides (`bg-mesh-surface-1 border-mesh-border`) removed — CI guard #2 violation. Input primitive owns its own chrome.
- Skeleton bg overrides removed; the primitive already renders the right surface.
- `Badge variant="outline"` border/text overrides stripped — variant already resolves to the same recipe.
- `AlertDialogContent` + `AlertDialogCancel` overrides removed.
- Destructive action uses `bg-destructive`.

## New primitive

`components/ui/textarea.tsx` — mirrors `<Input>` chrome (border-mesh-border-strong, bg-mesh-surface-1, mesh-accent focus ring) so multi-line inputs cannot drift into ad-hoc border+mesh-surface combos. Whitelisted by CI guards under `components/ui/`.

## Verification

```
bash scripts/check-design-tokens.sh
  OK: no raw Tailwind color literals in production code
  OK: no ad-hoc card recipe combos in production code
  OK: no gradient-on-mesh-surface combos in production code

bun run build
  Production build succeeded
```

## Why No E2E Test

Pure visual/CSS consolidation — no behavior change. All three routes' user-facing flows (loading skeleton, table render, dialog open/save, delete confirm) are unchanged and remain covered by existing E2E specs if any. The Save→reload requirement does not apply: no new settings page added.

## Test plan

- [ ] `bash scripts/check-design-tokens.sh` passes on CI
- [ ] `bun run build` passes on CI
- [ ] Visual smoke: `/audit-log` shows naked Card with t-h1 header, no double borders
- [ ] Visual smoke: `/certificates` table, "Let's Encrypt" dialog, "Upload Custom" dialog, delete confirm — all primitives render with matching chrome
- [ ] Visual smoke: `/ddns` KPI cards, Add Entry dialog with Select dropdowns + Inputs, delete confirm — all primitives render naked

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wave B design-token consistency sweep across `/audit-log`, `/certificates`, and `/ddns`. Raw color literals, ad-hoc card/border combos, and consumer-side primitive overrides are replaced with the established mesh token vocabulary, and a new `Textarea` primitive is introduced to prevent future PEM-input drift.

- **`/certificates`**: Swaps hard-coded `#67e8f9`/`#fb7185`/`text-white` for `mesh-accent`, `bg-destructive`, and `text-mesh-text`; replaces ad-hoc `<textarea>` markup with the new `<Textarea>` primitive; strips redundant className props from Dialog, AlertDialog, Badge, Input, Button, and TooltipContent.
- **`/ddns`**: Converts four native `<select>` elements to the project's shadcn `Select` primitive (state defaults are valid, `onValueChange` wiring is correct); removes Input, Skeleton, Badge, TableRow, and AlertDialog chrome overrides.
- **`components/ui/textarea.tsx`**: New `forwardRef` component that mirrors the `<Input>` recipe exactly, whitelisted by the CI token guards.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are pure token/class substitutions with no behavior modifications, and the new Textarea primitive is a straightforward forwardRef wrapper.

Every changed file limits itself to swapping class names and components that carry identical visual contracts. The native-select → shadcn Select migration in ddns is the most complex change, and inspection confirms that all four state values have non-empty defaults matching items in their respective option arrays, making the controlled components safe. The Textarea primitive correctly spreads all HTMLTextareaAttributes so existing props like rows pass through unchanged. No runtime logic was altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/audit-log/page.tsx | Minimal cleanup: replaces raw typography classes with t-h1 recipe and removes empty className from Card — no logic changes. |
| web/src/app/(app)/certificates/page.tsx | Large token sweep: replaces raw color literals (#67e8f9, #fb7185, text-white) with semantic tokens, strips redundant primitive overrides, and adopts the new Textarea component for PEM inputs. |
| web/src/app/(app)/ddns/page.tsx | Token sweep plus behaviorally correct swap of four native <select> elements for the shadcn Select primitive; all state defaults remain valid and onValueChange wiring is correct. |
| web/src/components/ui/textarea.tsx | New Textarea primitive correctly mirrors the Input recipe (border-mesh-border-strong, bg-mesh-surface-1, mesh-accent focus ring) using forwardRef and spreading all TextareaHTMLAttributes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): mesh-design consistency sweep f..."](https://github.com/befeast/panoptikon/commit/3236766567c8513f115f7e3ab858841c4e689bf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32651159)</sub>

<!-- /greptile_comment -->