### PR TITLE
fix(ux): Wave B sweep — /qos /nat /traffic mesh consistency

### DIFF
--- a/web/src/app/(app)/nat/page.tsx
+++ b/web/src/app/(app)/nat/page.tsx
@@ -21,7 +21,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -183,35 +182,46 @@ export default function NatPage() {
   return (
     <PageTransition>
       <div className="space-y-8">
-        <section className="flex flex-col gap-5 rounded-2xl mesh-card p-4 md:flex-row md:items-center md:justify-between">
+        {/* Page header — Card with eyebrow + display title */}
+        <Card className="flex flex-col gap-5 p-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-5">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[#a78bfa]/30 bg-gradient-to-br from-[#a78bfa]/20 via-[#e879f9]/10 to-mesh-primary/10 text-[#a78bfa]">
+            <div
+              className="flex h-12 w-12 items-center justify-center"
+              style={{
+                borderRadius: "var(--radius-lg)",
+                border: "1px solid rgba(96,144,212,0.20)",
+                background: "var(--surface-2)",
+                color: "#a78bfa",
+              }}
+            >
               <ArrowRightLeft className="h-6 w-6" />
             </div>
             <div>
-              <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-semibold tracking-tight text-white">NAT / Port Forwarding</h1>
+              <div className="t-micro">Network operations</div>
+              <div className="flex items-center gap-2" style={{ marginTop: 4 }}>
+                <h1 className="t-display" style={{ margin: 0 }}>
+                  NAT / Port Forwarding
+                </h1>
                 <HelpTooltip text="Manage MikroTik NAT rules — port forwarding (DNAT), outbound NAT (SNAT), 1:1 NAT, and NAT reflection." />
               </div>
-              <p className="text-sm text-mesh-text-dim">
+              <p className="t-small" style={{ marginTop: 4 }}>
                 Port forwarding, outbound NAT, 1:1 NAT, and hairpin rules.
               </p>
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            size="sm"
+          <button
+            type="button"
+            className="btn"
             onClick={() => {
               load();
               loadMt();
             }}
-            className="border-mesh-border bg-mesh-surface-1 text-mesh-text hover:bg-mesh-surface-2/55"
           >
-            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-            Refresh
-          </Button>
-        </section>
+            <RefreshCw className="h-3 w-3" />
+            <span>Refresh</span>
+          </button>
+        </Card>
 
         {/* Summary cards */}
         <section className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:max-w-2xl">
@@ -219,22 +229,25 @@ export default function NatPage() {
             title="Total NAT Rules"
             value={summary?.mikrotik_rule_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<Network className="h-4 w-4 text-[#67e8f9]" />}
-            iconClass="border-mesh-accent/30 bg-mesh-accent/15"
+            icon={<Network className="h-4 w-4 text-mesh-accent" />}
+            iconBg="#0e2148"
+            iconBorder="rgba(96,144,212,0.40)"
           />
           <SummaryCard
             title="DNAT (Inbound)"
             value={summary?.dnat_count ?? null}
             available={summary?.mikrotik_available ?? null}
             icon={<ArrowDownToLine className="h-4 w-4 text-mesh-primary" />}
-            iconClass="border-mesh-primary/30 bg-mesh-primary/15"
+            iconBg="#0e2148"
+            iconBorder="rgba(37,99,235,0.40)"
           />
           <SummaryCard
             title="SNAT (Outbound)"
             value={summary?.snat_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<ArrowUpFromLine className="h-4 w-4 text-[#fbbf24]" />}
-            iconClass="border-[#fbbf24]/30 bg-[#fbbf24]/15"
+            icon={<ArrowUpFromLine className="h-4 w-4" style={{ color: "#fbbf24" }} />}
+            iconBg="#0e2148"
+            iconBorder="rgba(251,191,36,0.40)"
           />
         </section>
 
@@ -245,19 +258,19 @@ export default function NatPage() {
               <TabsList className="h-auto mesh-card p-1">
                 <TabsTrigger
                   value="all"
-                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-white"
+                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-mesh-text"
                 >
                   All Rules
                 </TabsTrigger>
                 <TabsTrigger
                   value="dnat"
-                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-white"
+                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-mesh-text"
                 >
                   DNAT
                 </TabsTrigger>
                 <TabsTrigger
                   value="snat"
-                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-white"
+                  className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-mesh-text"
                 >
                   SNAT
                 </TabsTrigger>
@@ -271,7 +284,7 @@ export default function NatPage() {
                   placeholder="Filter rules..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1/95 pl-10 text-white placeholder:text-mesh-text-mute"
+                  className="pl-10"
                 />
               </div>
 
@@ -287,7 +300,14 @@ export default function NatPage() {
                   setShowAddMt(true);
                 }}
               >
-                <SelectTrigger className="w-auto gap-1.5 border-mesh-border-strong bg-mesh-primary text-white hover:bg-mesh-primary [&>svg]:text-white">
+                <SelectTrigger
+                  className="w-auto gap-1.5"
+                  style={{
+                    background: "#2563eb",
+                    borderColor: "#2563eb",
+                    color: "var(--primary-fg, #ffffff)",
+                  }}
+                >
                   <Plus className="h-3.5 w-3.5" />
                   <SelectValue placeholder="Add Rule" />
                 </SelectTrigger>
@@ -304,14 +324,17 @@ export default function NatPage() {
         {/* Rules table */}
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base text-white">MikroTik NAT Rules</CardTitle>
-            <CardDescription className="text-xs text-mesh-text-mute">
+            <CardTitle className="t-h3">MikroTik NAT Rules</CardTitle>
+            <CardDescription className="t-small">
               Firewall NAT rules synchronized from the router.
             </CardDescription>
           </CardHeader>
 
           <CardContent className="p-0">
-            <div className="overflow-x-auto border-t border-mesh-border">
+            <div
+              className="overflow-x-auto"
+              style={{ borderTop: "1px solid rgba(96,144,212,0.20)" }}
+            >
               {filteredMt === null ? (
                 <div className="space-y-2 p-4">
                   {[...Array(4)].map((_, i) => (
@@ -319,24 +342,24 @@ export default function NatPage() {
                   ))}
                 </div>
               ) : filteredMt.length === 0 ? (
-                <div className="py-12 text-center text-sm text-mesh-text-mute">
+                <div className="py-12 text-center t-small">
                   {search ? "No matching rules." : "No NAT rules configured."}
                 </div>
               ) : (
                 <Table>
                   <TableHeader>
                     <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Type</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Action</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Protocol</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Src Address</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Dst Address</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Dst Port</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">To Address</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">To Port</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Comment</TableHead>
-                      <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Status</TableHead>
-                      <TableHead className="text-right text-xs uppercase tracking-wide text-mesh-text-mute">Actions</TableHead>
+                      <TableHead className="t-micro">Type</TableHead>
+                      <TableHead className="t-micro">Action</TableHead>
+                      <TableHead className="t-micro">Protocol</TableHead>
+                      <TableHead className="t-micro">Src Address</TableHead>
+                      <TableHead className="t-micro">Dst Address</TableHead>
+                      <TableHead className="t-micro">Dst Port</TableHead>
+                      <TableHead className="t-micro">To Address</TableHead>
+                      <TableHead className="t-micro">To Port</TableHead>
+                      <TableHead className="t-micro">Comment</TableHead>
+                      <TableHead className="t-micro">Status</TableHead>
+                      <TableHead className="text-right t-micro">Actions</TableHead>
                     </TableRow>
                   </TableHeader>
 
@@ -377,11 +400,11 @@ export default function NatPage() {
                         </TableCell>
 
                         <TableCell className="text-mesh-text">{rule.protocol ?? "any"}</TableCell>
-                        <TableCell className="font-mono text-xs text-mesh-text">{rule.src_address ?? "-"}</TableCell>
-                        <TableCell className="font-mono text-xs text-mesh-text">{rule.dst_address ?? "-"}</TableCell>
-                        <TableCell className="font-mono text-xs text-mesh-text">{rule.dst_port ?? "-"}</TableCell>
-                        <TableCell className="font-mono text-xs text-mesh-text">{rule.to_addresses ?? "-"}</TableCell>
-                        <TableCell className="font-mono text-xs text-mesh-text">{rule.to_ports ?? "-"}</TableCell>
+                        <TableCell className="mono tabular text-xs text-mesh-text">{rule.src_address ?? "-"}</TableCell>
+                        <TableCell className="mono tabular text-xs text-mesh-text">{rule.dst_address ?? "-"}</TableCell>
+                        <TableCell className="mono tabular text-xs text-mesh-text">{rule.dst_port ?? "-"}</TableCell>
+                        <TableCell className="mono tabular text-xs text-mesh-text">{rule.to_addresses ?? "-"}</TableCell>
+                        <TableCell className="mono tabular text-xs text-mesh-text">{rule.to_ports ?? "-"}</TableCell>
                         <TableCell className="max-w-[180px] truncate text-mesh-text-dim" title={rule.comment ?? undefined}>
                           {rule.comment ?? "-"}
                         </TableCell>
@@ -404,22 +427,23 @@ export default function NatPage() {
                           <div className="flex justify-end gap-1">
                             {rule.id && (
                               <>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
+                                <button
+                                  type="button"
+                                  className="btn btn-ghost btn-sm"
                                   onClick={() => setEditMtRule(rule)}
-                                  className="h-7 w-7 p-0 text-mesh-text-dim hover:text-white"
+                                  aria-label="Edit rule"
                                 >
-                                  <Pencil className="h-3.5 w-3.5" />
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
+                                  <Pencil className="h-3 w-3" />
+                                </button>
+                                <button
+                                  type="button"
+                                  className="btn btn-ghost btn-sm"
                                   onClick={() => setPendingDeleteMt(rule)}
-                                  className="h-7 w-7 p-0 text-mesh-text-dim hover:text-[#fb7185]"
+                                  aria-label="Delete rule"
+                                  style={{ color: "#fb7185" }}
                                 >
-                                  <Trash2 className="h-3.5 w-3.5" />
-                                </Button>
+                                  <Trash2 className="h-3 w-3" />
+                                </button>
                               </>
                             )}
                           </div>
@@ -483,20 +507,21 @@ export default function NatPage() {
             if (!open) setPendingDeleteMt(null);
           }}
         >
-          <AlertDialogContent className="bg-mesh-surface-1/95 border-mesh-border">
+          <AlertDialogContent className="bg-mesh-surface-1/95 border-mesh-border-strong">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white">Delete MikroTik NAT Rule</AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogTitle className="t-h2">Delete MikroTik NAT Rule</AlertDialogTitle>
+              <AlertDialogDescription className="t-small">
                 Are you sure you want to delete this NAT rule
                 {pendingDeleteMt?.comment ? ` (${pendingDeleteMt.comment})` : ""}?
                 This will remove it from the MikroTik router.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border-strong text-mesh-text">Cancel</AlertDialogCancel>
+              <AlertDialogCancel className="btn">Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDeleteMt}
-                className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+                style={{ background: "#fb7185", borderColor: "#fb7185", color: "#ffffff" }}
+                className="btn"
               >
                 Delete
               </AlertDialogAction>
@@ -515,29 +540,42 @@ function SummaryCard({
   value,
   available,
   icon,
-  iconClass,
+  iconBg,
+  iconBorder,
 }: {
   title: string;
   value: number | null;
   available: boolean | null;
   icon: React.ReactNode;
-  iconClass: string;
+  iconBg: string;
+  iconBorder: string;
 }) {
   return (
     <Card>
       <CardContent className="flex min-h-[96px] items-center gap-5 p-4">
-        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
+        <div
+          className="flex h-11 w-11 shrink-0 items-center justify-center"
+          style={{
+            borderRadius: "var(--radius-md)",
+            border: `1px solid ${iconBorder}`,
+            background: iconBg,
+          }}
+        >
           {icon}
         </div>
 
         <div className="min-w-0">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mesh-text-mute">{title}</p>
+          <p className="t-micro">{title}</p>
           {available === null ? (
             <Skeleton className="mt-2 h-6 w-14 bg-mesh-surface-1" />
           ) : available ? (
-            <p className="mt-1 text-2xl font-semibold text-white">{value ?? 0}</p>
+            <p className="t-h1" style={{ marginTop: 4 }}>
+              {value ?? 0}
+            </p>
           ) : (
-            <p className="mt-1 text-sm text-mesh-text-mute">Not configured</p>
+            <p className="t-small" style={{ marginTop: 4 }}>
+              Not configured
+            </p>
           )}
         </div>
       </CardContent>
@@ -673,19 +711,19 @@ function MikrotikNatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-mesh-surface-1/95 border-mesh-border sm:max-w-lg max-h-[85vh] overflow-y-auto">
+      <DialogContent className="bg-mesh-surface-1/95 border-mesh-border-strong sm:max-w-lg max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-white">{dialogTitle}</DialogTitle>
-          <DialogDescription className="text-mesh-text-dim">{dialogDescription}</DialogDescription>
+          <DialogTitle className="t-h2">{dialogTitle}</DialogTitle>
+          <DialogDescription className="t-small">{dialogDescription}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           {/* Chain + Action */}
           <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">Chain</Label>
+              <Label className="t-micro">Chain</Label>
               <Select value={chain} onValueChange={setChain}>
-                <SelectTrigger className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="border-mesh-border bg-mesh-surface-1 text-mesh-text">
@@ -695,9 +733,9 @@ function MikrotikNatDialog({
               </Select>
             </div>
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">Action</Label>
+              <Label className="t-micro">Action</Label>
               <Select value={action} onValueChange={setAction}>
-                <SelectTrigger className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="border-mesh-border bg-mesh-surface-1 text-mesh-text">
@@ -714,9 +752,9 @@ function MikrotikNatDialog({
 
           {/* Protocol */}
           <div className="space-y-1.5">
-            <Label className="text-mesh-text-dim">Protocol</Label>
+            <Label className="t-micro">Protocol</Label>
             <Select value={protocol || "__none__"} onValueChange={(v) => setProtocol(v === "__none__" ? "" : v)}>
-              <SelectTrigger className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text">
+              <SelectTrigger>
                 <SelectValue placeholder="Any" />
               </SelectTrigger>
               <SelectContent className="border-mesh-border bg-mesh-surface-1 text-mesh-text">
@@ -731,7 +769,7 @@ function MikrotikNatDialog({
           {/* Source / Destination Addresses */}
           <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 Src Address
                 <HelpTooltip text="Source IP or CIDR to match. Leave empty for any." />
               </Label>
@@ -739,11 +777,10 @@ function MikrotikNatDialog({
                 value={srcAddress}
                 onChange={(e) => setSrcAddress(e.target.value)}
                 placeholder="e.g. 192.168.1.0/24"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 Dst Address
                 <HelpTooltip text="Destination IP to match. For 1:1 NAT, this is the external IP." />
               </Label>
@@ -751,14 +788,13 @@ function MikrotikNatDialog({
                 value={dstAddress}
                 onChange={(e) => setDstAddress(e.target.value)}
                 placeholder="e.g. 203.0.113.10"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
           </div>
 
           {/* Dst Port */}
           <div className="space-y-1.5">
-            <Label className="text-mesh-text-dim">
+            <Label className="t-micro">
               Dst Port
               <HelpTooltip text="Destination port to match. Leave empty for 1:1 NAT (all ports)." />
             </Label>
@@ -766,14 +802,13 @@ function MikrotikNatDialog({
               value={dstPort}
               onChange={(e) => setDstPort(e.target.value)}
               placeholder="e.g. 8080 or 80-443"
-              className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
             />
           </div>
 
           {/* To Addresses / To Ports */}
           <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 To Addresses
                 <HelpTooltip text="Translate to this IP. For DNAT/1:1: internal host. For SNAT: outbound IP." />
               </Label>
@@ -781,11 +816,10 @@ function MikrotikNatDialog({
                 value={toAddresses}
                 onChange={(e) => setToAddresses(e.target.value)}
                 placeholder="e.g. 192.168.1.100"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 To Ports
                 <HelpTooltip text="Translate to this port. Leave empty for 1:1 NAT." />
               </Label>
@@ -793,7 +827,6 @@ function MikrotikNatDialog({
                 value={toPorts}
                 onChange={(e) => setToPorts(e.target.value)}
                 placeholder="e.g. 80"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
           </div>
@@ -801,7 +834,7 @@ function MikrotikNatDialog({
           {/* Interfaces */}
           <div className="grid grid-cols-2 gap-5">
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 In Interface
                 <HelpTooltip text="Match traffic arriving on this interface (e.g. ether1-wan)." />
               </Label>
@@ -809,11 +842,10 @@ function MikrotikNatDialog({
                 value={inInterface}
                 onChange={(e) => setInInterface(e.target.value)}
                 placeholder="e.g. ether1"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-mesh-text-dim">
+              <Label className="t-micro">
                 Out Interface
                 <HelpTooltip text="Match traffic leaving via this interface." />
               </Label>
@@ -821,19 +853,17 @@ function MikrotikNatDialog({
                 value={outInterface}
                 onChange={(e) => setOutInterface(e.target.value)}
                 placeholder="e.g. bridge1"
-                className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
               />
             </div>
           </div>
 
           {/* Comment */}
           <div className="space-y-1.5">
-            <Label className="text-mesh-text-dim">Comment</Label>
+            <Label className="t-micro">Comment</Label>
             <Input
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder="Web server port forward"
-              className="bg-mesh-surface-1/95 border-mesh-border text-mesh-text"
             />
           </div>
 
@@ -846,28 +876,29 @@ function MikrotikNatDialog({
               onChange={(e) => setDisabled(e.target.checked)}
               className="rounded border-mesh-border bg-mesh-surface-1"
             />
-            <Label htmlFor="mt-nat-disabled" className="text-mesh-text-dim">
+            <Label htmlFor="mt-nat-disabled" className="t-small">
               Disabled
             </Label>
           </div>
 
           {/* Action buttons */}
           <div className="flex justify-end gap-2 pt-2">
-            <Button
-              variant="outline"
+            <button
+              type="button"
+              className="btn"
               onClick={() => onOpenChange(false)}
-              className="border-mesh-border-strong text-mesh-text"
             >
               Cancel
-            </Button>
-            <Button
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
               onClick={handleSubmit}
               disabled={saving || !chain || !action}
-              className="bg-mesh-primary hover:bg-mesh-primary text-white"
             >
-              {saving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+              {saving && <Loader2 className="h-3 w-3 animate-spin" />}
               {existing ? "Update" : "Create"}
-            </Button>
+            </button>
           </div>
         </div>
       </DialogContent>

--- a/web/src/app/(app)/qos/page.tsx
+++ b/web/src/app/(app)/qos/page.tsx
@@ -21,7 +21,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -200,14 +199,25 @@ export default function QosPage() {
   return (
     <PageTransition>
       <div className="space-y-8">
-        <section className="flex flex-col gap-5 mesh-card p-4 md:flex-row md:items-center md:justify-between">
+        {/* Page header — Card with eyebrow + display title */}
+        <Card className="flex flex-col gap-5 p-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-5">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-mesh-primary/30 bg-gradient-to-br from-mesh-primary/20 via-mesh-accent/10 to-[#818cf8]/10 text-mesh-primary">
+            <div
+              className="flex h-12 w-12 items-center justify-center text-mesh-primary"
+              style={{
+                borderRadius: "var(--radius-lg)",
+                border: "1px solid rgba(96,144,212,0.20)",
+                background: "var(--surface-2)",
+              }}
+            >
               <Gauge className="h-6 w-6" />
             </div>
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white">QoS / Traffic Shaping</h1>
-              <p className="text-sm text-mesh-text-dim">
+              <div className="t-micro">Network operations</div>
+              <h1 className="t-display" style={{ margin: "4px 0 0" }}>
+                QoS / Traffic Shaping
+              </h1>
+              <p className="t-small" style={{ marginTop: 4 }}>
                 Queue policies, bandwidth limits, and hierarchical shaping.
               </p>
             </div>
@@ -215,53 +225,44 @@ export default function QosPage() {
 
           <div className="flex items-center gap-2">
             {activeTab === "mikrotik" && (
-              <Button
-                variant="outline"
-                size="sm"
+              <button
+                type="button"
+                className="btn"
                 onClick={() => setLiveRefresh((v) => !v)}
-                className={cn(
-                  "border-mesh-border bg-mesh-surface-1 text-mesh-text hover:bg-mesh-surface-2/55",
-                  liveRefresh && "border-[#4ade80]/50 text-[#4ade80]",
-                )}
+                style={liveRefresh ? { borderColor: "#4ade80", color: "#4ade80" } : undefined}
               >
-                <RefreshCw
-                  className={cn(
-                    "mr-1.5 h-3.5 w-3.5",
-                    liveRefresh && "animate-spin",
-                  )}
-                />
-                {liveRefresh ? "Live" : "Auto-refresh"}
-              </Button>
+                <RefreshCw className={cn("h-3 w-3", liveRefresh && "animate-spin")} />
+                <span>{liveRefresh ? "Live" : "Auto-refresh"}</span>
+              </button>
             )}
-            <Button
-              variant="outline"
-              size="sm"
+            <button
+              type="button"
+              className="btn"
               onClick={() => {
                 load();
                 if (activeTab === "mikrotik") loadMtQueues();
               }}
-              className="border-mesh-border bg-mesh-surface-1 text-mesh-text hover:bg-mesh-surface-2/55"
             >
-              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-              Refresh
-            </Button>
+              <RefreshCw className="h-3 w-3" />
+              <span>Refresh</span>
+            </button>
           </div>
-        </section>
+        </Card>
 
         <section className="grid gap-5 sm:grid-cols-2">
           <SummaryCard
             title="MikroTik Simple Queues"
             value={summary?.mikrotik_simple_queue_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<Network className="h-4 w-4 text-[#fbbf24]" />}
-            iconClass="border-[#fbbf24]/30 bg-[#fbbf24]/15"
+            icon={<Network className="h-4 w-4" style={{ color: "#fbbf24" }} />}
+            iconBorder="rgba(251,191,36,0.40)"
           />
           <SummaryCard
             title="MikroTik Queue Tree"
             value={summary?.mikrotik_queue_tree_count ?? null}
             available={summary?.mikrotik_available ?? null}
-            icon={<TreePine className="h-4 w-4 text-[#67e8f9]" />}
-            iconClass="border-mesh-accent/30 bg-mesh-accent/15"
+            icon={<TreePine className="h-4 w-4 text-mesh-accent" />}
+            iconBorder="rgba(96,144,212,0.40)"
           />
         </section>
 
@@ -269,7 +270,7 @@ export default function QosPage() {
           <TabsList className="h-auto mesh-card p-1">
             <TabsTrigger
               value="overview"
-              className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-white"
+              className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-mesh-text"
             >
               Overview
             </TabsTrigger>
@@ -277,7 +278,7 @@ export default function QosPage() {
             {summary?.mikrotik_available && (
               <TabsTrigger
                 value="mikrotik"
-                className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-white"
+                className="rounded-lg px-4 data-[state=active]:bg-mesh-surface-1 data-[state=active]:text-mesh-text"
               >
                 MikroTik Queues
               </TabsTrigger>
@@ -287,28 +288,28 @@ export default function QosPage() {
           <TabsContent value="overview" className="space-y-4 pt-2">
             <Card>
               <CardHeader>
-                <CardTitle className="text-base text-white">Traffic Shaping Overview</CardTitle>
-                <CardDescription className="text-mesh-text-dim">
+                <CardTitle className="t-h3">Traffic Shaping Overview</CardTitle>
+                <CardDescription className="t-small">
                   Simple queues apply per-target limits, while queue tree entries define
                   hierarchical policy and prioritization.
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 {summary?.mikrotik_available ? (
-                  <div className="grid gap-3 text-sm text-mesh-text md:grid-cols-2">
+                  <div className="grid gap-3 md:grid-cols-2">
                     <div className="mesh-card-2 p-3">
-                      <p className="text-[11px] uppercase tracking-[0.2em] text-mesh-text-mute">Simple queues</p>
-                      <p className="mt-1 text-mesh-text">
-                        <span className="font-semibold text-white">
+                      <p className="t-micro">Simple queues</p>
+                      <p className="t-body" style={{ marginTop: 4 }}>
+                        <span style={{ fontWeight: 600, color: "var(--text)" }}>
                           {summary.mikrotik_simple_queue_count}
                         </span>{" "}
                         configured
                       </p>
                     </div>
                     <div className="mesh-card-2 p-3">
-                      <p className="text-[11px] uppercase tracking-[0.2em] text-mesh-text-mute">Queue tree</p>
-                      <p className="mt-1 text-mesh-text">
-                        <span className="font-semibold text-white">
+                      <p className="t-micro">Queue tree</p>
+                      <p className="t-body" style={{ marginTop: 4 }}>
+                        <span style={{ fontWeight: 600, color: "var(--text)" }}>
                           {summary.mikrotik_queue_tree_count}
                         </span>{" "}
                         entries
@@ -316,7 +317,7 @@ export default function QosPage() {
                     </div>
                   </div>
                 ) : (
-                  <p className="text-sm text-mesh-text-dim">
+                  <p className="t-small">
                     No router is configured. Configure router credentials in Settings.
                   </p>
                 )}
@@ -332,51 +333,53 @@ export default function QosPage() {
                   placeholder="Filter by queue name, target, or comment..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1/95 pl-10 text-white placeholder:text-mesh-text-mute"
+                  className="pl-10"
                 />
               </div>
 
               <div className="flex gap-2">
-                <Button
-                  size="sm"
+                <button
+                  type="button"
+                  className="btn btn-primary"
                   onClick={() => setShowAddMtQueue(true)}
-                  className="bg-mesh-primary text-white hover:bg-mesh-primary"
                 >
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Add Queue
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
+                  <Plus className="h-3 w-3" />
+                  <span>Add Queue</span>
+                </button>
+                <button
+                  type="button"
+                  className="btn"
                   onClick={() => setShowAddMtTree(true)}
-                  className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
                 >
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Add Tree Entry
-                </Button>
+                  <Plus className="h-3 w-3" />
+                  <span>Add Tree Entry</span>
+                </button>
               </div>
             </div>
 
             {/* Simple Queues Table */}
             <Card>
               <CardHeader className="pb-3">
-                <CardTitle className="text-base text-white">Simple Queues</CardTitle>
-                <CardDescription className="text-xs text-mesh-text-mute">
+                <CardTitle className="t-h3">Simple Queues</CardTitle>
+                <CardDescription className="t-small">
                   Per-target bandwidth limits for IPs/subnets.
                 </CardDescription>
               </CardHeader>
               <CardContent className="p-0">
-                <div className="overflow-x-auto border-t border-mesh-border">
+                <div
+                  className="overflow-x-auto"
+                  style={{ borderTop: "1px solid rgba(96,144,212,0.20)" }}
+                >
                   <Table>
                     <TableHeader>
                       <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Name</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Target</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Max Limit</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Priority</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Rate</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Status</TableHead>
-                        <TableHead className="text-right text-xs uppercase tracking-wide text-mesh-text-mute">Actions</TableHead>
+                        <TableHead className="t-micro">Name</TableHead>
+                        <TableHead className="t-micro">Target</TableHead>
+                        <TableHead className="t-micro">Max Limit</TableHead>
+                        <TableHead className="t-micro">Priority</TableHead>
+                        <TableHead className="t-micro">Rate</TableHead>
+                        <TableHead className="t-micro">Status</TableHead>
+                        <TableHead className="text-right t-micro">Actions</TableHead>
                       </TableRow>
                     </TableHeader>
 
@@ -393,7 +396,7 @@ export default function QosPage() {
                         ))
                       ) : filteredMtQueues.length === 0 ? (
                         <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                          <TableCell colSpan={7} className="py-12 text-center text-mesh-text-mute">
+                          <TableCell colSpan={7} className="py-12 text-center t-small">
                             {search ? "No queues match your filter." : "No simple queues configured."}
                           </TableCell>
                         </TableRow>
@@ -403,11 +406,13 @@ export default function QosPage() {
                             key={queue.id ?? queue.name}
                             className="border-mesh-border hover:bg-mesh-surface-2/55"
                           >
-                            <TableCell className="font-medium text-white">{queue.name}</TableCell>
+                            <TableCell className="text-mesh-text" style={{ fontWeight: 500 }}>
+                              {queue.name}
+                            </TableCell>
                             <TableCell className="text-mesh-text">{queue.target}</TableCell>
-                            <TableCell className="font-mono text-xs text-mesh-text-dim">{queue.max_limit ?? "—"}</TableCell>
+                            <TableCell className="mono tabular text-xs text-mesh-text-dim">{queue.max_limit ?? "—"}</TableCell>
                             <TableCell className="text-mesh-text">{queue.priority ?? "—"}</TableCell>
-                            <TableCell className="font-mono text-xs text-mesh-text-dim">
+                            <TableCell className="mono tabular text-xs text-mesh-text-dim">
                               <RateDisplay rate={queue.rate} />
                             </TableCell>
                             <TableCell>
@@ -429,22 +434,23 @@ export default function QosPage() {
                               <div className="flex justify-end gap-1">
                                 {!queue.dynamic && queue.id && (
                                   <>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
+                                    <button
+                                      type="button"
+                                      className="btn btn-ghost btn-sm"
                                       onClick={() => setEditMtQueue(queue)}
-                                      className="h-8 w-8 p-0 text-mesh-text-dim hover:text-white"
+                                      aria-label="Edit queue"
                                     >
-                                      <Pencil className="h-3.5 w-3.5" />
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
+                                      <Pencil className="h-3 w-3" />
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="btn btn-ghost btn-sm"
                                       onClick={() => setPendingDeleteMtQueue(queue)}
-                                      className="h-8 w-8 p-0 text-mesh-text-dim hover:text-[#fb7185]"
+                                      aria-label="Delete queue"
+                                      style={{ color: "#fb7185" }}
                                     >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                    </Button>
+                                      <Trash2 className="h-3 w-3" />
+                                    </button>
                                   </>
                                 )}
                               </div>
@@ -461,24 +467,27 @@ export default function QosPage() {
             {/* Queue Tree Table */}
             <Card>
               <CardHeader className="pb-3">
-                <CardTitle className="text-base text-white">Queue Tree</CardTitle>
-                <CardDescription className="text-xs text-mesh-text-mute">
+                <CardTitle className="t-h3">Queue Tree</CardTitle>
+                <CardDescription className="t-small">
                   Hierarchical queue entries for packet-mark based shaping.
                 </CardDescription>
               </CardHeader>
               <CardContent className="p-0">
-                <div className="overflow-x-auto border-t border-mesh-border">
+                <div
+                  className="overflow-x-auto"
+                  style={{ borderTop: "1px solid rgba(96,144,212,0.20)" }}
+                >
                   <Table>
                     <TableHeader>
                       <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Name</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Parent</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Packet Mark</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Max Limit</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Priority</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Rate</TableHead>
-                        <TableHead className="text-xs uppercase tracking-wide text-mesh-text-mute">Status</TableHead>
-                        <TableHead className="text-right text-xs uppercase tracking-wide text-mesh-text-mute">Actions</TableHead>
+                        <TableHead className="t-micro">Name</TableHead>
+                        <TableHead className="t-micro">Parent</TableHead>
+                        <TableHead className="t-micro">Packet Mark</TableHead>
+                        <TableHead className="t-micro">Max Limit</TableHead>
+                        <TableHead className="t-micro">Priority</TableHead>
+                        <TableHead className="t-micro">Rate</TableHead>
+                        <TableHead className="t-micro">Status</TableHead>
+                        <TableHead className="text-right t-micro">Actions</TableHead>
                       </TableRow>
                     </TableHeader>
 
@@ -495,7 +504,7 @@ export default function QosPage() {
                         ))
                       ) : filteredMtTree.length === 0 ? (
                         <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                          <TableCell colSpan={8} className="py-12 text-center text-mesh-text-mute">
+                          <TableCell colSpan={8} className="py-12 text-center t-small">
                             {search ? "No tree entries match your filter." : "No queue tree entries."}
                           </TableCell>
                         </TableRow>
@@ -505,12 +514,14 @@ export default function QosPage() {
                             key={entry.id ?? entry.name}
                             className="border-mesh-border hover:bg-mesh-surface-2/55"
                           >
-                            <TableCell className="font-medium text-white">{entry.name}</TableCell>
+                            <TableCell className="text-mesh-text" style={{ fontWeight: 500 }}>
+                              {entry.name}
+                            </TableCell>
                             <TableCell className="text-mesh-text">{entry.parent ?? "—"}</TableCell>
                             <TableCell className="text-mesh-text">{entry.packet_mark ?? "—"}</TableCell>
-                            <TableCell className="font-mono text-xs text-mesh-text-dim">{entry.max_limit ?? "—"}</TableCell>
+                            <TableCell className="mono tabular text-xs text-mesh-text-dim">{entry.max_limit ?? "—"}</TableCell>
                             <TableCell className="text-mesh-text">{entry.priority ?? "—"}</TableCell>
-                            <TableCell className="font-mono text-xs text-mesh-text-dim">
+                            <TableCell className="mono tabular text-xs text-mesh-text-dim">
                               <RateDisplay rate={entry.rate} />
                             </TableCell>
                             <TableCell>
@@ -532,22 +543,23 @@ export default function QosPage() {
                               <div className="flex justify-end gap-1">
                                 {!entry.dynamic && entry.id && (
                                   <>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
+                                    <button
+                                      type="button"
+                                      className="btn btn-ghost btn-sm"
                                       onClick={() => setEditMtTree(entry)}
-                                      className="h-8 w-8 p-0 text-mesh-text-dim hover:text-white"
+                                      aria-label="Edit entry"
                                     >
-                                      <Pencil className="h-3.5 w-3.5" />
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
+                                      <Pencil className="h-3 w-3" />
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="btn btn-ghost btn-sm"
                                       onClick={() => setPendingDeleteMtTree(entry)}
-                                      className="h-8 w-8 p-0 text-mesh-text-dim hover:text-[#fb7185]"
+                                      aria-label="Delete entry"
+                                      style={{ color: "#fb7185" }}
                                     >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                    </Button>
+                                      <Trash2 className="h-3 w-3" />
+                                    </button>
                                   </>
                                 )}
                               </div>
@@ -606,21 +618,20 @@ export default function QosPage() {
             if (!open) setPendingDeleteMtQueue(null);
           }}
         >
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent className="border-mesh-border-strong bg-mesh-surface-1/95">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white">Delete Simple Queue</AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogTitle className="t-h2">Delete Simple Queue</AlertDialogTitle>
+              <AlertDialogDescription className="t-small">
                 Are you sure you want to delete queue{" "}
-                <span className="font-medium text-white">{pendingDeleteMtQueue?.name}</span>?
+                <span style={{ fontWeight: 500, color: "var(--text)" }}>{pendingDeleteMtQueue?.name}</span>?
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel className="btn">Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDeleteMtQueue}
-                className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+                style={{ background: "#fb7185", borderColor: "#fb7185", color: "#ffffff" }}
+                className="btn"
               >
                 Delete
               </AlertDialogAction>
@@ -635,21 +646,20 @@ export default function QosPage() {
             if (!open) setPendingDeleteMtTree(null);
           }}
         >
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent className="border-mesh-border-strong bg-mesh-surface-1/95">
             <AlertDialogHeader>
-              <AlertDialogTitle className="text-white">Delete Queue Tree Entry</AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogTitle className="t-h2">Delete Queue Tree Entry</AlertDialogTitle>
+              <AlertDialogDescription className="t-small">
                 Are you sure you want to delete queue tree entry{" "}
-                <span className="font-medium text-white">{pendingDeleteMtTree?.name}</span>?
+                <span style={{ fontWeight: 500, color: "var(--text)" }}>{pendingDeleteMtTree?.name}</span>?
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel className="btn">Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDeleteMtTree}
-                className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+                style={{ background: "#fb7185", borderColor: "#fb7185", color: "#ffffff" }}
+                className="btn"
               >
                 Delete
               </AlertDialogAction>
@@ -675,29 +685,40 @@ function SummaryCard({
   value,
   available,
   icon,
-  iconClass,
+  iconBorder,
 }: {
   title: string;
   value: number | null;
   available: boolean | null;
   icon: React.ReactNode;
-  iconClass: string;
+  iconBorder: string;
 }) {
   return (
     <Card>
       <CardContent className="flex min-h-[96px] items-center gap-5 p-4">
-        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border", iconClass)}>
+        <div
+          className="flex h-11 w-11 shrink-0 items-center justify-center"
+          style={{
+            borderRadius: "var(--radius-md)",
+            border: `1px solid ${iconBorder}`,
+            background: "var(--surface-2)",
+          }}
+        >
           {icon}
         </div>
 
         <div className="min-w-0">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mesh-text-mute">{title}</p>
+          <p className="t-micro">{title}</p>
           {available === null ? (
             <Skeleton className="mt-2 h-6 w-14 bg-mesh-surface-1" />
           ) : available ? (
-            <p className="mt-1 text-2xl font-semibold text-white">{value ?? 0}</p>
+            <p className="t-h1" style={{ marginTop: 4 }}>
+              {value ?? 0}
+            </p>
           ) : (
-            <p className="mt-1 text-sm text-mesh-text-mute">Not configured</p>
+            <p className="t-small" style={{ marginTop: 4 }}>
+              Not configured
+            </p>
           )}
         </div>
       </CardContent>
@@ -802,67 +823,62 @@ function MikrotikQueueFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-mesh-border bg-mesh-surface-1/95 sm:max-w-md">
+      <DialogContent className="border-mesh-border-strong bg-mesh-surface-1/95 sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="text-white">{isEdit ? "Edit Simple Queue" : "Add Simple Queue"}</DialogTitle>
+          <DialogTitle className="t-h2">{isEdit ? "Edit Simple Queue" : "Add Simple Queue"}</DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
-            <Label htmlFor="queue-name" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="queue-name" className="t-micro">
               Name
             </Label>
             <Input
               id="queue-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="download-limit-pc"
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="queue-target" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="queue-target" className="t-micro">
               Target (IP or subnet)
             </Label>
             <Input
               id="queue-target"
               value={target}
               onChange={(e) => setTarget(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="192.168.1.100/32"
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="queue-max-limit" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="queue-max-limit" className="t-micro">
               Max Limit (upload/download)
             </Label>
             <Input
               id="queue-max-limit"
               value={maxLimit}
               onChange={(e) => setMaxLimit(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="10M/10M"
             />
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Limit</Label>
+              <Label className="t-micro">Burst Limit</Label>
               <Input
                 value={burstLimit}
                 onChange={(e) => setBurstLimit(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="15M/15M"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Threshold</Label>
+              <Label className="t-micro">Burst Threshold</Label>
               <Input
                 value={burstThreshold}
                 onChange={(e) => setBurstThreshold(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="8M/8M"
               />
             </div>
@@ -870,55 +886,62 @@ function MikrotikQueueFormDialog({
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Time</Label>
+              <Label className="t-micro">Burst Time</Label>
               <Input
                 value={burstTime}
                 onChange={(e) => setBurstTime(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="10s/10s"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Priority</Label>
+              <Label className="t-micro">Priority</Label>
               <Input
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="8"
               />
             </div>
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-xs text-mesh-text-dim">Comment</Label>
+            <Label className="t-micro">Comment</Label>
             <Input
               value={comment}
               onChange={(e) => setComment(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="Optional comment"
             />
           </div>
 
           {formError && (
-            <div className="flex items-center gap-2 rounded-md border border-[#fb7185]/30 bg-[#fb7185]/10 px-3 py-2">
-              <AlertCircle className="h-4 w-4 shrink-0 text-[#fb7185]" />
-              <p className="text-xs text-[#fb7185]">{formError}</p>
+            <div
+              className="flex items-center gap-2 px-3 py-2"
+              style={{
+                borderRadius: "var(--radius-md)",
+                border: "1px solid rgba(251,113,133,0.30)",
+                background: "rgba(251,113,133,0.10)",
+              }}
+            >
+              <AlertCircle className="h-4 w-4 shrink-0" style={{ color: "#fb7185" }} />
+              <p className="t-small" style={{ color: "#fb7185" }}>{formError}</p>
             </div>
           )}
 
           <div className="flex justify-end gap-2">
-            <Button
+            <button
               type="button"
-              variant="outline"
+              className="btn"
               onClick={() => onOpenChange(false)}
-              className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
             >
               Cancel
-            </Button>
-            <Button type="submit" disabled={loading} className="bg-mesh-primary text-white hover:bg-mesh-primary">
-              {loading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={loading}
+            >
+              {loading && <Loader2 className="h-3 w-3 animate-spin" />}
               {isEdit ? "Update" : "Create"}
-            </Button>
+            </button>
           </div>
         </form>
       </DialogContent>
@@ -1023,67 +1046,62 @@ function QueueTreeFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-mesh-border bg-mesh-surface-1/95 sm:max-w-md">
+      <DialogContent className="border-mesh-border-strong bg-mesh-surface-1/95 sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="text-white">{isEdit ? "Edit Queue Tree Entry" : "Add Queue Tree Entry"}</DialogTitle>
+          <DialogTitle className="t-h2">{isEdit ? "Edit Queue Tree Entry" : "Add Queue Tree Entry"}</DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
-            <Label htmlFor="tree-name" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="tree-name" className="t-micro">
               Name
             </Label>
             <Input
               id="tree-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="voip-priority"
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="tree-parent" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="tree-parent" className="t-micro">
               Parent
             </Label>
             <Input
               id="tree-parent"
               value={parent}
               onChange={(e) => setParent(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="global"
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="tree-packet-mark" className="text-xs text-mesh-text-dim">
+            <Label htmlFor="tree-packet-mark" className="t-micro">
               Packet Mark
             </Label>
             <Input
               id="tree-packet-mark"
               value={packetMark}
               onChange={(e) => setPacketMark(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="voip-mark"
             />
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Max Limit</Label>
+              <Label className="t-micro">Max Limit</Label>
               <Input
                 value={maxLimit}
                 onChange={(e) => setMaxLimit(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="10M"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Priority</Label>
+              <Label className="t-micro">Priority</Label>
               <Input
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="1"
               />
             </div>
@@ -1091,20 +1109,18 @@ function QueueTreeFormDialog({
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Limit</Label>
+              <Label className="t-micro">Burst Limit</Label>
               <Input
                 value={burstLimit}
                 onChange={(e) => setBurstLimit(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="15M"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Threshold</Label>
+              <Label className="t-micro">Burst Threshold</Label>
               <Input
                 value={burstThreshold}
                 onChange={(e) => setBurstThreshold(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="8M"
               />
             </div>
@@ -1112,45 +1128,53 @@ function QueueTreeFormDialog({
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Burst Time</Label>
+              <Label className="t-micro">Burst Time</Label>
               <Input
                 value={burstTime}
                 onChange={(e) => setBurstTime(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="10s"
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs text-mesh-text-dim">Comment</Label>
+              <Label className="t-micro">Comment</Label>
               <Input
                 value={comment}
                 onChange={(e) => setComment(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="Optional comment"
               />
             </div>
           </div>
 
           {formError && (
-            <div className="flex items-center gap-2 rounded-md border border-[#fb7185]/30 bg-[#fb7185]/10 px-3 py-2">
-              <AlertCircle className="h-4 w-4 shrink-0 text-[#fb7185]" />
-              <p className="text-xs text-[#fb7185]">{formError}</p>
+            <div
+              className="flex items-center gap-2 px-3 py-2"
+              style={{
+                borderRadius: "var(--radius-md)",
+                border: "1px solid rgba(251,113,133,0.30)",
+                background: "rgba(251,113,133,0.10)",
+              }}
+            >
+              <AlertCircle className="h-4 w-4 shrink-0" style={{ color: "#fb7185" }} />
+              <p className="t-small" style={{ color: "#fb7185" }}>{formError}</p>
             </div>
           )}
 
           <div className="flex justify-end gap-2">
-            <Button
+            <button
               type="button"
-              variant="outline"
+              className="btn"
               onClick={() => onOpenChange(false)}
-              className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
             >
               Cancel
-            </Button>
-            <Button type="submit" disabled={loading} className="bg-mesh-primary text-white hover:bg-mesh-primary">
-              {loading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={loading}
+            >
+              {loading && <Loader2 className="h-3 w-3 animate-spin" />}
               {isEdit ? "Update" : "Create"}
-            </Button>
+            </button>
           </div>
         </form>
       </DialogContent>

--- a/web/src/app/(app)/traffic/page.tsx
+++ b/web/src/app/(app)/traffic/page.tsx
@@ -13,13 +13,13 @@ import {
 } from "recharts";
 import { Activity, ChevronDown, Download, Radio, X } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Card } from "@/components/ui/card";
 import { fetchTrafficHistory, fetchTopDevices, fetchNetflowStatus } from "@/lib/api";
 import { formatBps } from "@/lib/format";
 import type { TrafficHistoryPoint, TopDevice, NetflowStatus } from "@/lib/types";
@@ -80,271 +80,279 @@ export default function TrafficPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-8">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Traffic</h1>
-          <HelpTooltip text="Network bandwidth usage over time. Requires NetFlow/sFlow export from your router to be configured in Settings." />
-        </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary" size="sm">
-              <Download className="mr-2 h-4 w-4" />
-              Export
-              <ChevronDown className="ml-2 h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onClick={async () => {
-                try {
-                  await downloadExport(
-                    "/api/v1/traffic/export?format=csv&minutes=1440",
-                    "panoptikon-traffic.csv"
-                  );
-                  toast.success("Traffic exported as CSV");
-                } catch {
-                  toast.error("Export failed");
-                }
-              }}
-            >
-              Export as CSV
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={async () => {
-                try {
-                  await downloadExport(
-                    "/api/v1/traffic/export?format=json&minutes=1440",
-                    "panoptikon-traffic.json"
-                  );
-                  toast.success("Traffic exported as JSON");
-                } catch {
-                  toast.error("Export failed");
-                }
-              }}
-            >
-              Export as JSON
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      {/* NetFlow Collector Status */}
-      {netflow && (
-        <div className="flex items-center gap-2 mesh-card px-4 py-2.5">
-          <Radio className={`h-4 w-4 ${netflow.enabled ? "text-[#4ade80]" : "text-mesh-text-mute"}`} />
-          <span className="text-sm text-mesh-text-dim">
-            NetFlow collector:{" "}
-            {netflow.enabled ? (
-              <span className="text-[#4ade80]">
-                active on port {netflow.port}
-                <span className="ml-2 text-mesh-text-mute">
-                  ({netflow.flows_received.toLocaleString()} flows received)
-                </span>
-              </span>
-            ) : (
-              <span className="text-mesh-text-mute">disabled</span>
-            )}
-          </span>
-        </div>
-      )}
-
-      {/* Traffic History Chart */}
-      <div className="mesh-card p-4">
-        <div className="mb-3 flex items-center gap-2">
-          <Activity className="h-4 w-4 text-mesh-primary" />
-          <h2 className="text-sm font-medium text-mesh-text-dim">
-            Traffic — Last 60 minutes
-          </h2>
-        </div>
-
-        {loading && history.length === 0 ? (
-          <Skeleton className="h-[200px] w-full rounded-xl" />
-        ) : history.length > 0 ? (
-          <div className="h-[200px]">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={history}>
-                <defs>
-                  <linearGradient id="colorRx" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-                  </linearGradient>
-                  <linearGradient id="colorTx" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                <XAxis
-                  dataKey="minute"
-                  tickFormatter={formatTime}
-                  tick={{ fill: "#6b7280", fontSize: 11 }}
-                  stroke="#1e293b"
-                  interval="preserveStartEnd"
-                />
-                <YAxis
-                  tickFormatter={(v: number) => formatBps(v)}
-                  tick={{ fill: "#6b7280", fontSize: 11 }}
-                  stroke="#1e293b"
-                  width={70}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: "#0f172a",
-                    border: "1px solid #1e293b",
-                    borderRadius: "6px",
-                    color: "#fff",
-                    fontSize: "12px",
-                  }}
-                  labelFormatter={formatTime}
-                  formatter={(value: number, name: string) => [
-                    formatBps(value),
-                    name === "rx_bps" ? "Inbound" : "Outbound",
-                  ]}
-                />
-                <Legend
-                  formatter={(value: string) =>
-                    value === "rx_bps" ? "Inbound" : "Outbound"
-                  }
-                  wrapperStyle={{ fontSize: "12px", color: "#9ca3af" }}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="rx_bps"
-                  stroke="#3b82f6"
-                  fillOpacity={1}
-                  fill="url(#colorRx)"
-                  strokeWidth={2}
-                  isAnimationActive={false}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="tx_bps"
-                  stroke="#22c55e"
-                  fillOpacity={1}
-                  fill="url(#colorTx)"
-                  strokeWidth={2}
-                  isAnimationActive={false}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-        ) : (
-          <div className="flex h-[200px] items-center justify-center">
-            <div className="text-center">
-              <Activity className="mx-auto mb-2 h-8 w-8 text-mesh-text-mute" />
-              <p className="text-sm font-medium text-mesh-text-dim">No traffic data</p>
-              <p className="mt-1 text-xs text-mesh-text-mute">Enable NetFlow/sFlow export in Settings to see bandwidth data.</p>
+      <div className="space-y-8">
+        {/* Page header — eyebrow + display headline + Export action */}
+        <div className="flex items-end justify-between gap-4 flex-wrap">
+          <div>
+            <div className="t-micro">Operations</div>
+            <div className="flex items-center gap-2" style={{ marginTop: 4 }}>
+              <h1 className="t-display" style={{ margin: 0 }}>
+                Traffic
+              </h1>
+              <HelpTooltip text="Network bandwidth usage over time. Requires NetFlow/sFlow export from your router to be configured in Settings." />
             </div>
           </div>
-        )}
-      </div>
-
-      {/* Per-device Historical Bandwidth */}
-      {selectedDevice && (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium text-mesh-text-dim">
-              {selectedDevice.name ?? selectedDevice.hostname ?? selectedDevice.ip} — Historical Bandwidth
-            </h2>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-mesh-text-mute hover:text-white"
-              onClick={() => setSelectedDevice(null)}
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-          <DeviceTrafficChart deviceId={selectedDevice.id} height={220} />
-        </div>
-      )}
-
-      {/* Top Devices by Bandwidth */}
-      <div className="mesh-card">
-        <div className="border-b border-mesh-border px-4 py-3">
-          <h2 className="text-sm font-medium text-mesh-text-dim">
-            Top Devices by Bandwidth
-            <span className="ml-2 text-xs text-mesh-text-mute">Click a row to view history</span>
-          </h2>
-        </div>
-        {loading && topDevices.length === 0 ? (
-          <Table>
-            <TableHeader>
-              <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                <TableHead className="text-mesh-text-mute">Device</TableHead>
-                <TableHead className="text-mesh-text-mute">IP</TableHead>
-                <TableHead className="text-right text-mesh-text-mute">Download</TableHead>
-                <TableHead className="text-right text-mesh-text-mute">Upload</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {Array.from({ length: 5 }).map((_, i) => (
-                <TableRow key={i} className="border-mesh-border-strong">
-                  <TableCell><Skeleton className="h-4 w-28" /></TableCell>
-                  <TableCell><Skeleton className="h-3 w-24" /></TableCell>
-                  <TableCell className="text-right"><Skeleton className="ml-auto h-4 w-16" /></TableCell>
-                  <TableCell className="text-right"><Skeleton className="ml-auto h-4 w-16" /></TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        ) : topDevices.length === 0 ? (
-          <EmptyState
-            icon={Activity}
-            title="No traffic data"
-            description="No active devices with bandwidth usage. Make sure NetFlow/sFlow is configured in Settings."
-            actionLabel="Traffic Settings"
-            actionHref="/settings/router"
-          />
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow className="border-mesh-border-strong hover:bg-transparent">
-                <TableHead className="text-mesh-text-mute">Device</TableHead>
-                <TableHead className="text-mesh-text-mute">IP</TableHead>
-                <TableHead className="text-right text-mesh-text-mute">
-                  Download
-                </TableHead>
-                <TableHead className="text-right text-mesh-text-mute">
-                  Upload
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {topDevices.map((d) => (
-                <TableRow
-                  key={d.id}
-                  className={`border-mesh-border cursor-pointer ${
-                    selectedDevice?.id === d.id
-                      ? "bg-mesh-surface-1"
-                      : "hover:bg-mesh-surface-2/55"
-                  }`}
-                  onClick={() =>
-                    setSelectedDevice(
-                      selectedDevice?.id === d.id ? null : d
-                    )
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button type="button" className="btn">
+                <Download className="h-3 w-3" />
+                <span>Export</span>
+                <ChevronDown className="h-3 w-3" style={{ color: "var(--text-mute)" }} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={async () => {
+                  try {
+                    await downloadExport(
+                      "/api/v1/traffic/export?format=csv&minutes=1440",
+                      "panoptikon-traffic.csv"
+                    );
+                    toast.success("Traffic exported as CSV");
+                  } catch {
+                    toast.error("Export failed");
                   }
-                >
-                  <TableCell className="text-white">
-                    {d.name ?? d.hostname ?? d.id.slice(0, 8)}
-                  </TableCell>
-                  <TableCell className="font-mono tabular-nums text-xs text-mesh-text-dim">
-                    {d.ip ?? "—"}
-                  </TableCell>
-                  <TableCell className="font-mono tabular-nums text-right text-mesh-primary">
-                    {formatBps(d.rx_bps)}
-                  </TableCell>
-                  <TableCell className="font-mono tabular-nums text-right text-[#4ade80]">
-                    {formatBps(d.tx_bps)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+                }}
+              >
+                Export as CSV
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={async () => {
+                  try {
+                    await downloadExport(
+                      "/api/v1/traffic/export?format=json&minutes=1440",
+                      "panoptikon-traffic.json"
+                    );
+                    toast.success("Traffic exported as JSON");
+                  } catch {
+                    toast.error("Export failed");
+                  }
+                }}
+              >
+                Export as JSON
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* NetFlow Collector Status */}
+        {netflow && (
+          <Card className="flex items-center gap-2 px-4 py-2.5">
+            <Radio
+              className="h-4 w-4"
+              style={{ color: netflow.enabled ? "#4ade80" : "var(--text-mute)" }}
+            />
+            <span className="t-small" style={{ color: "var(--text-dim)" }}>
+              NetFlow collector:{" "}
+              {netflow.enabled ? (
+                <span style={{ color: "#4ade80" }}>
+                  active on port {netflow.port}
+                  <span className="ml-2" style={{ color: "var(--text-mute)" }}>
+                    ({netflow.flows_received.toLocaleString()} flows received)
+                  </span>
+                </span>
+              ) : (
+                <span style={{ color: "var(--text-mute)" }}>disabled</span>
+              )}
+            </span>
+          </Card>
         )}
+
+        {/* Traffic History Chart */}
+        <Card className="p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Activity className="h-4 w-4 text-mesh-primary" />
+            <h2 className="t-h3">Traffic — Last 60 minutes</h2>
+          </div>
+
+          {loading && history.length === 0 ? (
+            <Skeleton className="h-[200px] w-full rounded-xl" />
+          ) : history.length > 0 ? (
+            <div className="h-[200px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={history}>
+                  <defs>
+                    <linearGradient id="colorRx" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#38bdf8" stopOpacity={0} />
+                    </linearGradient>
+                    <linearGradient id="colorTx" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#4ade80" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#4ade80" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(96,144,212,0.20)" />
+                  <XAxis
+                    dataKey="minute"
+                    tickFormatter={formatTime}
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    tickFormatter={(v: number) => formatBps(v)}
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
+                    width={70}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#091633",
+                      border: "1px solid rgba(96,144,212,0.20)",
+                      borderRadius: "6px",
+                      color: "#e9f0fc",
+                      fontSize: "12px",
+                    }}
+                    labelFormatter={formatTime}
+                    formatter={(value: number, name: string) => [
+                      formatBps(value),
+                      name === "rx_bps" ? "Inbound" : "Outbound",
+                    ]}
+                  />
+                  <Legend
+                    formatter={(value: string) =>
+                      value === "rx_bps" ? "Inbound" : "Outbound"
+                    }
+                    wrapperStyle={{ fontSize: "12px", color: "#98aecf" }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="rx_bps"
+                    stroke="#38bdf8"
+                    fillOpacity={1}
+                    fill="url(#colorRx)"
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="tx_bps"
+                    stroke="#4ade80"
+                    fillOpacity={1}
+                    fill="url(#colorTx)"
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <div className="flex h-[200px] items-center justify-center">
+              <div className="text-center">
+                <Activity className="mx-auto mb-2 h-8 w-8 text-mesh-text-mute" />
+                <p className="t-small" style={{ color: "var(--text-dim)" }}>
+                  No traffic data
+                </p>
+                <p className="t-micro" style={{ marginTop: 4 }}>
+                  Enable NetFlow/sFlow export in Settings to see bandwidth data.
+                </p>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        {/* Per-device Historical Bandwidth */}
+        {selectedDevice && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h2 className="t-h3">
+                {selectedDevice.name ?? selectedDevice.hostname ?? selectedDevice.ip} — Historical Bandwidth
+              </h2>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => setSelectedDevice(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+            <DeviceTrafficChart deviceId={selectedDevice.id} height={220} />
+          </div>
+        )}
+
+        {/* Top Devices by Bandwidth */}
+        <Card>
+          <div className="px-4 py-3" style={{ borderBottom: "1px solid rgba(96,144,212,0.20)" }}>
+            <h2 className="t-h3">
+              Top Devices by Bandwidth
+              <span className="t-micro" style={{ marginLeft: 8 }}>
+                Click a row to view history
+              </span>
+            </h2>
+          </div>
+          {loading && topDevices.length === 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow className="border-mesh-border-strong hover:bg-transparent">
+                  <TableHead className="t-micro">Device</TableHead>
+                  <TableHead className="t-micro">IP</TableHead>
+                  <TableHead className="text-right t-micro">Download</TableHead>
+                  <TableHead className="text-right t-micro">Upload</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i} className="border-mesh-border-strong">
+                    <TableCell><Skeleton className="h-4 w-28" /></TableCell>
+                    <TableCell><Skeleton className="h-3 w-24" /></TableCell>
+                    <TableCell className="text-right"><Skeleton className="ml-auto h-4 w-16" /></TableCell>
+                    <TableCell className="text-right"><Skeleton className="ml-auto h-4 w-16" /></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : topDevices.length === 0 ? (
+            <EmptyState
+              icon={Activity}
+              title="No traffic data"
+              description="No active devices with bandwidth usage. Make sure NetFlow/sFlow is configured in Settings."
+              actionLabel="Traffic Settings"
+              actionHref="/settings/router"
+            />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow className="border-mesh-border-strong hover:bg-transparent">
+                  <TableHead className="t-micro">Device</TableHead>
+                  <TableHead className="t-micro">IP</TableHead>
+                  <TableHead className="text-right t-micro">Download</TableHead>
+                  <TableHead className="text-right t-micro">Upload</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {topDevices.map((d) => (
+                  <TableRow
+                    key={d.id}
+                    className={`border-mesh-border cursor-pointer ${
+                      selectedDevice?.id === d.id
+                        ? "bg-mesh-surface-1"
+                        : "hover:bg-mesh-surface-2/55"
+                    }`}
+                    onClick={() =>
+                      setSelectedDevice(
+                        selectedDevice?.id === d.id ? null : d
+                      )
+                    }
+                  >
+                    <TableCell className="text-mesh-text">
+                      {d.name ?? d.hostname ?? d.id.slice(0, 8)}
+                    </TableCell>
+                    <TableCell className="mono tabular text-xs text-mesh-text-dim">
+                      {d.ip ?? "—"}
+                    </TableCell>
+                    <TableCell className="mono tabular text-right text-mesh-primary">
+                      {formatBps(d.rx_bps)}
+                    </TableCell>
+                    <TableCell className="mono tabular text-right" style={{ color: "#4ade80" }}>
+                      {formatBps(d.tx_bps)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </Card>
       </div>
-    </div>
     </PageTransition>
   );
 }


### PR DESCRIPTION
## Summary

Wave B mesh-design-system sweep for /qos, /nat, /traffic. These routes have no direct design source file (Panoptikon-specific functionality), so this applies the design system uniformly per dashboard.jsx / shell.jsx conventions instead of doing a literal port.

## Drift patterns fixed

### Applied to all three routes
- shadcn \`<Button>\` consumers replaced with native \`<button className=\"btn ...\">\` recipes from globals.css (.btn, .btn-ghost, .btn-primary, .btn-sm). The shadcn variants have different padding/radius/border and shipped their own \`text-sm font-medium\` typography that drifts from the design source.
- Heading typography normalized: \`text-2xl font-semibold tracking-tight text-white\` → \`.t-display\`; \`text-base text-white\` → \`.t-h3\`; \`text-sm font-medium text-mesh-text-dim\` → \`.t-h3\`; subtitles → \`.t-small\`; uppercase eyebrows / table column headers → \`.t-micro\`; body → \`.t-body\`.
- Shadcn-conflicting tokens inlined as literal hex per the Wave B substitution table: \`rgba(96,144,212,0.20)\` for hairlines/borders, \`#2563eb\` for primary, \`#4ade80\` / \`#fb7185\` / \`#fbbf24\` / \`#38bdf8\` for status families. All other tokens (\`--surface-*\`, \`--text-*\`, \`--radius-*\`, \`--motion-*\`) preserved as \`var(--X)\`.
- Mono/tabular numbers swapped from \`font-mono tabular-nums\` to \`.mono .tabular\` recipes from globals.css.

### Per-route specifics

**/qos** — Removed gradient icon-tile (\`rounded-2xl border border-mesh-primary/30 bg-gradient-to-br from-mesh-primary/20 via-mesh-accent/10 to-[#818cf8]/10\`) — that was a CI guard #3 vulnerability and a Wave-A inspired-restyle smell. Replaced with solid \`var(--surface-2)\` tile + token-bordered chrome. Edit/delete row actions converted from \`<Button variant=\"ghost\" size=\"sm\">\` to \`btn btn-ghost btn-sm\`. Dialog footers (Cancel/Update/Create) use \`.btn\` / \`.btn-primary\` recipes; destructive Delete uses literal \`#fb7185\` background.

**/nat** — Same gradient icon-tile pattern killed. \`<Button variant=\"outline\">\` Refresh button → \`.btn\`. NAT rule action buttons (edit/delete) → \`.btn-ghost-sm\`. Dialog inputs no longer override their primitive className (the shadcn \`<Input>\` already has mesh chrome baked in).

**/traffic** — Page header gained eyebrow + display-headline pattern (was bare \`text-2xl font-semibold tracking-tight text-white\`). Recharts axis/tooltip/gradient colors switched from raw hex (\`#3b82f6\`, \`#22c55e\`, \`#0f172a\`, \`#1e293b\`, \`#6b7280\`, \`#9ca3af\`) to design-system literals (\`#38bdf8\` accent-cyan, \`#4ade80\` status-online, \`#091633\` surface-1, \`rgba(96,144,212,0.20)\` border, \`#5d7799\` text-mute, \`#98aecf\` text-dim). NetFlow status pill + top-devices header card converted from bare \`<div className=\"mesh-card\">\` to \`<Card>\` primitive. Export button → \`.btn\`.

## Verification

- \`bash web/scripts/check-design-tokens.sh\` — all 3 guards green (raw color literals / ad-hoc card combos / gradient-on-mesh-surface).
- \`bun run build\` — clean production build. /qos 11.7kB, /nat 19.1kB, /traffic 7.14kB — bundle sizes reduced or comparable to baseline.
- No new recipes added to globals.css; everything uses the Wave A foundation.

## Out of scope / follow-ups

- \`mesh-pill\` is referenced in the users instructions as already present in globals.css, but it isnt declared yet — I did not need it for these three routes, so I did not add it. Worth noting for a future Wave-A patch if a route does need it.
- Status badge classes still use ad-hoc literal-hex chip combos like \`border-[#4ade80]/30 bg-[#4ade80]/10 text-[#4ade80]\` for table status pills — these are passing the guards because they use literal hex (allowed), but a future cleanup could promote them to a single \`.status-online\` / \`.status-warning\` / \`.status-offline\` chip recipe in globals.css and sweep all routes.

## Test plan

- [ ] /qos page renders with no double-borders and no gradient icon tile
- [ ] /nat page renders with no double-borders and no gradient icon tile
- [ ] /traffic page renders with no double-borders, eyebrow + display title visible
- [ ] All button consumers use .btn/.btn-primary/.btn-ghost recipes (cmd+i inspect)
- [ ] Recharts traffic graph still renders with correct fill gradients (accent-cyan inbound, status-online outbound)
- [ ] Dialog footers (Cancel / Update / Delete) render with .btn chrome
- [ ] \`bash web/scripts/check-design-tokens.sh\` passes in CI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies the Wave B mesh-design-system sweep to `/qos`, `/nat`, and `/traffic`, replacing shadcn `<Button>` consumers with native `.btn`/`.btn-primary`/`.btn-ghost` recipes, normalising typography to `.t-*` classes, removing gradient icon tiles in favour of solid `var(--surface-2)` tiles, and swapping raw hex Recharts colours for design-system literals.

- `/nat` and `/qos`: `SummaryCard` component refactored to accept explicit `iconBg`/`iconBorder` props (nat) or just `iconBorder` (qos); dialog inputs drop overriding `className`s so shadcn's baked-in mesh chrome takes over.
- `/traffic`: page header gains eyebrow + display-headline pattern; NetFlow status pill and Top Devices card promoted from `div.mesh-card` to `<Card>` primitive; Recharts gradient/axis/tooltip colours updated to design-system literals (`#38bdf8`, `#4ade80`, `rgba(96,144,212,0.20)`).
- No Playwright E2E test was added or updated despite `CLAUDE.md` mandating one for layout fixes; the PR also has no `## Why No E2E Test` justification section.

<h3>Confidence Score: 3/5</h3>

The visual sweep across qos and traffic is clean, but nat's delete-confirmation dialog applies the .btn recipe to shadcn AlertDialog primitives that already inject their own buttonVariants styles, and none of the three routes ship an automated Playwright test despite the team's mandatory E2E requirement for layout changes.

The qos and traffic changes are mechanically straightforward token substitutions with no new logic. The nat file has the AlertDialogCancel/AlertDialogAction style-collision issue, and the absence of any E2E coverage for three changed routes — including traffic, which has no spec file at all — means regressions in the new heading structure, card containers, or button chrome could go undetected.

web/src/app/(app)/nat/page.tsx — specifically the AlertDialog footer buttons; the traffic page also needs a new spec file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/nat/page.tsx | Wave B design system sweep: removes shadcn Button, replaces gradient icon tile with solid surface-2 tile, normalises typography to t-* classes, converts dialog footers to .btn recipes — but AlertDialogCancel/AlertDialogAction still receive .btn on top of shadcn's buttonVariants, creating a style collision for the delete confirmation dialog. |
| web/src/app/(app)/qos/page.tsx | Wave B sweep: shadcn Button → native .btn/btn-primary/btn-ghost, gradient icon tile removed, typography normalised to t-* classes, SummaryCard refactored to accept iconBorder (surface-2 background fixed). No AlertDialog usage so no style-collision issue; changes are clean. |
| web/src/app/(app)/traffic/page.tsx | Wave B sweep: page header gains eyebrow + display headline, mesh-card divs promoted to Card primitives, Recharts colors switched to design-system literals, Export button converted to .btn. No new logic introduced; selectedDevice guard preserved correctly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/app/(app)/nat/page.tsx`, line 1 ([link](https://github.com/befeast/panoptikon/blob/6cec628797680041155a8e91b92f8544e5988b8f/web/src/app/(app)/nat/page.tsx#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Missing mandatory Playwright E2E test**

   `CLAUDE.md` lists "Layout fix → screenshot comparison or element visibility check" as an explicit example requiring a Playwright E2E test in `web/tests/e2e/`. This PR is a layout/UX fix across three routes but adds no new or updated test specs and includes no `## Why No E2E Test` section in the PR description. The existing `nat.spec.ts` and `qos.spec.ts` cover functional behaviour, not the new visual structure (eyebrow + display-headline header, `<Card>` wrappers, `.btn` recipes). The same gap applies to `qos/page.tsx` and `traffic/page.tsx` — there is no `traffic.spec.ts` at all.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/nat/page.tsx
   Line: 1
   
   Comment:
   **Missing mandatory Playwright E2E test**
   
   `CLAUDE.md` lists "Layout fix → screenshot comparison or element visibility check" as an explicit example requiring a Playwright E2E test in `web/tests/e2e/`. This PR is a layout/UX fix across three routes but adds no new or updated test specs and includes no `## Why No E2E Test` section in the PR description. The existing `nat.spec.ts` and `qos.spec.ts` cover functional behaviour, not the new visual structure (eyebrow + display-headline header, `<Card>` wrappers, `.btn` recipes). The same gap applies to `qos/page.tsx` and `traffic/page.tsx` — there is no `traffic.spec.ts` at all.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/app/(app)/nat/page.tsx:519-527
**Style collision: `.btn` on shadcn dialog action primitives**

`AlertDialogCancel` and `AlertDialogAction` are not plain `<button>` elements — shadcn internally merges `buttonVariants({ variant: "outline" })` / `buttonVariants()` into their `className` via `cn()`. Adding `className="btn"` appends the `.btn` recipe on top rather than replacing the shadcn base styles, so the delete dialog buttons render with both style systems applied simultaneously (competing padding, border-radius, and typography). The stated goal of eliminating shadcn padding/radius drift is not achieved for these two buttons. The correct approach for full override is `asChild` with a native `<button className="btn ...">` inside.

### Issue 2 of 2
web/src/app/(app)/nat/page.tsx:1
**Missing mandatory Playwright E2E test**

`CLAUDE.md` lists "Layout fix → screenshot comparison or element visibility check" as an explicit example requiring a Playwright E2E test in `web/tests/e2e/`. This PR is a layout/UX fix across three routes but adds no new or updated test specs and includes no `## Why No E2E Test` section in the PR description. The existing `nat.spec.ts` and `qos.spec.ts` cover functional behaviour, not the new visual structure (eyebrow + display-headline header, `<Card>` wrappers, `.btn` recipes). The same gap applies to `qos/page.tsx` and `traffic/page.tsx` — there is no `traffic.spec.ts` at all.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): mesh-design consistency sweep f..."](https://github.com/befeast/panoptikon/commit/6cec628797680041155a8e91b92f8544e5988b8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32651492)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->