### PR TITLE
fix(ux): Wave B sweep — /agents /ssh-hosts /assets

### DIFF
--- a/web/src/app/(app)/agents/detail/content.tsx
+++ b/web/src/app/(app)/agents/detail/content.tsx
@@ -111,7 +111,7 @@ export default function AgentDetailContent() {
           Back to Agents
         </Link>
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">
+          <h1 className="t-display text-mesh-text">
             {agent.name ?? agent.id.slice(0, 8)}
           </h1>
           <Badge
@@ -151,25 +151,25 @@ export default function AgentDetailContent() {
             <div className="h-48">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(96,144,212,0.20)" />
                   <XAxis
                     dataKey="time"
-                    tick={{ fill: "#6b7280", fontSize: 11 }}
-                    stroke="#1e293b"
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
                     interval="preserveStartEnd"
                   />
                   <YAxis
                     domain={[0, 100]}
-                    tick={{ fill: "#6b7280", fontSize: 11 }}
-                    stroke="#1e293b"
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
                     width={35}
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "#0f172a",
-                      border: "1px solid #1e293b",
+                      backgroundColor: "#091633",
+                      border: "1px solid rgba(96,144,212,0.20)",
                       borderRadius: "6px",
-                      color: "#fff",
+                      color: "#e9f0fc",
                       fontSize: "12px",
                     }}
                     formatter={(value: number) => [`${value.toFixed(1)}%`, "CPU"]}
@@ -177,7 +177,7 @@ export default function AgentDetailContent() {
                   <Line
                     type="monotone"
                     dataKey="cpu"
-                    stroke="#22d3ee"
+                    stroke="#38bdf8"
                     strokeWidth={2}
                     dot={false}
                     connectNulls
@@ -194,25 +194,25 @@ export default function AgentDetailContent() {
             <div className="h-48">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(96,144,212,0.20)" />
                   <XAxis
                     dataKey="time"
-                    tick={{ fill: "#6b7280", fontSize: 11 }}
-                    stroke="#1e293b"
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
                     interval="preserveStartEnd"
                   />
                   <YAxis
                     domain={[0, 100]}
-                    tick={{ fill: "#6b7280", fontSize: 11 }}
-                    stroke="#1e293b"
+                    tick={{ fill: "#5d7799", fontSize: 11 }}
+                    stroke="rgba(96,144,212,0.20)"
                     width={35}
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "#0f172a",
-                      border: "1px solid #1e293b",
+                      backgroundColor: "#091633",
+                      border: "1px solid rgba(96,144,212,0.20)",
                       borderRadius: "6px",
-                      color: "#fff",
+                      color: "#e9f0fc",
                       fontSize: "12px",
                     }}
                     formatter={(value: number) => [`${value.toFixed(1)}%`, "RAM"]}
@@ -220,7 +220,7 @@ export default function AgentDetailContent() {
                   <Line
                     type="monotone"
                     dataKey="ram"
-                    stroke="#10b981"
+                    stroke="#4ade80"
                     strokeWidth={2}
                     dot={false}
                     connectNulls

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -115,7 +115,7 @@ export default function AgentsPage() {
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Agents</h1>
+          <h1 className="t-display text-mesh-text">Agents</h1>
           <HelpTooltip text="Lightweight agents installed on your machines that report system info (CPU, memory, disk, OS) back to Panoptikon." />
         </div>
         <AddAgentDialog
@@ -218,7 +218,7 @@ export default function AgentsPage() {
                             autoFocus
                             value={renameValue}
                             onChange={(e) => setRenameValue(e.target.value)}
-                            className="h-7 w-40 bg-mesh-surface-1 border-mesh-primary text-white text-sm px-2"
+                            className="h-7 w-40 text-sm px-2"
                           />
                           <button type="submit" className="text-[#4ade80] hover:text-[#4ade80] transition-colors">
                             <Check size={14} />
@@ -307,7 +307,7 @@ export default function AgentsPage() {
 
       {/* Delete confirmation dialog */}
       <AlertDialog open={!!pendingDelete} onOpenChange={(v) => { if (!v) setPendingDelete(null); }}>
-        <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+        <AlertDialogContent>
           <AlertDialogHeader>
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#fb7185]/10">
@@ -324,7 +324,7 @@ export default function AgentsPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel
-              className="border-mesh-border bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2/55 hover:text-white"
+              className="bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2 hover:text-mesh-text"
               disabled={deleting}
             >
               Cancel
@@ -333,7 +333,7 @@ export default function AgentsPage() {
               onClick={handleDelete}
               disabled={deleting}
               autoFocus
-              className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+              className="bg-[#fb7185] text-white hover:bg-[#fb7185]/90"
             >
               {deleting ? "Deleting…" : "Delete"}
             </AlertDialogAction>
@@ -413,7 +413,7 @@ function AddAgentDialog({ onCreated }: { onCreated: () => void }) {
           Add Agent
         </Button>
       </DialogTrigger>
-      <DialogContent className="w-full max-w-[680px] border-mesh-border bg-mesh-surface-1/95">
+      <DialogContent className="w-full max-w-[680px]">
         <DialogHeader>
           <DialogTitle className="text-white">
             {result ? "Agent Created" : "Add New Agent"}

--- a/web/src/app/(app)/assets/detail/content.tsx
+++ b/web/src/app/(app)/assets/detail/content.tsx
@@ -337,7 +337,7 @@ function AssetHeader({
           />
         ) : (
           <h1
-            className="text-2xl font-semibold text-white cursor-pointer hover:text-[#67e8f9] transition-colors group flex items-center gap-2"
+            className="t-display text-mesh-text cursor-pointer hover:text-mesh-accent transition-colors group flex items-center gap-2"
             onClick={() => setEdit({ field: "custom_name", value: device.custom_name || device.name || device.hostname || "" })}
           >
             {effectiveName}
@@ -396,7 +396,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-[#67e8f9] transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-mesh-accent transition-colors group"
             onClick={() => setEdit({ field: "tags", value: device.tags || "" })}
           >
             <Tag size={14} className="text-mesh-text-mute" />
@@ -432,7 +432,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-[#67e8f9] transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-mesh-accent transition-colors group"
             onClick={() => setEdit({ field: "location", value: device.location || "" })}
           >
             <MapPin size={14} className="text-mesh-text-mute" />
@@ -458,7 +458,7 @@ function AssetHeader({
           </div>
         ) : (
           <span
-            className="flex items-center gap-1 cursor-pointer hover:text-[#67e8f9] transition-colors group"
+            className="flex items-center gap-1 cursor-pointer hover:text-mesh-accent transition-colors group"
             onClick={() => setEdit({ field: "owner", value: device.owner || "" })}
           >
             <User size={14} className="text-mesh-text-mute" />
@@ -733,25 +733,25 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
         <div className="h-48">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(96,144,212,0.20)" />
               <XAxis
                 dataKey="time"
-                tick={{ fill: "#6b7280", fontSize: 11 }}
-                stroke="#1e293b"
+                tick={{ fill: "#5d7799", fontSize: 11 }}
+                stroke="rgba(96,144,212,0.20)"
                 interval="preserveStartEnd"
               />
               <YAxis
                 domain={[0, 100]}
-                tick={{ fill: "#6b7280", fontSize: 11 }}
-                stroke="#1e293b"
+                tick={{ fill: "#5d7799", fontSize: 11 }}
+                stroke="rgba(96,144,212,0.20)"
                 width={35}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: "#0f172a",
-                  border: "1px solid #1e293b",
+                  backgroundColor: "#091633",
+                  border: "1px solid rgba(96,144,212,0.20)",
                   borderRadius: "6px",
-                  color: "#fff",
+                  color: "#e9f0fc",
                   fontSize: "12px",
                 }}
                 formatter={(value: number) => [`${value.toFixed(1)}%`, "CPU"]}
@@ -759,7 +759,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
               <Line
                 type="monotone"
                 dataKey="cpu"
-                stroke="#22d3ee"
+                stroke="#38bdf8"
                 strokeWidth={2}
                 dot={false}
                 connectNulls
@@ -776,25 +776,25 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
         <div className="h-48">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(96,144,212,0.20)" />
               <XAxis
                 dataKey="time"
-                tick={{ fill: "#6b7280", fontSize: 11 }}
-                stroke="#1e293b"
+                tick={{ fill: "#5d7799", fontSize: 11 }}
+                stroke="rgba(96,144,212,0.20)"
                 interval="preserveStartEnd"
               />
               <YAxis
                 domain={[0, 100]}
-                tick={{ fill: "#6b7280", fontSize: 11 }}
-                stroke="#1e293b"
+                tick={{ fill: "#5d7799", fontSize: 11 }}
+                stroke="rgba(96,144,212,0.20)"
                 width={35}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: "#0f172a",
-                  border: "1px solid #1e293b",
+                  backgroundColor: "#091633",
+                  border: "1px solid rgba(96,144,212,0.20)",
                   borderRadius: "6px",
-                  color: "#fff",
+                  color: "#e9f0fc",
                   fontSize: "12px",
                 }}
                 formatter={(value: number) => [`${value.toFixed(1)}%`, "RAM"]}
@@ -802,7 +802,7 @@ function LiveMetricsPanel({ chartData }: { chartData: ChartPoint[] }) {
               <Line
                 type="monotone"
                 dataKey="ram"
-                stroke="#10b981"
+                stroke="#4ade80"
                 strokeWidth={2}
                 dot={false}
                 connectNulls
@@ -848,7 +848,7 @@ function LinkedSources({
           </div>
           <Link
             href={`/devices`}
-            className="mt-2 inline-flex items-center gap-1 text-xs text-[#67e8f9] hover:text-mesh-text transition-colors"
+            className="mt-2 inline-flex items-center gap-1 text-xs text-mesh-accent hover:text-mesh-text transition-colors"
           >
             View in Devices <ExternalLink size={10} />
           </Link>
@@ -878,7 +878,7 @@ function LinkedSources({
             </div>
             <Link
               href={`/agents/detail?id=${device.agent.id}`}
-              className="mt-2 inline-flex items-center gap-1 text-xs text-[#67e8f9] hover:text-mesh-text transition-colors"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-mesh-accent hover:text-mesh-text transition-colors"
             >
               Agent Detail <ExternalLink size={10} />
             </Link>
@@ -914,7 +914,7 @@ function LinkedSources({
             </div>
             <Link
               href="/ssh-hosts"
-              className="mt-2 inline-flex items-center gap-1 text-xs text-[#67e8f9] hover:text-mesh-text transition-colors"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-mesh-accent hover:text-mesh-text transition-colors"
             >
               SSH Hosts <ExternalLink size={10} />
             </Link>
@@ -982,7 +982,7 @@ function NotesSection({
         </div>
       ) : (
         <p
-          className="text-sm text-mesh-text cursor-pointer hover:text-[#67e8f9] transition-colors group"
+          className="text-sm text-mesh-text cursor-pointer hover:text-mesh-accent transition-colors group"
           onClick={() => setEdit({ field: "notes", value: device.notes || "" })}
         >
           {device.notes || (
@@ -1137,7 +1137,7 @@ function InlineEditInput({
         placeholder={placeholder}
         autoFocus
         disabled={saving}
-        className={`h-7 bg-mesh-surface-1 border-mesh-border text-white text-sm ${className || ""}`}
+        className={`h-7 text-sm ${className || ""}`}
       />
       <Button
         size="sm"

--- a/web/src/app/(app)/assets/page.tsx
+++ b/web/src/app/(app)/assets/page.tsx
@@ -402,7 +402,7 @@ ${filtered
       <div className="space-y-8">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">Assets</h1>
+          <h1 className="t-display text-mesh-text">Assets</h1>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -490,7 +490,7 @@ ${filtered
               placeholder="Search by name, location, IP, owner, tag..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1 pl-9 pr-8"
+              className="pl-9 pr-8"
             />
             {search && (
               <button
@@ -505,7 +505,7 @@ ${filtered
           <select
             value={typeFilter}
             onChange={(e) => setTypeFilter(e.target.value)}
-            className="flex h-10 mesh-card px-3 py-2 text-sm text-white focus:border-mesh-primary focus:outline-none focus:ring-1 focus:ring-mesh-primary"
+            className="flex h-10 mesh-card px-3 py-2 text-sm text-mesh-text focus:border-mesh-accent focus:outline-none focus:ring-2 focus:ring-mesh-accent/30"
           >
             <option value="">All types</option>
             {availableTypes.map((t) => (
@@ -518,7 +518,7 @@ ${filtered
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="flex h-10 mesh-card px-3 py-2 text-sm text-white focus:border-mesh-primary focus:outline-none focus:ring-1 focus:ring-mesh-primary"
+            className="flex h-10 mesh-card px-3 py-2 text-sm text-mesh-text focus:border-mesh-accent focus:outline-none focus:ring-2 focus:ring-mesh-accent/30"
           >
             <option value="">All statuses</option>
             {availableStatuses.map((s) => (
@@ -531,7 +531,7 @@ ${filtered
           <select
             value={locationFilter}
             onChange={(e) => setLocationFilter(e.target.value)}
-            className="flex h-10 mesh-card px-3 py-2 text-sm text-white focus:border-mesh-primary focus:outline-none focus:ring-1 focus:ring-mesh-primary"
+            className="flex h-10 mesh-card px-3 py-2 text-sm text-mesh-text focus:border-mesh-accent focus:outline-none focus:ring-2 focus:ring-mesh-accent/30"
           >
             <option value="">All locations</option>
             {availableLocations.map((l) => (
@@ -718,7 +718,7 @@ ${filtered
             if (!v) setPendingDelete(null);
           }}
         >
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#fb7185]/10">
@@ -737,7 +737,7 @@ ${filtered
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel
-                className="border-mesh-border bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2 hover:text-white"
+                className="bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2 hover:text-mesh-text"
                 disabled={deleting}
               >
                 Cancel
@@ -746,7 +746,7 @@ ${filtered
                 onClick={handleDelete}
                 disabled={deleting}
                 autoFocus
-                className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+                className="bg-[#fb7185] text-white hover:bg-[#fb7185]/90"
               >
                 {deleting ? "Deleting..." : "Delete"}
               </AlertDialogAction>
@@ -855,7 +855,7 @@ function ImportCSVDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-[520px] border-mesh-border bg-mesh-surface-1">
+      <DialogContent className="w-full max-w-[520px]">
         <DialogHeader>
           <DialogTitle className="text-white">Import Assets from CSV</DialogTitle>
           <DialogDescription>
@@ -870,7 +870,7 @@ function ImportCSVDialog({
             type="file"
             accept=".csv,text/csv"
             onChange={handleFileChange}
-            className="border-mesh-border bg-mesh-surface-1 file:text-mesh-text-dim"
+            className="file:text-mesh-text-dim"
           />
 
           {rows.length > 0 && (
@@ -984,7 +984,7 @@ function AssetFormDialog({
   };
 
   const dialogContent = (
-    <DialogContent className="w-full max-w-[560px] border-mesh-border bg-mesh-surface-1">
+    <DialogContent className="w-full max-w-[560px]">
       <DialogHeader>
         <DialogTitle className="text-white">
           {isEdit ? "Edit Asset" : "Add Asset"}

--- a/web/src/app/(app)/ssh-hosts/page.tsx
+++ b/web/src/app/(app)/ssh-hosts/page.tsx
@@ -121,7 +121,7 @@ export default function SshHostsPage() {
       <div className="space-y-8">
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold tracking-tight text-white">SSH Hosts</h1>
+          <h1 className="t-display text-mesh-text">SSH Hosts</h1>
           <SshTargetFormDialog
             open={addOpen}
             onOpenChange={setAddOpen}
@@ -285,7 +285,7 @@ export default function SshHostsPage() {
 
         {/* Delete confirmation */}
         <AlertDialog open={!!pendingDelete} onOpenChange={(v) => { if (!v) setPendingDelete(null); }}>
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#fb7185]/10">
@@ -300,7 +300,7 @@ export default function SshHostsPage() {
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel
-                className="border-mesh-border bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2/55 hover:text-white"
+                className="bg-transparent text-mesh-text-dim hover:bg-mesh-surface-2 hover:text-mesh-text"
                 disabled={deleting}
               >
                 Cancel
@@ -309,7 +309,7 @@ export default function SshHostsPage() {
                 onClick={handleDelete}
                 disabled={deleting}
                 autoFocus
-                className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
+                className="bg-[#fb7185] text-white hover:bg-[#fb7185]/90"
               >
                 {deleting ? "Deleting..." : "Delete"}
               </AlertDialogAction>
@@ -442,7 +442,7 @@ function SshTargetFormDialog({
   };
 
   const dialogContent = (
-    <DialogContent className="w-full max-w-[520px] border-mesh-border bg-mesh-surface-1/95">
+    <DialogContent className="w-full max-w-[520px]">
       <DialogHeader>
         <DialogTitle className="text-white">
           {isEdit ? "Edit SSH Host" : "Add SSH Host"}
@@ -496,7 +496,7 @@ function SshTargetFormDialog({
             <select
               value={authType}
               onChange={(e) => setAuthType(e.target.value as "password" | "key")}
-              className="flex h-10 w-full mesh-card px-3 py-2 text-sm text-white focus:border-mesh-primary focus:outline-none focus:ring-1 focus:ring-mesh-primary"
+              className="flex h-10 w-full mesh-card px-3 py-2 text-sm text-mesh-text focus:border-mesh-accent focus:outline-none focus:ring-2 focus:ring-mesh-accent/30"
             >
               <option value="password">Password</option>
               <option value="key">SSH Key</option>
@@ -528,7 +528,7 @@ function SshTargetFormDialog({
               )}
             </Label>
             <textarea
-              className="w-full mesh-card px-3 py-2 text-sm text-white font-mono placeholder:text-mesh-text-mute focus:border-mesh-primary focus:outline-none focus:ring-1 focus:ring-mesh-primary min-h-[100px]"
+              className="w-full mesh-card px-3 py-2 text-sm text-mesh-text font-mono placeholder:text-mesh-text-mute focus:border-mesh-accent focus:outline-none focus:ring-2 focus:ring-mesh-accent/30 min-h-[100px]"
               placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
               value={privateKey}
               onChange={(e) => setPrivateKey(e.target.value)}


### PR DESCRIPTION
## Summary

Wave B fleet sweep — brings /agents, /ssh-hosts, /assets (plus their detail pages) to mesh-design-system consistency. These routes have **no design-source file**, so this PR applies the existing design system uniformly per the *design-export-to-ux-issues* runbook (Forbidden Substitutions + Replace, Dont Repaint).

Baseline CI guards were already green; this sweep removes the *non-tripping* drift patterns that nonetheless violated the runbook (hex literals that evade the name-based regex, consumer-side primitive overrides, off-token hover colors, pre-mesh chart palette).

## Per-route drift fixes

### `/agents` (`page.tsx`)
- h1 → `.t-display text-mesh-text` (was `text-2xl font-semibold tracking-tight text-white`).
- Rename Input: dropped `bg-mesh-surface-1 border-mesh-primary` overrides — Input primitive owns the chrome.
- AlertDialogContent / DialogContent: dropped `border-mesh-border bg-mesh-surface-1/95` overrides — primitives own the chrome (`components/ui/{dialog,alert-dialog}.tsx` already render `border border-mesh-border-strong bg-mesh-surface-1`).
- AlertDialogCancel: dropped redundant `border-mesh-border` (primitive applies outline border), kept `bg-transparent` + token text/hover.
- AlertDialogAction destructive hover: `/90` opacity so hover state is visible.

### `/agents/detail` (`content.tsx`)
- h1 → `.t-display text-mesh-text`.
- recharts `CartesianGrid` / axis stroke `#1e293b` → `rgba(96,144,212,0.20)` (mesh-border literal).
- recharts tick fill `#6b7280` → `#5d7799` (mesh-text-mute literal).
- recharts Tooltip bg `#0f172a` → `#091633` (mesh-surface-1 literal); border + text moved to mesh tokens.
- CPU Line stroke `#22d3ee` → `#38bdf8` (mesh-accent / status-info).
- RAM Line stroke `#10b981` → `#4ade80` (status-online).

### `/ssh-hosts` (`page.tsx`)
- h1 → `.t-display text-mesh-text`.
- AlertDialogContent / DialogContent: dropped consumer-side border/bg overrides.
- AlertDialogCancel cleaned same way as agents.
- Auth-type `<select>` + private-key `<textarea>`: switched `text-white` → `text-mesh-text`, focus ring from `mesh-primary` (royal blue) → `mesh-accent` (sky) — matches the pattern already in `assets/page.tsx` form selects.

### `/assets` (`page.tsx`)
- h1 → `.t-display text-mesh-text`.
- Search Input + Import CSV Input: dropped `border-mesh-border bg-mesh-surface-1` overrides.
- All three filter `<select>`s normalized to `text-mesh-text` + `focus:border-mesh-accent focus:ring-2 focus:ring-mesh-accent/30` (consistent with the form selects elsewhere in the file).
- AlertDialogContent + 2× DialogContent: dropped overrides.
- AlertDialogCancel + Action cleaned same way as agents.

### `/assets/detail` (`content.tsx`)
- h1 → `.t-display text-mesh-text` (kept cursor-pointer + group hover semantics).
- 4× `hover:text-[#67e8f9]` (cyan-300, evades CI guard #1 because hex) → `hover:text-mesh-accent`.
- 3× `text-[#67e8f9]` link colors → `text-mesh-accent`.
- recharts palette swap identical to agents/detail (CartesianGrid, axes, Tooltip, Line strokes).
- InlineEditInput: dropped `bg-mesh-surface-1 border-mesh-border text-white` overrides on Input primitive.

## Build / guards status

```
$ bash scripts/check-design-tokens.sh
OK: no raw Tailwind color literals in production code
OK: no ad-hoc card recipe combos in production code
OK: no gradient-on-mesh-surface combos in production code

$ bun run build
✓ Compiled successfully  (zero warnings)
```

## What I saw but did NOT touch (scope discipline)

- **`text-white` in body cells / Back-link hover** across all five files. These arent CI violations and the prompt only listed the *card* and *primitive override* patterns. Replacing them broadly would be an inspired restyle.
- **`text-mesh-border-strong` used as an inline-pipe `|` color** in `assets/detail` (L418/L444). Semantically odd (border token applied to text), but visible and intentional.
- **`<button>` framework elements** in tables for delete/edit icons. These arent `.btn` candidates — they are icon-only ghost actions inside table rows. Switching to `.btn-ghost` would force a height/padding change that breaks the table-cell rhythm. Existing canonical routes (devices, alerts) use the same `<button>` pattern for in-cell actions.
- **Pre-mesh chart hex still lives in `/traffic/page.tsx`** (same `#1e293b` / `#6b7280` palette). Same drift, but out of Wave B scope. Worth a Wave C follow-up sweep.
- The dialog/alert-dialog/input primitives didnt need fixing — they already bake in the correct mesh chrome.

## Test plan

- [ ] /agents — table loads, status badges render, Add Agent dialog renders without double border, Delete confirmation dialog renders correctly
- [ ] /agents/detail — CPU + RAM charts use mesh palette (no slate/gray grid), h1 uses .t-display
- [ ] /ssh-hosts — table loads, Add/Edit dialog renders without double border, auth-type select focus uses sky/accent
- [ ] /assets — search Input has no double chrome, all three filter selects share focus ring style, Delete dialog renders cleanly
- [ ] /assets/detail — inline edits work, charts use mesh palette, link hover shows mesh-accent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wave B design-system sweep across `/agents`, `/ssh-hosts`, `/assets`, and their detail pages — removes consumer-side primitive overrides (border/bg on dialogs and Input), migrates all five page h1s to `.t-display text-mesh-text`, and replaces the pre-mesh recharts palette (CartesianGrid, axes, Tooltip, Line strokes) with mesh-token-aligned literals.

- **Dialog/Input chrome**: `border-mesh-border bg-mesh-surface-1` overrides stripped from `AlertDialogContent`, `DialogContent`, and inline `Input`/`textarea` elements across all three list pages and both detail pages; primitives now own their own chrome without duplication.
- **Chart palette**: All `#1e293b`/`#6b7280` grid/axis values replaced with `rgba(96,144,212,0.20)`/`#5d7799`; CPU stroke swapped `#22d3ee→#38bdf8`, RAM stroke `#10b981→#4ade80`; identical change applied in both `agents/detail` and `assets/detail`.
- **Focus rings and link colors**: Filter selects and form fields unified to `focus:border-mesh-accent focus:ring-2 focus:ring-mesh-accent/30`; `text-[#67e8f9]` link/hover literals in `assets/detail` converted to `text-mesh-accent`.

<h3>Confidence Score: 4/5</h3>

The changes are purely cosmetic class substitutions; no data flow, API calls, or state logic were altered, making a functional regression very unlikely.

All five files receive class-only edits — no business logic touches. The dialog, chart, and focus-ring changes are straightforward token replacements. The one gap is that CLAUDE.md requires a Playwright test for layout fixes and none was added; the existing agents.spec.ts heading assertions are test.skip'ed, so the visual sweep goes unguarded by CI.

No files have logic concerns; web/src/app/(app)/agents/page.tsx is the natural home for any follow-up E2E coverage given its skipped heading and dialog tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/app/(app)/agents/page.tsx | Drops consumer-side border/bg overrides on AlertDialogContent and DialogContent, strips Input primitive overrides, updates h1 to t-display/mesh-text, and adds opacity to destructive hover; several hex literals remain in untouched lines outside this PR's scope |
| web/src/app/(app)/agents/detail/content.tsx | Replaces all pre-mesh recharts hex literals (CartesianGrid stroke, axis tick fill/stroke, Tooltip bg/border/color, CPU/RAM Line strokes) with mesh-aligned values; h1 updated to t-display/mesh-text |
| web/src/app/(app)/assets/detail/content.tsx | Converts four hover:text-[#67e8f9] and three text-[#67e8f9] link colors to mesh-accent, applies identical recharts palette swap as agents/detail, removes Input primitive overrides in InlineEditInput, and updates h1 |
| web/src/app/(app)/assets/page.tsx | Normalizes three filter selects to mesh-accent focus ring, drops Input/dialog consumer overrides, updates h1, and adds opacity to destructive hover — consistent with the pattern already present elsewhere in the file |
| web/src/app/(app)/ssh-hosts/page.tsx | Switches auth-type select and private-key textarea from text-white/mesh-primary focus ring to text-mesh-text/mesh-accent, drops dialog consumer overrides, and updates h1 — matches the focus-ring pattern in assets/page.tsx |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/app/(app)/agents/page.tsx`, line 1-5 ([link](https://github.com/befeast/panoptikon/blob/7ba3f3cd269e438746e8ff802c164eeae1972aea/web/src/app/(app)/agents/page.tsx#L1-L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Missing E2E test for UX changes**

   `CLAUDE.md` explicitly lists "Layout fix → screenshot comparison or element visibility check" as a PR type that **must** include a Playwright test in `web/tests/e2e/`. This PR changes h1 classes, dialog chrome, Input overrides, and chart palette across five pages, yet no new test file (or augmentation to `agents.spec.ts`, `assets.spec.ts`) was added, and the PR description contains no `## Why No E2E Test` section. The same gap applies to `ssh-hosts/page.tsx` and both `detail/content.tsx` files, none of which have coverage for the post-sweep visual state. The existing `agents.spec.ts` tests that assert heading visibility (`level: 1`) are already `test.skip`'ed, so the heading class change is entirely unguarded.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: web/src/app/(app)/agents/page.tsx
   Line: 1-5
   
   Comment:
   **Missing E2E test for UX changes**
   
   `CLAUDE.md` explicitly lists "Layout fix → screenshot comparison or element visibility check" as a PR type that **must** include a Playwright test in `web/tests/e2e/`. This PR changes h1 classes, dialog chrome, Input overrides, and chart palette across five pages, yet no new test file (or augmentation to `agents.spec.ts`, `assets.spec.ts`) was added, and the PR description contains no `## Why No E2E Test` section. The same gap applies to `ssh-hosts/page.tsx` and both `detail/content.tsx` files, none of which have coverage for the post-sweep visual state. The existing `agents.spec.ts` tests that assert heading visibility (`level: 1`) are already `test.skip`'ed, so the heading class change is entirely unguarded.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/app/(app)/agents/page.tsx:1-5
**Missing E2E test for UX changes**

`CLAUDE.md` explicitly lists "Layout fix → screenshot comparison or element visibility check" as a PR type that **must** include a Playwright test in `web/tests/e2e/`. This PR changes h1 classes, dialog chrome, Input overrides, and chart palette across five pages, yet no new test file (or augmentation to `agents.spec.ts`, `assets.spec.ts`) was added, and the PR description contains no `## Why No E2E Test` section. The same gap applies to `ssh-hosts/page.tsx` and both `detail/content.tsx` files, none of which have coverage for the post-sweep visual state. The existing `agents.spec.ts` tests that assert heading visibility (`level: 1`) are already `test.skip`'ed, so the heading class change is entirely unguarded.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): mesh-design consistency sweep f..."](https://github.com/befeast/panoptikon/commit/7ba3f3cd269e438746e8ff802c164eeae1972aea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32651520)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->