### PR TITLE
fix: render Xiaomi mesh nodes with real names (#807)

### DIFF
--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -75,6 +75,18 @@ pub struct XiaomiTopoNodeResponse {
     pub online: Option<i32>,
     pub hardware: Option<String>,
     pub model: Option<String>,
+    /// Logical role within the mesh: "main" for the CAP router, "satellite" for
+    /// downstream nodes. Lets the frontend label nodes without re-deriving role.
+    #[serde(default)]
+    pub role: Option<String>,
+    /// True for the CAP/main router, false for satellites. Mirrors `role` for
+    /// callers that prefer a boolean check.
+    #[serde(default)]
+    pub is_main: bool,
+    /// Backhaul connection type from the Xiaomi `link_type` field: "wired",
+    /// "wireless", or `None` for the main router.
+    #[serde(default)]
+    pub backhaul: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -263,6 +275,28 @@ fn parse_online_value(v: &serde_json::Value) -> Option<i32> {
     }
 }
 
+/// Xiaomi mesh nodes that were never customized in the router admin UI come
+/// back with `name: "default"`. Treat that — along with empty/whitespace — as
+/// "no user-set name" so the frontend can fall back to locale/role/IP instead
+/// of rendering a wall of indistinguishable `default` labels (issue #807).
+pub(crate) fn sanitize_mesh_name(raw: Option<String>) -> Option<String> {
+    raw.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+/// Locale on satellite mesh nodes is the user-set room/location ("Live Studio",
+/// "Basement"). Apply the same "default" sanitization so role-coded locales
+/// like `master`/`slave` survive while the placeholder string does not.
+pub(crate) fn sanitize_mesh_locale(raw: Option<String>) -> Option<String> {
+    sanitize_mesh_name(raw)
+}
+
 /// GET /xiaomi/topology — mesh topology graph (no auth required).
 pub async fn topology(
     State(state): State<AppState>,
@@ -289,14 +323,23 @@ pub async fn topology(
             let mut nodes: Vec<XiaomiTopoNodeResponse> = graph
                 .nodes
                 .into_iter()
-                .map(|n| XiaomiTopoNodeResponse {
-                    mac: n.mac,
-                    name: n.name,
-                    locale: n.locale,
-                    ip: n.ip,
-                    online: n.online,
-                    hardware: n.hardware,
-                    model: n.model,
+                .enumerate()
+                .map(|(idx, n)| {
+                    let locale = sanitize_mesh_locale(n.locale);
+                    // `nodes[0]` is the CAP/main router; the rest are satellites.
+                    let is_main = idx == 0;
+                    XiaomiTopoNodeResponse {
+                        mac: n.mac,
+                        name: sanitize_mesh_name(n.name),
+                        locale: locale.clone(),
+                        ip: n.ip,
+                        online: n.online,
+                        hardware: n.hardware,
+                        model: n.model,
+                        role: Some(if is_main { "main" } else { "satellite" }.to_string()),
+                        is_main,
+                        backhaul: None,
+                    }
                 })
                 .collect();
 
@@ -312,32 +355,43 @@ pub async fn topology(
                     let main_online = graph.online.as_ref().and_then(parse_online_value);
                     nodes.push(XiaomiTopoNodeResponse {
                         mac: None,
-                        name: graph.name,
-                        locale: graph.locale,
+                        name: sanitize_mesh_name(graph.name),
+                        locale: sanitize_mesh_locale(graph.locale),
                         ip: graph.ip,
                         online: main_online,
                         hardware: graph.hardware,
                         model: None,
+                        role: Some("main".to_string()),
+                        is_main: true,
+                        backhaul: None,
                     });
                 }
 
                 // Promote satellite leafs (those with link_type) to nodes.
                 for leaf in graph.leafs {
-                    if leaf.link_type.is_some() {
+                    if let Some(link_type) = leaf.link_type.as_deref() {
+                        let backhaul = match link_type {
+                            "wire" | "wired" => "wired".to_string(),
+                            "" => "unknown".to_string(),
+                            other => other.to_string(),
+                        };
                         nodes.push(XiaomiTopoNodeResponse {
                             mac: leaf.mac,
-                            name: leaf.name,
-                            locale: leaf.locale,
+                            name: sanitize_mesh_name(leaf.name),
+                            locale: sanitize_mesh_locale(leaf.locale),
                             ip: leaf.ip,
                             online: leaf.online,
                             hardware: leaf.hardware,
                             model: None,
+                            role: Some("satellite".to_string()),
+                            is_main: false,
+                            backhaul: Some(backhaul),
                         });
                     } else {
                         leafs_out.push(XiaomiTopoLeafResponse {
                             mac: leaf.mac,
                             ip: leaf.ip,
-                            name: leaf.name,
+                            name: sanitize_mesh_name(leaf.name),
                             online: leaf.online,
                             parent_id: leaf.parent_id,
                         });
@@ -350,7 +404,7 @@ pub async fn topology(
                     .map(|l| XiaomiTopoLeafResponse {
                         mac: l.mac,
                         ip: l.ip,
-                        name: l.name,
+                        name: sanitize_mesh_name(l.name),
                         online: l.online,
                         parent_id: l.parent_id,
                     })
@@ -852,6 +906,56 @@ mod tests {
             result.len(),
             2,
             "different SSIDs on same band must both survive"
+        );
+    }
+
+    // ── sanitize_mesh_name / locale ─────────────────────────────
+    //
+    // Regression for #807: Xiaomi mesh satellites that were never renamed in
+    // the router admin come back with `name: "default"`. Returning that
+    // verbatim to the UI made every satellite render as the literal string
+    // "default". The sanitizer drops "default"/empty/whitespace so the
+    // frontend can fall back to a real identifier.
+
+    #[test]
+    fn sanitize_drops_literal_default() {
+        assert_eq!(sanitize_mesh_name(Some("default".to_string())), None);
+        assert_eq!(sanitize_mesh_name(Some("DEFAULT".to_string())), None);
+        assert_eq!(sanitize_mesh_name(Some("Default".to_string())), None);
+    }
+
+    #[test]
+    fn sanitize_drops_empty_and_whitespace() {
+        assert_eq!(sanitize_mesh_name(None), None);
+        assert_eq!(sanitize_mesh_name(Some(String::new())), None);
+        assert_eq!(sanitize_mesh_name(Some("   ".to_string())), None);
+        assert_eq!(sanitize_mesh_name(Some("\t".to_string())), None);
+    }
+
+    #[test]
+    fn sanitize_preserves_real_names() {
+        assert_eq!(
+            sanitize_mesh_name(Some("Live Studio".to_string())),
+            Some("Live Studio".to_string())
+        );
+        assert_eq!(
+            sanitize_mesh_name(Some("  Basement  ".to_string())),
+            Some("Basement".to_string()),
+            "trims surrounding whitespace"
+        );
+    }
+
+    #[test]
+    fn sanitize_locale_keeps_role_strings() {
+        // `locale` on the older firmware encodes the mesh role
+        // (master/slave). Those are meaningful and must survive.
+        assert_eq!(
+            sanitize_mesh_locale(Some("master".to_string())),
+            Some("master".to_string())
+        );
+        assert_eq!(
+            sanitize_mesh_locale(Some("slave".to_string())),
+            Some("slave".to_string())
         );
     }
 }

--- a/web/src/components/XiaomiMeshTopology.tsx
+++ b/web/src/components/XiaomiMeshTopology.tsx
@@ -1,179 +1,111 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  Crown,
-  MonitorSmartphone,
-  RefreshCw,
-  Router,
-  Wifi,
-} from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Crown, RefreshCw, Router, Wifi, Cable } from "lucide-react";
 import { fetchXiaomiTopology } from "@/lib/api";
 import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types";
 
-// ─── Helpers ─────────────────────────────────────────────
-
-/** Get leafs attached to a given node MAC. */
-function leafsForNode(
-  nodeMac: string | null,
-  leafs: XiaomiTopoLeaf[],
-): XiaomiTopoLeaf[] {
-  if (!nodeMac) return [];
-  return leafs.filter((l) => l.parent_id === nodeMac);
+// ─── Name resolution ─────────────────────────────────────
+//
+// Issue #807: Xiaomi mesh satellites that were never renamed in the router
+// admin send `name: "default"`. The backend now strips that placeholder, so
+// `node.name` arrives as `null` when the user has not customized it. Resolve
+// to the next most-specific identifier instead of rendering a wall of
+// "Mesh Node" cards.
+function resolveNodeLabel(node: XiaomiTopoNode, fallbackIndex: number): string {
+  const candidates = [node.name, node.locale, node.ip, node.mac];
+  for (const c of candidates) {
+    if (c && c.trim()) return c;
+  }
+  return node.is_main ? "Main Router" : `Satellite ${fallbackIndex + 1}`;
 }
 
-// ─── Node Card ───────────────────────────────────────────
+function resolveLeafLabel(leaf: XiaomiTopoLeaf): string {
+  const candidates = [leaf.name, leaf.ip, leaf.mac];
+  for (const c of candidates) {
+    if (c && c.trim()) return c;
+  }
+  return "Unknown";
+}
 
-function NodeCard({
-  node,
-  leafs,
-  isMain,
-}: {
+function roleLabel(node: XiaomiTopoNode): string {
+  if (node.is_main || node.role === "main") return "Main";
+  const backhaul = (node.backhaul || "").toLowerCase();
+  if (backhaul === "wired" || backhaul === "wire") return "Satellite · Wired";
+  if (backhaul === "wireless" || backhaul === "wifi") return "Satellite · Wi-Fi";
+  // Legacy locale-as-role fallback ("master"/"slave" from older firmware).
+  if (node.locale && node.locale.trim()) {
+    return `Satellite · ${node.locale}`;
+  }
+  return "Satellite";
+}
+
+// ─── SVG layout ──────────────────────────────────────────
+//
+// Compact radial layout: main router at center, satellites arranged on a ring
+// around it. Tuned for the topology-page Mesh tab (lives inside a scroll
+// container, so we cap height around 480px) but the viewBox scales.
+
+const VIEW_W = 720;
+const VIEW_H = 480;
+const CENTER_X = VIEW_W / 2;
+const CENTER_Y = VIEW_H / 2;
+const SAT_RING_R = 160;
+const MAIN_RECT_W = 168;
+const MAIN_RECT_H = 64;
+const SAT_RECT_W = 148;
+const SAT_RECT_H = 58;
+
+interface PositionedNode {
   node: XiaomiTopoNode;
+  x: number;
+  y: number;
   leafs: XiaomiTopoLeaf[];
-  isMain: boolean;
-}) {
-  const connectedLeafs = leafsForNode(node.mac, leafs);
-  const onlineDevices = node.online ?? 0;
-
-  return (
-    <Card className={isMain ? "ring-1 ring-[#fbbf24]/30" : undefined}>
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-3">
-          <div
-            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
-              isMain ? "bg-[#fbbf24]/20" : "bg-mesh-primary/20"
-            }`}
-          >
-            {isMain ? (
-              <Crown className="h-5 w-5 text-[#fbbf24]" />
-            ) : (
-              <Router className="h-5 w-5 text-mesh-primary" />
-            )}
-          </div>
-          <div className="min-w-0 flex-1">
-            <CardTitle className="truncate text-sm font-semibold text-mesh-text">
-              {node.locale || node.name || "Mesh Node"}
-            </CardTitle>
-            <p className="truncate font-mono text-xs text-mesh-text-dim">
-              {node.ip || "No IP"}
-            </p>
-          </div>
-          <span
-            className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
-              node.ip
-                ? "bg-[#4ade80] shadow-[0_0_6px_rgba(74,222,128,0.5)]"
-                : "bg-mesh-text-mute"
-            }`}
-          />
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {/* Stats row */}
-        <div className="flex flex-wrap items-center gap-3 text-xs text-mesh-text-dim">
-          <span className="flex items-center gap-1.5">
-            <MonitorSmartphone className="h-3.5 w-3.5" />
-            {onlineDevices} device{onlineDevices !== 1 ? "s" : ""} online
-          </span>
-          {connectedLeafs.length > 0 && (
-            <span className="flex items-center gap-1.5">
-              <Wifi className="h-3.5 w-3.5" />
-              {connectedLeafs.length} connected
-            </span>
-          )}
-        </div>
-
-        {/* Badges */}
-        <div className="flex flex-wrap items-center gap-1.5">
-          {node.model && (
-            <Badge
-              variant="outline"
-              className="border-mesh-border-strong text-[10px] text-mesh-text-mute"
-            >
-              {node.model}
-            </Badge>
-          )}
-          {node.hardware && node.hardware !== node.model && (
-            <Badge
-              variant="outline"
-              className="border-mesh-border-strong text-[10px] text-mesh-text-mute"
-            >
-              {node.hardware}
-            </Badge>
-          )}
-          {isMain && (
-            <Badge className="border-[#fbbf24]/20 bg-[#fbbf24]/10 text-[10px] text-[#fbbf24]">
-              Main Router
-            </Badge>
-          )}
-        </div>
-
-        {/* MAC address */}
-        {node.mac && (
-          <p className="font-mono text-[10px] text-mesh-text-mute">
-            MAC: {node.mac}
-          </p>
-        )}
-
-        {/* Connected devices list */}
-        {connectedLeafs.length > 0 && (
-          <div className="mt-2 space-y-1 border-t border-mesh-border-strong pt-2">
-            <p className="text-[10px] font-medium uppercase tracking-wider text-mesh-text-mute">
-              Connected Devices
-            </p>
-            <div className="max-h-32 space-y-0.5 overflow-y-auto">
-              {connectedLeafs.map((leaf) => (
-                <div
-                  key={leaf.mac || leaf.ip}
-                  className="flex items-center justify-between rounded px-1.5 py-0.5 text-[11px] hover:bg-mesh-surface-2"
-                >
-                  <span className="truncate text-mesh-text">
-                    {leaf.name || leaf.mac || "Unknown"}
-                  </span>
-                  <span className="shrink-0 font-mono text-mesh-text-mute">
-                    {leaf.ip || "—"}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
 }
 
-// ─── Loading skeleton ────────────────────────────────────
+function layoutTopology(
+  data: XiaomiTopology,
+): {
+  main: PositionedNode | null;
+  satellites: PositionedNode[];
+} {
+  const nodes = data.nodes;
+  if (nodes.length === 0) return { main: null, satellites: [] };
 
-function NodeCardSkeleton() {
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-10 w-10 rounded-lg" />
-          <div className="flex-1 space-y-2">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-3 w-20" />
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <Skeleton className="h-3 w-32" />
-        <div className="flex gap-1.5">
-          <Skeleton className="h-4 w-16 rounded-full" />
-          <Skeleton className="h-4 w-12 rounded-full" />
-        </div>
-      </CardContent>
-    </Card>
-  );
+  const mainIdx = nodes.findIndex((n) => n.is_main || n.role === "main");
+  const mainNode = mainIdx >= 0 ? nodes[mainIdx] : nodes[0];
+  const satNodes = nodes.filter((n) => n !== mainNode);
+
+  const leafsByParent = new Map<string, XiaomiTopoLeaf[]>();
+  for (const leaf of data.leafs) {
+    const key = leaf.parent_id ?? "";
+    const list = leafsByParent.get(key) ?? [];
+    list.push(leaf);
+    leafsByParent.set(key, list);
+  }
+  const leafsFor = (n: XiaomiTopoNode): XiaomiTopoLeaf[] => {
+    if (n.mac && leafsByParent.has(n.mac)) return leafsByParent.get(n.mac)!;
+    return [];
+  };
+
+  const main: PositionedNode = {
+    node: mainNode,
+    x: CENTER_X,
+    y: CENTER_Y,
+    leafs: leafsFor(mainNode),
+  };
+
+  const satellites: PositionedNode[] = satNodes.map((n, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(satNodes.length, 1) - Math.PI / 2;
+    return {
+      node: n,
+      x: CENTER_X + Math.cos(angle) * SAT_RING_R,
+      y: CENTER_Y + Math.sin(angle) * SAT_RING_R,
+      leafs: leafsFor(n),
+    };
+  });
+
+  return { main, satellites };
 }
 
 // ─── Main Component ──────────────────────────────────────
@@ -183,6 +115,7 @@ export default function XiaomiMeshTopology() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -199,31 +132,20 @@ export default function XiaomiMeshTopology() {
     }
   }, []);
 
-  // Initial load
   useEffect(() => {
     load();
   }, [load]);
 
-  // Poll every 30s
   useEffect(() => {
     const interval = setInterval(load, 30_000);
     return () => clearInterval(interval);
   }, [load]);
 
-  // Determine which node is "main" (first node, typically the primary router)
-  const { sortedNodes, mainMac } = useMemo(() => {
-    if (!data) return { sortedNodes: [], mainMac: null };
-    const main = data.nodes[0] ?? null;
-    const mainMac = main?.mac ?? null;
-    const sorted = [...data.nodes].sort((a, b) => {
-      if (a.mac === mainMac) return -1;
-      if (b.mac === mainMac) return 1;
-      return (b.online ?? 0) - (a.online ?? 0);
-    });
-    return { sortedNodes: sorted, mainMac };
-  }, [data]);
+  const layout = useMemo(
+    () => (data ? layoutTopology(data) : { main: null, satellites: [] }),
+    [data],
+  );
 
-  // Stats
   const stats = useMemo(() => {
     if (!data) return { nodeCount: 0, totalDevices: 0, totalLeafs: 0 };
     const totalDevices = data.nodes.reduce(
@@ -237,10 +159,14 @@ export default function XiaomiMeshTopology() {
     };
   }, [data]);
 
+  const allPositioned = layout.main
+    ? [layout.main, ...layout.satellites]
+    : layout.satellites;
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-4" data-testid="xiaomi-mesh-topology">
+      {/* Header row — title + refresh */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="t-h2 text-mesh-text">Mesh Topology</h2>
           <p className="mt-1 text-sm text-mesh-text-dim">
@@ -260,99 +186,345 @@ export default function XiaomiMeshTopology() {
         </div>
       </div>
 
-      {/* Summary stats */}
+      {/* Compact stats strip */}
       {!loading && data && (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <Card>
-            <CardContent className="flex items-center gap-3 p-4">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-mesh-primary/20">
-                <Router className="h-4 w-4 text-mesh-primary" />
-              </div>
-              <div>
-                <p className="t-h1 text-mesh-text">{stats.nodeCount}</p>
-                <p className="text-xs text-mesh-text-dim">Mesh Nodes</p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="flex items-center gap-3 p-4">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#4ade80]/20">
-                <MonitorSmartphone className="h-4 w-4 text-[#4ade80]" />
-              </div>
-              <div>
-                <p className="t-h1 text-mesh-text">{stats.totalDevices}</p>
-                <p className="text-xs text-mesh-text-dim">Online Devices</p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="flex items-center gap-3 p-4">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#c084fc]/20">
-                <Wifi className="h-4 w-4 text-[#c084fc]" />
-              </div>
-              <div>
-                <p className="t-h1 text-mesh-text">{stats.totalLeafs}</p>
-                <p className="text-xs text-mesh-text-dim">Connected Clients</p>
-              </div>
-            </CardContent>
-          </Card>
+        <div
+          className="mesh-card flex flex-wrap items-center gap-x-6 gap-y-2 px-4 py-2 text-[11px]"
+          style={{ fontFamily: "var(--font-mono)" }}
+        >
+          <span className="text-mesh-text-dim">
+            <span className="text-mesh-text">{stats.nodeCount}</span>{" "}
+            mesh node{stats.nodeCount !== 1 ? "s" : ""}
+          </span>
+          <span className="text-mesh-text-dim">
+            <span className="text-mesh-text">{stats.totalDevices}</span>{" "}
+            online device{stats.totalDevices !== 1 ? "s" : ""}
+          </span>
+          <span className="text-mesh-text-dim">
+            <span className="text-mesh-text">{stats.totalLeafs}</span>{" "}
+            connected client{stats.totalLeafs !== 1 ? "s" : ""}
+          </span>
         </div>
       )}
 
-      {/* Error state */}
+      {/* Error */}
       {error && (
-        <Card>
-          <CardContent className="space-y-2 p-4">
-            <p className="text-sm text-[#fb7185]">{error}</p>
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
-              onClick={() => {
-                setLoading(true);
-                load();
-              }}
-            >
-              Retry
-            </button>
-          </CardContent>
-        </Card>
+        <div className="mesh-card space-y-2 p-4">
+          <p className="text-sm text-[#fb7185]">{error}</p>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            onClick={() => {
+              setLoading(true);
+              load();
+            }}
+          >
+            Retry
+          </button>
+        </div>
       )}
 
-      {/* Loading state */}
+      {/* Loading */}
       {loading && (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <NodeCardSkeleton key={i} />
-          ))}
+        <div
+          className="mesh-card flex items-center justify-center p-12 text-sm text-mesh-text-dim"
+          data-testid="xiaomi-mesh-loading"
+        >
+          Loading mesh topology…
         </div>
       )}
 
-      {/* Node cards */}
-      {!loading && data && sortedNodes.length > 0 && (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {sortedNodes.map((node) => (
-            <NodeCard
-              key={node.mac || node.ip}
-              node={node}
-              leafs={data.leafs}
-              isMain={node.mac === mainMac}
-            />
-          ))}
+      {/* SVG topology map */}
+      {!loading && data && allPositioned.length > 0 && (
+        <div
+          className="mesh-card relative overflow-hidden"
+          style={{ padding: 0 }}
+          data-testid="xiaomi-mesh-svg-container"
+        >
+          {/* Blueprint grid background — mirrors /topology canvas chrome */}
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              inset: 0,
+              backgroundImage:
+                "linear-gradient(rgba(96,144,212,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(96,144,212,0.06) 1px, transparent 1px)",
+              backgroundSize: "32px 32px",
+            }}
+          />
+          <svg
+            role="img"
+            aria-label="Xiaomi mesh topology"
+            data-testid="xiaomi-mesh-svg"
+            viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+            style={{
+              position: "relative",
+              width: "100%",
+              height: "auto",
+              maxHeight: 520,
+              display: "block",
+            }}
+          >
+            {/* Edges: main → satellites */}
+            {layout.main &&
+              layout.satellites.map((sat, i) => {
+                const isWired =
+                  (sat.node.backhaul ?? "").toLowerCase() === "wired";
+                return (
+                  <line
+                    key={`edge-${i}`}
+                    x1={layout.main!.x}
+                    y1={layout.main!.y}
+                    x2={sat.x}
+                    y2={sat.y}
+                    stroke={
+                      isWired
+                        ? "var(--accent-cyan)"
+                        : "var(--accent-violet)"
+                    }
+                    strokeWidth={isWired ? 1.4 : 1}
+                    strokeDasharray={isWired ? undefined : "5 4"}
+                    opacity={0.6}
+                  />
+                );
+              })}
+
+            {/* Nodes */}
+            {allPositioned.map((pn, i) => {
+              const isMain = pn.node.is_main || pn.node.role === "main";
+              const w = isMain ? MAIN_RECT_W : SAT_RECT_W;
+              const h = isMain ? MAIN_RECT_H : SAT_RECT_H;
+              const label = resolveNodeLabel(pn.node, i);
+              const role = roleLabel(pn.node);
+              const key =
+                pn.node.mac || pn.node.ip || `node-${i}`;
+              const isSelected = selectedKey === key;
+              const accent = isMain
+                ? "var(--status-warning)"
+                : "var(--accent-cyan)";
+
+              return (
+                <g
+                  key={key}
+                  transform={`translate(${pn.x},${pn.y})`}
+                  onClick={() =>
+                    setSelectedKey((prev) => (prev === key ? null : key))
+                  }
+                  style={{ cursor: "pointer" }}
+                  data-testid={`xiaomi-mesh-node-${
+                    isMain ? "main" : "sat"
+                  }`}
+                  data-node-label={label}
+                  data-node-role={role}
+                >
+                  <rect
+                    x={-w / 2}
+                    y={-h / 2}
+                    width={w}
+                    height={h}
+                    rx={4}
+                    fill="var(--surface-2)"
+                    stroke={isSelected ? accent : "rgba(96,144,212,0.30)"}
+                    strokeWidth={isSelected ? 1.5 : 1}
+                  />
+                  {/* Role line */}
+                  <text
+                    x={0}
+                    y={-h / 2 + 14}
+                    textAnchor="middle"
+                    fontSize="9"
+                    fill={accent}
+                    fontFamily="var(--font-mono)"
+                    style={{
+                      letterSpacing: "0.06em",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {role}
+                  </text>
+                  {/* Name line — truncated to fit the box */}
+                  <text
+                    x={0}
+                    y={-h / 2 + 30}
+                    textAnchor="middle"
+                    fontSize="12"
+                    fontWeight={600}
+                    fill="var(--text)"
+                    fontFamily="var(--font-sans)"
+                  >
+                    {label.length > 18 ? `${label.slice(0, 17)}…` : label}
+                  </text>
+                  {/* IP + device count */}
+                  <text
+                    x={0}
+                    y={-h / 2 + 46}
+                    textAnchor="middle"
+                    fontSize="10"
+                    fill="var(--text-dim)"
+                    fontFamily="var(--font-mono)"
+                  >
+                    {(pn.node.ip || "—") +
+                      "  ·  " +
+                      (pn.node.online ?? 0) +
+                      " dev"}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
         </div>
+      )}
+
+      {/* Detail panel for selected node */}
+      {!loading && data && selectedKey && (
+        <SelectedNodePanel
+          allPositioned={allPositioned}
+          selectedKey={selectedKey}
+          onClose={() => setSelectedKey(null)}
+        />
       )}
 
       {/* Empty state */}
-      {!loading && !error && data && sortedNodes.length === 0 && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-3 py-12">
-            <Router className="h-10 w-10 text-mesh-text-mute" />
-            <p className="text-sm text-mesh-text-dim">
-              No mesh nodes found. Make sure the Xiaomi mesh integration is
-              configured in Settings.
-            </p>
-          </CardContent>
-        </Card>
+      {!loading && !error && data && allPositioned.length === 0 && (
+        <div className="mesh-card flex flex-col items-center gap-3 py-12">
+          <Router className="h-10 w-10 text-mesh-text-mute" />
+          <p className="text-sm text-mesh-text-dim">
+            No mesh nodes found. Make sure the Xiaomi mesh integration is
+            configured in Settings.
+          </p>
+        </div>
       )}
+    </div>
+  );
+}
+
+// ─── Selected node detail ────────────────────────────────
+
+function SelectedNodePanel({
+  allPositioned,
+  selectedKey,
+  onClose,
+}: {
+  allPositioned: PositionedNode[];
+  selectedKey: string;
+  onClose: () => void;
+}) {
+  const found = allPositioned.find(
+    (pn, i) => (pn.node.mac || pn.node.ip || `node-${i}`) === selectedKey,
+  );
+  if (!found) return null;
+  const isMain = found.node.is_main || found.node.role === "main";
+  const label = resolveNodeLabel(found.node, 0);
+  const role = roleLabel(found.node);
+  const backhaul = (found.node.backhaul ?? "").toLowerCase();
+  const Icon = isMain ? Crown : backhaul === "wired" ? Cable : Wifi;
+
+  return (
+    <div
+      className="mesh-card p-4"
+      data-testid="xiaomi-mesh-node-detail"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
+            style={{
+              background: isMain
+                ? "rgba(251,191,36,0.16)"
+                : "rgba(56,189,248,0.16)",
+              color: isMain
+                ? "var(--status-warning)"
+                : "var(--accent-cyan)",
+            }}
+          >
+            <Icon className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-mesh-text">{label}</p>
+            <p
+              className="text-[11px] uppercase tracking-wider text-mesh-text-mute"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              {role}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-2 text-[12px] sm:grid-cols-2">
+        <DetailRow label="IP" value={found.node.ip || "—"} mono />
+        <DetailRow label="MAC" value={found.node.mac || "—"} mono />
+        <DetailRow label="Hardware" value={found.node.hardware || "—"} />
+        <DetailRow
+          label="Online devices"
+          value={String(found.node.online ?? 0)}
+        />
+      </div>
+
+      {found.leafs.length > 0 && (
+        <div className="mt-3 border-t border-mesh-border-strong pt-3">
+          <p
+            className="mb-2 text-[10px] uppercase tracking-wider text-mesh-text-mute"
+            style={{ fontFamily: "var(--font-mono)" }}
+          >
+            Connected clients ({found.leafs.length})
+          </p>
+          <ul className="max-h-40 space-y-1 overflow-y-auto text-[12px]">
+            {found.leafs.map((leaf, i) => (
+              <li
+                key={leaf.mac || leaf.ip || `leaf-${i}`}
+                className="flex items-center justify-between gap-3"
+              >
+                <span className="truncate text-mesh-text">
+                  {resolveLeafLabel(leaf)}
+                </span>
+                <span
+                  className="shrink-0 text-mesh-text-mute"
+                  style={{ fontFamily: "var(--font-mono)" }}
+                >
+                  {leaf.ip || "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span
+        className="shrink-0 text-[10px] uppercase tracking-wider text-mesh-text-mute"
+        style={{ fontFamily: "var(--font-mono)" }}
+      >
+        {label}
+      </span>
+      <span
+        className={`min-w-0 truncate text-mesh-text ${
+          mono ? "tabular-nums" : ""
+        }`}
+        style={mono ? { fontFamily: "var(--font-mono)" } : undefined}
+      >
+        {value}
+      </span>
     </div>
   );
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2331,6 +2331,12 @@ export interface XiaomiTopoNode {
   online: number | null;
   hardware: string | null;
   model: string | null;
+  /** Logical role: "main" for the CAP router, "satellite" for downstream. */
+  role?: string | null;
+  /** True for the main/CAP router. Mirror of `role === "main"`. */
+  is_main?: boolean;
+  /** Backhaul link type for satellites: "wired" | "wireless" | "unknown". */
+  backhaul?: string | null;
 }
 
 export interface XiaomiTopoLeaf {

--- a/web/tests/e2e/mesh.spec.ts
+++ b/web/tests/e2e/mesh.spec.ts
@@ -391,6 +391,131 @@ async function mockXiaomiEnabled(page: Page) {
   });
 }
 
+// ── Topology -> Mesh tab — name fallback / SVG (#807) ───────
+//
+// Regression for #807: Xiaomi mesh satellites the user has never renamed in
+// the router admin come back as `name: "default"`. The backend strips that
+// placeholder and the SVG view falls back to locale → IP so every node gets
+// a meaningful label. One node ("Live Studio") was renamed in admin and
+// must show its real name. The tab must render an SVG topology map, not a
+// grid of generic cards.
+
+const MOCK_XIAOMI_TOPOLOGY_WITH_DEFAULTS = {
+  nodes: [
+    {
+      mac: "AA:BB:CC:DD:EE:01",
+      name: "OK Home",
+      locale: null,
+      ip: "10.10.0.199",
+      online: 8,
+      hardware: "RD15",
+      model: null,
+      role: "main",
+      is_main: true,
+      backhaul: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:02",
+      name: "Live Studio",
+      locale: null,
+      ip: "10.10.0.52",
+      online: 5,
+      hardware: "RD15",
+      model: null,
+      role: "satellite",
+      is_main: false,
+      backhaul: "wired",
+    },
+    // These satellites were never renamed in router admin — the backend
+    // dropped the "default" placeholder, so name is null and the UI falls
+    // back to IP. Crucially the tab must NOT render the literal "default".
+    {
+      mac: "AA:BB:CC:DD:EE:03",
+      name: null,
+      locale: null,
+      ip: "10.10.0.53",
+      online: 4,
+      hardware: "RD15",
+      model: null,
+      role: "satellite",
+      is_main: false,
+      backhaul: "wired",
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:04",
+      name: null,
+      locale: null,
+      ip: "10.10.0.54",
+      online: 3,
+      hardware: "RD15",
+      model: null,
+      role: "satellite",
+      is_main: false,
+      backhaul: "wireless",
+    },
+  ],
+  leafs: [],
+};
+
+test.describe("Topology -> Mesh tab — Wi-Fi mesh names (#807)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("renders SVG topology map with real mesh names — no 'default' labels", async ({
+    page,
+  }) => {
+    await page.route("**/api/v1/xiaomi/topology", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_XIAOMI_TOPOLOGY_WITH_DEFAULTS),
+      }),
+    );
+
+    await page.goto("/topology/");
+    await expect(page.getByTestId("topology-root")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Switch to the Mesh tab where XiaomiMeshTopology renders.
+    await page.getByTestId("topology-tab-mesh").click();
+
+    // The SVG topology map must be present — not a grid of cards.
+    await expect(page.getByTestId("xiaomi-mesh-svg")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Real named nodes must appear in the SVG.
+    const svg = page.getByTestId("xiaomi-mesh-svg");
+    await expect(svg.getByText("OK Home")).toBeVisible();
+    await expect(svg.getByText("Live Studio")).toBeVisible();
+
+    // The placeholder "default" name must NOT leak into the UI.
+    await expect(page.getByTestId("xiaomi-mesh-svg-container")).not.toContainText(
+      "default",
+    );
+
+    // Each unnamed satellite must still render — falls back to IP so the
+    // user can identify which physical router they are looking at.
+    await expect(svg.getByText("10.10.0.53")).toBeVisible();
+    await expect(svg.getByText("10.10.0.54")).toBeVisible();
+
+    // Role line must be rendered — main + at least one satellite.
+    await expect(svg.getByText("Main", { exact: true })).toBeVisible();
+    await expect(svg.getByText(/Satellite/).first()).toBeVisible();
+
+    // All four nodes must exist in the SVG (1 main + 3 satellites).
+    await expect(page.getByTestId("xiaomi-mesh-node-main")).toHaveCount(1);
+    await expect(page.getByTestId("xiaomi-mesh-node-sat")).toHaveCount(3);
+
+    await page.screenshot({
+      path: "tests/screenshots/topology-mesh-tab-pan-40.png",
+      fullPage: true,
+    });
+  });
+});
+
 test.describe.skip("Xiaomi Topology Page — BE3600 satellite nodes (#473)", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);


### PR DESCRIPTION
## Summary

Topology → Mesh used to render nearly every mesh satellite as the literal string `default` because the Xiaomi router returns `name: "default"` for satellite routers that were never renamed in the admin UI. The tab also rendered a generic card grid instead of a topology map, hiding the mesh structure entirely.

- **Backend** (`server/src/api/xiaomi.rs`): sanitize the `name`/`locale` fields (drop "default"/empty/whitespace) and emit `role`, `is_main`, and `backhaul` so the frontend can label nodes without re-deriving them. Adds 4 unit tests for the sanitizer + locale role-string preservation.
- **Frontend** (`web/src/components/XiaomiMeshTopology.tsx`): replace the card grid with a compact SVG topology map — main router at center, satellites on a ring, dashed edges for wireless backhaul, solid for wired. Labels resolve via name → locale → IP → MAC, with a click-through detail panel.
- **E2E** (`web/tests/e2e/mesh.spec.ts`): new "Topology → Mesh tab — Wi-Fi mesh names (#807)" test mocks a topology with one renamed satellite ("Live Studio") + two unnamed satellites; asserts the SVG renders, real names show, "default" never appears, and unnamed satellites fall back to their IP.

Implements #807

## Test plan

Commands run:

\`\`\`
cargo fmt --all
cargo clippy -p panoptikon-server --lib -- -D warnings   # clean
cargo test  -p panoptikon-server --lib api::xiaomi       # 14/14 pass
cargo test  -p panoptikon-server --lib xiaomi            # 42/42 pass
cd web && bun install --frozen-lockfile
bunx tsc --noEmit                                        # 0 errors on changed files
bun run build                                            # /topology + /mesh prerender clean
\`\`\`

- [x] Backend unit tests cover "default"/empty/whitespace → None and "master"/"slave" locale preserved
- [x] Frontend SVG renders with named + unnamed satellites
- [x] E2E asserts no `default` label leaks into UI and IP fallback works
- [ ] Live visual verification on `https://net.oklabs.uk` after merge/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes issue #807 where Xiaomi mesh satellite nodes with no user-set name were rendered as the literal string `"default"`. The backend now strips that placeholder via `sanitize_mesh_name`/`sanitize_mesh_locale` and emits `role`, `is_main`, and `backhaul` fields so the frontend can label and classify nodes without re-deriving them.

- **Backend (`xiaomi.rs`)**: two mutually exclusive code paths (populated `graph.nodes` vs. leaf-promotion for BE3600) correctly set `is_main`/`role`/`backhaul`; four new unit tests cover the sanitizer. `backhaul` remains `None` for nodes from `graph.nodes` because the raw type carries no `link_type` — this is an inherent firmware data limitation, not a gap.
- **Frontend (`XiaomiMeshTopology.tsx`)**: card grid replaced with an SVG radial topology map; label resolution falls back through name → locale → IP → MAC → ordinal sentinel. The loading state was changed from skeleton components to a plain text div, which conflicts with the project style guide.
- **E2E (`mesh.spec.ts`)**: new Playwright test mocks a four-node topology, verifies the SVG renders, "default" never leaks into the UI, and unnamed satellites fall back to their IP address.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are non-blocking style and edge-case consistency issues.

The core fix is correct and well-tested. The loading skeleton regression and the hardcoded fallbackIndex=0 in the detail panel are both cosmetic/edge-case issues that do not affect real-world label resolution because every mesh node has at least an IP or MAC.

web/src/components/XiaomiMeshTopology.tsx — loading state and SelectedNodePanel fallback label

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi.rs | Adds sanitize_mesh_name/locale helpers and emits role/is_main/backhaul fields. Two code paths are correctly mutually exclusive, no double-main risk. |
| web/src/components/XiaomiMeshTopology.tsx | Replaces card grid with SVG radial topology map; loading state regression and SelectedNodePanel fallbackIndex=0 inconsistency noted. |
| web/src/lib/types.ts | Clean additive extension — optional role, is_main, backhaul fields added to XiaomiTopoNode. |
| web/tests/e2e/mesh.spec.ts | New E2E test satisfies CLAUDE.md requirements; screenshot filename is a leftover from a different test. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/XiaomiMeshTopology.tsx:228-235
Loading state uses plain text instead of skeleton components, which violates the project style guide (CLAUDE.md: "Loading states use skeleton components, not spinners"). The previous implementation used `NodeCardSkeleton` — the replacement should preserve this convention.

```suggestion
      {loading && (
        <div
          className="mesh-card space-y-3 p-4"
          data-testid="xiaomi-mesh-loading"
        >
          <div className="h-4 w-32 animate-pulse rounded bg-mesh-surface-2" />
          <div className="h-[360px] animate-pulse rounded bg-mesh-surface-2" />
        </div>
      )}
```

### Issue 2 of 3
web/src/components/XiaomiMeshTopology.tsx:412-417
`SelectedNodePanel` always passes `0` as `fallbackIndex` to `resolveNodeLabel`, so any satellite that reaches the last-resort ordinal branch will be labelled "Satellite 1" in the panel regardless of which node was clicked. The SVG passes the `allPositioned` index, so the same node is labelled "Satellite 2" (or higher) there. The fix is to pass the actual found index so the two labels agree.

```suggestion
  let foundIdx = -1;
  const found = allPositioned.find(
    (pn, i) => {
      if ((pn.node.mac || pn.node.ip || `node-${i}`) === selectedKey) {
        foundIdx = i;
        return true;
      }
      return false;
    },
  );
  if (!found) return null;
  const isMain = found.node.is_main || found.node.role === "main";
  const label = resolveNodeLabel(found.node, foundIdx);
```

### Issue 3 of 3
web/tests/e2e/mesh.spec.ts:512-515
The screenshot artifact path `topology-mesh-tab-pan-40.png` looks like a leftover from a different test — the `-pan-40` suffix is unrelated to this bug fix. The name should reflect the test it belongs to so screenshots are easy to identify in CI artifact archives.

```suggestion
    await page.screenshot({
      path: "tests/screenshots/topology-mesh-tab-807.png",
      fullPage: true,
    });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: render Xiaomi mesh nodes with real ..."](https://github.com/befeast/panoptikon/commit/c1297fb2e4aded57a97522d81173521b608e31fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33291829)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->