### PR TITLE
fix(ux): Cmd+K consistently opens the global command palette (#805)

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -59,10 +59,15 @@ export function CommandPalette() {
   const [scanning, setScanning] = useState(false)
 
   // ── Global Cmd+K / Ctrl+K listener ──
+  // Captured at the document level so it triggers consistently from any
+  // authenticated route — including while focus is inside a text input,
+  // textarea, or contentEditable region. preventDefault overrides the
+  // browser's default Cmd/Ctrl+K (e.g. focus the URL bar search box).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'k') {
         e.preventDefault()
+        e.stopPropagation()
         setOpen((prev) => !prev)
       }
     }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -560,17 +560,6 @@ function SidebarSearch() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  useEffect(() => {
-    function onHotkey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onHotkey);
-    return () => window.removeEventListener("keydown", onHotkey);
-  }, []);
-
   const flatItems = useMemo(() => {
     if (!results) return [] as Array<{ type: string; id: string; label: string }>;
     const items: Array<{ type: string; id: string; label: string }> = [];

--- a/web/tests/e2e/cmdk-global-shortcut.spec.ts
+++ b/web/tests/e2e/cmdk-global-shortcut.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E coverage for the Cmd+K / Ctrl+K global shortcut (#805).
+ *
+ * Verifies the acceptance criteria on the issue:
+ *  - Pressing Cmd+K (mac) or Ctrl+K (non-mac) opens the global command/search
+ *    palette consistently from authenticated routes.
+ *  - The palette input is focused and ready for typing after the shortcut fires.
+ *  - The shortcut works even when focus is inside a text input — i.e. it does
+ *    not get swallowed by native browser shortcuts.
+ *  - Escape closes the palette (existing UX pattern).
+ *  - There is only ever one palette dialog (no duplicate listener fight with
+ *    the sidebar search input).
+ */
+test.describe("Cmd+K global search shortcut (#805)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Ctrl+K opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeVisible();
+    await expect(input).toBeFocused();
+
+    await page.keyboard.type("dash");
+    await expect(input).toHaveValue("dash");
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-global-opens-and-focuses.png",
+      fullPage: true,
+    });
+  });
+
+  test("Meta+K (mac shortcut) opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Meta+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+  });
+
+  test("Ctrl+K works while focus is inside a text input", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The sidebar search input is a plain text input on the authenticated
+    // shell. Focus it first, then fire the shortcut — the palette must still
+    // open regardless of where focus currently lives.
+    const sidebarInput = page
+      .locator('input[placeholder="Search"]')
+      .first();
+    await expect(sidebarInput).toBeVisible();
+    await sidebarInput.click();
+    await expect(sidebarInput).toBeFocused();
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const paletteInput = page.locator("[cmdk-input]");
+    await expect(paletteInput).toBeFocused();
+  });
+
+  test("Escape closes the palette", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden({ timeout: 2000 });
+  });
+
+  test("Ctrl+K toggles the palette (second press closes it)", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const dialog = page.locator("[cmdk-dialog]");
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeHidden({ timeout: 2000 });
+  });
+
+  test("only one palette dialog opens (no duplicate listeners)", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialogs = page.locator("[cmdk-dialog]");
+    await expect(dialogs).toHaveCount(1, { timeout: 3000 });
+  });
+
+  test("shortcut works on other authenticated routes (devices)", async ({
+    page,
+  }) => {
+    await page.goto("/devices");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
- Drop the sidebar's duplicate Cmd/Ctrl+K listener so the `CommandPalette` is the single global handler. Previously both fired with `preventDefault`, racing for focus.
- Tighten the palette listener: require no Alt/Shift, normalize key case, and `stopPropagation()` so it wins from any focus context (including text inputs) and overrides the browser's native Cmd+K (URL-bar search).
- Add `web/tests/e2e/cmdk-global-shortcut.spec.ts` covering the issue's acceptance criteria.

Implements #805.

## Verification
```bash
cd web
bun install --frozen-lockfile
bun run build           # ✅ passes
bunx tsc --noEmit       # ✅ passes
```

`bun run build` succeeds in this worktree. E2E run requires the panoptikon server; the new spec is not skipped and will run as part of the standard `bunx playwright test` invocation.

## Test plan
- [ ] `bunx playwright test cmdk-global-shortcut` against a live `panoptikon` server.
- [ ] Manually: press Ctrl+K on `/dashboard` → palette opens, input focused, typing works. Esc closes. Press Ctrl+K twice → toggles.
- [ ] Manually: click into the sidebar Search input → press Ctrl+K → palette still opens (focus moves to palette input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the race condition where both `CommandPalette` and `SidebarSearch` attached independent `keydown` listeners for Cmd/Ctrl+K, causing the sidebar input to steal focus from the palette. The sidebar's `window`-level listener is removed entirely, and the palette's `document`-level handler is tightened with modifier-key guards, case normalization, and `stopPropagation()`.

- **`CommandPalette.tsx`**: adds `!e.altKey && !e.shiftKey`, `e.key.toLowerCase()`, and `e.stopPropagation()` to the existing document listener — correctly prevents Alt+K / Shift+K from triggering the palette and stops the event from reaching any remaining `window`-level handlers.
- **`Sidebar.tsx`**: removes the duplicate `useEffect` / `window.addEventListener` block that was the root cause of the focus-stealing race.
- **`cmdk-global-shortcut.spec.ts`**: adds six E2E tests covering open/focus, Mac shortcut, sidebar-focus override, Escape, toggle, and cross-route behaviour — all consistent with the existing test-suite conventions.

<h3>Confidence Score: 4/5</h3>

Safe to merge — removes a clearly problematic duplicate listener and tightens the surviving handler without touching unrelated logic.

The sidebar deletion and the CommandPalette guard changes are correct. The only open question is whether stopPropagation() fully captures the intent: it prevents window-level handlers but not other document-level handlers registered in the same phase; stopImmediatePropagation() would be the strict equivalent. This has no practical impact today because the competing listener is gone, but the comment warrants clarification.

No files require special attention; the CommandPalette.tsx stopPropagation vs stopImmediatePropagation distinction is worth a quick read.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Tightens the global Cmd+K listener: adds !altKey/!shiftKey guards, normalises key case, and calls stopPropagation() to prevent window-level handlers from also firing. The handler was already on document, so the change is purely additive and correct. |
| web/src/components/layout/Sidebar.tsx | Removes the duplicate window-level Cmd+K listener that was racing with the CommandPalette handler. Clean deletion, no other logic touched. |
| web/tests/e2e/cmdk-global-shortcut.spec.ts | New E2E spec covering the six acceptance criteria from issue #805. Import path, fixture usage, and locator patterns are consistent with the existing test suite. No skips; requires a live server to pass. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/CommandPalette.tsx:69-71
`stopPropagation()` on a `document`-level bubbling listener stops the event from reaching `window` listeners, but does **not** stop other handlers also registered on `document` in the same phase — for those, `stopImmediatePropagation()` is required. The PR description states the goal is to have a single winning handler "from any focus context," but as written, any other `document`-level `keydown` listener (e.g. from a third-party library) will still fire after this one. If strict single-handler semantics are needed, consider `stopImmediatePropagation()`; otherwise the comment should be tightened to reflect the actual effect.

```suggestion
        e.preventDefault()
        e.stopImmediatePropagation()
        setOpen((prev) => !prev)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): Cmd+K consistently opens the gl..."](https://github.com/befeast/panoptikon/commit/8141627ddcd2a291da3817b3f275607655eca3cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33326289)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->