### PR TITLE
fix(ux): Wave B sweep — /xiaomi-mesh /xiaomi /mesh

### DIFF
--- a/web/src/app/(app)/mesh/page.tsx
+++ b/web/src/app/(app)/mesh/page.tsx
@@ -39,7 +39,6 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 
@@ -100,15 +99,18 @@ function MeshNodeComponent({ data }: NodeProps<MeshNodeType>) {
 
   const BackhaulIcon = backhaulIcon
 
+  // ReactFlow custom node — uses the design-system .mesh-card recipe
+  // (solid surface, hairline border, recipe shadow) plus an isMain accent
+  // ring. Gradients are forbidden by CI guard #3.
+  const accentClass = isMain
+    ? 'ring-1 ring-[#fbbf24]/40'
+    : node.is_online
+      ? 'ring-1 ring-mesh-primary/30'
+      : ''
+
   return (
     <div
-      className={`flex flex-col gap-2 rounded-xl border px-4 py-3 shadow-lg transition-shadow hover:shadow-xl ${
-        isMain
-          ? 'border-[#fbbf24]/30 bg-gradient-to-br from-mesh-border-strong to-mesh-surface-1 shadow-[#fbbf24]/10'
-          : node.is_online
-            ? 'border-mesh-primary/30 bg-gradient-to-br from-mesh-border-strong to-mesh-surface-1 shadow-mesh-primary/10'
-            : 'border-mesh-text-mute/30 bg-mesh-surface-1 shadow-mesh-border-strong/10'
-      }`}
+      className={`mesh-card flex flex-col gap-2 px-4 py-3 ${accentClass}`}
       style={{ width: NODE_WIDTH, minHeight: NODE_HEIGHT }}
     >
       <Handle type="target" position={Position.Top} className="!bg-mesh-primary" />
@@ -212,7 +214,7 @@ function MeshNodeDetailPanel({ node }: { node: MeshNode }) {
         </div>
       </SheetHeader>
 
-      <Separator className="my-4 bg-mesh-surface-1" />
+      <Separator className="my-4" />
 
       <div className="space-y-3">
         <InfoRow label="IP Address" value={node.ip || '—'} mono />
@@ -423,16 +425,16 @@ export default function MeshPage() {
               <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[#fb7185]/10">
                 <WifiOff className="h-8 w-8 text-[#fb7185]" />
               </div>
-              <h1 className="text-xl font-semibold text-white">
+              <h1 className="t-h1 text-mesh-text">
                 Mesh Topology Unavailable
               </h1>
               <p className="text-center text-sm text-mesh-text-dim">
                 Could not load mesh topology from the Xiaomi router. Make sure the router is powered on and the IP address is correct in Settings.
               </p>
               <div className="flex items-center gap-3">
-                <Button
-                  variant="outline"
-                  className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
+                <button
+                  type="button"
+                  className="btn"
                   onClick={() => {
                     setLoading(true)
                     buildGraph(true)
@@ -440,15 +442,10 @@ export default function MeshPage() {
                 >
                   <RefreshCw className="mr-2 h-4 w-4" />
                   Retry
-                </Button>
-                <Link href="/settings/xiaomi-mesh">
-                  <Button
-                    variant="outline"
-                    className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
-                  >
-                    <Settings className="mr-2 h-4 w-4" />
-                    Settings
-                  </Button>
+                </button>
+                <Link href="/settings/xiaomi-mesh" className="btn">
+                  <Settings className="mr-2 h-4 w-4" />
+                  Settings
                 </Link>
               </div>
             </CardContent>
@@ -506,8 +503,9 @@ export default function MeshPage() {
             </span>
             <div className="h-3 w-px bg-mesh-border-strong" />
             <button
+              type="button"
               onClick={() => buildGraph(false)}
-              className="text-mesh-text-dim transition-colors hover:text-white"
+              className="btn btn-ghost btn-sm"
               title="Refresh now"
             >
               <RefreshCw className="h-3.5 w-3.5" />
@@ -530,7 +528,7 @@ export default function MeshPage() {
       >
         <SheetContent
           side="right"
-          className="w-full overflow-y-auto border-mesh-border bg-mesh-surface-1/95 sm:max-w-md"
+          className="w-full overflow-y-auto sm:max-w-md"
         >
           {selectedNode && <MeshNodeDetailPanel node={selectedNode} />}
         </SheetContent>

--- a/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
+++ b/web/src/app/(app)/settings/xiaomi-mesh/page.tsx
@@ -9,7 +9,6 @@ import {
   AlertCircle,
   ArrowLeft,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -216,11 +215,12 @@ export default function XiaomiMeshSettingsPage() {
         <div className="flex items-center gap-3">
           <Link
             href="/settings"
-            className="flex h-8 w-8 items-center justify-center rounded-md border border-mesh-border text-mesh-text-dim transition-colors hover:bg-mesh-surface-2/55 hover:text-white"
+            aria-label="Back to settings"
+            className="btn btn-ghost btn-sm h-8 w-8 justify-center px-0"
           >
             <ArrowLeft className="h-4 w-4" />
           </Link>
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Xiaomi Mesh</h1>
+          <h1 className="t-h1 text-mesh-text">Xiaomi Mesh</h1>
         </div>
 
         <SettingsSection
@@ -259,13 +259,13 @@ export default function XiaomiMeshSettingsPage() {
                 value={ip}
                 onChange={(e) => setIp(e.target.value)}
                 autoComplete="one-time-code"
-                className={`border-mesh-border bg-mesh-surface-1 text-white placeholder:text-mesh-text-mute ${
+                className={
                   ipValidation === "valid"
                     ? "border-[#4ade80]/40"
                     : ipValidation === "error"
                       ? "border-[#fb7185]/40"
-                      : ""
-                }`}
+                      : undefined
+                }
                 placeholder="10.10.0.199"
               />
               {ipValidation === "valid" && (
@@ -299,7 +299,6 @@ export default function XiaomiMeshSettingsPage() {
               value={proxyHost}
               onChange={(e) => setProxyHost(e.target.value)}
               autoComplete="one-time-code"
-              className="border-mesh-border bg-mesh-surface-1 text-white placeholder:text-mesh-text-mute"
               placeholder="e.g. 10.10.0.14:9199"
             />
             <p className="text-xs text-mesh-text-mute">
@@ -326,7 +325,6 @@ export default function XiaomiMeshSettingsPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               autoComplete="new-password"
-              className="border-mesh-border bg-mesh-surface-1 text-white placeholder:text-mesh-text-mute"
               placeholder={
                 passwordSet
                   ? "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022  (leave blank to keep current)"
@@ -356,13 +354,13 @@ export default function XiaomiMeshSettingsPage() {
                 max={300}
                 value={pollInterval}
                 onChange={(e) => setPollInterval(e.target.value)}
-                className={`border-mesh-border bg-mesh-surface-1 text-white placeholder:text-mesh-text-mute ${
+                className={
                   intervalValidation === "valid"
                     ? "border-[#4ade80]/40"
                     : intervalValidation === "error"
                       ? "border-[#fb7185]/40"
-                      : ""
-                }`}
+                      : undefined
+                }
                 placeholder="30"
               />
               {intervalValidation === "valid" && (
@@ -431,11 +429,11 @@ export default function XiaomiMeshSettingsPage() {
               disabled={!canSave}
               onClick={handleSave}
             />
-            <Button
-              variant="outline"
+            <button
+              type="button"
               onClick={handleTest}
               disabled={!ip || !ipValid || testStatus === "loading"}
-              className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55 disabled:opacity-40"
+              className="btn disabled:cursor-not-allowed disabled:opacity-40"
             >
               {testStatus === "loading" ? (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -443,7 +441,7 @@ export default function XiaomiMeshSettingsPage() {
                 <Plug className="mr-1.5 h-3.5 w-3.5" />
               )}
               Test Connection
-            </Button>
+            </button>
           </div>
         </SettingsSection>
       </div>

--- a/web/src/components/XiaomiMeshTopology.tsx
+++ b/web/src/components/XiaomiMeshTopology.tsx
@@ -15,7 +15,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchXiaomiTopology } from "@/lib/api";
 import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types";
@@ -46,13 +45,7 @@ function NodeCard({
   const onlineDevices = node.online ?? 0;
 
   return (
-    <Card
-      className={`border-mesh-border bg-mesh-surface-1 transition-shadow hover:shadow-lg ${
-        isMain
-          ? "border-[#fbbf24]/30 shadow-[#fbbf24]/5"
-          : "hover:border-mesh-border"
-      }`}
-    >
+    <Card className={isMain ? "ring-1 ring-[#fbbf24]/30" : undefined}>
       <CardHeader className="pb-3">
         <div className="flex items-center gap-3">
           <div
@@ -67,7 +60,7 @@ function NodeCard({
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <CardTitle className="truncate text-sm font-semibold text-white">
+            <CardTitle className="truncate text-sm font-semibold text-mesh-text">
               {node.locale || node.name || "Mesh Node"}
             </CardTitle>
             <p className="truncate font-mono text-xs text-mesh-text-dim">
@@ -77,7 +70,7 @@ function NodeCard({
           <span
             className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
               node.ip
-                ? "bg-[#4ade80] shadow-[0_0_6px_rgba(52,211,153,0.5)]"
+                ? "bg-[#4ade80] shadow-[0_0_6px_rgba(74,222,128,0.5)]"
                 : "bg-mesh-text-mute"
             }`}
           />
@@ -146,7 +139,7 @@ function NodeCard({
                     {leaf.name || leaf.mac || "Unknown"}
                   </span>
                   <span className="shrink-0 font-mono text-mesh-text-mute">
-                    {leaf.ip || "\u2014"}
+                    {leaf.ip || "—"}
                   </span>
                 </div>
               ))}
@@ -162,7 +155,7 @@ function NodeCard({
 
 function NodeCardSkeleton() {
   return (
-    <Card className="">
+    <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center gap-3">
           <Skeleton className="h-10 w-10 rounded-lg" />
@@ -249,9 +242,7 @@ export default function XiaomiMeshTopology() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg font-semibold text-white">
-            Mesh Topology
-          </h2>
+          <h2 className="t-h2 text-mesh-text">Mesh Topology</h2>
           <p className="mt-1 text-sm text-mesh-text-dim">
             Network mesh nodes from the Xiaomi router topology graph
           </p>
@@ -262,56 +253,45 @@ export default function XiaomiMeshTopology() {
               Updated {lastRefresh.toLocaleTimeString()}
             </span>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={load}
-            className="border-mesh-border bg-mesh-surface-1 text-mesh-text hover:bg-mesh-surface-2"
-          >
+          <button type="button" className="btn btn-sm" onClick={load}>
             <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
             Refresh
-          </Button>
+          </button>
         </div>
       </div>
 
       {/* Summary stats */}
       {!loading && data && (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <Card className="">
+          <Card>
             <CardContent className="flex items-center gap-3 p-4">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-mesh-primary/20">
-                <Router className="h-4.5 w-4.5 text-mesh-primary" />
+                <Router className="h-4 w-4 text-mesh-primary" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-white">
-                  {stats.nodeCount}
-                </p>
+                <p className="t-h1 text-mesh-text">{stats.nodeCount}</p>
                 <p className="text-xs text-mesh-text-dim">Mesh Nodes</p>
               </div>
             </CardContent>
           </Card>
-          <Card className="">
+          <Card>
             <CardContent className="flex items-center gap-3 p-4">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#4ade80]/20">
-                <MonitorSmartphone className="h-4.5 w-4.5 text-[#4ade80]" />
+                <MonitorSmartphone className="h-4 w-4 text-[#4ade80]" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-white">
-                  {stats.totalDevices}
-                </p>
+                <p className="t-h1 text-mesh-text">{stats.totalDevices}</p>
                 <p className="text-xs text-mesh-text-dim">Online Devices</p>
               </div>
             </CardContent>
           </Card>
-          <Card className="">
+          <Card>
             <CardContent className="flex items-center gap-3 p-4">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#c084fc]/20">
-                <Wifi className="h-4.5 w-4.5 text-[#c084fc]" />
+                <Wifi className="h-4 w-4 text-[#c084fc]" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-white">
-                  {stats.totalLeafs}
-                </p>
+                <p className="t-h1 text-mesh-text">{stats.totalLeafs}</p>
                 <p className="text-xs text-mesh-text-dim">Connected Clients</p>
               </div>
             </CardContent>
@@ -321,15 +301,16 @@ export default function XiaomiMeshTopology() {
 
       {/* Error state */}
       {error && (
-        <Card className="border-[#fb7185]/20 bg-[#fb7185]/5">
-          <CardContent className="p-4">
+        <Card>
+          <CardContent className="space-y-2 p-4">
             <p className="text-sm text-[#fb7185]">{error}</p>
             <button
+              type="button"
+              className="btn btn-ghost btn-sm"
               onClick={() => {
                 setLoading(true);
                 load();
               }}
-              className="mt-2 text-xs text-mesh-primary hover:underline"
             >
               Retry
             </button>
@@ -362,7 +343,7 @@ export default function XiaomiMeshTopology() {
 
       {/* Empty state */}
       {!loading && !error && data && sortedNodes.length === 0 && (
-        <Card className="">
+        <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12">
             <Router className="h-10 w-10 text-mesh-text-mute" />
             <p className="text-sm text-mesh-text-dim">

--- a/web/src/components/XiaomiRouter.tsx
+++ b/web/src/components/XiaomiRouter.tsx
@@ -106,7 +106,7 @@ function SystemStats({ status }: { status: XiaomiStatus }) {
   const memUsage = status.mem_usage ? Math.round(status.mem_usage * 100) : 0;
 
   return (
-    <Card className="">
+    <Card>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-mesh-text">
           <Cpu className="h-4 w-4 text-[#fbbf24]" />
@@ -211,7 +211,7 @@ function WanInfoSection({ wan }: { wan: XiaomiWanInfo }) {
   const dnsServers = wan.dns?.split(",").map((d) => d.trim()) ?? [];
 
   return (
-    <Card className="">
+    <Card>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-mesh-text">
           <Globe className="h-4 w-4 text-mesh-primary" />
@@ -347,7 +347,7 @@ function WifiBandsSection({
     wifiDevices.length > 0 && wifiDevices.some((d) => d.band != null);
 
   return (
-    <Card className="">
+    <Card>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-mesh-text">
           <Wifi className="h-4 w-4 text-[#a78bfa]" />
@@ -378,7 +378,7 @@ function WifiBandsSection({
               return (
                 <div
                   key={`${bandLabel}|${band.ssid ?? i}`}
-                  className="mesh-card p-4"
+                  className="mesh-card-2 p-4"
                 >
                   <div className="mb-3 flex items-center justify-between">
                     <Badge className="bg-[#a78bfa]/20 text-[#a78bfa]">
@@ -446,7 +446,7 @@ function WifiBandsSection({
 
 function FirmwareSection({ firmware }: { firmware: XiaomiFirmware }) {
   return (
-    <Card className="">
+    <Card>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-mesh-text">
           <HardDrive className="h-4 w-4 text-mesh-accent" />


### PR DESCRIPTION
## Summary

Wave B sweep — bring the remaining Xiaomi/mesh surfaces in line with the mesh-design-system primitives. These routes have **no direct design source file**, so the goal is uniform application of existing recipes (`.mesh-card`, `.mesh-card-2`, `.btn`/`.btn-ghost`, `.t-h*`) and removal of consumer-side drift. `/mesh` is preserved for backward compatibility (the Mesh tab is now embedded in `/topology`).

## Per-route drift fixed

**`/mesh/page.tsx`**
- ReactFlow custom node: replaced `bg-gradient-to-br from-mesh-border-strong to-mesh-surface-1` (CI guard #3 timebomb) with `.mesh-card` recipe + `ring-1 ring-*` accent for main / online states.
- Error block: shadcn `<Button>` with consumer-side `border-mesh-border` overrides -> `.btn`.
- Floating toolbar: native `<button>` -> `.btn .btn-ghost .btn-sm`.
- SheetContent: dropped redundant `border-mesh-border bg-mesh-surface-1/95` (the Sheet primitive already ships `bg-mesh-surface-1` + `border-mesh-border-strong`).
- Separator: dropped consumer `bg-mesh-surface-1` override.
- Error heading: `text-xl font-semibold text-white` -> `.t-h1`.

**`/settings/xiaomi-mesh/page.tsx`**
- Four `<Input>` elements: stripped redundant `border-mesh-border bg-mesh-surface-1 text-white placeholder:text-mesh-text-mute` overrides (the Input primitive ships those tokens). Validation-state border colors retained.
- Back link: ad-hoc `border border-mesh-border` square -> `.btn .btn-ghost .btn-sm`.
- Test Connection: shadcn `<Button>` with consumer overrides -> `.btn`.
- Page H1: `text-2xl font-semibold text-white` -> `.t-h1`.

**`components/XiaomiRouter.tsx`**
- `<div className="mesh-card p-4">` nested inside `<Card>` (which is itself a `.mesh-card`) -> `.mesh-card-2`. This was a same-recipe nesting violation (anti-pattern from runbook).
- Collapsed empty `<Card className="">` to `<Card>`.

**`components/XiaomiMeshTopology.tsx`**
- `<Card className="border-mesh-border bg-mesh-surface-1 ...">` consumer override -> `<Card>` naked. Main-node highlight done with `ring-1 ring-[#fbbf24]/30` rather than a custom border combo.
- Section H2: `text-lg font-semibold text-white` -> `.t-h2`.
- Stat tile numbers: `text-2xl font-bold` -> `.t-h1`.
- Header refresh: shadcn `<Button variant="outline">` with override overlay -> `.btn .btn-sm`.
- Error block: native `<button>` -> `.btn .btn-ghost .btn-sm`.

## Verification

```
bash scripts/check-design-tokens.sh
# OK: no raw Tailwind color literals in production code
# OK: no ad-hoc card recipe combos in production code
# OK: no gradient-on-mesh-surface combos in production code

bun run build
# compiled successfully
```

## Notes / out-of-scope observations

- `/router/xiaomi/page.tsx` (the route `/xiaomi` redirects to) still has `TabsList className="mesh-card"` in its `legacy=1` branch, but this is non-default rendering and uses the same recipe as its parent `RouterWorkspace`. Not regressing; out of scope.
- `/router/xiaomi`'s non-legacy path delegates to `XiaomiRouterDesign` -> `RouterPage`, which is its own design-source port and untouched here.
- `components/router/RouterWorkspace.tsx` uses `className="card"` which currently renders nothing because `.card` is not defined in globals.css. Pre-existing; flagged for a future Wave (would be either drop the class or define `.card` byte-exact from the design source).

## Test plan

- [ ] Visual regression: open `/mesh` (legacy mesh graph) — node tiles render with mesh-card chrome, main node has amber ring, online satellites have primary ring; floating toolbar refresh works.
- [ ] Visual regression: open `/settings/xiaomi-mesh` — inputs render with consistent default border/bg; Test Connection button matches `.btn` look across the app.
- [ ] Functional: save -> reload roundtrip on `/settings/xiaomi-mesh` still persists IP / proxy / poll interval.
- [ ] Open `/xiaomi?legacy=1` — XiaomiRouter system stats render; WiFi band tiles use the slightly lifted `.mesh-card-2` chrome inside their parent Card.
- [ ] `bash scripts/check-design-tokens.sh` continues to pass in CI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wave B design-system sweep across four Xiaomi/mesh surfaces: replaces consumer-side Tailwind drift (raw gradients, ad-hoc `border-*`/`bg-*` overrides, naked `text-white` headings) with the established `.mesh-card`, `.mesh-card-2`, `.btn`, `.btn-ghost`, and `.t-h*` recipes, and removes a same-recipe nesting anti-pattern in `XiaomiRouter`.

- **`mesh/page.tsx`**: ReactFlow node tiles now use `.mesh-card` + accent `ring-*` instead of the gradient-on-surface combo flagged by CI guard #3; shadcn `<Button>` and bare `<button>` usages unified to `.btn`/`.btn-ghost`; SheetContent and Separator overrides dropped.
- **`settings/xiaomi-mesh/page.tsx`**: Four `<Input>` elements shed redundant token overrides (validation-state borders retained); back-link and \"Test Connection\" button aligned to `.btn` primitives; page heading moved to `.t-h1`.
- **`XiaomiMeshTopology.tsx` / `XiaomiRouter.tsx`**: Card consumer overrides removed, stat-tile numbers and section headings converted to recipe classes, WiFi band tiles promoted from `.mesh-card` (nesting violation) to `.mesh-card-2`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the caveat that the settings page save/reload behavior should be covered by an automated Playwright test before the branch is considered fully verified.

The styling changes themselves are correct and consistent — no logic errors were found in the save/test-connection flow, the Input validation states are preserved, and the mesh graph refresh path is unchanged. The one gap is that the PR modifies the settings page (including changing the "Test Connection" button from a shadcn component to a native button) without adding or updating any Playwright test, which CLAUDE.md requires for all settings-page changes. Existing tests in settings-xiaomi.spec.ts may still pass if they select by text content, but the missing save→reload automation leaves functional regressions undetected.

web/src/app/(app)/settings/xiaomi-mesh/page.tsx — verify the existing settings-xiaomi.spec.ts still selects the "Test Connection" button correctly after the element-type change, and add the save→reload roundtrip test required by CLAUDE.md.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/mesh/page.tsx | Replaced gradient node tiles with `.mesh-card` recipe, converted shadcn Button usages to `.btn` / `.btn-ghost`, stripped redundant SheetContent and Separator overrides, and updated the error-state heading to `.t-h1`. Changes are functionally clean. |
| web/src/app/(app)/settings/xiaomi-mesh/page.tsx | Stripped redundant Input class overrides, replaced shadcn Button with native button for "Test Connection", and aligned heading/back-link to design-system primitives. No functional regressions in the save logic, but the PR is missing a required E2E test per CLAUDE.md. |
| web/src/components/XiaomiMeshTopology.tsx | Removed consumer-side Card overrides, updated heading/stat utilities to design-system recipes, corrected shadow color literal, replaced shadcn Button with native button, and cleaned up empty className props. All changes are cosmetic and correct. |
| web/src/components/XiaomiRouter.tsx | Fixed same-recipe nesting violation by changing nested `.mesh-card` to `.mesh-card-2` inside WiFi band tiles; collapsed five empty `<Card className="">` props to bare `<Card>`. Clean and correct. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/app/(app)/settings/xiaomi-mesh/page.tsx`, line 212-215 ([link](https://github.com/befeast/panoptikon/blob/670fea19859f34b1121abba3533275f5c76b70a5/web/src/app/(app)/settings/xiaomi-mesh/page.tsx#L212-L215)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Missing required E2E test (CLAUDE.md)**

   `CLAUDE.md` mandates that any PR touching a settings page must include a Playwright save→reload roundtrip test in `web/tests/e2e/`. The PR description lists "Functional: save → reload roundtrip on `/settings/xiaomi-mesh` still persists IP / proxy / poll interval" as a **manual** test plan item, but no automated test was added or updated. The same doc requires that a PR without a test include a `## Why No E2E Test` justification section, which is absent here. Note that the "Test Connection" button was changed from shadcn `<Button>` to a native `<button>` — if `settings-xiaomi.spec.ts` selects that element by a shadcn-specific attribute or role, the existing test may now silently pass against the wrong element.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/settings/xiaomi-mesh/page.tsx
   Line: 212-215
   
   Comment:
   **Missing required E2E test (CLAUDE.md)**
   
   `CLAUDE.md` mandates that any PR touching a settings page must include a Playwright save→reload roundtrip test in `web/tests/e2e/`. The PR description lists "Functional: save → reload roundtrip on `/settings/xiaomi-mesh` still persists IP / proxy / poll interval" as a **manual** test plan item, but no automated test was added or updated. The same doc requires that a PR without a test include a `## Why No E2E Test` justification section, which is absent here. Note that the "Test Connection" button was changed from shadcn `<Button>` to a native `<button>` — if `settings-xiaomi.spec.ts` selects that element by a shadcn-specific attribute or role, the existing test may now silently pass against the wrong element.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/app/(app)/settings/xiaomi-mesh/page.tsx:212-215
**Missing required E2E test (CLAUDE.md)**

`CLAUDE.md` mandates that any PR touching a settings page must include a Playwright save→reload roundtrip test in `web/tests/e2e/`. The PR description lists "Functional: save → reload roundtrip on `/settings/xiaomi-mesh` still persists IP / proxy / poll interval" as a **manual** test plan item, but no automated test was added or updated. The same doc requires that a PR without a test include a `## Why No E2E Test` justification section, which is absent here. Note that the "Test Connection" button was changed from shadcn `<Button>` to a native `<button>` — if `settings-xiaomi.spec.ts` selects that element by a shadcn-specific attribute or role, the existing test may now silently pass against the wrong element.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): mesh-design consistency sweep f..."](https://github.com/befeast/panoptikon/commit/670fea19859f34b1121abba3533275f5c76b70a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32651377)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->