### PR TITLE
test(login): cover SSO action visibility against backend state (#768)

### DIFF
--- a/web/tests/e2e/login-sso-visibility.spec.ts
+++ b/web/tests/e2e/login-sso-visibility.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "../../e2e/fixtures";
+
+/**
+ * Focused coverage for the `Continue with SSO` action and `OR` divider on
+ * `/login`. The block must stay hidden unless the backend `/api/v1/auth/status`
+ * response advertises `sso_enabled: true`. Refs #768.
+ */
+test.describe("Login SSO visibility (#768)", () => {
+  test("default backend state hides OR divider and SSO action", async ({
+    page,
+  }) => {
+    await page.route("**/api/v1/auth/status", async (route) => {
+      await route.fulfill({
+        json: {
+          authenticated: false,
+          needs_setup: false,
+          sso_enabled: false,
+          sso_login_url: null,
+        },
+      });
+    });
+
+    await page.goto("/login/");
+
+    await expect(
+      page.getByRole("heading", { name: "Panoptikon", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByLabel("Operator")).toHaveValue("operator");
+
+    const form = page.locator("main.login-bg form");
+    await expect(form).toBeVisible();
+    await expect(form.getByText(/^OR$/)).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: "Continue with SSO" }),
+    ).toHaveCount(0);
+
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/login-sso-hidden.png",
+      fullPage: true,
+    });
+  });
+
+  test("sso_enabled response renders OR divider and SSO link", async ({
+    page,
+  }) => {
+    const ssoUrl = "/api/v1/auth/sso/login";
+    await page.route("**/api/v1/auth/status", async (route) => {
+      await route.fulfill({
+        json: {
+          authenticated: false,
+          needs_setup: false,
+          sso_enabled: true,
+          sso_login_url: ssoUrl,
+        },
+      });
+    });
+
+    await page.goto("/login/");
+
+    await expect(
+      page.getByRole("heading", { name: "Panoptikon", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const form = page.locator("main.login-bg form");
+    await expect(form).toBeVisible();
+    await expect(form.getByText(/^OR$/)).toBeVisible();
+
+    const ssoLink = page.getByRole("link", { name: "Continue with SSO" });
+    await expect(ssoLink).toBeVisible();
+    await expect(ssoLink).toHaveAttribute("href", ssoUrl);
+
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Sign in/i })).toBeVisible();
+
+    await page.screenshot({
+      path: "tests/screenshots/login-sso-visible.png",
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `/login` already gates the `OR` divider and `Continue with SSO` action on `authStatus.sso_enabled` (see `web/src/app/login/page.tsx:222-238`); the backend `/api/v1/auth/status` handler currently hardcodes `sso_enabled: false` (`server/src/api/auth.rs:403-408`), so a fresh/default install never exposes an SSO affordance.
- Existing specs (`login-visual`, `login-rebrand`, `brand-palette`) brush against this behaviour as a side assertion, but there is no focused test that proves the conditional behaves both ways. This PR adds one.
- New spec `web/tests/e2e/login-sso-visibility.spec.ts` mocks `GET /api/v1/auth/status` with `route.fulfill` and asserts:
  - `sso_enabled: false` → no `OR` text in the form, no `Continue with SSO` link, password form intact.
  - `sso_enabled: true` with `sso_login_url` → `OR` divider visible, SSO link visible and `href` points at the configured URL.

No production source files change — the requirement is already implemented in code, and this PR locks the behaviour with focused E2E coverage so a regression (e.g. someone reintroducing a static SSO block) gets caught.

Implements #768

## Verification

Ran from `web/`:

```
bun install --frozen-lockfile
bun run build        # ✓ next build succeeded
bun run test         # ✓ 66 vitest tests passed
bunx tsc --noEmit    # ✓ no type errors
```

And from the repo root:

```
cargo check -p panoptikon-server   # ✓ compiles
```

Playwright E2E (`bunx playwright test login-sso-visibility`) requires a running server and was not executed in the worker environment; the spec is self-contained and uses the standard `page.route` mocking pattern already in use in `topbar-polish.spec.ts` and `ui-regression-fix.spec.ts`.

## Test plan

- [ ] Deploy to `https://net.oklabs.uk`
- [ ] Manually load `/login` on fresh install → confirm no `OR`, no `Continue with SSO`
- [ ] Run `bunx playwright test login-sso-visibility` against the deployed instance
- [ ] Confirm `tests/screenshots/login-sso-hidden.png` and `tests/screenshots/login-sso-visible.png` render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a focused E2E spec (`login-sso-visibility.spec.ts`) to verify that the `/login` page correctly shows or hides the `OR` divider and `Continue with SSO` link depending on the `sso_enabled` field returned by `GET /api/v1/auth/status`. No production code changes are included.

- The two visibility-gating assertions (hidden when `sso_enabled: false`, visible when `sso_enabled: true`) are logically correct and follow the existing `page.route` mocking pattern.
- The `href` assertion in the SSO-enabled test uses `\"/api/v1/auth/sso/login\"`, which is identical to the hardcoded fallback in `page.tsx:231` (`href={ssoLoginUrl ?? \"/api/v1/auth/sso/login\"}`), so the assertion would pass even if `sso_login_url` was never read from the mocked response — the dynamic URL binding is not actually exercised.

<h3>Confidence Score: 3/5</h3>

Test-only change; no production code is modified. Safe to merge once the href-assertion gap is addressed.

The boolean visibility assertions are sound, but the href check in the SSO-enabled test uses a URL identical to the production fallback, so a regression where the code ignores sso_login_url and always falls back to the hardcoded path would not be caught by this test.

web/tests/e2e/login-sso-visibility.spec.ts — specifically the ssoUrl constant and the href assertion in the second test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/tests/e2e/login-sso-visibility.spec.ts | New E2E spec covering SSO visibility gating. Boolean show/hide assertions are correct, but the href assertion in the enabled-test uses the same URL as the production fallback, so it cannot catch a regression where sso_login_url is not consumed from the API response. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/login-sso-visibility.spec.ts:49
The `ssoUrl` constant is set to `"/api/v1/auth/sso/login"`, which is exactly the same value as the hardcoded fallback in `page.tsx:231` (`href={ssoLoginUrl ?? "/api/v1/auth/sso/login"}`). The `toHaveAttribute("href", ssoUrl)` assertion on line 73 would pass even if `sso_login_url` was never read from the API response and the production code fell back to the hardcoded default — making it impossible for this test to catch a regression where `ssoLoginUrl` is not being bound from the API. Using a distinct URL (e.g. `"https://sso.example.com/callback"`) would make the assertion meaningful.

```suggestion
    const ssoUrl = "https://sso.example.com/callback";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(login): cover SSO action visibility..."](https://github.com/befeast/panoptikon/commit/0039fdddca8e6b4ef8f50c4f08ab4dd252aef95c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33299511)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->