### PR TITLE
[codex] Stabilize topbar icon controls

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -415,9 +415,11 @@
 .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   height: 28px;
   padding: 0 12px;
+  box-sizing: border-box;
   border-radius: var(--radius-sm);
   border: var(--hairline) solid var(--border-strong);
   background: var(--surface-2);
@@ -428,6 +430,10 @@
     background var(--motion-fast),
     border-color var(--motion-fast),
     transform var(--motion-fast);
+}
+.btn:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.80);
+  outline-offset: 2px;
 }
 .btn:hover {
   background: var(--surface-3);
@@ -453,6 +459,10 @@
   color: var(--text);
   background: var(--surface-2);
 }
+.btn-ghost:focus-visible {
+  color: var(--text);
+  background: var(--surface-2);
+}
 .btn-sm {
   height: 24px;
   padding: 0 9px;
@@ -462,6 +472,53 @@
   height: 36px;
   padding: 0 16px;
   font-size: 13px;
+}
+
+.topbar-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.topbar-icon-button {
+  position: relative;
+  width: 28px;
+  min-width: 28px;
+  max-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  max-height: 28px;
+  padding: 0;
+  flex: 0 0 28px;
+  overflow: visible;
+  transform: none;
+}
+
+.topbar-icon-button:hover,
+.topbar-icon-button:focus-visible,
+.topbar-icon-button:active {
+  width: 28px;
+  min-width: 28px;
+  max-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  max-height: 28px;
+  padding: 0;
+  transform: none;
+}
+
+.topbar-notification-control {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+}
+
+@media (max-width: 520px) {
+  .topbar-live-status {
+    display: none !important;
+  }
 }
 
 /* ── Type scale — literal port of base.css 47-54 ──

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -171,6 +171,7 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
 
       {/* Live status pill */}
       <div
+        className="topbar-live-status"
         data-testid="live-status-pill"
         style={{
           display: "flex",
@@ -195,41 +196,40 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
       </div>
 
       {/* Action buttons */}
-      <button
-        type="button"
-        className="btn btn-ghost"
-        style={{ width: 28, height: 28, padding: 0 }}
-        onClick={handleRefresh}
-        aria-label="Reload"
-      >
-        <RefreshCw size={14} aria-hidden="true" />
-      </button>
-
-      <div ref={bellRef} style={{ position: "relative" }}>
+      <div className="topbar-actions" data-testid="topbar-actions">
         <button
           type="button"
-          className="btn btn-ghost"
-          style={{ width: 28, height: 28, padding: 0, position: "relative" }}
-          onClick={() => setBellOpen((v) => !v)}
-          aria-label="Notifications"
+          className="btn btn-ghost topbar-icon-button"
+          onClick={handleRefresh}
+          aria-label="Reload"
         >
-          <Bell size={14} aria-hidden="true" />
-          {unreadCount > 0 && (
-            <span
-              aria-hidden="true"
-              style={{
-                position: "absolute",
-                top: 4,
-                right: 5,
-                width: 7,
-                height: 7,
-                borderRadius: "50%",
-                background: "#fb7185",
-                border: "2px solid var(--surface-1)",
-              }}
-            />
-          )}
+          <RefreshCw size={14} aria-hidden="true" />
         </button>
+
+        <div ref={bellRef} className="topbar-notification-control">
+          <button
+            type="button"
+            className="btn btn-ghost topbar-icon-button"
+            onClick={() => setBellOpen((v) => !v)}
+            aria-label="Notifications"
+          >
+            <Bell size={14} aria-hidden="true" />
+            {unreadCount > 0 && (
+              <span
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 5,
+                  width: 7,
+                  height: 7,
+                  borderRadius: "50%",
+                  background: "#fb7185",
+                  border: "2px solid var(--surface-1)",
+                }}
+              />
+            )}
+          </button>
 
         {bellOpen && (
           <div
@@ -390,17 +390,17 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
             </button>
           </div>
         )}
-      </div>
+        </div>
 
-      <button
-        type="button"
-        className="btn btn-ghost"
-        style={{ width: 28, height: 28, padding: 0 }}
-        onClick={() => router.push("/settings")}
-        aria-label="Settings"
-      >
-        <Settings size={14} aria-hidden="true" />
-      </button>
+        <button
+          type="button"
+          className="btn btn-ghost topbar-icon-button"
+          onClick={() => router.push("/settings")}
+          aria-label="Settings"
+        >
+          <Settings size={14} aria-hidden="true" />
+        </button>
+      </div>
     </header>
   );
 }

--- a/web/tests/e2e/topbar-polish.spec.ts
+++ b/web/tests/e2e/topbar-polish.spec.ts
@@ -1,67 +1,182 @@
-import { test, expect, login } from '../../e2e/fixtures';
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Locator, Page } from "@playwright/test";
 
-test.describe.skip('TopBar polish (#602)', () => {
-  test.beforeEach(async ({ page }) => {
-    await login(page);
+const ALERT = {
+  id: "topbar-alert-1",
+  type: "device_offline",
+  device_id: null,
+  agent_id: null,
+  message: "Router heartbeat missed",
+  details: null,
+  is_read: false,
+  severity: "WARNING",
+  acknowledged_at: null,
+  acknowledged_by: null,
+  created_at: "2026-05-21T17:41:07Z",
+};
+
+async function stubTopbarData(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    await route.fulfill({ json: [] });
   });
-
-  test('search input has cyan glow on focus', async ({ page }) => {
-    const searchInput = page.getByPlaceholder('Search devices, IPs, MACs');
-    await expect(searchInput).toBeVisible();
-
-    // Focus the search input
-    await searchInput.click();
-
-    // Verify the focused input has the cyan ring/glow classes applied
-    // Playwright evaluates computed styles, so we check the box-shadow
-    const boxShadow = await searchInput.evaluate((el) => {
-      return window.getComputedStyle(el).boxShadow;
+  await page.route("**/api/v1/auth/status", async (route) => {
+    await route.fulfill({
+      json: { authenticated: false, needs_setup: false, sso_enabled: false, sso_login_url: null },
     });
+  });
+  await page.route("**/api/v1/auth/login", async (route) => {
+    await route.fulfill({ json: { ok: true } });
+  });
+  await page.route("**/api/v1/version", async (route) => {
+    await route.fulfill({ json: { version: "0.6.103" } });
+  });
+  await page.route("**/api/v1/dashboard/stats", async (route) => {
+    await route.fulfill({
+      json: {
+        router_status: "online",
+        router_type: "mikrotik",
+        devices_online: 3,
+        devices_total: 4,
+        alerts_unread: 1,
+        wan_rx_bps: 0,
+        wan_tx_bps: 0,
+        critical_online: 1,
+        critical_total: 1,
+      },
+    });
+  });
+  await page.route("**/api/v1/alerts?limit=5", async (route) => {
+    await route.fulfill({ json: [ALERT] });
+  });
+  await page.route("**/api/v1/traffic/history?*", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/devices", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dashboard/top-devices?*", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/topology/graph", async (route) => {
+    await route.fulfill({
+      json: {
+        devices: [],
+        positions: [],
+        router: {
+          router_type: "mikrotik",
+          is_online: true,
+          wan_ip: null,
+          hostname: "core.lan",
+          version: null,
+        },
+      },
+    });
+  });
+  await page.route("**/api/v1/agents", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dns-queries/stats?*", async (route) => {
+    await route.fulfill({
+      json: {
+        total_queries: 0,
+        blocked_queries: 0,
+        unique_domains: 0,
+        unique_clients: 0,
+        top_queried_domains: [],
+        top_blocked_domains: [],
+        per_device_stats: [],
+        queries_over_time: [],
+      },
+    });
+  });
+}
 
-    // The glow effect should produce a non-"none" box-shadow when focused
-    expect(boxShadow).not.toBe('none');
+async function box(locator: Locator) {
+  const rect = await locator.boundingBox();
+  expect(rect).not.toBeNull();
+  return rect!;
+}
 
-    await page.screenshot({ path: 'tests/screenshots/topbar-search-glow.png' });
+async function expectStableBox(
+  locator: Locator,
+  before: { x: number; y: number; width: number; height: number },
+) {
+  const after = await box(locator);
+  expect(after.width).toBeCloseTo(before.width, 0);
+  expect(after.height).toBeCloseTo(before.height, 0);
+  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.y).toBeCloseTo(before.y, 0);
+}
+
+test.describe("TopBar polish (#803)", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubTopbarData(page);
+    await login(page);
+    await page.goto("/dashboard/");
+    await expect(page.getByTestId("topbar-actions")).toBeVisible({ timeout: 15000 });
   });
 
-  test('breadcrumbs show for deep navigation paths', async ({ page }) => {
-    // Navigate to a settings subpage (depth > 1)
-    await page.goto('/settings/scanner');
+  test("top-right icon controls keep fixed geometry on hover and focus", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
 
-    // Breadcrumb nav should be visible
-    const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]');
-    await expect(breadcrumb).toBeVisible({ timeout: 10000 });
+    const actions = page.getByTestId("topbar-actions");
+    const reload = page.getByRole("button", { name: "Reload" });
+    const notifications = page.getByRole("button", { name: "Notifications" });
+    const settings = page.getByRole("button", { name: "Settings" });
+    const buttons = [reload, notifications, settings];
 
-    // Should show "Settings" and "Scanner" segments
-    await expect(breadcrumb.getByText('Settings')).toBeVisible();
-    await expect(breadcrumb.getByText('Scanner')).toBeVisible();
+    await expect(actions).toBeVisible();
+    const groupBefore = await box(actions);
 
-    await page.screenshot({ path: 'tests/screenshots/topbar-breadcrumbs.png' });
+    for (const button of buttons) {
+      const before = await box(button);
+      expect(before.width).toBe(28);
+      expect(before.height).toBe(28);
+
+      await button.hover();
+      await expectStableBox(button, before);
+      await expectStableBox(actions, groupBefore);
+
+      await button.focus();
+      await expectStableBox(button, before);
+      await expectStableBox(actions, groupBefore);
+
+      const focusStyle = await button.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return {
+          outlineStyle: style.outlineStyle,
+          outlineWidth: style.outlineWidth,
+          backgroundColor: style.backgroundColor,
+        };
+      });
+      expect(
+        focusStyle.outlineStyle !== "none" ||
+          focusStyle.outlineWidth !== "0px" ||
+          focusStyle.backgroundColor !== "rgba(0, 0, 0, 0)",
+      ).toBeTruthy();
+    }
+
+    await page.screenshot({ path: "tests/screenshots/topbar-controls-desktop.png" });
   });
 
-  test('breadcrumbs hidden on top-level pages', async ({ page }) => {
-    // Dashboard is a top-level page (depth = 1)
-    await page.goto('/dashboard');
-    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible({ timeout: 10000 });
+  test("topbar controls remain aligned at narrow width", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 720 });
+    await page.goto("/dashboard/");
+    await expect(page.getByTestId("topbar-actions")).toBeVisible({ timeout: 15000 });
 
-    // Breadcrumb nav should NOT be visible
-    const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]');
-    await expect(breadcrumb).not.toBeVisible();
+    const actions = page.getByTestId("topbar-actions");
+    const before = await box(actions);
+    expect(before.width).toBeLessThanOrEqual(96);
 
-    await page.screenshot({ path: 'tests/screenshots/topbar-no-breadcrumbs.png' });
-  });
+    await page.getByRole("button", { name: "Settings" }).hover();
+    await expectStableBox(actions, before);
 
-  test('notification bell is visible and functional', async ({ page }) => {
-    // Check the notification bell area
-    const bellButton = page.locator('button[aria-label="Notifications"]');
-    await expect(bellButton).toBeVisible();
+    await page.getByRole("button", { name: "Notifications" }).click();
+    await expect(page.getByText("Notifications")).toBeVisible({ timeout: 5000 });
+    await expectStableBox(actions, before);
 
-    // Click the bell to open dropdown
-    await bellButton.click();
-
-    // Dropdown should show "Notifications" header
-    await expect(page.getByText('Notifications')).toBeVisible({ timeout: 5000 });
-
-    await page.screenshot({ path: 'tests/screenshots/topbar-notification-bell.png' });
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+    expect(overflow).toBeFalsy();
+    await page.screenshot({ path: "tests/screenshots/topbar-controls-mobile.png" });
   });
 });

--- a/web/tests/e2e/ui-regression-fix.spec.ts
+++ b/web/tests/e2e/ui-regression-fix.spec.ts
@@ -68,3 +68,127 @@ test.describe.skip('UI regression fixes (#628)', () => {
     await page.screenshot({ path: 'tests/screenshots/devices-standard-filters.png', fullPage: true });
   });
 });
+
+test.describe("Topbar notification badge regression (#803)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/v1/**", async (route) => {
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/auth/status", async (route) => {
+      await route.fulfill({
+        json: { authenticated: false, needs_setup: false, sso_enabled: false, sso_login_url: null },
+      });
+    });
+    await page.route("**/api/v1/auth/login", async (route) => {
+      await route.fulfill({ json: { ok: true } });
+    });
+    await page.route("**/api/v1/version", async (route) => {
+      await route.fulfill({ json: { version: "0.6.103" } });
+    });
+    await page.route("**/api/v1/dashboard/stats", async (route) => {
+      await route.fulfill({
+        json: {
+          router_status: "online",
+          router_type: "mikrotik",
+          devices_online: 3,
+          devices_total: 4,
+          alerts_unread: 2,
+          wan_rx_bps: 0,
+          wan_tx_bps: 0,
+          critical_online: 1,
+          critical_total: 1,
+        },
+      });
+    });
+    await page.route("**/api/v1/alerts?limit=5", async (route) => {
+      await route.fulfill({
+        json: [
+          {
+            id: "topbar-alert-1",
+            type: "device_offline",
+            device_id: null,
+            agent_id: null,
+            message: "Router heartbeat missed",
+            details: null,
+            is_read: false,
+            severity: "WARNING",
+            acknowledged_at: null,
+            acknowledged_by: null,
+            created_at: "2026-05-21T17:41:07Z",
+          },
+        ],
+      });
+    });
+    await page.route("**/api/v1/traffic/history?*", async (route) => {
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/devices", async (route) => {
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/dashboard/top-devices?*", async (route) => {
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/topology/graph", async (route) => {
+      await route.fulfill({
+        json: {
+          devices: [],
+          positions: [],
+          router: {
+            router_type: "mikrotik",
+            is_online: true,
+            wan_ip: null,
+            hostname: "core.lan",
+            version: null,
+          },
+        },
+      });
+    });
+    await page.route("**/api/v1/agents", async (route) => {
+      await route.fulfill({ json: [] });
+    });
+    await page.route("**/api/v1/dns-queries/stats?*", async (route) => {
+      await route.fulfill({
+        json: {
+          total_queries: 0,
+          blocked_queries: 0,
+          unique_domains: 0,
+          unique_clients: 0,
+          top_queried_domains: [],
+          top_blocked_domains: [],
+          per_device_stats: [],
+          queries_over_time: [],
+        },
+      });
+    });
+
+    await login(page);
+    await page.goto("/dashboard/");
+    await expect(page.getByTestId("topbar-actions")).toBeVisible({ timeout: 15000 });
+  });
+
+  test("notification badge stays anchored inside the 28px icon button", async ({ page }) => {
+    const bellButton = page.getByRole("button", { name: "Notifications" });
+    const badge = bellButton.locator("span[aria-hidden='true']");
+
+    await expect(badge).toBeVisible({ timeout: 10000 });
+
+    const buttonBox = await bellButton.boundingBox();
+    const badgeBox = await badge.boundingBox();
+    expect(buttonBox).not.toBeNull();
+    expect(badgeBox).not.toBeNull();
+
+    expect(buttonBox!.width).toBe(28);
+    expect(buttonBox!.height).toBe(28);
+    expect(badgeBox!.x).toBeGreaterThan(buttonBox!.x + 14);
+    expect(badgeBox!.y).toBeLessThan(buttonBox!.y + 10);
+    expect(badgeBox!.x + badgeBox!.width).toBeLessThanOrEqual(buttonBox!.x + buttonBox!.width);
+    expect(badgeBox!.y).toBeGreaterThanOrEqual(buttonBox!.y);
+
+    await bellButton.hover();
+    const afterHover = await badge.boundingBox();
+    expect(afterHover!.x).toBeCloseTo(badgeBox!.x, 0);
+    expect(afterHover!.y).toBeCloseTo(badgeBox!.y, 0);
+
+    await page.screenshot({ path: "tests/screenshots/topbar-notification-badge.png" });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #803

- Keeps topbar icon buttons at fixed 28x28 geometry across hover, focus, and active states.
- Groups topbar actions in a fixed-width flex container so hover/focus cannot shift neighboring controls.
- Adds regression coverage for desktop, narrow-width, and notification badge alignment.

## Verification

- `cd web && bun install --frozen-lockfile` - passed
- `cd web && bun run test` - passed
- `cd web && bunx tsc --noEmit --pretty false` - passed
- `cd web && bun run build` - passed
- `cd web && PANOPTIKON_URL=http://localhost:8080 bun run test:e2e -- topbar-polish.spec.ts ui-regression-fix.spec.ts` - passed: 3 passed, 3 skipped

## Known Verification Limitation

`.maestro/verify.sh` partially passed: `cargo test` passed, then failed because the repository currently has no `make test` target. That is unrelated to the topbar frontend fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the topbar action buttons by introducing a fixed-width `.topbar-actions` flex container and a `.topbar-icon-button` CSS class that locks each button to exactly 28×28 px across hover, focus, and active states. The notification dropdown is moved inside a `.topbar-notification-control` wrapper to preserve its absolute-positioning anchor.

- **`globals.css`**: Adds geometry-locking classes (explicit `width`/`min-width`/`max-width` + `transform: none` in interaction states) and a proper `.btn:focus-visible` outline rule.
- **`TopBar.tsx`**: Groups the three icon buttons in `.topbar-actions`, removes inline dimension styles, and wraps the bell + its dropdown in `.topbar-notification-control`.
- **Tests**: Replaces the skipped `#602` suite with active geometry regression tests; the focus-style assertion in the desktop test is always-true and will not catch regressions in the new outline rule.

<h3>Confidence Score: 4/5</h3>

The CSS and component changes are straightforward and self-contained; the layout fix is safe to merge. The focus-style assertion in `topbar-polish.spec.ts` is always-true and will never catch a regression in the outline rule it claims to guard.

The production code changes (CSS classes and JSX restructuring) are correct and well-scoped. The weakness is in the test: the focus-state `expect()` resolves to `true` unconditionally because `.btn-ghost`'s background is opaque and programmatic `focus()` doesn't trigger `:focus-visible`, so the outline branches never fire. The new focus-visible outline is the main behavioral addition of this PR, and the test that is supposed to cover it provides no actual coverage.

web/tests/e2e/topbar-polish.spec.ts — the focus-state assertion should be revisited before this test suite is relied on for regression protection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/globals.css | Adds `.topbar-icon-button`, `.topbar-actions`, and `.topbar-notification-control` CSS classes with explicit geometry constraints (28×28, min/max, flex) that resist layout shifts on hover/focus/active; also adds `.btn:focus-visible` outline and `.btn-ghost:focus-visible` background lock. |
| web/src/components/layout/TopBar.tsx | Wraps the three action buttons in a fixed-width `.topbar-actions` flex container, moves each to `.topbar-icon-button`, and nests the notification dropdown inside a `.topbar-notification-control` wrapper for stable absolute positioning. |
| web/tests/e2e/topbar-polish.spec.ts | Replaces the skipped #602 tests with active geometry regression tests for desktop and mobile. The focus-state assertion in the desktop test uses programmatic `focus()` (which doesn't trigger `:focus-visible`) and an OR branch that is always truthy, so the assertion never fails regardless of whether the focus outline is applied. |
| web/tests/e2e/ui-regression-fix.spec.ts | Adds a new notification badge geometry test; the API stub setup is duplicated verbatim from `topbar-polish.spec.ts` rather than sharing the `stubTopbarData` helper. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/topbar-polish.spec.ts:120-142
**Focus-style assertion is structurally always-true**

The OR condition includes `focusStyle.backgroundColor !== "rgba(0, 0, 0, 0)"` as a final branch. Because `.btn-ghost` has `background: var(--surface-2)` (a non-transparent resolved color), `backgroundColor` will never equal `"rgba(0, 0, 0, 0)"`, so this branch evaluates to `true` unconditionally. The `expect(...).toBeTruthy()` can never fail regardless of whether the focus outline exists.

Additionally, `button.focus()` is programmatic focus, which browsers typically do not treat as keyboard-initiated — meaning `:focus-visible` styles are not applied, so `outlineStyle` will be `"none"` and `outlineWidth` will be `"0px"`. The assertion therefore always resolves to `true` via the backgroundColor branch alone. This means the test provides no regression protection for the focus indicator added in this PR.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stabilize topbar icon controls"](https://github.com/befeast/panoptikon/commit/ca4e6e24305d1565a85fe4bbc823478b2d953d67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33283003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->