### PR TITLE
[codex] Continue live UX shell fidelity

### DIFF
--- a/web/src/app/(app)/vpn-status/page.tsx
+++ b/web/src/app/(app)/vpn-status/page.tsx
@@ -156,14 +156,14 @@ export default function VpnStatusPage() {
 
   return (
     <PageTransition>
-      <div className="space-y-6">
+      <div data-testid="vpn-status-root" className="space-y-4">
         {/* ─── Page header ─────────────────────────────── */}
-        <section className="flex flex-col gap-4 border-b border-mesh-border pb-5 md:flex-row md:items-end md:justify-between">
+        <section className="flex flex-col gap-4 border-b border-mesh-border pb-4 md:flex-row md:items-end md:justify-between">
           <div className="flex items-center gap-3">
             <Shield className="h-5 w-5 text-mesh-accent" />
             <div>
               <p className={meshSectionTitle}>Network · secure overlay</p>
-              <h1 className="t-h1 mt-1 text-mesh-text">VPN status</h1>
+              <h1 className="t-h1 mt-1 text-mesh-text">VPN Status</h1>
               <p className="mt-1 font-mono text-xs text-mesh-text-mute">
                 {subtitle}
               </p>
@@ -177,7 +177,7 @@ export default function VpnStatusPage() {
         </section>
 
         {/* ─── KPI row ─────────────────────────────────── */}
-        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <section className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
           <SummaryCard
             label="Interfaces"
             value={data ? overviewInterfaces.length.toString() : null}
@@ -234,7 +234,7 @@ export default function VpnStatusPage() {
           </TabsList>
 
           {/* ─── Overview tab ─────────────────────────── */}
-          <TabsContent value="overview" className="space-y-4 pt-4">
+          <TabsContent value="overview" className="space-y-3 pt-3">
             <Card>
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-2">
@@ -348,7 +348,7 @@ export default function VpnStatusPage() {
           </TabsContent>
 
           {/* ─── MikroTik / WireGuard tab ─────────────── */}
-          <TabsContent value="mikrotik" className="space-y-4 pt-4">
+          <TabsContent value="mikrotik" className="space-y-3 pt-3">
             <FilterInput
               value={search}
               onChange={setSearch}
@@ -383,7 +383,7 @@ export default function VpnStatusPage() {
           </TabsContent>
 
           {/* ─── OpenVPN tab ──────────────────────────── */}
-          <TabsContent value="openvpn" className="space-y-4 pt-4">
+          <TabsContent value="openvpn" className="space-y-3 pt-3">
             <FilterInput
               value={search}
               onChange={setSearch}
@@ -443,18 +443,18 @@ function SummaryCard({
     accent === "emerald" ? "text-[#4ade80]" : "text-white";
 
   return (
-    <Card className="h-full min-h-[8.25rem]">
-      <CardHeader className="flex flex-row items-start justify-between pb-3">
+    <Card className="h-full min-h-[6.5rem]">
+      <CardHeader className="flex flex-row items-start justify-between p-3 pb-2">
         <CardTitle className={meshSectionTitle}>{label}</CardTitle>
         <span className="text-mesh-accent">{icon}</span>
       </CardHeader>
-      <CardContent className="space-y-2">
+      <CardContent className="space-y-1.5 p-3 pt-0">
         {loading ? (
           <Skeleton className="h-7 w-24" />
         ) : (
           <p
             className={cn(
-              "truncate text-[1.65rem] font-semibold leading-none tabular-nums",
+              "truncate text-[1.45rem] font-semibold leading-none tabular-nums",
               valueClass,
             )}
           >
@@ -510,7 +510,7 @@ function EmptyState({
 }) {
   return (
     <Card>
-      <CardContent className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-12 text-center">
         <Icon className="h-10 w-10 text-mesh-text-faint/80" />
         <p className="text-sm text-mesh-text">{title}</p>
         <p className="max-w-md text-sm text-mesh-text-dim">{message}</p>
@@ -527,7 +527,7 @@ function EmptyState({
 function InterfaceSkeleton() {
   return (
     <Card>
-      <CardHeader className="space-y-3 pb-3">
+      <CardHeader className="space-y-3 p-3 pb-3">
         <div className="flex items-center gap-2">
           <Skeleton className="h-4 w-32" />
           <Skeleton className="h-5 w-12" />
@@ -593,7 +593,7 @@ function InterfaceCard({ iface }: { iface: VpnInterfaceStatus }) {
 
   return (
     <Card>
-      <CardHeader className="space-y-3 pb-3">
+      <CardHeader className="space-y-3 p-3 pb-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <Cable className="h-4 w-4 text-mesh-accent" />

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -571,6 +571,11 @@
     grid-template-columns: repeat(2, 1fr) !important;
   }
 }
+@media (max-width: 479px) {
+  .dashboard-kpi-grid {
+    grid-template-columns: 1fr !important;
+  }
+}
 
 /* ── Settings tile grid — responsive override on the design-source
  *    `gridTemplateColumns: repeat(3, 1fr)` so tiles don't crush below

--- a/web/src/components/brand/BrandMark.tsx
+++ b/web/src/components/brand/BrandMark.tsx
@@ -16,11 +16,11 @@ interface BrandMarkProps {
  */
 export function BrandMark({ size = 32, className, glow = true }: BrandMarkProps) {
   const nodes = [
-    { x: 14, y: 18, r: 4 },
-    { x: 50, y: 14, r: 3 },
-    { x: 32, y: 32, r: 5 },
-    { x: 12, y: 48, r: 3 },
-    { x: 52, y: 50, r: 4 },
+    { x: 14, y: 18, r: 2.6 },
+    { x: 50, y: 14, r: 2.2 },
+    { x: 32, y: 32, r: 3.2 },
+    { x: 12, y: 48, r: 2.2 },
+    { x: 52, y: 50, r: 2.6 },
   ];
   const links: Array<[number, number]> = [
     [0, 2],
@@ -58,8 +58,8 @@ export function BrandMark({ size = 32, className, glow = true }: BrandMarkProps)
             x2={nodes[b].x}
             y2={nodes[b].y}
             stroke={isAxis ? "url(#panoptikonMeshAxis)" : "rgba(96,144,212,0.35)"}
-            strokeWidth={isAxis ? 1.5 : 1}
-            strokeDasharray={isAxis ? undefined : "2 3"}
+            strokeWidth={isAxis ? 1 : 0.75}
+            strokeDasharray={isAxis ? undefined : "2 4"}
             strokeLinecap="round"
           />
         );
@@ -69,7 +69,7 @@ export function BrandMark({ size = 32, className, glow = true }: BrandMarkProps)
         return (
           <g key={i}>
             {isCenter && glow && (
-              <circle cx={n.x} cy={n.y} r={n.r + 4} fill="#2563eb" opacity="0.18" />
+              <circle cx={n.x} cy={n.y} r={n.r + 4} fill="#2563eb" opacity="0.14" />
             )}
             <circle
               cx={n.x}
@@ -77,9 +77,9 @@ export function BrandMark({ size = 32, className, glow = true }: BrandMarkProps)
               r={n.r}
               fill={isCenter ? "#2563eb" : "#0c1b30"}
               stroke={isCenter ? "#5eead4" : "#38bdf8"}
-              strokeWidth={1.5}
+              strokeWidth={1}
             />
-            {isCenter && <circle cx={n.x} cy={n.y} r={1.5} fill="#5eead4" />}
+            {isCenter && <circle cx={n.x} cy={n.y} r={1} fill="#5eead4" />}
           </g>
         );
       })}

--- a/web/src/components/layout/MobileSidebar.tsx
+++ b/web/src/components/layout/MobileSidebar.tsx
@@ -13,6 +13,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
+import { BrandMark } from "@/components/brand/BrandMark";
 
 function formatUptime(seconds: number | null): string {
   if (seconds == null || seconds < 0) return "—";
@@ -52,10 +53,8 @@ export function MobileSidebar() {
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           {/* Logo */}
           <div className="flex h-14 shrink-0 items-center border-b border-mesh-border-strong px-4">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-mesh-accent/40 bg-mesh-accent/12 text-sm font-bold text-mesh-accent">
-              P
-            </div>
-            <span className="ml-2 text-lg font-semibold text-white">
+            <BrandMark size={30} className="text-mesh-accent" />
+            <span className="ml-2 font-mono text-[13px] font-semibold uppercase tracking-[0.08em] text-white">
               Panoptikon
             </span>
           </div>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -98,6 +98,7 @@ export const navGroups: NavGroup[] = [
       { href: "/dns-queries", label: "DNS queries", icon: SearchIcon },
       { href: "/certificates", label: "Certificates", icon: Shield },
       { href: "/caddy", label: "Caddy", icon: Server },
+      { href: "/vpn-status", label: "VPN status", icon: Shield },
       { href: "/cloudflare-tunnel", label: "Cloudflare tunnel", icon: Cloud },
       { href: "/services", label: "Services", icon: Share2 },
     ],

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -8,6 +8,7 @@ import { Bell, ChevronRight, RefreshCw, Settings } from "lucide-react";
 import { fetchDashboardStats, fetchRecentAlerts, markAllAlertsRead, deleteAllAlerts } from "@/lib/api";
 import { useWsEvent } from "@/lib/ws";
 import { useWsConnected } from "@/components/providers/WebSocketProvider";
+import { BrandMark } from "@/components/brand/BrandMark";
 import { StatusDot } from "@/components/mesh/StatusDot";
 import type { Alert } from "@/lib/types";
 import { timeAgo } from "@/lib/format";
@@ -143,6 +144,8 @@ export function TopBar({ mobileMenu }: { mobileMenu?: ReactNode }) {
       }}
     >
       {mobileMenu}
+
+      <BrandMark size={18} className="hidden text-mesh-accent md:block" glow={false} />
 
       {/* Breadcrumbs */}
       <div style={{ display: "flex", alignItems: "center", gap: 6, flex: 1, minWidth: 0 }}>
@@ -421,7 +424,7 @@ function severityColor(severity: string): string {
 // Realm root (core.lan) is fixed in the render. This helper returns just the
 // route-derived trail per shell.jsx breadcrumb pattern.
 const BREADCRUMB_LABELS: Record<string, string> = {
-  dashboard: "Dashboard",
+  dashboard: "Overview",
   alerts: "Alerts",
   "audit-log": "Audit log",
   devices: "Devices",


### PR DESCRIPTION
## Summary

Refs #767

- Continues the accepted live UX shell repair with thinner shared Panoptikon brand mark treatment.
- Adds shared brand usage in topbar/mobile sidebar and keeps dashboard breadcrumb context aligned with `core.lan > Overview`.
- Tightens VPN status/dashboard density and adds a sub-480px KPI grid rule to avoid horizontal overflow.

## Verification

- `cd web && bun run test` - passed
- `cd web && bun run build` - passed
- `bash web/scripts/check-design-tokens.sh` - passed
- `git diff --check` - passed
- Mocked Playwright visual QA screenshots produced no horizontal overflow for dashboard and VPN status.

## Known Verification Limitation

Authenticated E2E was attempted, but the dev proxy target `10.10.0.14:8080` was unreachable, so login-backed specs timed out before reaching the app. Login visual specs passed before the authenticated route failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR continues the live UX shell fidelity work by replacing the \"P\" lettermark with the shared `BrandMark` SVG in TopBar and MobileSidebar, tightening VPN Status page density, adding the VPN Status entry to the sidebar nav, and introducing a sub-480 px single-column override for the dashboard KPI grid.

- **BrandMark rollout**: `TopBar` and `MobileSidebar` now render the shared `BrandMark` component (desktop-only in the topbar); node radii, stroke widths, and glow opacity in `BrandMark.tsx` are globally reduced for a thinner appearance.
- **VPN Status density**: KPI card min-height, padding, font size, and tab spacing are all reduced; `data-testid=\"vpn-status-root\"` is added and the heading is capitalised to `\"VPN Status\"` (already matched by existing E2E expectations).
- **Sidebar + CSS**: `/vpn-status` is wired into the Services nav group and a `max-width: 479px` CSS rule prevents KPI grid overflow on very small screens.

<h3>Confidence Score: 4/5</h3>

Mostly safe visual and layout changes; the missing E2E coverage for the new sidebar entry, BrandMark insertion, and breadcrumb label rename should be addressed before merging.

All six files contain purely cosmetic or structural UI tweaks with no data-flow or API changes, so runtime regressions are unlikely. The main gap is that the CLAUDE.md mandatory E2E test policy is not satisfied: the new sidebar VPN entry, the BrandMark in the topbar, and the renamed breadcrumb label are all untested, and the PR description does not include the required justification section for skipping them.

web/src/components/layout/TopBar.tsx (breadcrumb label rename) and web/src/components/layout/Sidebar.tsx (duplicate Shield icon) are worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/app/(app)/vpn-status/page.tsx | Density pass: tighter spacing/padding on KPI cards, tabs, and header; data-testid added to root; heading capitalised to match existing E2E test expectation. No logic changes. |
| web/src/app/globals.css | Adds a max-width: 479px single-column override for .dashboard-kpi-grid to prevent horizontal overflow on very narrow viewports. |
| web/src/components/brand/BrandMark.tsx | Visual thinning of the SVG brand mark: reduced node radii, stroke widths, glow opacity, and inner highlight radius. Purely cosmetic; no interface changes. |
| web/src/components/layout/MobileSidebar.tsx | Replaces the P lettermark placeholder with the shared BrandMark component and updates the wordmark to mono/uppercase styling to match the desktop sidebar. |
| web/src/components/layout/Sidebar.tsx | Adds /vpn-status nav item to the Services group using the Shield icon, which is already used by /certificates in the same group — both entries share an identical icon. |
| web/src/components/layout/TopBar.tsx | Inserts a small BrandMark (desktop-only) before the breadcrumbs; renames the dashboard breadcrumb label from Dashboard to Overview, diverging from the sidebar nav item label. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/layout/Sidebar.tsx:101
**Duplicate icon with Certificates nav item**

Both `/certificates` (line 99) and `/vpn-status` use the `Shield` icon from lucide-react, so the two sidebar entries look identical at a glance. A more semantically appropriate icon — e.g. `Lock`, `KeyRound`, `Wifi`, or `Network` — would let users distinguish VPN Status from Certificates without reading the label.

### Issue 2 of 3
web/src/components/layout/TopBar.tsx:424
**Breadcrumb label diverges from the sidebar nav item label**

The `BREADCRUMB_LABELS` entry for the dashboard route is now `"Overview"`, but the sidebar nav item label remains `"Dashboard"` (`Sidebar.tsx` line 75). A user on `/dashboard` will see `"Dashboard"` highlighted in the sidebar while the topbar breadcrumb reads `core.lan › Overview`, which refers to the sidebar *section* name rather than the page name. The divergence may be intentional (aligning the breadcrumb trail to the realm hierarchy), but it warrants a comment explaining the design choice so future contributors don't "fix" the mismatch and reintroduce the original label.

### Issue 3 of 3
web/src/app/(app)/vpn-status/page.tsx:159
**Missing Playwright E2E test for layout changes**

`CLAUDE.md` mandates a Playwright E2E test for every layout fix, with "Layout fix → screenshot comparison or element visibility check" listed as an explicit example. This PR touches VPN Status density, the sidebar VPN entry, BrandMark in TopBar/MobileSidebar, and the dashboard breadcrumb label — but no new spec file is added and none of the changed areas are covered by the existing `vpn-status.spec.ts`. The PR description also lacks the required `## Why No E2E Test` section that would justify skipping.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: continue live UX shell fidelity"](https://github.com/befeast/panoptikon/commit/02a1ce3494687568f1cfc72d2eb0325c0922d96d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33283672)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->