### PR TITLE
fix(mesh): real Wi-Fi names + SVG topology on /topology Mesh tab

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -212,11 +212,8 @@ pub async fn topology(
     nodes.push(MeshNode {
         ip: graph.ip.clone(),
         mac: main_mac.clone(),
-        name: if graph.name.is_empty() {
-            graph.locale.clone()
-        } else {
-            graph.name
-        },
+        name: super::xiaomi::effective_mesh_name(Some(&graph.name), Some(&graph.locale))
+            .unwrap_or_default(),
         model: String::new(),
         hardware: graph.hardware,
         is_main: true,
@@ -246,11 +243,8 @@ pub async fn topology(
         nodes.push(MeshNode {
             ip: leaf.ip.clone(),
             mac: leaf_mac,
-            name: if leaf.name.is_empty() {
-                leaf.locale.clone()
-            } else {
-                leaf.name
-            },
+            name: super::xiaomi::effective_mesh_name(Some(&leaf.name), Some(&leaf.locale))
+                .unwrap_or_default(),
             model: String::new(),
             hardware: leaf.hardware,
             is_main: false,

--- a/server/src/api/xiaomi.rs
+++ b/server/src/api/xiaomi.rs
@@ -263,6 +263,33 @@ fn parse_online_value(v: &serde_json::Value) -> Option<i32> {
     }
 }
 
+/// Pick the best human-readable mesh node label from the raw MiWiFi fields.
+///
+/// MiWiFi firmware reports the satellite/main router name in **two** fields:
+///
+/// * `name`   — the radio/internal identifier. Frequently emitted as the
+///   literal string `"default"` (or empty) for satellite mesh routers that
+///   the user has not renamed via the Xiaomi app.
+/// * `locale` — the user-facing room/location label set via the Mi Home app
+///   (e.g. "Live Studio", "Basement"). Empty when the user hasn't named the
+///   node.
+///
+/// Pre-#807 we passed both fields through verbatim and the frontend rendered
+/// `locale || name`. That meant any satellite without a `locale` (which is
+/// every satellite on some BE3600 firmware paths) rendered as the literal
+/// `"default"`. This helper trims, drops the `"default"` sentinel, and
+/// returns the first usable value so the UI never shows a placeholder when a
+/// real name exists in either field.
+pub(crate) fn effective_mesh_name(name: Option<&str>, locale: Option<&str>) -> Option<String> {
+    fn clean(s: Option<&str>) -> Option<String> {
+        s.map(str::trim)
+            .filter(|v| !v.is_empty())
+            .filter(|v| !v.eq_ignore_ascii_case("default"))
+            .map(|v| v.to_string())
+    }
+    clean(locale).or_else(|| clean(name))
+}
+
 /// GET /xiaomi/topology — mesh topology graph (no auth required).
 pub async fn topology(
     State(state): State<AppState>,
@@ -291,7 +318,7 @@ pub async fn topology(
                 .into_iter()
                 .map(|n| XiaomiTopoNodeResponse {
                     mac: n.mac,
-                    name: n.name,
+                    name: effective_mesh_name(n.name.as_deref(), n.locale.as_deref()),
                     locale: n.locale,
                     ip: n.ip,
                     online: n.online,
@@ -312,7 +339,7 @@ pub async fn topology(
                     let main_online = graph.online.as_ref().and_then(parse_online_value);
                     nodes.push(XiaomiTopoNodeResponse {
                         mac: None,
-                        name: graph.name,
+                        name: effective_mesh_name(graph.name.as_deref(), graph.locale.as_deref()),
                         locale: graph.locale,
                         ip: graph.ip,
                         online: main_online,
@@ -326,7 +353,7 @@ pub async fn topology(
                     if leaf.link_type.is_some() {
                         nodes.push(XiaomiTopoNodeResponse {
                             mac: leaf.mac,
-                            name: leaf.name,
+                            name: effective_mesh_name(leaf.name.as_deref(), leaf.locale.as_deref()),
                             locale: leaf.locale,
                             ip: leaf.ip,
                             online: leaf.online,
@@ -337,7 +364,7 @@ pub async fn topology(
                         leafs_out.push(XiaomiTopoLeafResponse {
                             mac: leaf.mac,
                             ip: leaf.ip,
-                            name: leaf.name,
+                            name: effective_mesh_name(leaf.name.as_deref(), leaf.locale.as_deref()),
                             online: leaf.online,
                             parent_id: leaf.parent_id,
                         });
@@ -350,7 +377,7 @@ pub async fn topology(
                     .map(|l| XiaomiTopoLeafResponse {
                         mac: l.mac,
                         ip: l.ip,
-                        name: l.name,
+                        name: effective_mesh_name(l.name.as_deref(), l.locale.as_deref()),
                         online: l.online,
                         parent_id: l.parent_id,
                     })
@@ -852,6 +879,63 @@ mod tests {
             result.len(),
             2,
             "different SSIDs on same band must both survive"
+        );
+    }
+
+    // ── effective_mesh_name (#807) ────────────────────────
+
+    #[test]
+    fn effective_mesh_name_prefers_locale_when_name_is_default_sentinel() {
+        // Production root-cause case for #807: MiWiFi emits `name="default"`
+        // for every satellite mesh router that hasn't been renamed via the
+        // radio settings, even when the user has set a room label in
+        // `locale`. Pre-fix we showed "default" for every satellite except
+        // the one with a non-empty `locale` ("Live Studio").
+        assert_eq!(
+            effective_mesh_name(Some("default"), Some("Live Studio")),
+            Some("Live Studio".to_string()),
+        );
+    }
+
+    #[test]
+    fn effective_mesh_name_prefers_locale_case_insensitively() {
+        assert_eq!(
+            effective_mesh_name(Some("DEFAULT"), Some("Basement")),
+            Some("Basement".to_string()),
+        );
+        assert_eq!(
+            effective_mesh_name(Some("Default"), Some("Floor 2")),
+            Some("Floor 2".to_string()),
+        );
+    }
+
+    #[test]
+    fn effective_mesh_name_falls_back_to_name_when_locale_is_empty() {
+        assert_eq!(
+            effective_mesh_name(Some("OK Home"), Some("")),
+            Some("OK Home".to_string()),
+        );
+        assert_eq!(
+            effective_mesh_name(Some("OK Home"), None),
+            Some("OK Home".to_string()),
+        );
+    }
+
+    #[test]
+    fn effective_mesh_name_returns_none_when_both_fields_are_unusable() {
+        assert_eq!(effective_mesh_name(Some("default"), Some("")), None);
+        assert_eq!(effective_mesh_name(Some(""), Some("default")), None);
+        assert_eq!(effective_mesh_name(Some("default"), Some("default")), None);
+        assert_eq!(effective_mesh_name(None, None), None);
+        // Whitespace-only fields are treated as empty.
+        assert_eq!(effective_mesh_name(Some("   "), Some("\t")), None);
+    }
+
+    #[test]
+    fn effective_mesh_name_trims_surrounding_whitespace() {
+        assert_eq!(
+            effective_mesh_name(Some("default"), Some("  Live Studio  ")),
+            Some("Live Studio".to_string()),
         );
     }
 }

--- a/web/src/components/XiaomiMeshTopology.tsx
+++ b/web/src/components/XiaomiMeshTopology.tsx
@@ -21,6 +21,28 @@ import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types
 
 // ─── Helpers ─────────────────────────────────────────────
 
+/**
+ * Pick the best human-readable mesh node label.
+ *
+ * MiWiFi reports a name in two fields — `locale` (user-facing room label set
+ * via the Mi Home app) and `name` (internal radio identifier). The router
+ * frequently emits the literal string `"default"` in `name` for satellites
+ * the user has not renamed via the radio settings. The backend
+ * (`effective_mesh_name` in `server/src/api/xiaomi.rs`) already strips this
+ * sentinel, but we mirror the logic here so the UI degrades gracefully if a
+ * stale build of the backend is in play (#807).
+ */
+function meshNodeLabel(node: { name?: string | null; locale?: string | null; ip?: string | null }): string {
+  const clean = (s: string | null | undefined): string | null => {
+    if (!s) return null;
+    const trimmed = s.trim();
+    if (!trimmed) return null;
+    if (trimmed.toLowerCase() === "default") return null;
+    return trimmed;
+  };
+  return clean(node.locale) ?? clean(node.name) ?? node.ip?.trim() ?? "Mesh Node";
+}
+
 /** Get leafs attached to a given node MAC. */
 function leafsForNode(
   nodeMac: string | null,
@@ -28,6 +50,222 @@ function leafsForNode(
 ): XiaomiTopoLeaf[] {
   if (!nodeMac) return [];
   return leafs.filter((l) => l.parent_id === nodeMac);
+}
+
+// ─── SVG topology map ────────────────────────────────────
+
+const SVG_W = 720;
+const SVG_H = 360;
+const SVG_CX = SVG_W / 2;
+const SVG_CY = SVG_H / 2;
+const SAT_RING = 130;
+
+interface PositionedNode {
+  node: XiaomiTopoNode;
+  isMain: boolean;
+  x: number;
+  y: number;
+  leafCount: number;
+}
+
+/**
+ * Lay out the mesh nodes radially: main router at the centre, satellites on a
+ * ring around it. Mirrors the SVG geometry used on `/topology` (Subnets tab)
+ * so the two views read as the same family.
+ */
+function layoutNodes(
+  data: XiaomiTopology,
+  mainMac: string | null,
+): PositionedNode[] {
+  const main = data.nodes.find((n) => n.mac === mainMac) ?? data.nodes[0];
+  const satellites = data.nodes.filter((n) => n !== main);
+
+  const out: PositionedNode[] = [];
+  if (main) {
+    out.push({
+      node: main,
+      isMain: true,
+      x: SVG_CX,
+      y: SVG_CY,
+      leafCount: leafsForNode(main.mac, data.leafs).length,
+    });
+  }
+  satellites.forEach((sat, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(satellites.length, 1) - Math.PI / 2;
+    out.push({
+      node: sat,
+      isMain: false,
+      x: SVG_CX + Math.cos(angle) * SAT_RING,
+      y: SVG_CY + Math.sin(angle) * SAT_RING,
+      leafCount: leafsForNode(sat.mac, data.leafs).length,
+    });
+  });
+  return out;
+}
+
+function MeshTopologyMap({
+  data,
+  mainMac,
+}: {
+  data: XiaomiTopology;
+  mainMac: string | null;
+}) {
+  const positioned = useMemo(() => layoutNodes(data, mainMac), [data, mainMac]);
+  const main = positioned.find((p) => p.isMain) ?? null;
+
+  if (positioned.length === 0) return null;
+
+  return (
+    <div
+      className="mesh-card relative overflow-hidden"
+      style={{ padding: 0, height: SVG_H }}
+      data-testid="xiaomi-mesh-svg-card"
+    >
+      {/* Blueprint grid background — matches /topology canvas */}
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(96,144,212,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(96,144,212,0.08) 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+        }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 50% 50%, rgba(56,189,248,0.05), transparent 60%)",
+        }}
+      />
+
+      <svg
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        role="img"
+        aria-label="Xiaomi mesh topology"
+        data-testid="xiaomi-mesh-svg"
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        <defs>
+          <radialGradient id="xmesh-glow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stopColor="#38bdf8" stopOpacity="0.35" />
+            <stop offset="1" stopColor="#38bdf8" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        {/* Edges: main → each satellite */}
+        {main &&
+          positioned
+            .filter((p) => !p.isMain)
+            .map((sat) => (
+              <line
+                key={`edge-${sat.node.mac ?? sat.node.ip}`}
+                x1={main.x}
+                y1={main.y}
+                x2={sat.x}
+                y2={sat.y}
+                stroke="rgba(56,189,248,0.45)"
+                strokeWidth={1.2}
+                strokeDasharray="6 4"
+              />
+            ))}
+
+        {/* Nodes */}
+        {positioned.map((p) => {
+          const label = meshNodeLabel(p.node);
+          const fill = p.isMain ? "#fbbf24" : "#2563eb";
+          const stroke = p.isMain ? "#fbbf24" : "#38bdf8";
+          const r = p.isMain ? 20 : 16;
+          return (
+            <g
+              key={`node-${p.node.mac ?? p.node.ip ?? label}`}
+              transform={`translate(${p.x},${p.y})`}
+              data-testid="xiaomi-mesh-svg-node"
+              data-node-name={label}
+              data-node-role={p.isMain ? "main" : "satellite"}
+            >
+              <circle r={r + 12} fill="url(#xmesh-glow)" />
+              <rect
+                x={-r}
+                y={-r}
+                width={r * 2}
+                height={r * 2}
+                rx={4}
+                fill={fill}
+                fillOpacity={0.2}
+                stroke={stroke}
+                strokeWidth={1.5}
+              />
+              <text
+                y={-r - 8}
+                textAnchor="middle"
+                fontSize="11"
+                fill="var(--text, #e2e8f0)"
+                fontFamily="var(--font-sans)"
+                fontWeight={600}
+              >
+                {label.length > 22 ? `${label.slice(0, 21)}…` : label}
+              </text>
+              <text
+                y={r + 14}
+                textAnchor="middle"
+                fontSize="9"
+                fill="var(--text-mute, #94a3b8)"
+                fontFamily="var(--font-mono)"
+              >
+                {p.node.ip ?? "—"} · {p.node.online ?? 0} dev
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Legend */}
+      <div
+        className="absolute"
+        style={{
+          bottom: 10,
+          left: 12,
+          display: "flex",
+          gap: 12,
+          padding: "6px 10px",
+          background: "rgba(6,15,37,0.85)",
+          border: "var(--hairline) solid rgba(96,144,212,0.20)",
+          borderRadius: "var(--radius-sm)",
+          font: "500 10px var(--font-mono)",
+          color: "var(--text-dim)",
+          backdropFilter: "blur(8px)",
+        }}
+      >
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              background: "#fbbf24",
+              borderRadius: 1,
+            }}
+          />
+          main router
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              background: "#2563eb",
+              borderRadius: 1,
+            }}
+          />
+          satellite
+        </span>
+      </div>
+    </div>
+  );
 }
 
 // ─── Node Card ───────────────────────────────────────────
@@ -43,9 +281,14 @@ function NodeCard({
 }) {
   const connectedLeafs = leafsForNode(node.mac, leafs);
   const onlineDevices = node.online ?? 0;
+  const label = meshNodeLabel(node);
 
   return (
-    <Card className={isMain ? "ring-1 ring-[#fbbf24]/30" : undefined}>
+    <Card
+      className={isMain ? "ring-1 ring-[#fbbf24]/30" : undefined}
+      data-testid="xiaomi-mesh-node-card"
+      data-node-name={label}
+    >
       <CardHeader className="pb-3">
         <div className="flex items-center gap-3">
           <div
@@ -61,7 +304,7 @@ function NodeCard({
           </div>
           <div className="min-w-0 flex-1">
             <CardTitle className="truncate text-sm font-semibold text-mesh-text">
-              {node.locale || node.name || "Mesh Node"}
+              {label}
             </CardTitle>
             <p className="truncate font-mono text-xs text-mesh-text-dim">
               {node.ip || "No IP"}
@@ -136,7 +379,7 @@ function NodeCard({
                   className="flex items-center justify-between rounded px-1.5 py-0.5 text-[11px] hover:bg-mesh-surface-2"
                 >
                   <span className="truncate text-mesh-text">
-                    {leaf.name || leaf.mac || "Unknown"}
+                    {meshNodeLabel(leaf) || leaf.mac || "Unknown"}
                   </span>
                   <span className="shrink-0 font-mono text-mesh-text-mute">
                     {leaf.ip || "—"}
@@ -238,7 +481,7 @@ export default function XiaomiMeshTopology() {
   }, [data]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="xiaomi-mesh-topology">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -325,6 +568,11 @@ export default function XiaomiMeshTopology() {
             <NodeCardSkeleton key={i} />
           ))}
         </div>
+      )}
+
+      {/* SVG topology map */}
+      {!loading && data && sortedNodes.length > 0 && (
+        <MeshTopologyMap data={data} mainMac={mainMac} />
       )}
 
       {/* Node cards */}

--- a/web/tests/e2e/topology-mesh-svg.spec.ts
+++ b/web/tests/e2e/topology-mesh-svg.spec.ts
@@ -1,0 +1,268 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * Regression coverage for issue #807 — "Mesh topology should render correct
+ * Wi-Fi SVG/topology roles".
+ *
+ * Before #807 the `/topology` Mesh tab rendered every Xiaomi mesh node as the
+ * literal string `"default"` (only nodes the user had renamed in the Mi Home
+ * app via the `locale` field — like "Live Studio" — survived), and the tab
+ * showed cards-only with no SVG topology map.
+ *
+ * The fix has two parts:
+ *  1. Backend `effective_mesh_name` strips the `"default"` sentinel and
+ *     prefers `locale` over `name` so the real user-set room labels reach
+ *     the UI.
+ *  2. The `XiaomiMeshTopology` component now renders an SVG topology map
+ *     (main router center, satellites on a ring) on top of the existing
+ *     detail cards and applies the same sentinel filter in the label
+ *     fallback chain.
+ *
+ * The tests mock `/api/v1/xiaomi/topology` with a payload that mirrors the
+ * production response shape from the user's RD15 mesh — including a
+ * satellite whose `name` is `"default"` and whose real label lives in
+ * `locale: "Live Studio"`.
+ */
+
+// ── Mock payload (verbatim shape from production /api/v1/xiaomi/topology) ──
+
+const MOCK_TOPOLOGY = {
+  nodes: [
+    {
+      mac: "AA:BB:CC:DD:EE:01",
+      // After the backend fix `name` is the *effective* name with the
+      // "default" sentinel stripped. The fixture mirrors what the frontend
+      // actually receives now: the room label promoted from `locale`.
+      name: "OK Home",
+      locale: "OK Home",
+      ip: "10.10.0.199",
+      online: 8,
+      hardware: "RD15",
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:02",
+      name: "Live Studio",
+      locale: "Live Studio",
+      ip: "10.10.0.52",
+      online: 5,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:03",
+      name: "Basement",
+      locale: "Basement",
+      ip: "10.10.0.54",
+      online: 4,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:04",
+      name: "Floor 2",
+      locale: "Floor 2",
+      ip: "10.10.0.53",
+      online: 8,
+      hardware: null,
+      model: null,
+    },
+  ],
+  leafs: [],
+};
+
+/**
+ * Same payload but with the **pre-fix backend** shape — `name="default"`
+ * sentinel and only `Live Studio` carrying a usable `locale`. This locks in
+ * the frontend safety net: even with a stale backend, the UI must not
+ * render the "default" sentinel.
+ */
+const MOCK_TOPOLOGY_RAW_SENTINEL = {
+  nodes: [
+    {
+      mac: "AA:BB:CC:DD:EE:01",
+      name: "OK Home",
+      locale: null,
+      ip: "10.10.0.199",
+      online: 8,
+      hardware: "RD15",
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:02",
+      name: "default",
+      locale: "Live Studio",
+      ip: "10.10.0.52",
+      online: 5,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:03",
+      name: "default",
+      locale: "Basement",
+      ip: "10.10.0.54",
+      online: 4,
+      hardware: null,
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:DD:EE:04",
+      name: "default",
+      locale: null,
+      ip: "10.10.0.53",
+      online: 8,
+      hardware: null,
+      model: null,
+    },
+  ],
+  leafs: [],
+};
+
+async function mockXiaomiTopology(page: Page, payload: unknown) {
+  await page.route("**/api/v1/xiaomi/topology", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+async function mockTopologyGraph(page: Page) {
+  await page.route("**/api/v1/topology/graph", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        router: {
+          router_type: "mikrotik",
+          is_online: false,
+          wan_ip: null,
+          hostname: null,
+          version: null,
+        },
+        devices: [],
+        positions: [],
+      }),
+    }),
+  );
+  await page.route("**/api/v1/topology/positions", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
+    }),
+  );
+}
+
+test.describe("Topology → Mesh tab (#807)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTopologyGraph(page);
+    await login(page);
+  });
+
+  test("renders real Wi-Fi mesh names, an SVG topology, and never the 'default' sentinel", async ({
+    page,
+  }) => {
+    await mockXiaomiTopology(page, MOCK_TOPOLOGY);
+    await page.goto("/topology");
+
+    await expect(page.getByTestId("topology-root")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Switch to the Mesh tab.
+    await page.getByTestId("topology-tab-mesh").click();
+
+    const meshPane = page.getByTestId("topology-mesh-pane");
+    await expect(meshPane).toBeVisible();
+    await expect(
+      meshPane.getByTestId("xiaomi-mesh-topology"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // SVG topology map is present — fixes "only generic repeated cards".
+    const svg = meshPane.getByTestId("xiaomi-mesh-svg");
+    await expect(svg).toBeVisible();
+
+    // Each node from the mocked topology renders as a positioned <g> in the
+    // SVG with the user-facing label as `data-node-name`. This is the
+    // load-bearing assertion: pre-fix every satellite would have rendered
+    // with name="default".
+    const svgNodes = meshPane.getByTestId("xiaomi-mesh-svg-node");
+    await expect(svgNodes).toHaveCount(4);
+    await expect(
+      meshPane.locator('[data-testid="xiaomi-mesh-svg-node"][data-node-role="main"]'),
+    ).toHaveCount(1);
+
+    const labels = await svgNodes.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-node-name")),
+    );
+    expect(labels).toEqual(
+      expect.arrayContaining(["OK Home", "Live Studio", "Basement", "Floor 2"]),
+    );
+    for (const label of labels) {
+      expect(label?.toLowerCase()).not.toBe("default");
+    }
+
+    // Detail cards still render alongside the SVG (one per node).
+    const cards = meshPane.getByTestId("xiaomi-mesh-node-card");
+    await expect(cards).toHaveCount(4);
+    const cardLabels = await cards.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-node-name")),
+    );
+    for (const label of cardLabels) {
+      expect(label?.toLowerCase()).not.toBe("default");
+    }
+
+    // "default" must not appear anywhere in the visible mesh pane text — this
+    // is the user-visible bug from the issue report.
+    const paneText = (await meshPane.innerText()).toLowerCase();
+    expect(paneText).not.toContain("default");
+
+    await page.screenshot({
+      path: "tests/screenshots/topology-mesh-svg.png",
+      fullPage: true,
+    });
+  });
+
+  test("frontend label fallback also strips 'default' when backend hasn't normalized", async ({
+    page,
+  }) => {
+    // Stale backend safety net: feed the raw MiWiFi shape with name="default"
+    // sentinels and verify the UI still shows the real `locale`-based names
+    // and falls back to the IP for nodes with neither.
+    await mockXiaomiTopology(page, MOCK_TOPOLOGY_RAW_SENTINEL);
+    await page.goto("/topology");
+
+    await expect(page.getByTestId("topology-root")).toBeVisible({
+      timeout: 15000,
+    });
+    await page.getByTestId("topology-tab-mesh").click();
+
+    const meshPane = page.getByTestId("topology-mesh-pane");
+    await expect(
+      meshPane.getByTestId("xiaomi-mesh-topology"),
+    ).toBeVisible({ timeout: 15000 });
+
+    const svgNodes = meshPane.getByTestId("xiaomi-mesh-svg-node");
+    await expect(svgNodes).toHaveCount(4);
+    const labels = await svgNodes.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-node-name") ?? ""),
+    );
+    // Renamed nodes via `locale`.
+    expect(labels).toEqual(
+      expect.arrayContaining(["OK Home", "Live Studio", "Basement"]),
+    );
+    // The node with name="default" and locale=null must fall back to IP,
+    // never to the literal "default".
+    expect(labels).toContain("10.10.0.53");
+    for (const label of labels) {
+      expect(label.toLowerCase()).not.toBe("default");
+    }
+
+    const paneText = (await meshPane.innerText()).toLowerCase();
+    expect(paneText).not.toContain("default");
+  });
+});


### PR DESCRIPTION
## Summary

Refs #807. Topology → Mesh rendered nearly every mesh node as the literal string `default` (only nodes whose user-facing label happened to live in MiWiFi's `locale` field, like "Live Studio", survived), and the tab showed cards only — no SVG topology map.

**Root cause:** MiWiFi emits `name="default"` for every satellite mesh router the user hasn't renamed via the radio settings; the user-set room label lives in `locale`. The handler passed both fields through verbatim and the frontend rendered `locale || name`, so any satellite without a `locale` rendered as the sentinel.

**Backend fix** (`server/src/api/xiaomi.rs`, `server/src/api/mesh.rs`)
- New `effective_mesh_name(name, locale)` helper: trims, drops the case-insensitive `"default"` sentinel, prefers `locale` over `name`.
- Applied on every node + leaf in both `/api/v1/xiaomi/topology` and `/api/v1/mesh/topology`.
- 5 unit tests covering the sentinel, case-insensitivity, fallback to `name`, both-fields-unusable, and whitespace trimming.

**Frontend fix** (`web/src/components/XiaomiMeshTopology.tsx`)
- Mirror the sentinel filter in `meshNodeLabel` so the UI degrades gracefully against a stale backend.
- Render an inline SVG topology map (main router center, satellites on a ring, blueprint grid + legend) above the detail cards — addresses the "visual SVG/topology map, not only generic repeated cards" acceptance criterion.
- `data-testid` markers on the topology root, SVG, SVG nodes, and node cards.

**E2E** (`web/tests/e2e/topology-mesh-svg.spec.ts`)
- Mocks `/api/v1/xiaomi/topology` with the production response shape including a satellite where `name="default"` and `locale="Live Studio"`.
- Asserts: SVG visible, all four mesh nodes render with their real labels, and the literal string `default` never appears in the mesh pane (case-insensitive).
- Second test locks in the frontend safety net against a pre-fix backend.

## Commands run

```bash
cargo fmt --all -- --check        # clean
cargo clippy -p panoptikon-server --lib --no-deps -- -D warnings  # clean
cargo test -p panoptikon-server --lib api::xiaomi
# → 15 passed (5 new effective_mesh_name_* + 10 existing band/dedup)

cd web
bun install --frozen-lockfile      # 535 packages
bun run build                      # ✓ Compiled successfully in 29.5s
bun run test                       # 15 files, 66 tests passed (vitest)
bunx playwright test --list tests/e2e/topology-mesh-svg.spec.ts
# → 2 tests discovered
```

## E2E execution

`bunx playwright test tests/e2e/topology-mesh-svg.spec.ts` requires the Rust backend running on `localhost:8080` (which embeds the web assets); no backend was running in this worktree. The spec is parseable and the assertions are deterministic via route-level mocks, so it will run on the CI/maestro pipeline that boots the full stack.

## Test plan

- [ ] CI runs `tests/e2e/topology-mesh-svg.spec.ts` and both cases pass.
- [ ] On `https://net.oklabs.uk`, open `/topology`, click the **Mesh** tab, and visually verify:
  - The SVG topology map is visible above the cards.
  - Every node — main + satellites — shows its real user-set name (Live Studio, Basement, Floor 2, etc.). No node should display the literal string `default`.
  - The cards below show the same names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs on the Topology → Mesh tab: every satellite mesh node was rendering as the literal string `"default"` (because MiWiFi emits `name="default"` for unrenamed satellites), and no SVG topology map was shown — only detail cards.

- **Backend** (`xiaomi.rs`, `mesh.rs`): a new `effective_mesh_name(name, locale)` helper trims, drops the `"default"` sentinel, and prefers the user-facing `locale` label; applied uniformly to every node and leaf across both topology endpoints, covered by five focused unit tests.
- **Frontend** (`XiaomiMeshTopology.tsx`): mirrors the same sentinel filter in `meshNodeLabel` for graceful degradation against a stale backend, and renders a new inline SVG topology map (main router centred, satellites on a ring) above the existing detail cards.
- **E2E** (`topology-mesh-svg.spec.ts`): two Playwright tests with route-level mocks verify the fixed-backend shape and the stale-backend fallback, asserting the literal string `"default"` never appears in the mesh pane.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the leaf-display MAC fallback regression in XiaomiMeshTopology.tsx.

The Rust backend changes and tests are clean. The frontend SVG map and meshNodeLabel sentinel filter work correctly for mesh nodes. The one gap is in leaf-device display: meshNodeLabel never returns a falsy value, so the MAC fallback for IP-less devices is now dead code.

web/src/components/XiaomiMeshTopology.tsx — specifically the leaf label expression on the connected-devices list inside NodeCard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/xiaomi.rs | Adds `effective_mesh_name` helper that trims, drops the "default" sentinel, and prefers `locale` over `name`; applied to all node and leaf mappings in the topology handler. Five unit tests cover all edge cases cleanly. |
| server/src/api/mesh.rs | Replaces the old empty-string guard with `super::xiaomi::effective_mesh_name`, keeping both the main router and satellite leaf name normalization consistent with the xiaomi handler. |
| web/src/components/XiaomiMeshTopology.tsx | Adds SVG topology map with radial layout and `meshNodeLabel` sentinel filter. The MAC fallback for leaf-device display is now unreachable because `meshNodeLabel` never returns a falsy value. |
| web/tests/e2e/topology-mesh-svg.spec.ts | New E2E spec with route-level mocks exercises both the post-fix backend shape and the stale-backend sentinel-passthrough. Fixtures, login, screenshot on assertion, and `data-testid` markers all follow project conventions. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/XiaomiMeshTopology.tsx:381-383
`meshNodeLabel` always returns at least `"Mesh Node"` (never an empty string), so the `|| leaf.mac || "Unknown"` tail of this expression is permanently unreachable. Before this change the code fell through to the MAC for leaves that had neither a name nor an IP, which is useful for identifying a device before DHCP completes. Now those leaves silently show "Mesh Node" instead of their hardware address.

```suggestion
                  <span className="truncate text-mesh-text">
                    {(meshNodeLabel(leaf) === "Mesh Node" ? null : meshNodeLabel(leaf)) ?? leaf.mac ?? "Mesh Node"}
                  </span>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mesh): render real Wi-Fi mesh names ..."](https://github.com/befeast/panoptikon/commit/5acd9905f37cb1beb9fc1ffd97cc5ae663c4bf39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33329520)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->