### PR TITLE
fix(ux): Wave B sweep — /caddy /services /cloudflare-tunnel /vpn-status

### DIFF
--- a/web/src/app/(app)/caddy/page.tsx
+++ b/web/src/app/(app)/caddy/page.tsx
@@ -41,6 +41,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -207,9 +214,7 @@ export default function CaddyPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-semibold tracking-tight text-white">
-              Caddy Reverse Proxy
-            </h1>
+            <h1 className="t-h1 text-white">Caddy Reverse Proxy</h1>
             <HelpTooltip text="Manage reverse-proxy hosts that Caddy serves. Add domains, point them to internal services, and enable automatic HTTPS." />
           </div>
           <div className="flex items-center gap-2">
@@ -237,7 +242,6 @@ export default function CaddyPage() {
                   size="sm"
                   onClick={handleTestConnection}
                   disabled={testing}
-                  className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
                 >
                   {testing ? (
                     <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -247,7 +251,7 @@ export default function CaddyPage() {
                   Test Connection
                 </Button>
               </TooltipTrigger>
-              <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
+              <TooltipContent className="max-w-xs">
                 Verify that Panoptikon can reach the Caddy admin API
               </TooltipContent>
             </Tooltip>
@@ -258,7 +262,6 @@ export default function CaddyPage() {
                   size="sm"
                   onClick={handleSync}
                   disabled={syncing}
-                  className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
                 >
                   {syncing ? (
                     <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -268,15 +271,11 @@ export default function CaddyPage() {
                   Sync to Caddy
                 </Button>
               </TooltipTrigger>
-              <TooltipContent className="max-w-xs border-mesh-border bg-mesh-surface-1 text-mesh-text">
+              <TooltipContent className="max-w-xs">
                 Push current proxy host configuration to the Caddy reverse proxy
               </TooltipContent>
             </Tooltip>
-            <Button
-              size="sm"
-              onClick={() => setShowAdd(true)}
-              className="bg-mesh-primary text-white hover:bg-mesh-primary"
-            >
+            <Button size="sm" onClick={() => setShowAdd(true)}>
               <Plus className="mr-1.5 h-3.5 w-3.5" />
               Add Host
             </Button>
@@ -284,7 +283,7 @@ export default function CaddyPage() {
         </div>
 
         {/* Admin URL Configuration */}
-        <Card className="">
+        <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-sm font-medium text-white">
               Caddy Admin API
@@ -303,7 +302,6 @@ export default function CaddyPage() {
                   id="admin-url"
                   value={adminUrl}
                   onChange={(e) => setAdminUrl(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                   placeholder="http://localhost:2019"
                 />
               </div>
@@ -311,7 +309,6 @@ export default function CaddyPage() {
                 size="sm"
                 onClick={handleSaveUrl}
                 disabled={savingUrl || adminUrl.trim() === savedAdminUrl}
-                className="bg-mesh-primary text-white hover:bg-mesh-primary"
               >
                 {savingUrl && (
                   <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -329,12 +326,12 @@ export default function CaddyPage() {
             placeholder="Filter by domain or upstream..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="border-mesh-border bg-mesh-surface-1/95 pl-10 text-white placeholder:text-mesh-text-mute"
+            className="pl-10"
           />
         </div>
 
         {/* Table */}
-        <Card className="">
+        <Card>
           <CardContent className="p-0">
             <Table>
               <TableHeader>
@@ -391,7 +388,7 @@ export default function CaddyPage() {
                   filtered.map((host) => (
                     <TableRow
                       key={host.id}
-                      className="border-mesh-border hover:bg-mesh-surface-2/55"
+                      className="border-mesh-border-strong hover:bg-mesh-surface-2/55"
                     >
                       <TableCell className="font-medium text-white">
                         <a
@@ -473,12 +470,12 @@ export default function CaddyPage() {
             if (!open) setPendingDelete(null);
           }}
         >
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle className="text-white">
                 Delete Proxy Host
               </AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogDescription>
                 Are you sure you want to delete{" "}
                 <span className="font-medium text-white">
                   {pendingDelete?.domain}
@@ -487,9 +484,7 @@ export default function CaddyPage() {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDelete}
                 className="bg-[#fb7185] text-white hover:bg-[#fb7185]"
@@ -591,7 +586,7 @@ function ProxyHostFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-mesh-border bg-mesh-surface-1/95 sm:max-w-md">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="text-white">
             {isEdit ? "Edit Proxy Host" : "Add Proxy Host"}
@@ -606,7 +601,6 @@ function ProxyHostFormDialog({
               id="domain"
               value={domain}
               onChange={(e) => setDomain(e.target.value)}
-              className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
               placeholder="app.example.com"
             />
           </div>
@@ -619,15 +613,18 @@ function ProxyHostFormDialog({
               >
                 Scheme
               </Label>
-              <select
-                id="forward-scheme"
+              <Select
                 value={forwardScheme}
-                onChange={(e) => setForwardScheme(e.target.value)}
-                className="flex h-9 w-full mesh-card px-3 py-1 text-sm text-white"
+                onValueChange={setForwardScheme}
               >
-                <option value="http">http</option>
-                <option value="https">https</option>
-              </select>
+                <SelectTrigger id="forward-scheme" className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="http">http</SelectItem>
+                  <SelectItem value="https">https</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div className="col-span-1 space-y-1.5">
               <Label
@@ -640,7 +637,6 @@ function ProxyHostFormDialog({
                 id="forward-host"
                 value={forwardHost}
                 onChange={(e) => setForwardHost(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="10.0.0.5"
               />
             </div>
@@ -658,7 +654,6 @@ function ProxyHostFormDialog({
                 max={65535}
                 value={forwardPort}
                 onChange={(e) => setForwardPort(e.target.value)}
-                className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 placeholder="80"
               />
             </div>
@@ -687,15 +682,10 @@ function ProxyHostFormDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={loading}
-              className="bg-mesh-primary text-white hover:bg-mesh-primary"
-            >
+            <Button type="submit" disabled={loading}>
               {loading && (
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
               )}

--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -254,9 +254,7 @@ export default function CloudflareTunnelPage() {
           <div className="flex items-center gap-3">
             <Cloud className="h-6 w-6 text-[#fbbf24]" />
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white">
-                Cloudflare Tunnel
-              </h1>
+              <h1 className="t-h1 text-white">Cloudflare Tunnel</h1>
               <p className="text-sm text-mesh-text-dim">
                 Manage tunnel routes and monitor connection status
               </p>
@@ -268,7 +266,6 @@ export default function CloudflareTunnelPage() {
               size="sm"
               onClick={load}
               disabled={loading}
-              className="border-mesh-border bg-mesh-surface-1 text-mesh-text hover:bg-mesh-border-strong"
             >
               <RefreshCw
                 className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
@@ -276,11 +273,7 @@ export default function CloudflareTunnelPage() {
               Refresh
             </Button>
             {!notConfigured && (
-              <Button
-                size="sm"
-                onClick={() => setAddDialogOpen(true)}
-                className="bg-mesh-primary hover:bg-mesh-primary"
-              >
+              <Button size="sm" onClick={() => setAddDialogOpen(true)}>
                 <Plus className="mr-2 h-4 w-4" />
                 Add Route
               </Button>
@@ -290,10 +283,10 @@ export default function CloudflareTunnelPage() {
 
         {/* Not configured message */}
         {notConfigured && (
-          <Card className="">
+          <Card>
             <CardContent className="py-8 text-center">
               <Cloud className="mx-auto mb-4 h-12 w-12 text-mesh-text-mute" />
-              <h3 className="text-lg font-medium text-mesh-text">
+              <h3 className="t-h2 text-mesh-text">
                 Cloudflare Tunnel Not Configured
               </h3>
               <p className="mt-2 text-sm text-mesh-text-mute">
@@ -314,7 +307,7 @@ export default function CloudflareTunnelPage() {
         {!notConfigured && status && (
           <div className="grid gap-5 md:grid-cols-3">
             {/* Tunnel Status */}
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardDescription className="text-mesh-text-dim">
                   Tunnel Status
@@ -347,7 +340,7 @@ export default function CloudflareTunnelPage() {
             </Card>
 
             {/* Active Connections */}
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardDescription className="text-mesh-text-dim">
                   Active Connections
@@ -373,7 +366,7 @@ export default function CloudflareTunnelPage() {
             </Card>
 
             {/* Active Routes */}
-            <Card className="">
+            <Card>
               <CardHeader className="pb-2">
                 <CardDescription className="text-mesh-text-dim">
                   Active Routes
@@ -394,7 +387,7 @@ export default function CloudflareTunnelPage() {
 
         {/* Connections table */}
         {!notConfigured && status && status.connections.length > 0 && (
-          <Card className="">
+          <Card>
             <CardHeader>
               <CardTitle className="text-mesh-text">Connections</CardTitle>
               <CardDescription className="text-mesh-text-dim">
@@ -452,7 +445,7 @@ export default function CloudflareTunnelPage() {
 
         {/* Routes table */}
         {!notConfigured && (
-          <Card className="">
+          <Card>
             <CardHeader>
               <CardTitle className="text-mesh-text">Tunnel Routes</CardTitle>
               <CardDescription className="text-mesh-text-dim">
@@ -547,7 +540,7 @@ export default function CloudflareTunnelPage() {
 
         {/* Add Route Dialog */}
         <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-          <DialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <DialogContent>
             <DialogHeader>
               <DialogTitle className="text-mesh-text">
                 Add Tunnel Route
@@ -563,7 +556,6 @@ export default function CloudflareTunnelPage() {
                   placeholder="app.example.com"
                   value={formHostname}
                   onChange={(e) => setFormHostname(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="space-y-2">
@@ -575,7 +567,6 @@ export default function CloudflareTunnelPage() {
                   placeholder="http://localhost:8080"
                   value={formService}
                   onChange={(e) => setFormService(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="space-y-2">
@@ -587,21 +578,18 @@ export default function CloudflareTunnelPage() {
                   placeholder="/"
                   value={formPath}
                   onChange={(e) => setFormPath(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="flex justify-end gap-2">
                 <Button
                   variant="outline"
                   onClick={() => setAddDialogOpen(false)}
-                  className="border-mesh-border-strong text-mesh-text"
                 >
                   Cancel
                 </Button>
                 <Button
                   onClick={handleAddRoute}
                   disabled={saving || !formHostname || !formService}
-                  className="bg-mesh-primary hover:bg-mesh-primary"
                 >
                   {saving ? "Adding..." : "Add Route"}
                 </Button>
@@ -612,7 +600,7 @@ export default function CloudflareTunnelPage() {
 
         {/* Edit Route Dialog */}
         <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-          <DialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <DialogContent>
             <DialogHeader>
               <DialogTitle className="text-mesh-text">
                 Edit Tunnel Route
@@ -628,7 +616,6 @@ export default function CloudflareTunnelPage() {
                   placeholder="app.example.com"
                   value={editHostname}
                   onChange={(e) => setEditHostname(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="space-y-2">
@@ -640,7 +627,6 @@ export default function CloudflareTunnelPage() {
                   placeholder="http://localhost:8080"
                   value={editService}
                   onChange={(e) => setEditService(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="space-y-2">
@@ -652,21 +638,18 @@ export default function CloudflareTunnelPage() {
                   placeholder="/"
                   value={editPath}
                   onChange={(e) => setEditPath(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1 text-mesh-text"
                 />
               </div>
               <div className="flex justify-end gap-2">
                 <Button
                   variant="outline"
                   onClick={() => setEditDialogOpen(false)}
-                  className="border-mesh-border-strong text-mesh-text"
                 >
                   Cancel
                 </Button>
                 <Button
                   onClick={handleEditRoute}
                   disabled={saving || !editHostname || !editService}
-                  className="bg-mesh-primary hover:bg-mesh-primary"
                 >
                   {saving ? "Saving..." : "Save Changes"}
                 </Button>
@@ -680,21 +663,19 @@ export default function CloudflareTunnelPage() {
           open={!!deleteTarget}
           onOpenChange={(open) => !open && setDeleteTarget(null)}
         >
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle className="text-mesh-text">
                 Remove Route
               </AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogDescription>
                 Are you sure you want to remove the route for{" "}
                 <strong className="text-mesh-text">{deleteTarget}</strong>? This
                 will immediately update the tunnel configuration.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border-strong text-mesh-text">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => deleteTarget && handleDeleteRoute(deleteTarget)}
                 className="bg-[#fb7185] hover:bg-[#fb7185]"

--- a/web/src/app/(app)/services/page.tsx
+++ b/web/src/app/(app)/services/page.tsx
@@ -55,13 +55,19 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   addService,
   removeService,
   fetchCaddyProxyHosts,
   fetchCaddyStatus,
   fetchMikrotikStatus,
   toggleCaddyProxyHost,
-  deleteCaddyProxyHost,
   updateCaddyProxyHost,
 } from "@/lib/api";
 import type {
@@ -71,10 +77,6 @@ import type {
   CaddyStatus,
   MikrotikStatus,
 } from "@/lib/types";
-
-// ─── Styled select matching the dark theme ──────────────────
-const selectCls =
-  "w-full mesh-card px-3 py-2 text-sm text-white placeholder:text-mesh-text-mute focus:outline-none focus:ring-2 focus:ring-mesh-primary";
 
 // ─── Page ───────────────────────────────────────────────────
 export default function ServicesPage() {
@@ -281,7 +283,7 @@ export default function ServicesPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight text-white">Services</h1>
+            <h1 className="t-h1 text-white">Services</h1>
             <p className="mt-1 text-sm text-mesh-text-dim">
               Manage reverse proxy entries and port-forwarding rules
             </p>
@@ -339,7 +341,6 @@ export default function ServicesPage() {
                 loadHosts();
                 loadStatuses();
               }}
-              className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
             >
               <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
               Refresh
@@ -350,7 +351,6 @@ export default function ServicesPage() {
                 resetAddForm();
                 setAddOpen(true);
               }}
-              className="bg-mesh-primary text-white hover:bg-mesh-primary"
             >
               <Plus className="mr-1.5 h-3.5 w-3.5" />
               Add Service
@@ -395,7 +395,7 @@ export default function ServicesPage() {
                 {hosts.map((host) => (
                   <TableRow
                     key={host.id}
-                    className="border-mesh-border hover:bg-mesh-surface-2/55"
+                    className="border-mesh-border-strong hover:bg-mesh-surface-2/55"
                   >
                     <TableCell className="max-w-[250px]">
                       <div className="flex items-center gap-2 min-w-0">
@@ -514,7 +514,7 @@ export default function ServicesPage() {
             setAddOpen(open);
           }}
         >
-          <DialogContent className="max-w-md border-mesh-border bg-mesh-surface-1/95 text-white">
+          <DialogContent className="max-w-md">
             <DialogHeader>
               <DialogTitle>Add Service</DialogTitle>
             </DialogHeader>
@@ -554,7 +554,6 @@ export default function ServicesPage() {
                       setAddOpen(false);
                       resetAddForm();
                     }}
-                    className="bg-mesh-primary text-white hover:bg-mesh-primary"
                   >
                     Done
                   </Button>
@@ -571,7 +570,6 @@ export default function ServicesPage() {
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder="My App"
-                    className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                   />
                 </div>
 
@@ -584,7 +582,6 @@ export default function ServicesPage() {
                       value={internalIp}
                       onChange={(e) => setInternalIp(e.target.value)}
                       placeholder="10.10.0.50"
-                      className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                     />
                   </div>
                   <div className="space-y-1.5">
@@ -596,7 +593,6 @@ export default function ServicesPage() {
                       value={internalPort}
                       onChange={(e) => setInternalPort(e.target.value)}
                       placeholder="8080"
-                      className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                     />
                   </div>
                 </div>
@@ -609,7 +605,6 @@ export default function ServicesPage() {
                     value={domain}
                     onChange={(e) => setDomain(e.target.value)}
                     placeholder="myapp.oklabs.uk"
-                    className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                   />
                 </div>
 
@@ -618,14 +613,18 @@ export default function ServicesPage() {
                     <Label className="text-xs text-mesh-text-dim">
                       Forward Scheme
                     </Label>
-                    <select
+                    <Select
                       value={forwardScheme}
-                      onChange={(e) => setForwardScheme(e.target.value)}
-                      className={selectCls}
+                      onValueChange={setForwardScheme}
                     >
-                      <option value="http">HTTP</option>
-                      <option value="https">HTTPS</option>
-                    </select>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="http">HTTP</SelectItem>
+                        <SelectItem value="https">HTTPS</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                   <div className="flex items-end pb-1">
                     <div className="flex items-center gap-2">
@@ -640,8 +639,8 @@ export default function ServicesPage() {
                   </div>
                 </div>
 
-                {/* MikroTik port-forward section */}
-                <div className="rounded-md border border-mesh-border-strong p-3">
+                {/* MikroTik port-forward section — inner-tier surface */}
+                <div className="mesh-card-2 p-3">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Network className="h-4 w-4 text-mesh-text-mute" />
@@ -665,22 +664,25 @@ export default function ServicesPage() {
                           value={externalPort}
                           onChange={(e) => setExternalPort(e.target.value)}
                           placeholder="443"
-                          className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                         />
                       </div>
                       <div className="space-y-1.5">
                         <Label className="text-xs text-mesh-text-dim">
                           Protocol
                         </Label>
-                        <select
+                        <Select
                           value={protocol}
-                          onChange={(e) => setProtocol(e.target.value)}
-                          className={selectCls}
+                          onValueChange={setProtocol}
                         >
-                          <option value="tcp">TCP</option>
-                          <option value="udp">UDP</option>
-                          <option value="tcp,udp">TCP+UDP</option>
-                        </select>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="tcp">TCP</SelectItem>
+                            <SelectItem value="udp">UDP</SelectItem>
+                            <SelectItem value="tcp,udp">TCP+UDP</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                     </div>
                   )}
@@ -693,14 +695,12 @@ export default function ServicesPage() {
                       setAddOpen(false);
                       resetAddForm();
                     }}
-                    className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
                   >
                     Cancel
                   </Button>
                   <Button
                     onClick={handleAddService}
                     disabled={!addValid || adding}
-                    className="bg-mesh-primary text-white hover:bg-mesh-primary disabled:opacity-40"
                   >
                     {adding && (
                       <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -715,7 +715,7 @@ export default function ServicesPage() {
 
         {/* ── Edit Dialog ── */}
         <Dialog open={editOpen} onOpenChange={setEditOpen}>
-          <DialogContent className="max-w-md border-mesh-border bg-mesh-surface-1/95 text-white">
+          <DialogContent className="max-w-md">
             <DialogHeader>
               <DialogTitle>Edit Service</DialogTitle>
             </DialogHeader>
@@ -725,7 +725,6 @@ export default function ServicesPage() {
                 <Input
                   value={editDomain}
                   onChange={(e) => setEditDomain(e.target.value)}
-                  className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                 />
               </div>
               <div className="grid grid-cols-2 gap-3">
@@ -736,7 +735,6 @@ export default function ServicesPage() {
                   <Input
                     value={editForwardHost}
                     onChange={(e) => setEditForwardHost(e.target.value)}
-                    className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -747,7 +745,6 @@ export default function ServicesPage() {
                     type="number"
                     value={editForwardPort}
                     onChange={(e) => setEditForwardPort(e.target.value)}
-                    className="border-mesh-border bg-mesh-surface-1/95 text-white placeholder:text-mesh-text-mute"
                   />
                 </div>
               </div>
@@ -756,14 +753,18 @@ export default function ServicesPage() {
                   <Label className="text-xs text-mesh-text-dim">
                     Forward Scheme
                   </Label>
-                  <select
+                  <Select
                     value={editForwardScheme}
-                    onChange={(e) => setEditForwardScheme(e.target.value)}
-                    className={selectCls}
+                    onValueChange={setEditForwardScheme}
                   >
-                    <option value="http">HTTP</option>
-                    <option value="https">HTTPS</option>
-                  </select>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="http">HTTP</SelectItem>
+                      <SelectItem value="https">HTTPS</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="flex items-end pb-1">
                   <div className="flex items-center gap-2">
@@ -779,18 +780,10 @@ export default function ServicesPage() {
               </div>
             </div>
             <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setEditOpen(false)}
-                className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55"
-              >
+              <Button variant="outline" onClick={() => setEditOpen(false)}>
                 Cancel
               </Button>
-              <Button
-                onClick={handleEditSave}
-                disabled={editSaving}
-                className="bg-mesh-primary text-white hover:bg-mesh-primary disabled:opacity-40"
-              >
+              <Button onClick={handleEditSave} disabled={editSaving}>
                 {editSaving && (
                   <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                 )}
@@ -802,12 +795,12 @@ export default function ServicesPage() {
 
         {/* ── Delete Confirmation ── */}
         <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-          <AlertDialogContent className="border-mesh-border bg-mesh-surface-1/95">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle className="text-white">
                 Delete Service
               </AlertDialogTitle>
-              <AlertDialogDescription className="text-mesh-text-dim">
+              <AlertDialogDescription>
                 This will remove the Caddy proxy host for{" "}
                 <span className="font-medium text-white">
                   {deleteHost?.domain}
@@ -816,9 +809,7 @@ export default function ServicesPage() {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="border-mesh-border text-mesh-text hover:bg-mesh-surface-2/55">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleDelete}
                 disabled={deleting}

--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -38,11 +38,7 @@ import { fetchVpnStatus } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { VpnInterfaceStatus, VpnStatusResponse } from "@/lib/types";
 
-// ─── Mesh design tokens ───────────────────────────────────
-
-const meshSurface =
-  "border-mesh-border bg-mesh-surface-1/95 shadow-[0_18px_40px_-28px_rgba(56,189,248,0.45)]";
-const meshSurfaceQuiet = "border-mesh-border bg-mesh-surface-1/62";
+// ─── Section title — type recipe token ─────────────────────
 const meshSectionTitle =
   "text-[11px] font-medium uppercase tracking-wider text-mesh-text-mute";
 
@@ -167,21 +163,14 @@ export default function VpnStatusPage() {
             <Shield className="h-5 w-5 text-mesh-accent" />
             <div>
               <p className={meshSectionTitle}>Network · secure overlay</p>
-              <h1 className="mt-1 text-xl font-semibold tracking-tight text-mesh-text">
-                VPN status
-              </h1>
+              <h1 className="t-h1 mt-1 text-mesh-text">VPN status</h1>
               <p className="mt-1 font-mono text-xs text-mesh-text-mute">
                 {subtitle}
               </p>
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={load}
-            className="border-mesh-border bg-mesh-surface-1/70 text-mesh-text hover:border-mesh-accent/40 hover:bg-mesh-surface-2/60 hover:text-white"
-          >
+          <Button variant="outline" size="sm" onClick={load}>
             <RefreshCw className="mr-1.5 h-3.5 w-3.5 text-mesh-accent" />
             Refresh
           </Button>
@@ -246,7 +235,7 @@ export default function VpnStatusPage() {
 
           {/* ─── Overview tab ─────────────────────────── */}
           <TabsContent value="overview" className="space-y-4 pt-4">
-            <Card className={meshSurface}>
+            <Card>
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-2">
                   <Shield className="h-4 w-4 text-mesh-accent" />
@@ -271,12 +260,7 @@ export default function VpnStatusPage() {
                 ) : (
                   <div className="grid gap-2 md:grid-cols-2">
                     {data?.mikrotik_available ? (
-                      <div
-                        className={cn(
-                          "rounded-md border p-3",
-                          meshSurfaceQuiet,
-                        )}
-                      >
+                      <div className="mesh-card-2 p-3">
                         <p className={meshSectionTitle}>MikroTik coverage</p>
                         <p className="mt-2 text-sm text-mesh-text">
                           <span className="font-mono font-semibold tabular-nums text-white">
@@ -309,12 +293,7 @@ export default function VpnStatusPage() {
                         </p>
                       </div>
                     ) : (
-                      <div
-                        className={cn(
-                          "rounded-md border p-3 text-sm text-mesh-text-dim",
-                          meshSurfaceQuiet,
-                        )}
-                      >
+                      <div className="mesh-card-2 p-3 text-sm text-mesh-text-dim">
                         <p className={meshSectionTitle}>MikroTik coverage</p>
                         <p className="mt-2">
                           No router is configured. Configure router credentials
@@ -323,12 +302,7 @@ export default function VpnStatusPage() {
                       </div>
                     )}
                     {data?.openvpn_available && (
-                      <div
-                        className={cn(
-                          "rounded-md border p-3",
-                          meshSurfaceQuiet,
-                        )}
-                      >
+                      <div className="mesh-card-2 p-3">
                         <p className={meshSectionTitle}>OpenVPN</p>
                         <p className="mt-2 text-sm text-mesh-text">
                           <span className="font-mono font-semibold tabular-nums text-white">
@@ -469,7 +443,7 @@ function SummaryCard({
     accent === "emerald" ? "text-[#4ade80]" : "text-white";
 
   return (
-    <Card className={cn("h-full min-h-[8.25rem]", meshSurface)}>
+    <Card className="h-full min-h-[8.25rem]">
       <CardHeader className="flex flex-row items-start justify-between pb-3">
         <CardTitle className={meshSectionTitle}>{label}</CardTitle>
         <span className="text-mesh-accent">{icon}</span>
@@ -515,7 +489,7 @@ function FilterInput({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="border-mesh-border bg-mesh-surface-1/70 pl-10 text-mesh-text placeholder:text-mesh-text-mute focus-visible:border-mesh-accent/45 focus-visible:ring-mesh-accent/30"
+        className="pl-10"
       />
     </div>
   );
@@ -535,7 +509,7 @@ function EmptyState({
   hint?: string;
 }) {
   return (
-    <Card className={meshSurface}>
+    <Card>
       <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center">
         <Icon className="h-10 w-10 text-mesh-text-faint/80" />
         <p className="text-sm text-mesh-text">{title}</p>
@@ -552,7 +526,7 @@ function EmptyState({
 
 function InterfaceSkeleton() {
   return (
-    <Card className={meshSurface}>
+    <Card>
       <CardHeader className="space-y-3 pb-3">
         <div className="flex items-center gap-2">
           <Skeleton className="h-4 w-32" />
@@ -596,7 +570,7 @@ function StatusPill({
       ? "border-[#4ade80]/30 bg-[#4ade80]/10 text-[#4ade80]"
       : tone === "offline"
         ? "border-[#fb7185]/30 bg-[#fb7185]/10 text-[#fb7185]"
-        : "border-mesh-border bg-mesh-surface-1/70 text-mesh-text-dim";
+        : "border-mesh-border-strong text-mesh-text-dim";
 
   return (
     <span
@@ -618,7 +592,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
     iface.vpn_type === "openvpn" || iface.source === "mikrotik-openvpn";
 
   return (
-    <Card className={meshSurface}>
+    <Card>
       <CardHeader className="space-y-3 pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -636,12 +610,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
             )}
           </div>
 
-          <div
-            className={cn(
-              "rounded-md border px-2.5 py-1 font-mono text-xs",
-              meshSurfaceQuiet,
-            )}
-          >
+          <div className="mesh-card-2 px-2.5 py-1 font-mono text-xs">
             <span className="font-semibold tabular-nums text-[#4ade80]">
               {iface.peers_online}
             </span>
@@ -657,34 +626,19 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
 
         <div className="flex flex-wrap gap-2 text-[11px]">
           {iface.address && (
-            <span
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-mesh-text",
-                meshSurfaceQuiet,
-              )}
-            >
+            <span className="mesh-card-2 inline-flex items-center gap-1.5 px-2 py-1 font-mono text-mesh-text">
               <span className="text-mesh-text-mute">addr</span>
               <span className="tabular-nums">{iface.address}</span>
             </span>
           )}
           {iface.port && (
-            <span
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded border px-2 py-1 font-mono text-mesh-text",
-                meshSurfaceQuiet,
-              )}
-            >
+            <span className="mesh-card-2 inline-flex items-center gap-1.5 px-2 py-1 font-mono text-mesh-text">
               <span className="text-mesh-text-mute">port</span>
               <span className="tabular-nums">{iface.port}</span>
             </span>
           )}
           {iface.public_key && (
-            <span
-              className={cn(
-                "inline-flex max-w-full items-center gap-1.5 truncate rounded border px-2 py-1 font-mono text-mesh-text",
-                meshSurfaceQuiet,
-              )}
-            >
+            <span className="mesh-card-2 inline-flex max-w-full items-center gap-1.5 truncate px-2 py-1 font-mono text-mesh-text">
               <KeyRound className="h-3 w-3 text-mesh-accent" />
               <span className="truncate">
                 {iface.public_key.substring(0, 16)}…
@@ -698,7 +652,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
         <div className="overflow-x-auto border-t border-mesh-border">
           <Table>
             <TableHeader>
-              <TableRow className="border-mesh-border hover:bg-transparent">
+              <TableRow className="border-mesh-border-strong hover:bg-transparent">
                 <TableHead className={meshSectionTitle}>Status</TableHead>
                 <TableHead className={meshSectionTitle}>
                   {isOpenvpn ? "Client" : "Peer"}
@@ -725,7 +679,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
 
             <TableBody>
               {iface.peers.length === 0 ? (
-                <TableRow className="border-mesh-border hover:bg-transparent">
+                <TableRow className="border-mesh-border-strong hover:bg-transparent">
                   <TableCell
                     colSpan={7}
                     className="py-10 text-center"
@@ -744,7 +698,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
                 iface.peers.map((peer, idx) => (
                   <TableRow
                     key={peer.public_key ?? `${iface.name}-${idx}`}
-                    className="border-mesh-border/30 hover:bg-mesh-surface-2/40"
+                    className="border-mesh-border-strong/30 hover:bg-mesh-surface-2/40"
                   >
                     <TableCell>
                       <div className="flex items-center gap-2">

--- a/web/tests/e2e/router.spec.ts
+++ b/web/tests/e2e/router.spec.ts
@@ -304,7 +304,7 @@ test.describe("Router Page — Xiaomi (#491)", () => {
 
     // Should see the RouterSelector with Xiaomi button
     await expect(
-      page.getByRole("link", { name: /Xiaomi/ }),
+      page.getByRole("link", { name: "Xiaomi", exact: true }),
     ).toBeVisible({ timeout: 15000 });
 
     await page.screenshot({


### PR DESCRIPTION
## Summary

Wave B mesh-design consistency sweep for four routes that have NO design
source file. Goal: uniform application of the mesh design system the rest
of the app already follows. No new globals.css recipes.

## Per-route drift fixes

### /caddy/page.tsx
- Stripped `border-mesh-border bg-mesh-surface-1/95` from
  DialogContent / AlertDialogContent / TooltipContent / Input /
  AlertDialogCancel consumers (15+ sites). These are baked into the
  shadcn primitives already (`border-mesh-border-strong bg-mesh-surface-1`).
- Converted the raw `<select>` element (which was carrying a wrong
  `mesh-card` class — that recipe is for cards, not inputs) to the
  shadcn `<Select>` primitive.
- Removed Button override classes that shadowed the variant styling.
- Heading now uses `.t-h1` instead of ad-hoc `text-2xl font-semibold tracking-tight`.

### /services/page.tsx
- Deleted the `selectCls` constant (ad-hoc `border border-mesh-border-strong bg-mesh-surface-1 ...`) and converted all three `<select>` to shadcn `<Select>`.
- Inner MikroTik port-forward panel: was `rounded-md border border-mesh-border-strong p-3` → `.mesh-card-2 p-3` (the inner-tier recipe).
- Stripped Button / DialogContent / AlertDialogContent / AlertDialogCancel override classes (15+ sites).
- Heading uses `.t-h1`.

### /cloudflare-tunnel/page.tsx
- Stripped Button override classes (Refresh, primary Add Route, primary Save Changes) and Input `border-mesh-border bg-mesh-surface-1` overrides.
- Stripped DialogContent / AlertDialogContent / AlertDialogCancel overrides.
- Heading uses `.t-h1`; the not-configured sub-heading uses `.t-h2`.

### /vpn-status/page.tsx (the biggest one)
- Deleted the `meshSurface` (`border-mesh-border bg-mesh-surface-1/95 shadow-[...]`) and `meshSurfaceQuiet` (`border-mesh-border bg-mesh-surface-1/62`) constants — these were the exact surfaceClass anti-pattern killed on /qos and /nat in #788.
- All `<Card className={meshSurface}>` consumers (5x) are now naked `<Card>` and inherit `.mesh-card` from the primitive.
- All inline 'quiet' surfaces (KPI online-count chip, addr/port/key chips on each InterfaceCard, MikroTik & OpenVPN summary tiles) switched from ad-hoc combos using `meshSurfaceQuiet` to the `.mesh-card-2` utility.
- Heading uses `.t-h1`.

## Token policy

- Only `mesh-*` token aliases or literal hex copied from the design
  source were used. No raw Tailwind family literals (CI guard #1 stays
  green).
- `text-mesh-primary` / `text-mesh-accent` retained where they were
  already in use — these are project token aliases, not shadcn-conflicting
  `var()` references.

## Verification

- `bash web/scripts/check-design-tokens.sh` — guards 1/2/3 all green
- `bun run build` — clean, no warnings, no errors

## Why no E2E test

This PR is a pure UX consistency sweep — strips redundant className
overrides from consumer sites and switches three raw `<select>` elements
to the shadcn `<Select>` primitive that already lives in the codebase.
No new behavior, no new save/reload roundtrips, no new dashboard widgets,
no new API endpoints. The verification surface is visual fidelity to the
mesh design system, which is asserted by the CI design-token guard plus
the existing build smoke test.

## Test plan

- [ ] CI design-token guard passes
- [ ] CI build passes
- [ ] /caddy — admin URL form, search, table, Add/Edit dialog, Delete confirm all render with single mesh chrome
- [ ] /services — table, Add Service dialog (incl. MikroTik panel), Edit dialog, Delete confirm
- [ ] /cloudflare-tunnel — header, summary cards, connections table, routes table, Add Route dialog, Edit Route dialog, Delete confirm
- [ ] /vpn-status — header, KPI row, Overview / WireGuard / OpenVPN tabs, InterfaceCard chips, peers table

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a uniform mesh design-system sweep across four routes (`/caddy`, `/services`, `/cloudflare-tunnel`, `/vpn-status`) that previously had no design source file, eliminating ad-hoc `surfaceClass` constants and redundant `className` overrides that shadcn primitives already cover.

- **Class removal**: Strips `border-mesh-border bg-mesh-surface-1/95` from every `DialogContent`, `AlertDialogContent`, `Input`, and `Button` consumer; heading elements are updated to `.t-h1` / `.t-h2` type-recipe tokens.
- **Select migration**: Three raw `<select>` elements in `/services` and one in `/caddy` are converted to the shadcn `<Select>` primitive; the dead `deleteCaddyProxyHost` import in `services/page.tsx` (delete path already used `removeService`) is also cleaned up.
- **Surface tokens**: `/vpn-status` drops the `meshSurface` / `meshSurfaceQuiet` anti-pattern in favour of naked `<Card>` (inheriting `.mesh-card`) and `.mesh-card-2` for nested chips and summary tiles, consistent with the `/qos` and `/nat` cleanup in #788.

<h3>Confidence Score: 5/5</h3>

Pure UX consistency sweep with no new behaviour — safe to merge.

All functional paths are unchanged. The `deleteCaddyProxyHost` removal is safe (confirmed: `handleDelete` uses `removeService`). The `<Select>` migrations are drop-in replacements with equivalent state bindings. `.mesh-card-2` includes `border-radius: 6px` and `border: 1px solid` matching the old explicit Tailwind combos it replaces. The `cn` import in `vpn-status/page.tsx` remains used. No logic or data path is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/caddy/page.tsx | Design-system sweep: removes ad-hoc className overrides from dialogs/inputs/buttons, migrates raw `<select>` to shadcn `<Select>`, switches heading to `.t-h1`, corrects `border-mesh-border` → `border-mesh-border-strong` on TableRow. |
| web/src/app/(app)/cloudflare-tunnel/page.tsx | Design-system sweep: strips override classes from Refresh/Add Route/Save Changes buttons and all Input/DialogContent/AlertDialogContent consumers; heading and sub-heading updated to `.t-h1` / `.t-h2`; empty `className=""` attrs removed from Cards. |
| web/src/app/(app)/services/page.tsx | Removes dead `deleteCaddyProxyHost` import (delete path uses `removeService`), deletes `selectCls` constant, converts three `<select>` elements to shadcn `<Select>`, replaces inner MikroTik panel border combo with `.mesh-card-2`, strips button/dialog overrides. |
| web/src/app/(app)/vpn-status/page.tsx | Largest sweep: eliminates `meshSurface` / `meshSurfaceQuiet` surfaceClass constants, converts five `<Card className={meshSurface}>` to naked `<Card>`, replaces all `meshSurfaceQuiet` combos on inline chips and summary tiles with `.mesh-card-2`, updates TableRow border tokens. |
| web/tests/e2e/router.spec.ts | Single-line selector refinement: `getByRole("link", { name: /Xiaomi/ })` → `{ name: "Xiaomi", exact: true }` to avoid partial-match false positives. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): tighten /xiaomi redirect sele..."](https://github.com/befeast/panoptikon/commit/c663c04db297bb329862c260996eb630fdd3de58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32651689)</sub>

<!-- /greptile_comment -->