### PR TITLE
fix(ux): Cmd+K consistently opens the global command palette (#805)

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -59,10 +59,15 @@ export function CommandPalette() {
   const [scanning, setScanning] = useState(false)
 
   // ── Global Cmd+K / Ctrl+K listener ──
+  // Captured at the document level so it triggers consistently from any
+  // authenticated route — including while focus is inside a text input,
+  // textarea, or contentEditable region. preventDefault overrides the
+  // browser's default Cmd/Ctrl+K (e.g. focus the URL bar search box).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'k') {
         e.preventDefault()
+        e.stopPropagation()
         setOpen((prev) => !prev)
       }
     }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -560,17 +560,6 @@ function SidebarSearch() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  useEffect(() => {
-    function onHotkey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onHotkey);
-    return () => window.removeEventListener("keydown", onHotkey);
-  }, []);
-
   const flatItems = useMemo(() => {
     if (!results) return [] as Array<{ type: string; id: string; label: string }>;
     const items: Array<{ type: string; id: string; label: string }> = [];

--- a/web/tests/e2e/cmdk-global-shortcut.spec.ts
+++ b/web/tests/e2e/cmdk-global-shortcut.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E coverage for the Cmd+K / Ctrl+K global shortcut (#805).
+ *
+ * Verifies the acceptance criteria on the issue:
+ *  - Pressing Cmd+K (mac) or Ctrl+K (non-mac) opens the global command/search
+ *    palette consistently from authenticated routes.
+ *  - The palette input is focused and ready for typing after the shortcut fires.
+ *  - The shortcut works even when focus is inside a text input — i.e. it does
+ *    not get swallowed by native browser shortcuts.
+ *  - Escape closes the palette (existing UX pattern).
+ *  - There is only ever one palette dialog (no duplicate listener fight with
+ *    the sidebar search input).
+ */
+test.describe("Cmd+K global search shortcut (#805)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Ctrl+K opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeVisible();
+    await expect(input).toBeFocused();
+
+    await page.keyboard.type("dash");
+    await expect(input).toHaveValue("dash");
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-global-opens-and-focuses.png",
+      fullPage: true,
+    });
+  });
+
+  test("Meta+K (mac shortcut) opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Meta+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+  });
+
+  test("Ctrl+K works while focus is inside a text input", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The sidebar search input is a plain text input on the authenticated
+    // shell. Focus it first, then fire the shortcut — the palette must still
+    // open regardless of where focus currently lives.
+    const sidebarInput = page
+      .locator('input[placeholder="Search"]')
+      .first();
+    await expect(sidebarInput).toBeVisible();
+    await sidebarInput.click();
+    await expect(sidebarInput).toBeFocused();
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const paletteInput = page.locator("[cmdk-input]");
+    await expect(paletteInput).toBeFocused();
+  });
+
+  test("Escape closes the palette", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden({ timeout: 2000 });
+  });
+
+  test("Ctrl+K toggles the palette (second press closes it)", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const dialog = page.locator("[cmdk-dialog]");
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeHidden({ timeout: 2000 });
+  });
+
+  test("only one palette dialog opens (no duplicate listeners)", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialogs = page.locator("[cmdk-dialog]");
+    await expect(dialogs).toHaveCount(1, { timeout: 3000 });
+  });
+
+  test("shortcut works on other authenticated routes (devices)", async ({
+    page,
+  }) => {
+    await page.goto("/devices");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary

- Drops the duplicate `Cmd/Ctrl+K` listener that lived on the sidebar search input. It was racing the `CommandPalette` listener (both called `preventDefault`), so the palette would flicker or fail to take focus depending on render order.
- Keeps `CommandPalette` as the single global target. Hardens the listener: require no Alt/Shift modifiers, `stopPropagation`, and case-insensitive key match so it wins reliably from any focus context — including while typing in a text input — and overrides the browser's native `Cmd+K` (URL bar search).
- Adds Playwright E2E coverage for the shortcut.

Implements #805

## Behavior

| Trigger | Before | After |
|---|---|---|
| `Ctrl+K` from `/dashboard` | Palette opens but sidebar input also briefly grabs focus | Palette opens, palette input focused |
| `Ctrl+K` while focus is in another text input | Inconsistent — sidebar focus race | Palette opens, palette input focused |
| `Cmd+K` on macOS | Same as above | Same — `Meta+K` opens palette |
| `Esc` while palette open | Closes | Closes (unchanged) |
| `Ctrl+K` again while palette open | Toggle | Toggle (unchanged) |

## Test plan

- [x] `bun run test` (vitest) — 66 tests pass
- [x] `bun run build` — production build succeeds
- [x] `cargo check -p panoptikon-server` — backend compiles
- [x] New Playwright spec `web/tests/e2e/cmdk-global-shortcut.spec.ts` covers:
  - Ctrl+K opens palette and focuses the input
  - Meta+K (macOS shortcut) opens palette and focuses the input
  - Ctrl+K works while focus is in a text input (sidebar search)
  - Escape closes the palette
  - Ctrl+K toggles (second press closes)
  - Only one `[cmdk-dialog]` opens (no duplicate listener)
  - Shortcut also works on `/devices`
- [ ] Live verification on `https://net.oklabs.uk` after merge + deploy

## Why No E2E Test
N/A — E2E test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Ctrl+K / Cmd+K race condition by removing the duplicate `window`-level listener in `SidebarSearch` and consolidating all handling in `CommandPalette`'s single `document`-level listener, which is hardened with modifier guards, a case-insensitive key check, and `preventDefault`/`stopPropagation`.

- **`CommandPalette.tsx`**: The global keydown handler gains `!e.altKey && !e.shiftKey` guards and `e.stopPropagation()` to prevent the event from reaching `window`-level handlers; `stopImmediatePropagation()` would be more precise for stopping other document-level handlers, but is not strictly necessary given the current codebase.
- **`Sidebar.tsx`**: The conflicting `useEffect` that focused the sidebar search input on Ctrl+K is removed entirely — the palette is now the single canonical handler.
- **`cmdk-global-shortcut.spec.ts`**: New Playwright spec covering open, Meta+K, focus-while-in-input, Escape, toggle, duplicate-listener, and cross-route scenarios; five of the six tests are missing the `page.screenshot()` call required by `CLAUDE.md`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the race condition is correctly resolved and no existing behaviour is broken.

The core fix — removing the sidebar's competing window listener — is straightforward and correct. The only issue is that stopPropagation() at the document level stops bubbling to window but does not prevent other document-level handlers from also firing; stopImmediatePropagation() would be the stronger guard. Five of the six new E2E tests also omit the page.screenshot() call required by the project guidelines.

The stopPropagation → stopImmediatePropagation change in CommandPalette.tsx is worth a second look; the E2E spec missing screenshots is a convention gap but does not affect runtime behaviour.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Hardens the Ctrl+K listener with modifier guards, case-insensitive key match, and stopPropagation; stopImmediatePropagation would be more precise for document-level exclusivity. |
| web/src/components/layout/Sidebar.tsx | Removes the duplicate window-level Ctrl+K listener that was racing the CommandPalette handler; clean deletion with no side effects. |
| web/tests/e2e/cmdk-global-shortcut.spec.ts | New Playwright spec with good scenario coverage (Ctrl+K, Meta+K, focus-in-input, Escape, toggle, no-duplicates, other route), but only the first test captures a screenshot as required by CLAUDE.md. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/CommandPalette.tsx:69-71
`stopPropagation` at the `document` level only stops the event from bubbling further to `window`. It does NOT prevent other `document`-level keydown handlers (from third-party libraries or future code) from also firing. The PR description says this makes the handler "win reliably from any focus context," but that guarantee only holds against `window`-level listeners. If any future `document`-level handler also toggles or acts on Ctrl+K, both would fire. `stopImmediatePropagation()` is the correct call to truly prevent other handlers registered on `document` from executing.

```suggestion
        e.preventDefault()
        e.stopImmediatePropagation()
        setOpen((prev) => !prev)
```

### Issue 2 of 2
web/tests/e2e/cmdk-global-shortcut.spec.ts:60-149
**Missing screenshots on key assertions**

`CLAUDE.md` requires that every E2E test "includes a screenshot on key assertions." Only the first test (`Ctrl+K opens the palette and focuses the search input`) has a `page.screenshot()` call. The five remaining tests — Meta+K, Ctrl+K-from-input, Escape, toggle, no-duplicates, and `/devices` route — all assert visible UI state without a screenshot. Add a `page.screenshot()` after each test's primary assertion to comply with the project convention.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): Cmd+K consistently opens the gl..."](https://github.com/befeast/panoptikon/commit/d85e402d4aebcaccbf0261b44c9578ac49f7b537) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33289851)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->