### PR TITLE
test(login): cover SSO gating both disabled and enabled (Refs #768)

### DIFF
--- a/web/tests/e2e/login-sso-gating.spec.ts
+++ b/web/tests/e2e/login-sso-gating.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "../../e2e/fixtures";
+
+/**
+ * Regression coverage for Refs #768: the OR divider and "Continue with SSO"
+ * action on /login must only render when the backend reports
+ * `sso_enabled: true`. A fresh install (the default) returns `sso_enabled: false`
+ * from /api/v1/auth/status, so the password form is the only auth affordance.
+ */
+test.describe("Login SSO gating (Refs #768)", () => {
+  test("default backend state hides OR divider and SSO action", async ({
+    page,
+  }) => {
+    await page.goto("/login/");
+
+    await expect(
+      page.getByRole("heading", { name: "Panoptikon", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
+
+    // Password affordances must remain present.
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+
+    // No SSO affordances when sso_enabled is false (the default).
+    await expect(
+      page.getByRole("link", { name: "Continue with SSO" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Continue with SSO" }),
+    ).toHaveCount(0);
+    // The OR divider only renders inside the SSO block, so it must be gone too.
+    const orDivider = page.locator("form").getByText("OR", { exact: true });
+    await expect(orDivider).toHaveCount(0);
+
+    await page.screenshot({
+      path: "tests/screenshots/login-sso-disabled.png",
+      fullPage: true,
+    });
+  });
+
+  test("backend-reported sso_enabled reveals divider and SSO link", async ({
+    page,
+  }) => {
+    const ssoUrl = "https://idp.example.test/sso/start";
+
+    await page.route("**/api/v1/auth/status", async (route) => {
+      await route.fulfill({
+        json: {
+          authenticated: false,
+          needs_setup: false,
+          sso_enabled: true,
+          sso_login_url: ssoUrl,
+        },
+      });
+    });
+
+    await page.goto("/login/");
+
+    await expect(page.getByLabel("Operator")).toHaveValue("operator", {
+      timeout: 15000,
+    });
+
+    const ssoLink = page.getByRole("link", { name: "Continue with SSO" });
+    await expect(ssoLink).toBeVisible();
+    await expect(ssoLink).toHaveAttribute("href", ssoUrl);
+
+    const orDivider = page.locator("form").getByText("OR", { exact: true });
+    await expect(orDivider).toBeVisible();
+
+    // Password login affordances must still be present alongside SSO.
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/login-sso-enabled.png",
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #768 — on `/login`, the OR divider and the *Continue with SSO* action must only appear when the backend reports `sso_enabled: true`. The frontend already wraps both elements behind `authStatus.sso_enabled` (`web/src/app/login/page.tsx:222`) and the backend `/api/v1/auth/status` handler emits the field as `false` until SSO is actually wired up (`server/src/api/auth.rs:136-141, 403-408`). Existing specs only assert the SSO button is absent in the default state — they do not exercise the divider or the SSO-enabled path.

This PR adds a dedicated Playwright spec that:
- Visits `/login` against the default backend response and asserts the password form renders while the OR divider and *Continue with SSO* link are both absent.
- Mocks `/api/v1/auth/status` to return `sso_enabled: true` plus an `sso_login_url`, then asserts the divider is visible, the SSO link is visible with the configured `href`, and the password form continues to work.

No production code changes — the gating already exists and is correct; this PR is the missing regression evidence.

## Verification

```bash
cd web
bun install --frozen-lockfile
bun run test     # 66/66 passing (vitest)
bun run build    # /login route compiled, no errors
```

Backend tests (`cargo test -p panoptikon-server`) were not run in this worktree because `cargo` is not installed in the worker sandbox. No backend code changed.

E2E run was not executed locally — the panoptikon backend is not running in this worker sandbox, so the new spec can only be validated against the deployed environment / CI. The spec uses the same fixture and `page.route` mocking patterns already established by `web/tests/e2e/topbar-polish.spec.ts` and `web/tests/e2e/login-rebrand.spec.ts`.

## Test plan

- [ ] CI executes `web/tests/e2e/login-sso-gating.spec.ts` and both scenarios pass
- [ ] Screenshots `login-sso-disabled.png` and `login-sso-enabled.png` are produced
- [ ] `/login` on the deployed environment still shows the password form only (no OR divider, no SSO button) for a default install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dedicated Playwright spec (`login-sso-gating.spec.ts`) providing regression coverage for Refs #768: the OR divider and *Continue with SSO* link on `/login` must only render when the backend reports `sso_enabled: true`. No production code is changed.

- The SSO-enabled scenario correctly intercepts `/api/v1/auth/status` with `page.route` before navigation, returning `sso_enabled: true` plus an `sso_login_url`, then asserts divider visibility, link `href`, and co-existence of the password form.
- The SSO-disabled scenario navigates to `/login` without a route stub and asserts that both the OR divider and the SSO link (role: link) are absent — fixing the gap in `login-rebrand.spec.ts`, which only checked for a button variant and would have missed the `<a>`-rendered SSO element.

<h3>Confidence Score: 4/5</h3>

Test-only change with no production code modifications; safe to merge.

The spec is structurally sound and the SSO-enabled scenario is fully self-contained via route mocking. The one concern is that the SSO-disabled scenario relies on a live backend call instead of a stub, so a network failure would produce a passing test for the wrong reason.

web/tests/e2e/login-sso-gating.spec.ts — specifically the first test's missing route stub for the default auth-status response.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/tests/e2e/login-sso-gating.spec.ts | New E2E spec covering SSO gating on /login; route mocking, selectors, and assertions are logically correct. The disabled-state test relies on the live backend rather than a stub, which can mask a backend outage as a passing test. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/login-sso-gating.spec.ts:12-45
**First scenario silently passes when backend is unreachable**

The SSO-disabled test relies on the real `/api/v1/auth/status` endpoint with no route mock. When the backend is down, `fetchAuthStatus()` throws, the component's `.catch(() => setReady(true))` fires, and `authStatus` stays `null` — so `ssoEnabled` resolves to `Boolean(undefined) = false` and the SSO elements never render. The `toHaveCount(0)` assertions pass, but not because the backend returned `sso_enabled: false`; the test cannot distinguish a healthy default response from a network failure. Consider adding a `page.route` stub that returns the default `{ sso_enabled: false, ... }` shape (matching the pattern in `topbar-polish.spec.ts`) so the test verifies the actual backend contract rather than accepting a silent fetch failure as a valid "disabled" proof.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(login): cover SSO gating both disab..."](https://github.com/befeast/panoptikon/commit/059576b54abe495b262db3abcaa840e8ffa83007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33295661)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->