### PR TITLE
fix(pfsense): switch panels per hash subroute on /router/pfsense

### DIFF
--- a/web/src/components/router/PfSenseRouterDesign.tsx
+++ b/web/src/components/router/PfSenseRouterDesign.tsx
@@ -2,14 +2,25 @@
 
 /**
  * PfSenseRouterDesign — pfSense vendor wrapper for the literal-port
- * RouterPage. Same recipe as MikrotikRouterDesign, with pfSense-specific
- * data hooks. The design source only ships a MikroTik artboard, so the
- * tab set is adapted to pfSense's surfaces (Status / Interfaces / Firewall
- * / NAT / DHCP / DNS / Routing / Config / Services) but the chrome,
- * spacing and recipes are byte-exact from router-page.jsx.
+ * RouterPage. Same chrome (header + stats + tabs + footer) as the
+ * MikroTik wrapper, but with pfSense-specific data hooks and per-tab
+ * panel switching:
+ *
+ *   - system      → SystemTab (legacy CRUD card grid)
+ *   - interfaces  → literal-port Interfaces table
+ *   - firewall    → literal-port Firewall rules panel
+ *   - dhcp        → literal-port DHCP leases panel
+ *   - dns         → DnsTab
+ *   - services    → ServicesTab
+ *   - routing     → RoutingTab
+ *   - config      → ConfigTab
+ *
+ * The legacy tab components are reused for the non-design sub-routes
+ * because the design source only ships interfaces / firewall / dhcp as
+ * literal artboards.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { Shield, RefreshCcw, Save, TerminalSquare } from "lucide-react";
 import { useData } from "@/hooks/useData";
 import {
@@ -29,6 +40,11 @@ import {
 } from "@/components/router/RouterPage";
 import type { RouterTab } from "@/components/router/RouterTabs";
 import type { RouterHeaderMeta } from "@/components/router/RouterHeader";
+import { SystemTab } from "@/components/pfsense/tabs/SystemTab";
+import { DnsTab } from "@/components/pfsense/tabs/DnsTab";
+import { ServicesTab } from "@/components/pfsense/tabs/ServicesTab";
+import { RoutingTab } from "@/components/pfsense/tabs/RoutingTab";
+import { ConfigTab } from "@/components/pfsense/tabs/ConfigTab";
 
 const PFSENSE_TABS: RouterTab[] = [
   { id: "system", label: "System" },
@@ -184,6 +200,49 @@ export default function PfSenseRouterDesign({
     ? `pfSense · ${status.data.hostname}`
     : "pfSense Firewall";
 
+  // ── Per-tab panel selection. The header/stats/tabs strip + footer stay
+  //    identical across tabs; only the body content swaps. ───────────────
+  const showInterfaces = activeTab === "interfaces";
+  const showFirewall = activeTab === "firewall";
+  const showDhcp = activeTab === "dhcp";
+
+  const extraContent: ReactNode = (() => {
+    switch (activeTab) {
+      case "system":
+        return status.data ? (
+          <div data-testid="pfsense-panel-system">
+            <SystemTab status={status.data} />
+          </div>
+        ) : null;
+      case "dns":
+        return (
+          <div data-testid="pfsense-panel-dns">
+            <DnsTab />
+          </div>
+        );
+      case "services":
+        return (
+          <div data-testid="pfsense-panel-services">
+            <ServicesTab />
+          </div>
+        );
+      case "routing":
+        return (
+          <div data-testid="pfsense-panel-routing">
+            <RoutingTab />
+          </div>
+        );
+      case "config":
+        return (
+          <div data-testid="pfsense-panel-config">
+            <ConfigTab />
+          </div>
+        );
+      default:
+        return null;
+    }
+  })();
+
   return (
     <RouterPage
       headerTitle={title}
@@ -197,6 +256,7 @@ export default function PfSenseRouterDesign({
       activeTab={activeTab}
       onTabChange={onTabChange}
       interfaces={ifaceRows}
+      showInterfaces={showInterfaces}
       interfacesTotalsLabel={
         totalIfaces > 0
           ? `${totalIfaces} total · ${runningIfaces} up · ${downIfaces} down`
@@ -204,24 +264,33 @@ export default function PfSenseRouterDesign({
             ? "loading…"
             : "no data"
       }
-      firewall={{
-        rules: fwRows,
-        label:
-          fwRows.length > 0
-            ? `${fwRows.length} rules · ${disabledRules} disabled`
-            : rules.loading
-              ? "loading…"
-              : "no rules",
-      }}
-      dhcp={{
-        leases: dhcpRows,
-        label:
-          dhcpRows.length > 0
-            ? `${dhcpRows.length} · ${staticLeases} static`
-            : leases.loading
-              ? "loading…"
-              : "no leases",
-      }}
+      firewall={
+        showFirewall
+          ? {
+              rules: fwRows,
+              label:
+                fwRows.length > 0
+                  ? `${fwRows.length} rules · ${disabledRules} disabled`
+                  : rules.loading
+                    ? "loading…"
+                    : "no rules",
+            }
+          : undefined
+      }
+      dhcp={
+        showDhcp
+          ? {
+              leases: dhcpRows,
+              label:
+                dhcpRows.length > 0
+                  ? `${dhcpRows.length} · ${staticLeases} static`
+                  : leases.loading
+                    ? "loading…"
+                    : "no leases",
+            }
+          : undefined
+      }
+      extraContent={extraContent}
       footer={{
         snapshotLabel: "Live pfSense state",
         driftLabel: status.data?.domain

--- a/web/src/components/router/RouterPage.tsx
+++ b/web/src/components/router/RouterPage.tsx
@@ -184,6 +184,9 @@ export type RouterPageProps = {
   interfacesTotalsLabel?: string; // e.g. "9 total · 8 running · 1 down"
   onAddInterface?: () => void;
   onFilterInterface?: () => void;
+  /** Pass `false` to hide the interfaces panel entirely (e.g. when another
+   *  tab owns the body slot). Defaults to `true` for backward compatibility. */
+  showInterfaces?: boolean;
 
   // Firewall panel (omit to hide the panel — e.g. Xiaomi)
   firewall?: {
@@ -198,6 +201,12 @@ export type RouterPageProps = {
     label?: string; // e.g. "6 · 3 static"
     onFilter?: () => void;
   };
+
+  /** Additional content rendered below the interfaces/firewall/dhcp panels
+   *  and above the footer. Used by per-tab vendor wrappers (pfSense) to slot
+   *  in DNS / Services / Routing / Config sub-pages while keeping the page
+   *  chrome (header + stats + tabs + footer) intact. */
+  extraContent?: ReactNode;
 
   // Quick actions footer (omit to hide)
   footer?: {
@@ -259,8 +268,10 @@ export function RouterPage(props: RouterPageProps) {
     interfacesTotalsLabel,
     onAddInterface,
     onFilterInterface,
+    showInterfaces = true,
     firewall,
     dhcp,
+    extraContent,
     footer,
   } = props;
 
@@ -321,6 +332,7 @@ export function RouterPage(props: RouterPageProps) {
       <RouterTabs tabs={tabs} active={activeTab} onChange={onTabChange} />
 
       {/* Interfaces table — router-page.jsx lines 73-141 */}
+      {showInterfaces && (
       <div className="card" style={{ padding: 0 }}>
         <div
           style={{
@@ -505,6 +517,7 @@ export function RouterPage(props: RouterPageProps) {
           </div>
         ))}
       </div>
+      )}
 
       {/* Two-pane — Firewall + DHCP — router-page.jsx lines 143-200 */}
       {(firewall || dhcp) && (
@@ -768,6 +781,11 @@ export function RouterPage(props: RouterPageProps) {
           )}
         </div>
       )}
+
+      {/* Per-tab slot — used by vendor wrappers (e.g. pfSense) to render
+          DNS / Services / Routing / Config / System sub-panels in place of
+          the literal-port interfaces/firewall/dhcp grid. */}
+      {extraContent}
 
       {/* Quick actions footer — router-page.jsx lines 203-216 */}
       {footer && (

--- a/web/src/hooks/useHashTab.ts
+++ b/web/src/hooks/useHashTab.ts
@@ -1,10 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Like useState, but syncs the active tab value with the URL hash.
- * Opening /page#tab-name activates that tab; clicking a tab updates the hash.
+ *
+ * - Opening `/page#tab-name` activates that tab on mount.
+ * - Clicking a tab pushes a new history entry so the browser back/forward
+ *   buttons step between previously-visited tabs.
+ * - `hashchange` (fired by the browser on back/forward across hash entries)
+ *   keeps the in-memory tab in sync with the URL.
+ *
+ * Callers typically pass a freshly-spread array for `validValues`. The hook
+ * stashes the latest values in a ref so the `setTab` identity stays stable
+ * across renders.
  */
 export function useHashTab<T extends string>(
   defaultValue: T,
@@ -12,31 +21,59 @@ export function useHashTab<T extends string>(
 ): [T, (value: string) => void] {
   const [tab, setTabState] = useState<T>(defaultValue);
 
-  // On mount, read hash from URL
-  useEffect(() => {
-    const hash = window.location.hash.slice(1);
-    if (hash && (!validValues || validValues.includes(hash as T))) {
-      setTabState(hash as T);
+  const defaultRef = useRef(defaultValue);
+  const validRef = useRef(validValues);
+  defaultRef.current = defaultValue;
+  validRef.current = validValues;
+
+  const resolveHash = useCallback((raw: string): T | null => {
+    const hash = raw.replace(/^#/, "");
+    if (!hash) return null;
+    const valid = validRef.current;
+    if (!valid || valid.includes(hash as T)) {
+      return hash as T;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return null;
   }, []);
 
-  const setTab = useCallback((value: string) => {
-    setTabState(value as T);
-    window.history.replaceState(null, "", `#${value}`);
-  }, []);
+  // On mount, read the hash from the URL. Falls through to the default if the
+  // hash is missing or not in the validValues list.
+  useEffect(() => {
+    const next = resolveHash(window.location.hash);
+    if (next !== null) {
+      setTabState(next);
+    }
+  }, [resolveHash]);
 
-  // Listen for hash changes (browser back/forward)
+  const setTab = useCallback(
+    (value: string) => {
+      const valid = validRef.current;
+      const next =
+        valid && !valid.includes(value as T)
+          ? defaultRef.current
+          : (value as T);
+      setTabState(next);
+      if (typeof window === "undefined") return;
+      const currentHash = window.location.hash.replace(/^#/, "");
+      if (currentHash === next) return;
+      // Push instead of replace so browser back/forward steps between tabs.
+      const { pathname, search } = window.location;
+      window.history.pushState(null, "", `${pathname}${search}#${next}`);
+    },
+    [],
+  );
+
+  // Listen for hash changes (browser back/forward across hash entries, or any
+  // external hash mutation). Falls back to defaultValue when the new hash is
+  // not in validValues so an invalid deep-link does not strand the panel.
   useEffect(() => {
     const onHashChange = () => {
-      const hash = window.location.hash.slice(1);
-      if (hash && (!validValues || validValues.includes(hash as T))) {
-        setTabState(hash as T);
-      }
+      const next = resolveHash(window.location.hash);
+      setTabState(next ?? defaultRef.current);
     };
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, [validValues]);
+  }, [resolveHash]);
 
   return [tab, setTab];
 }

--- a/web/tests/e2e/pfsense-hash-subroutes.spec.ts
+++ b/web/tests/e2e/pfsense-hash-subroutes.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * Refs #806 — pfSense router page hash subroutes must switch panels.
+ *
+ * Each tab on /router/pfsense is addressable by its URL hash
+ * (#system, #interfaces, #firewall, #dhcp, #dns, #services, #routing,
+ * #config). Direct URL loads, in-page tab clicks, and browser back/forward
+ * must all stay in sync with the active panel. Invalid hashes must fall
+ * back to the default (system) panel without breaking the page.
+ *
+ * The tests route-mock pfSense endpoints so they pass in CI with no real
+ * firewall available.
+ */
+
+async function mockPfsenseApis(page: Page) {
+  // Catch-all for any pfSense endpoint we don't override below.
+  await page.route("**/api/v1/pfsense/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+
+  await page.route("**/api/v1/settings", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          mikrotik_enabled: false,
+          pfsense_enabled: true,
+          xiaomi_mesh_enabled: false,
+          default_router: "pfsense",
+        }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.route("**/api/v1/pfsense/status", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        configured: true,
+        reachable: true,
+        hostname: "pfSense-test",
+        domain: "localdomain",
+        version: "2.7.0",
+        uptime: "1 day",
+        cpu_usage: 5,
+        memory_total: 8 * 1024 * 1024 * 1024,
+        memory_used: 2 * 1024 * 1024 * 1024,
+        platform: "amd64",
+      }),
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/interfaces", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          name: "wan",
+          descr: "WAN",
+          iface_type: "ethernet",
+          status: "up",
+          ip_address: "203.0.113.1",
+          subnet: 24,
+          mac: "aa:bb:cc:dd:ee:01",
+          mtu: 1500,
+        },
+        {
+          name: "lan",
+          descr: "LAN",
+          iface_type: "ethernet",
+          status: "up",
+          ip_address: "192.168.1.1",
+          subnet: 24,
+          mac: "aa:bb:cc:dd:ee:02",
+          mtu: 1500,
+        },
+      ]),
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/firewall/rules", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          tracker: "1700000001",
+          interface: "wan",
+          action: "pass",
+          source: "any",
+          destination: "any",
+          description: "Allow HTTPS",
+          disabled: false,
+        },
+      ]),
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/dhcp/leases", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          ip: "192.168.1.100",
+          mac: "aa:bb:cc:dd:ee:99",
+          hostname: "test-device",
+          start: "2026-05-21T10:00:00Z",
+          end: "2026-05-22T10:00:00Z",
+          status: "active",
+          interface: "lan",
+        },
+      ]),
+    }),
+  );
+}
+
+const HASH_TO_PANEL: Record<string, string> = {
+  system: "pfsense-panel-system",
+  dns: "pfsense-panel-dns",
+  services: "pfsense-panel-services",
+  routing: "pfsense-panel-routing",
+  config: "pfsense-panel-config",
+};
+
+async function expectTabActive(page: Page, tabId: string) {
+  await expect(page.getByTestId(`router-tab-${tabId}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+}
+
+test.describe("pfSense router hash subroutes (#806)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await mockPfsenseApis(page);
+  });
+
+  for (const tabId of [
+    "system",
+    "interfaces",
+    "firewall",
+    "dhcp",
+    "dns",
+    "services",
+    "routing",
+    "config",
+  ] as const) {
+    test(`direct navigation to #${tabId} activates the ${tabId} tab`, async ({
+      page,
+    }) => {
+      await page.goto(`/router/pfsense/#${tabId}`);
+      await expect(page.getByTestId("router-tabs")).toBeVisible({
+        timeout: 25_000,
+      });
+      await expectTabActive(page, tabId);
+
+      const expectedPanel = HASH_TO_PANEL[tabId];
+      if (expectedPanel) {
+        await expect(page.getByTestId(expectedPanel)).toBeVisible({
+          timeout: 15_000,
+        });
+      } else {
+        // For interfaces / firewall / dhcp the panel is the literal-port
+        // table card. Verify the heading rendered by RouterPage.
+        const headings: Record<string, string> = {
+          interfaces: "Interfaces",
+          firewall: "Firewall rules",
+          dhcp: "DHCP leases",
+        };
+        await expect(
+          page.getByRole("heading", { name: headings[tabId] }),
+        ).toBeVisible({ timeout: 15_000 });
+      }
+    });
+  }
+
+  test("clicking a tab updates the URL hash and switches the panel", async ({
+    page,
+  }) => {
+    await page.goto("/router/pfsense/");
+    await expect(page.getByTestId("router-tabs")).toBeVisible({
+      timeout: 25_000,
+    });
+
+    await page.getByTestId("router-tab-dhcp").click();
+    await expect(page).toHaveURL(/\/router\/pfsense\/?#dhcp$/);
+    await expectTabActive(page, "dhcp");
+    await expect(
+      page.getByRole("heading", { name: "DHCP leases" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTestId("router-tab-dns").click();
+    await expect(page).toHaveURL(/\/router\/pfsense\/?#dns$/);
+    await expectTabActive(page, "dns");
+    await expect(page.getByTestId("pfsense-panel-dns")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("browser back/forward steps between previously-visited tabs", async ({
+    page,
+  }) => {
+    await page.goto("/router/pfsense/");
+    await expect(page.getByTestId("router-tabs")).toBeVisible({
+      timeout: 25_000,
+    });
+
+    await page.getByTestId("router-tab-firewall").click();
+    await expect(page).toHaveURL(/#firewall$/);
+    await expectTabActive(page, "firewall");
+
+    await page.getByTestId("router-tab-routing").click();
+    await expect(page).toHaveURL(/#routing$/);
+    await expectTabActive(page, "routing");
+    await expect(page.getByTestId("pfsense-panel-routing")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.goBack();
+    await expect(page).toHaveURL(/#firewall$/);
+    await expectTabActive(page, "firewall");
+    await expect(
+      page.getByRole("heading", { name: "Firewall rules" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.goForward();
+    await expect(page).toHaveURL(/#routing$/);
+    await expectTabActive(page, "routing");
+    await expect(page.getByTestId("pfsense-panel-routing")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("invalid hash falls back to the default (system) panel", async ({
+    page,
+  }) => {
+    await page.goto("/router/pfsense/#totally-unknown");
+    await expect(page.getByTestId("router-tabs")).toBeVisible({
+      timeout: 25_000,
+    });
+
+    await expectTabActive(page, "system");
+    await expect(page.getByTestId("pfsense-panel-system")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
Implements #806.

## Problem

`/router/pfsense` was wired to `useHashTab` and read `#system|#interfaces|…` on
mount, but the rendered page (`PfSenseRouterDesign` → `RouterPage`) always
displayed the same Interfaces + Firewall + DHCP panels regardless of the active
tab — only the underline highlight moved. As a result:

- Direct loads of `/router/pfsense/#dhcp`, `/router/pfsense/#dns`, etc. did not
  reveal different content.
- `useHashTab` used `history.replaceState`, so browser back / forward did not
  navigate between previously-visited tabs.
- An invalid hash left the URL in a broken-ish state.

## Fix

- `RouterPage` (literal port of `router-page.jsx`) gains a `showInterfaces`
  flag (defaults to `true`, so existing MikroTik / Xiaomi wrappers are
  unaffected) and an `extraContent` slot rendered above the footer.
- `PfSenseRouterDesign` now switches body content per active tab:
    - `system` → `<SystemTab />` (legacy CRUD card grid)
    - `interfaces` → literal-port Interfaces table
    - `firewall` → literal-port Firewall rules panel
    - `dhcp` → literal-port DHCP leases panel
    - `dns`, `services`, `routing`, `config` → the existing legacy tab
      components reused as drop-ins
  The header, stats grid, tabs strip, and footer are unchanged across tabs.
- `useHashTab` switches from `replaceState` to `pushState` (with a
  duplicate-entry guard) so browser back/forward steps between tabs; the
  `hashchange` listener falls back to `defaultValue` when the new hash is
  not in `validValues`, so an invalid deep-link no longer strands the panel.

## Test plan

E2E spec added at `web/tests/e2e/pfsense-hash-subroutes.spec.ts`:

- Direct navigation to each `#system | #interfaces | #firewall | #dhcp | #dns
  | #services | #routing | #config` activates the matching tab and renders the
  matching panel.
- Clicking a tab updates the URL hash and swaps panels.
- Browser back/forward steps between previously-visited tabs.
- An invalid hash (`#totally-unknown`) falls back to the default `system`
  panel.

The spec mocks pfSense + `/api/v1/settings` so it runs without a real firewall.

## Verification commands run

```
cd web
bun install --frozen-lockfile          # 535 packages
bunx tsc -p tsconfig.json --noEmit     # clean
bun run test                            # 15 files, 66 tests ✓
bun run build                           # ✓ all routes prerender, /router/pfsense 14.7 kB
```

`cargo fmt --all` produced no diff (no Rust files changed).

## Why no live-deploy screenshot

This worktree does not run the Panoptikon Rust backend, so the Next.js page
needs the API to mount. The Playwright spec route-mocks every endpoint it
hits, but cannot run end-to-end without a deployed app + auth. Per the
Maestro brief, live verification on `https://net.oklabs.uk` happens after
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `/router/pfsense` so that the URL hash (`#system`, `#interfaces`, `#firewall`, etc.) controls which panel is rendered, and switches `useHashTab` from `replaceState` to `pushState` so browser back/forward navigates between tabs.

- `PfSenseRouterDesign` now computes `showInterfaces`/`showFirewall`/`showDhcp` flags and an `extraContent` slot to swap panel content per active tab; `RouterPage` gains the matching props (both backward-compatible).
- `useHashTab` adds a stable `resolveHash` helper, replaces `replaceState` with `pushState` plus a duplicate-entry guard, and makes the `hashchange` listener fall back to `defaultValue` on unknown hashes.
- A new Playwright spec covers direct navigation to every hash, tab clicks, back/forward, and the invalid-hash fallback \u2014 but is missing `page.screenshot()` calls required by the project's E2E guidelines.

<h3>Confidence Score: 3/5</h3>

The core routing logic and backward-compat props are sound, but the system tab body is entirely invisible while status data loads, and the E2E spec does not meet the project screenshot requirement — both should be addressed before merge.

The hash-routing and pushState mechanics are well-implemented and RouterPage changes are non-breaking. The system tab renders a completely empty body during the initial API fetch (no skeleton, no loading label, unlike every other tab), and the new E2E spec omits page.screenshot() calls that CLAUDE.md marks as mandatory.

PfSenseRouterDesign.tsx (system-tab loading state) and pfsense-hash-subroutes.spec.ts (missing screenshots)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/router/PfSenseRouterDesign.tsx | Adds per-tab panel switching via showInterfaces/showFirewall/showDhcp flags and an extraContent slot; system tab returns null for extraContent when status.data is not yet available, leaving the body completely empty during load |
| web/src/components/router/RouterPage.tsx | Adds showInterfaces prop (defaults true for backward compat) and extraContent slot above footer; changes are additive and do not affect existing MikroTik/Xiaomi wrappers |
| web/src/hooks/useHashTab.ts | Switches from replaceState to pushState for browser back/forward support, adds duplicate-entry guard and a hashchange fallback to defaultValue; minor edge case where guard allows a redundant push when clicking the default tab on a hash-less URL |
| web/tests/e2e/pfsense-hash-subroutes.spec.ts | Comprehensive Playwright spec covering direct navigation, tab clicks, back/forward, and invalid-hash fallback for all 8 pfSense tabs; missing page.screenshot() calls required by CLAUDE.md |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/router/PfSenseRouterDesign.tsx:211-216
**System tab blank during load / API error**

When `status.data` is falsy (initial load or unreachable firewall), `extraContent` returns `null`. Combined with `showInterfaces={false}` and no `firewall`/`dhcp` props, the system tab body is completely empty — no skeleton, no error state. Every other tab (interfaces, firewall, dhcp) renders its panel with a "loading…" label during the fetch; the system tab shows nothing at all. Per the project guidelines (`CLAUDE.md`), loading states should use skeleton components.

### Issue 2 of 3
web/tests/e2e/pfsense-hash-subroutes.spec.ts:1-15
**No `page.screenshot()` calls in E2E spec**

`CLAUDE.md` lists "Includes a screenshot on key assertions (`page.screenshot(...)`)" as a required characteristic of a valid E2E test. This 250-line spec has zero `page.screenshot()` calls across all four test cases (direct navigation, tab click, back/forward, and invalid hash fallback). Without screenshots, the test satisfies CI but doesn't meet the project's definition of a valid E2E test.

### Issue 3 of 3
web/src/hooks/useHashTab.ts:57-58
**History push fires for the already-active default tab on no-hash URL**

When the page loads at `/router/pfsense` (no hash), `tab` defaults to `"system"` and `window.location.hash` is `""`. If the user then explicitly clicks the already-visible "System" tab, `setTab("system")` is called: `currentHash = ""` ≠ `next = "system"`, so `#system` is pushed to history. One Back press then lands on the hash-less URL rather than a previous page. The guard only suppresses duplicate pushes when the hash is already set; it doesn't cover the hash-absent initial state.

```suggestion
      const currentHash = window.location.hash.replace(/^#/, "");
      if (currentHash === next || (!currentHash && next === defaultRef.current)) return;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pfsense): switch panels per hash sub..."](https://github.com/befeast/panoptikon/commit/180c1fd990795f0a8b4cc691e93d6484292b3729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33328017)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->