### PR TITLE
fix(pfsense): swap panels on hash subroute and sync browser navigation (#806)

### DIFF
--- a/web/src/components/router/PfSenseRouterDesign.tsx
+++ b/web/src/components/router/PfSenseRouterDesign.tsx
@@ -20,6 +20,9 @@ import {
 } from "@/lib/api";
 import {
   RouterPage,
+  RouterInterfacesPanel,
+  RouterFirewallPanel,
+  RouterDhcpPanel,
   type RouterFirewallRow,
   type RouterDhcpRow,
   type RouterInterfaceRow,
@@ -29,6 +32,11 @@ import {
 } from "@/components/router/RouterPage";
 import type { RouterTab } from "@/components/router/RouterTabs";
 import type { RouterHeaderMeta } from "@/components/router/RouterHeader";
+import { SystemTab } from "@/components/pfsense/tabs/SystemTab";
+import { DnsTab } from "@/components/pfsense/tabs/DnsTab";
+import { ServicesTab } from "@/components/pfsense/tabs/ServicesTab";
+import { RoutingTab } from "@/components/pfsense/tabs/RoutingTab";
+import { ConfigTab } from "@/components/pfsense/tabs/ConfigTab";
 
 const PFSENSE_TABS: RouterTab[] = [
   { id: "system", label: "System" },
@@ -184,6 +192,99 @@ export default function PfSenseRouterDesign({
     ? `pfSense · ${status.data.hostname}`
     : "pfSense Firewall";
 
+  const interfacesTotalsLabel =
+    totalIfaces > 0
+      ? `${totalIfaces} total · ${runningIfaces} up · ${downIfaces} down`
+      : interfaces.loading
+        ? "loading…"
+        : "no data";
+
+  const firewallSection = {
+    rules: fwRows,
+    label:
+      fwRows.length > 0
+        ? `${fwRows.length} rules · ${disabledRules} disabled`
+        : rules.loading
+          ? "loading…"
+          : "no rules",
+  };
+
+  const dhcpSection = {
+    leases: dhcpRows,
+    label:
+      dhcpRows.length > 0
+        ? `${dhcpRows.length} · ${staticLeases} static`
+        : leases.loading
+          ? "loading…"
+          : "no leases",
+  };
+
+  const tabPanels = (() => {
+    switch (activeTab) {
+      case "system":
+        return status.data ? (
+          <div data-testid="router-tabpanel-system">
+            <SystemTab status={status.data} />
+          </div>
+        ) : (
+          <div
+            data-testid="router-tabpanel-system"
+            className="mono"
+            style={{ color: "var(--text-mute)", padding: 14 }}
+          >
+            {status.loading ? "loading…" : "no system data"}
+          </div>
+        );
+      case "interfaces":
+        return (
+          <div data-testid="router-tabpanel-interfaces">
+            <RouterInterfacesPanel
+              interfaces={ifaceRows}
+              interfacesTotalsLabel={interfacesTotalsLabel}
+            />
+          </div>
+        );
+      case "firewall":
+        return (
+          <div data-testid="router-tabpanel-firewall">
+            <RouterFirewallPanel firewall={firewallSection} />
+          </div>
+        );
+      case "dhcp":
+        return (
+          <div data-testid="router-tabpanel-dhcp">
+            <RouterDhcpPanel dhcp={dhcpSection} />
+          </div>
+        );
+      case "dns":
+        return (
+          <div data-testid="router-tabpanel-dns">
+            <DnsTab />
+          </div>
+        );
+      case "services":
+        return (
+          <div data-testid="router-tabpanel-services">
+            <ServicesTab />
+          </div>
+        );
+      case "routing":
+        return (
+          <div data-testid="router-tabpanel-routing">
+            <RoutingTab />
+          </div>
+        );
+      case "config":
+        return (
+          <div data-testid="router-tabpanel-config">
+            <ConfigTab />
+          </div>
+        );
+      default:
+        return null;
+    }
+  })();
+
   return (
     <RouterPage
       headerTitle={title}
@@ -197,31 +298,10 @@ export default function PfSenseRouterDesign({
       activeTab={activeTab}
       onTabChange={onTabChange}
       interfaces={ifaceRows}
-      interfacesTotalsLabel={
-        totalIfaces > 0
-          ? `${totalIfaces} total · ${runningIfaces} up · ${downIfaces} down`
-          : interfaces.loading
-            ? "loading…"
-            : "no data"
-      }
-      firewall={{
-        rules: fwRows,
-        label:
-          fwRows.length > 0
-            ? `${fwRows.length} rules · ${disabledRules} disabled`
-            : rules.loading
-              ? "loading…"
-              : "no rules",
-      }}
-      dhcp={{
-        leases: dhcpRows,
-        label:
-          dhcpRows.length > 0
-            ? `${dhcpRows.length} · ${staticLeases} static`
-            : leases.loading
-              ? "loading…"
-              : "no leases",
-      }}
+      interfacesTotalsLabel={interfacesTotalsLabel}
+      firewall={firewallSection}
+      dhcp={dhcpSection}
+      tabPanels={tabPanels}
       footer={{
         snapshotLabel: "Live pfSense state",
         driftLabel: status.data?.domain

--- a/web/src/components/router/RouterPage.tsx
+++ b/web/src/components/router/RouterPage.tsx
@@ -199,6 +199,14 @@ export type RouterPageProps = {
     onFilter?: () => void;
   };
 
+  /**
+   * Custom content rendered between the tab bar and the footer.
+   * When provided, REPLACES the default Interfaces / Firewall / DHCP panels —
+   * letting vendor wrappers swap panel content per active tab (e.g. pfSense
+   * hash subroutes).
+   */
+  tabPanels?: ReactNode;
+
   // Quick actions footer (omit to hide)
   footer?: {
     snapshotLabel?: string; // "Config snapshot · 14m ago"
@@ -261,6 +269,7 @@ export function RouterPage(props: RouterPageProps) {
     onFilterInterface,
     firewall,
     dhcp,
+    tabPanels,
     footer,
   } = props;
 
@@ -320,453 +329,29 @@ export function RouterPage(props: RouterPageProps) {
 
       <RouterTabs tabs={tabs} active={activeTab} onChange={onTabChange} />
 
-      {/* Interfaces table — router-page.jsx lines 73-141 */}
-      <div className="card" style={{ padding: 0 }}>
-        <div
-          style={{
-            padding: "10px 14px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "baseline",
-              gap: 8,
-              flexWrap: "wrap",
-            }}
-          >
-            <h3 className="t-h3">Interfaces</h3>
-            {interfacesTotalsLabel && (
-              <span
-                className="mono"
-                style={{
-                  font: "500 11px var(--font-mono)",
-                  color: "var(--text-mute)",
-                }}
-              >
-                {interfacesTotalsLabel}
-              </span>
-            )}
-          </div>
-          <div style={{ display: "flex", gap: 6 }}>
-            <button
-              type="button"
-              className="btn btn-sm"
-              onClick={onFilterInterface}
-            >
-              <Filter size={11} />
-              <span>Type · all</span>
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
-              onClick={onAddInterface}
-            >
-              <Plus size={11} />
-              <span>Add</span>
-            </button>
-          </div>
-        </div>
-        <div style={IFACE_HEADER_STYLE}>
-          <span>State</span>
-          <span>Interface</span>
-          <span>Type</span>
-          <span>IP / role</span>
-          <span>MAC</span>
-          <span>MTU</span>
-          <span style={{ textAlign: "right" }}>RX GB</span>
-          <span style={{ textAlign: "right" }}>TX GB</span>
-          <span>24h</span>
-          <span />
-        </div>
-        {interfaces.map((it, i) => (
-          <div
-            key={it.name}
-            style={{
-              display: "grid",
-              gridTemplateColumns: IFACE_GRID,
-              padding: "8px 14px",
-              alignItems: "center",
-              borderBottom:
-                i < interfaces.length - 1
-                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                  : "none",
-              background: !it.running
-                ? "rgba(251,113,133,0.03)"
-                : "transparent",
-              font: "400 12.5px var(--font-sans)",
-            }}
-          >
-            <span>
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 5,
-                  font: "600 9px var(--font-sans)",
-                  letterSpacing: "0.06em",
-                  padding: "1px 6px",
-                  borderRadius: 2,
-                  background: it.running
-                    ? "rgba(74,222,128,0.10)"
-                    : "var(--surface-2)",
-                  color: it.running ? "#4ade80" : "var(--text-mute)",
-                  border: `var(--hairline) solid ${
-                    it.running
-                      ? "rgba(74,222,128,0.30)"
-                      : "rgba(96,144,212,0.20)"
-                  }`,
-                }}
-              >
-                <span
-                  style={{
-                    width: 4,
-                    height: 4,
-                    borderRadius: 2,
-                    background: it.running ? "#4ade80" : "#fb7185",
-                  }}
-                />
-                {it.running ? "UP" : "DOWN"}
-              </span>
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text)", fontWeight: 500 }}
-            >
-              {it.name}
-            </span>
-            <span>{ifaceTypeBadge(it.type)}</span>
-            <span style={{ minWidth: 0 }}>
-              <div
-                className="mono"
-                style={{ color: "var(--text-dim)", fontSize: 11.5 }}
-              >
-                {it.ip}
-              </div>
-              {it.role !== "—" && it.role !== "" && (
-                <div
-                  style={{
-                    font: "500 10px var(--font-sans)",
-                    color: "var(--accent-cyan)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.06em",
-                  }}
-                >
-                  {it.role}
-                </div>
-              )}
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text-mute)", fontSize: 11 }}
-            >
-              {it.mac}
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text-mute)", fontSize: 11 }}
-            >
-              {it.mtu}
-            </span>
-            <span
-              className="mono"
-              style={{ textAlign: "right", color: "var(--text)" }}
-            >
-              {it.rx.toFixed(1)}
-            </span>
-            <span
-              className="mono"
-              style={{ textAlign: "right", color: "var(--text-dim)" }}
-            >
-              {it.tx.toFixed(1)}
-            </span>
-            <span>
-              <Spark
-                data={gen(20, 30 + it.rx / 5, 18)}
-                width={70}
-                height={20}
-                color={it.running ? "#38bdf8" : "var(--text-mute)"}
-              />
-            </span>
-            <span
+      {tabPanels !== undefined ? (
+        tabPanels
+      ) : (
+        <>
+          <RouterInterfacesPanel
+            interfaces={interfaces}
+            interfacesTotalsLabel={interfacesTotalsLabel}
+            onAddInterface={onAddInterface}
+            onFilterInterface={onFilterInterface}
+          />
+          {(firewall || dhcp) && (
+            <div
               style={{
-                color: "var(--text-mute)",
-                display: "flex",
-                justifyContent: "flex-end",
+                display: "grid",
+                gridTemplateColumns: firewall && dhcp ? "1.4fr 1fr" : "1fr",
+                gap: 12,
               }}
             >
-              <ChevronRight size={12} />
-            </span>
-          </div>
-        ))}
-      </div>
-
-      {/* Two-pane — Firewall + DHCP — router-page.jsx lines 143-200 */}
-      {(firewall || dhcp) && (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: firewall && dhcp ? "1.4fr 1fr" : "1fr",
-            gap: 12,
-          }}
-        >
-          {firewall && (
-            <div className="card" style={{ padding: 0 }}>
-              <div
-                style={{
-                  padding: "10px 14px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  flexWrap: "wrap",
-                  gap: 8,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: 8,
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <h3 className="t-h3">Firewall rules</h3>
-                  {firewall.label && (
-                    <span
-                      className="mono"
-                      style={{
-                        font: "500 11px var(--font-mono)",
-                        color: "var(--text-mute)",
-                      }}
-                    >
-                      {firewall.label}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-primary"
-                  onClick={firewall.onAdd}
-                >
-                  <Plus size={11} />
-                  <span>New rule</span>
-                </button>
-              </div>
-              <div
-                style={{
-                  borderTop:
-                    "var(--hairline) solid rgba(96,144,212,0.20)",
-                }}
-              >
-                {firewall.rules.map((r, i) => (
-                  <div
-                    key={`${r.idx}-${r.chain}-${r.src}-${r.dst}`}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: FW_GRID,
-                      padding: "7px 14px",
-                      alignItems: "center",
-                      gap: 8,
-                      borderBottom:
-                        i < firewall.rules.length - 1
-                          ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                          : "none",
-                      font: "400 12px var(--font-sans)",
-                      opacity: r.enabled ? 1 : 0.55,
-                    }}
-                  >
-                    <span
-                      style={{
-                        color: "var(--text-faint)",
-                        cursor: "grab",
-                      }}
-                    >
-                      ⋮⋮
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-mute)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.idx}
-                    </span>
-                    <span
-                      style={{
-                        font: "500 10.5px var(--font-mono)",
-                        color: "var(--text-dim)",
-                      }}
-                    >
-                      {r.chain}
-                    </span>
-                    <span>{actionBadge(r.action)}</span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-dim)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.src}
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-dim)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.dst}
-                    </span>
-                    <span
-                      style={{
-                        color: "var(--text-mute)",
-                        fontSize: 11.5,
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
-                    >
-                      {r.comment}
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        textAlign: "right",
-                        color:
-                          r.action === "fasttrack" || r.action === "accept"
-                            ? "var(--text)"
-                            : "#fbbf24",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.hits}
-                    </span>
-                  </div>
-                ))}
-              </div>
+              {firewall && <RouterFirewallPanel firewall={firewall} />}
+              {dhcp && <RouterDhcpPanel dhcp={dhcp} />}
             </div>
           )}
-
-          {dhcp && (
-            <div className="card" style={{ padding: 0 }}>
-              <div
-                style={{
-                  padding: "10px 14px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  flexWrap: "wrap",
-                  gap: 8,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: 8,
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <h3 className="t-h3">DHCP leases</h3>
-                  {dhcp.label && (
-                    <span
-                      className="mono"
-                      style={{
-                        font: "500 11px var(--font-mono)",
-                        color: "var(--text-mute)",
-                      }}
-                    >
-                      {dhcp.label}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-ghost"
-                  onClick={dhcp.onFilter}
-                >
-                  <Filter size={11} />
-                </button>
-              </div>
-              <div
-                style={{
-                  borderTop:
-                    "var(--hairline) solid rgba(96,144,212,0.20)",
-                }}
-              >
-                {dhcp.leases.map((l, i) => (
-                  <div
-                    key={`${l.ip}-${l.mac}`}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: DHCP_GRID,
-                      padding: "8px 14px",
-                      alignItems: "center",
-                      gap: 6,
-                      borderBottom:
-                        i < dhcp.leases.length - 1
-                          ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                          : "none",
-                      font: "400 12px var(--font-sans)",
-                    }}
-                  >
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text)",
-                        fontSize: 11.5,
-                      }}
-                    >
-                      {l.ip}
-                    </span>
-                    <span style={{ minWidth: 0 }}>
-                      <div
-                        style={{
-                          color: "var(--text)",
-                          fontWeight: 500,
-                          fontSize: 12,
-                        }}
-                      >
-                        {l.name}
-                      </div>
-                      <div
-                        className="mono"
-                        style={{
-                          color: "var(--text-mute)",
-                          fontSize: 10,
-                        }}
-                      >
-                        {l.mac} · {l.server}
-                      </div>
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: l.static
-                          ? "var(--accent-cyan)"
-                          : "var(--text-mute)",
-                        fontSize: 11,
-                        textAlign: "right",
-                      }}
-                    >
-                      {l.static ? "static" : l.exp}
-                    </span>
-                    <span style={{ color: "var(--text-mute)" }}>
-                      {l.static ? <Pin size={11} /> : <Plus size={11} />}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+        </>
       )}
 
       {/* Quick actions footer — router-page.jsx lines 203-216 */}
@@ -834,3 +419,448 @@ export const DEFAULT_ROUTER_FOOTER_ACTIONS: RouterHeaderAction[] = [
   { label: "Export .rsc", icon: ServerCog },
   { label: "Apply staged changes", icon: Check, primary: true },
 ];
+
+// ── Panel components ──────────────────────────────────────────────────────
+// Extracted so vendor wrappers can compose them per active tab (e.g. pfSense
+// hash subroutes). The default RouterPage layout uses them together.
+
+export type RouterInterfacesPanelProps = {
+  interfaces: RouterInterfaceRow[];
+  interfacesTotalsLabel?: string;
+  onAddInterface?: () => void;
+  onFilterInterface?: () => void;
+};
+
+export function RouterInterfacesPanel({
+  interfaces,
+  interfacesTotalsLabel,
+  onAddInterface,
+  onFilterInterface,
+}: RouterInterfacesPanelProps) {
+  return (
+    <div className="card" style={{ padding: 0 }} data-testid="router-panel-interfaces">
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">Interfaces</h3>
+          {interfacesTotalsLabel && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {interfacesTotalsLabel}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={onFilterInterface}
+          >
+            <Filter size={11} />
+            <span>Type · all</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            onClick={onAddInterface}
+          >
+            <Plus size={11} />
+            <span>Add</span>
+          </button>
+        </div>
+      </div>
+      <div style={IFACE_HEADER_STYLE}>
+        <span>State</span>
+        <span>Interface</span>
+        <span>Type</span>
+        <span>IP / role</span>
+        <span>MAC</span>
+        <span>MTU</span>
+        <span style={{ textAlign: "right" }}>RX GB</span>
+        <span style={{ textAlign: "right" }}>TX GB</span>
+        <span>24h</span>
+        <span />
+      </div>
+      {interfaces.map((it, i) => (
+        <div
+          key={it.name}
+          style={{
+            display: "grid",
+            gridTemplateColumns: IFACE_GRID,
+            padding: "8px 14px",
+            alignItems: "center",
+            borderBottom:
+              i < interfaces.length - 1
+                ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                : "none",
+            background: !it.running
+              ? "rgba(251,113,133,0.03)"
+              : "transparent",
+            font: "400 12.5px var(--font-sans)",
+          }}
+        >
+          <span>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 5,
+                font: "600 9px var(--font-sans)",
+                letterSpacing: "0.06em",
+                padding: "1px 6px",
+                borderRadius: 2,
+                background: it.running
+                  ? "rgba(74,222,128,0.10)"
+                  : "var(--surface-2)",
+                color: it.running ? "#4ade80" : "var(--text-mute)",
+                border: `var(--hairline) solid ${
+                  it.running
+                    ? "rgba(74,222,128,0.30)"
+                    : "rgba(96,144,212,0.20)"
+                }`,
+              }}
+            >
+              <span
+                style={{
+                  width: 4,
+                  height: 4,
+                  borderRadius: 2,
+                  background: it.running ? "#4ade80" : "#fb7185",
+                }}
+              />
+              {it.running ? "UP" : "DOWN"}
+            </span>
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text)", fontWeight: 500 }}
+          >
+            {it.name}
+          </span>
+          <span>{ifaceTypeBadge(it.type)}</span>
+          <span style={{ minWidth: 0 }}>
+            <div
+              className="mono"
+              style={{ color: "var(--text-dim)", fontSize: 11.5 }}
+            >
+              {it.ip}
+            </div>
+            {it.role !== "—" && it.role !== "" && (
+              <div
+                style={{
+                  font: "500 10px var(--font-sans)",
+                  color: "var(--accent-cyan)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                {it.role}
+              </div>
+            )}
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text-mute)", fontSize: 11 }}
+          >
+            {it.mac}
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text-mute)", fontSize: 11 }}
+          >
+            {it.mtu}
+          </span>
+          <span
+            className="mono"
+            style={{ textAlign: "right", color: "var(--text)" }}
+          >
+            {it.rx.toFixed(1)}
+          </span>
+          <span
+            className="mono"
+            style={{ textAlign: "right", color: "var(--text-dim)" }}
+          >
+            {it.tx.toFixed(1)}
+          </span>
+          <span>
+            <Spark
+              data={gen(20, 30 + it.rx / 5, 18)}
+              width={70}
+              height={20}
+              color={it.running ? "#38bdf8" : "var(--text-mute)"}
+            />
+          </span>
+          <span
+            style={{
+              color: "var(--text-mute)",
+              display: "flex",
+              justifyContent: "flex-end",
+            }}
+          >
+            <ChevronRight size={12} />
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export type RouterFirewallPanelProps = {
+  firewall: NonNullable<RouterPageProps["firewall"]>;
+};
+
+export function RouterFirewallPanel({ firewall }: RouterFirewallPanelProps) {
+  return (
+    <div className="card" style={{ padding: 0 }} data-testid="router-panel-firewall">
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">Firewall rules</h3>
+          {firewall.label && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {firewall.label}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-primary"
+          onClick={firewall.onAdd}
+        >
+          <Plus size={11} />
+          <span>New rule</span>
+        </button>
+      </div>
+      <div
+        style={{
+          borderTop: "var(--hairline) solid rgba(96,144,212,0.20)",
+        }}
+      >
+        {firewall.rules.map((r, i) => (
+          <div
+            key={`${r.idx}-${r.chain}-${r.src}-${r.dst}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: FW_GRID,
+              padding: "7px 14px",
+              alignItems: "center",
+              gap: 8,
+              borderBottom:
+                i < firewall.rules.length - 1
+                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                  : "none",
+              font: "400 12px var(--font-sans)",
+              opacity: r.enabled ? 1 : 0.55,
+            }}
+          >
+            <span style={{ color: "var(--text-faint)", cursor: "grab" }}>
+              ⋮⋮
+            </span>
+            <span
+              className="mono"
+              style={{ color: "var(--text-mute)", fontSize: 11 }}
+            >
+              {r.idx}
+            </span>
+            <span
+              style={{
+                font: "500 10.5px var(--font-mono)",
+                color: "var(--text-dim)",
+              }}
+            >
+              {r.chain}
+            </span>
+            <span>{actionBadge(r.action)}</span>
+            <span
+              className="mono"
+              style={{ color: "var(--text-dim)", fontSize: 11 }}
+            >
+              {r.src}
+            </span>
+            <span
+              className="mono"
+              style={{ color: "var(--text-dim)", fontSize: 11 }}
+            >
+              {r.dst}
+            </span>
+            <span
+              style={{
+                color: "var(--text-mute)",
+                fontSize: 11.5,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {r.comment}
+            </span>
+            <span
+              className="mono"
+              style={{
+                textAlign: "right",
+                color:
+                  r.action === "fasttrack" || r.action === "accept"
+                    ? "var(--text)"
+                    : "#fbbf24",
+                fontSize: 11,
+              }}
+            >
+              {r.hits}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export type RouterDhcpPanelProps = {
+  dhcp: NonNullable<RouterPageProps["dhcp"]>;
+};
+
+export function RouterDhcpPanel({ dhcp }: RouterDhcpPanelProps) {
+  return (
+    <div className="card" style={{ padding: 0 }} data-testid="router-panel-dhcp">
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">DHCP leases</h3>
+          {dhcp.label && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {dhcp.label}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={dhcp.onFilter}
+        >
+          <Filter size={11} />
+        </button>
+      </div>
+      <div
+        style={{
+          borderTop: "var(--hairline) solid rgba(96,144,212,0.20)",
+        }}
+      >
+        {dhcp.leases.map((l, i) => (
+          <div
+            key={`${l.ip}-${l.mac}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: DHCP_GRID,
+              padding: "8px 14px",
+              alignItems: "center",
+              gap: 6,
+              borderBottom:
+                i < dhcp.leases.length - 1
+                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                  : "none",
+              font: "400 12px var(--font-sans)",
+            }}
+          >
+            <span
+              className="mono"
+              style={{ color: "var(--text)", fontSize: 11.5 }}
+            >
+              {l.ip}
+            </span>
+            <span style={{ minWidth: 0 }}>
+              <div
+                style={{
+                  color: "var(--text)",
+                  fontWeight: 500,
+                  fontSize: 12,
+                }}
+              >
+                {l.name}
+              </div>
+              <div
+                className="mono"
+                style={{ color: "var(--text-mute)", fontSize: 10 }}
+              >
+                {l.mac} · {l.server}
+              </div>
+            </span>
+            <span
+              className="mono"
+              style={{
+                color: l.static ? "var(--accent-cyan)" : "var(--text-mute)",
+                fontSize: 11,
+                textAlign: "right",
+              }}
+            >
+              {l.static ? "static" : l.exp}
+            </span>
+            <span style={{ color: "var(--text-mute)" }}>
+              {l.static ? <Pin size={11} /> : <Plus size={11} />}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/useHashTab.ts
+++ b/web/src/hooks/useHashTab.ts
@@ -1,10 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Like useState, but syncs the active tab value with the URL hash.
- * Opening /page#tab-name activates that tab; clicking a tab updates the hash.
+ *
+ * Behavior:
+ *   - On mount, if the URL hash matches a valid value, that tab is selected.
+ *     If the hash is non-empty but invalid, it is cleared (replaced) so the
+ *     default tab is shown and the URL no longer carries a broken anchor.
+ *   - Calling `setTab` pushes a new history entry so browser back/forward
+ *     navigates between tab selections.
+ *   - Browser back/forward fires `hashchange`, which re-reads the hash and
+ *     updates state to match.
  */
 export function useHashTab<T extends string>(
   defaultValue: T,
@@ -12,31 +20,61 @@ export function useHashTab<T extends string>(
 ): [T, (value: string) => void] {
   const [tab, setTabState] = useState<T>(defaultValue);
 
-  // On mount, read hash from URL
+  // Keep the latest validValues + default in refs so we don't re-subscribe
+  // every render (the caller often passes a fresh array each render).
+  const validRef = useRef<T[] | undefined>(validValues);
+  validRef.current = validValues;
+  const defaultRef = useRef<T>(defaultValue);
+  defaultRef.current = defaultValue;
+
+  const isValid = useCallback((candidate: string): candidate is T => {
+    const list = validRef.current;
+    if (!list) return candidate.length > 0;
+    return list.includes(candidate as T);
+  }, []);
+
+  // Initial read of the hash, plus invalid-hash cleanup.
   useEffect(() => {
     const hash = window.location.hash.slice(1);
-    if (hash && (!validValues || validValues.includes(hash as T))) {
+    if (hash && isValid(hash)) {
       setTabState(hash as T);
+    } else if (hash) {
+      // Invalid hash → strip it without adding a history entry so the
+      // default tab loads cleanly.
+      window.history.replaceState(
+        null,
+        "",
+        window.location.pathname + window.location.search,
+      );
+      setTabState(defaultRef.current);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isValid]);
 
-  const setTab = useCallback((value: string) => {
-    setTabState(value as T);
-    window.history.replaceState(null, "", `#${value}`);
-  }, []);
+  const setTab = useCallback(
+    (value: string) => {
+      const next = isValid(value) ? (value as T) : defaultRef.current;
+      setTabState(next);
+      const currentHash = window.location.hash.slice(1);
+      if (currentHash === next) return;
+      // pushState so browser back/forward steps through tab selections.
+      window.history.pushState(null, "", `#${next}`);
+    },
+    [isValid],
+  );
 
-  // Listen for hash changes (browser back/forward)
+  // Listen for hash changes (browser back/forward).
   useEffect(() => {
     const onHashChange = () => {
       const hash = window.location.hash.slice(1);
-      if (hash && (!validValues || validValues.includes(hash as T))) {
+      if (hash && isValid(hash)) {
         setTabState(hash as T);
+      } else if (!hash) {
+        setTabState(defaultRef.current);
       }
     };
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, [validValues]);
+  }, [isValid]);
 
   return [tab, setTab];
 }

--- a/web/tests/e2e/pfsense-hash-subroutes.spec.ts
+++ b/web/tests/e2e/pfsense-hash-subroutes.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * E2E coverage for pfSense router page hash subroutes (#806).
+ *
+ * Verifies:
+ *   - Direct navigation to `/router/pfsense#<tab>` renders the matching panel.
+ *   - Clicking a tab updates `location.hash` and swaps the visible panel.
+ *   - Browser back/forward navigates between previously-selected tabs.
+ *   - Invalid hashes (#bogus) fall back to the default tab and clean the URL.
+ */
+
+const HASH_TABS = [
+  "system",
+  "interfaces",
+  "firewall",
+  "dhcp",
+  "dns",
+  "services",
+  "routing",
+  "config",
+] as const;
+
+async function mockPfsenseApis(page: Page) {
+  // Generic catch-all for any pfSense endpoint we don't explicitly mock.
+  await page.route("**/api/v1/pfsense/**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+
+  await page.route("**/api/v1/settings", (route) =>
+    route.fulfill({
+      json: {
+        mikrotik_enabled: false,
+        pfsense_enabled: true,
+        xiaomi_mesh_enabled: false,
+        default_router: "pfsense",
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/status", (route) =>
+    route.fulfill({
+      json: {
+        configured: true,
+        reachable: true,
+        hostname: "pfsense-test",
+        domain: "example.lan",
+        version: "2.7.0",
+        uptime: "1d 02:03",
+        cpu_usage: 7,
+        memory_total: 8 * 1024 * 1024 * 1024,
+        memory_used: 2 * 1024 * 1024 * 1024,
+        platform: "pfSense",
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/interfaces", (route) =>
+    route.fulfill({
+      json: [
+        {
+          name: "wan",
+          descr: "WAN",
+          iface_type: "ethernet",
+          status: "up",
+          ip_address: "203.0.113.5",
+          subnet: "24",
+          mac: "aa:bb:cc:dd:ee:01",
+          mtu: 1500,
+          media: "1000baseT",
+        },
+        {
+          name: "lan",
+          descr: "LAN",
+          iface_type: "ethernet",
+          status: "up",
+          ip_address: "192.168.1.1",
+          subnet: "24",
+          mac: "aa:bb:cc:dd:ee:02",
+          mtu: 1500,
+          media: "1000baseT",
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/firewall/rules", (route) =>
+    route.fulfill({
+      json: [
+        {
+          id: "1",
+          action: "pass",
+          interface: "wan",
+          protocol: "tcp",
+          source: "any",
+          destination: "192.168.1.1",
+          port: "443",
+          description: "Allow HTTPS",
+          disabled: false,
+          log: false,
+          tracker: "100",
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/dhcp/leases", (route) =>
+    route.fulfill({
+      json: [
+        {
+          ip: "192.168.1.100",
+          mac: "aa:bb:cc:dd:ee:10",
+          hostname: "client-1",
+          start: "2026-05-20T10:00:00Z",
+          end: "2026-05-21T10:00:00Z",
+          status: "active",
+          interface: "lan",
+        },
+      ],
+    }),
+  );
+}
+
+test.describe("pfSense hash subroutes (#806)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await mockPfsenseApis(page);
+  });
+
+  test("direct navigation to each hash route renders the matching panel", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    for (const tab of HASH_TABS) {
+      await page.goto(`/router/pfsense/#${tab}`);
+      await expect(page.getByTestId("router-page").first()).toBeVisible({
+        timeout: 30_000,
+      });
+      // Active tab has aria-selected=true
+      await expect(page.getByTestId(`router-tab-${tab}`)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      // Matching panel is rendered
+      await expect(page.getByTestId(`router-tabpanel-${tab}`)).toBeVisible();
+      // Other panels are NOT in the DOM
+      for (const other of HASH_TABS) {
+        if (other === tab) continue;
+        await expect(
+          page.getByTestId(`router-tabpanel-${other}`),
+        ).toHaveCount(0);
+      }
+    }
+    await page.screenshot({
+      path: "tests/screenshots/pfsense-hash-subroutes-final.png",
+      fullPage: true,
+    });
+  });
+
+  test("clicking a tab updates the hash and swaps the visible panel", async ({
+    page,
+  }) => {
+    await page.goto("/router/pfsense/");
+    await expect(page.getByTestId("router-page").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("router-tabpanel-system")).toBeVisible();
+
+    await page.getByTestId("router-tab-firewall").click();
+    await expect(page).toHaveURL(/#firewall$/);
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible();
+    await expect(page.getByTestId("router-tabpanel-system")).toHaveCount(0);
+
+    await page.getByTestId("router-tab-dhcp").click();
+    await expect(page).toHaveURL(/#dhcp$/);
+    await expect(page.getByTestId("router-tabpanel-dhcp")).toBeVisible();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toHaveCount(0);
+  });
+
+  test("browser back/forward navigates between tabs", async ({ page }) => {
+    await page.goto("/router/pfsense/");
+    await expect(page.getByTestId("router-page").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByTestId("router-tab-interfaces").click();
+    await expect(page).toHaveURL(/#interfaces$/);
+    await expect(
+      page.getByTestId("router-tabpanel-interfaces"),
+    ).toBeVisible();
+
+    await page.getByTestId("router-tab-firewall").click();
+    await expect(page).toHaveURL(/#firewall$/);
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible();
+
+    // Back → interfaces
+    await page.goBack();
+    await expect(page).toHaveURL(/#interfaces$/);
+    await expect(
+      page.getByTestId("router-tabpanel-interfaces"),
+    ).toBeVisible();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toHaveCount(0);
+
+    // Forward → firewall
+    await page.goForward();
+    await expect(page).toHaveURL(/#firewall$/);
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible();
+    await expect(
+      page.getByTestId("router-tabpanel-interfaces"),
+    ).toHaveCount(0);
+  });
+
+  test("invalid hash falls back to the default tab and cleans the URL", async ({
+    page,
+  }) => {
+    await page.goto("/router/pfsense/#bogus-not-a-tab");
+    await expect(page.getByTestId("router-page").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    // Default tab is "system"
+    await expect(page.getByTestId("router-tabpanel-system")).toBeVisible();
+    await expect(page.getByTestId("router-tab-system")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    // URL should no longer carry the bogus hash
+    await expect(page).not.toHaveURL(/#bogus-not-a-tab/);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the Interfaces / Firewall / DHCP cards from `RouterPage` into exported `Router{Interfaces,Firewall,Dhcp}Panel` components and add an optional `tabPanels` slot so vendor wrappers can swap panel content per active tab without losing the header, stats, tabs, or footer chrome. Default behavior (Mikrotik / Xiaomi) is unchanged.
- Rebuild `PfSenseRouterDesign` to compose `tabPanels` per `activeTab`, reusing the existing pfSense tab components (System / DNS / Services / Routing / Config) and the new literal-port panels for Interfaces / Firewall / DHCP.
- Fix `useHashTab` to push a history entry on tab change (so browser back/forward step through previously-selected tabs), keep listening for `hashchange`, and replace invalid hashes with the default tab while cleaning up the URL.

## Why
The pfSense page rendered all panels at once and `useHashTab` only used `replaceState`, so neither direct hash navigation nor browser back/forward swapped sections. With the fix, `/router/pfsense#firewall` renders only the firewall panel, tab clicks update the hash, back/forward navigates between tabs, and `#bogus-hash` falls back to System without breaking state.

## Commands run
```
cd web
bun install --frozen-lockfile
bunx tsc --noEmit                          # clean
bun run test                               # 15 files / 66 tests passed
bun run build                              # build OK; /router/pfsense static
bunx playwright test pfsense-hash-subroutes router-literal-port dhcp-tabs --list  # 11 tests listed
cargo check                                # OK (no Rust changes)
```

## Test plan
- [x] Direct nav to `/router/pfsense#<tab>` for system / interfaces / firewall / dhcp / dns / services / routing / config renders only the matching panel.
- [x] Clicking each tab updates `location.hash` and swaps the visible panel.
- [x] Browser back/forward navigates between previously-selected tabs.
- [x] `#bogus-not-a-tab` falls back to the default `system` tab and cleans the URL.
- [x] Existing `router-literal-port` MikroTik/pfSense/Xiaomi assertions still hold (tab strip + header are present).

Refs #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes pfSense hash-based tab navigation by switching `useHashTab` from `replaceState` to `pushState` (enabling browser back/forward), adding invalid-hash cleanup on mount, and extracting the Interfaces/Firewall/DHCP panels from `RouterPage` into individually exported components. It also rebuilds `PfSenseRouterDesign` to compose a per-active-tab `tabPanels` slot so only the relevant panel is rendered for each hash route, while leaving all other router consumers unchanged.

- `useHashTab` now pushes history entries on tab change and listens for `hashchange` to sync back/forward navigation; invalid hashes are stripped on mount via `replaceState`.
- `RouterPage` gains three exported panel components (`RouterInterfacesPanel`, `RouterFirewallPanel`, `RouterDhcpPanel`) and an optional `tabPanels` slot that replaces the default layout when supplied.
- A new Playwright E2E spec covers all four scenarios: direct hash navigation, tab-click URL updates, back/forward traversal, and invalid-hash fallback.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are scoped to pfSense's design wrapper and a shared hook, with no impact on other router consumers.

The hook rewrite and panel extraction are structurally sound. Two minor gaps exist: the `hashchange` handler doesn't clean up or reset state for invalid non-empty hashes that arrive after mount (e.g. manual URL edits), and `PfSenseRouterDesign` forwards `interfaces`/`firewall`/`dhcp` props to `RouterPage` where they're never consumed when `tabPanels` overrides the layout. Neither affects the documented behaviour or existing consumers.

web/src/hooks/useHashTab.ts — the hashchange handler's handling of invalid non-empty hashes after mount.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/hooks/useHashTab.ts | Rewrites hook to push history entries on tab change and listen for hashchange; mount-time cleanup of invalid hashes is correct, but the hashchange handler leaves a gap for invalid non-empty hashes that arrive via manual URL edits. |
| web/src/components/router/PfSenseRouterDesign.tsx | Adds per-tab panel switching via tabPanels IIFE; still forwards interfaces/firewall/dhcp props to RouterPage where they have no effect when tabPanels is present. |
| web/src/components/router/RouterPage.tsx | Extracts RouterInterfacesPanel, RouterFirewallPanel, RouterDhcpPanel as exported components and adds the optional tabPanels slot; default rendering path for existing consumers is unchanged. |
| web/tests/e2e/pfsense-hash-subroutes.spec.ts | New E2E spec covering direct hash navigation, tab-click hash update, browser back/forward, and invalid-hash fallback; mocking is comprehensive and test assertions are correct. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/components/router/PfSenseRouterDesign.tsx`, line 288-313 ([link](https://github.com/befeast/panoptikon/blob/a63f1e0a727bd44bc5f3a2493d3591daeb1a4aae/web/src/components/router/PfSenseRouterDesign.tsx#L288-L313)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Dead props alongside `tabPanels`**

   `interfaces`, `interfacesTotalsLabel`, `firewall`, and `dhcp` are still forwarded to `RouterPage` even though `tabPanels` is always non-`undefined` for pfSense, making `RouterPage` skip the default panels entirely. These four props are used only in that default rendering path, so the values passed here are computed but never consumed. They could be dropped from the `RouterPage` call site to make the intent of the slot override clearer, or left as documentation/fallback — but as written they silently do nothing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/components/router/PfSenseRouterDesign.tsx
   Line: 288-313

   Comment:
   **Dead props alongside `tabPanels`**

   `interfaces`, `interfacesTotalsLabel`, `firewall`, and `dhcp` are still forwarded to `RouterPage` even though `tabPanels` is always non-`undefined` for pfSense, making `RouterPage` skip the default panels entirely. These four props are used only in that default rendering path, so the values passed here are computed but never consumed. They could be dropped from the `RouterPage` call site to make the intent of the slot override clearer, or left as documentation/fallback — but as written they silently do nothing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/hooks/useHashTab.ts:66-77
**`hashchange` ignores invalid non-empty hashes**

The `onHashChange` handler only handles a valid hash or an empty hash. If the URL somehow carries an invalid non-empty fragment (e.g. the user types `#bogus` in the address bar, or a manually-crafted link is followed), the handler is a silent no-op: the tab state stays on whatever was last active while the URL shows the bogus hash, creating a mismatch between the displayed panel and the URL. The mount effect already has the correct cleanup pattern with `replaceState` + `setTabState(defaultRef.current)` — adding the same `else` branch here would make the runtime behaviour consistent.

### Issue 2 of 2
web/src/components/router/PfSenseRouterDesign.tsx:288-313
**Dead props alongside `tabPanels`**

`interfaces`, `interfacesTotalsLabel`, `firewall`, and `dhcp` are still forwarded to `RouterPage` even though `tabPanels` is always non-`undefined` for pfSense, making `RouterPage` skip the default panels entirely. These four props are used only in that default rendering path, so the values passed here are computed but never consumed. They could be dropped from the `RouterPage` call site to make the intent of the slot override clearer, or left as documentation/fallback — but as written they silently do nothing.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pfsense): swap panels on hash subrou..."](https://github.com/befeast/panoptikon/commit/a63f1e0a727bd44bc5f3a2493d3591daeb1a4aae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33291172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->