### PR TITLE
fix(ux): Cmd+K / Ctrl+K reliably opens command palette (#805)

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { Command } from 'cmdk'
 import {
@@ -57,18 +57,34 @@ export function CommandPalette() {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS)
   const [scanning, setScanning] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // ── Global Cmd+K / Ctrl+K listener ──
+  // Toggles the dialog open/closed. Fires regardless of focused element so the
+  // shortcut works from text inputs (Linear/GitHub/Slack convention). Uses
+  // case-insensitive match so Shift+Cmd+K still triggers.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'k') {
         e.preventDefault()
+        e.stopPropagation()
         setOpen((prev) => !prev)
       }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [])
+
+  // Belt-and-braces: cmdk's autoFocus normally focuses the input, but Radix
+  // focus-trap timing can briefly hand focus to the dialog root first. Force
+  // focus to the input whenever the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    const id = requestAnimationFrame(() => {
+      inputRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [open])
 
   // ── Reset state when closed ──
   useEffect(() => {
@@ -147,6 +163,7 @@ export function CommandPalette() {
       <div className="flex items-center gap-3 border-b border-mesh-border-strong px-4 py-3">
         <Search className="h-5 w-5 shrink-0 text-mesh-text-dim" />
         <Command.Input
+          ref={inputRef}
           value={query}
           onValueChange={setQuery}
           placeholder="Search pages, devices, actions…"

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -560,17 +560,6 @@ function SidebarSearch() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  useEffect(() => {
-    function onHotkey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onHotkey);
-    return () => window.removeEventListener("keydown", onHotkey);
-  }, []);
-
   const flatItems = useMemo(() => {
     if (!results) return [] as Array<{ type: string; id: string; label: string }>;
     const items: Array<{ type: string; id: string; label: string }> = [];

--- a/web/tests/e2e/command-palette-shortcut.spec.ts
+++ b/web/tests/e2e/command-palette-shortcut.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E coverage for the global Cmd+K / Ctrl+K shortcut (#805).
+ *
+ * Verifies that pressing the platform-appropriate shortcut from any
+ * authenticated route opens the command palette and lands focus on the
+ * search input ready for typing, and that Escape closes the palette.
+ */
+test.describe("Cmd+K / Ctrl+K global search shortcut (#805)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Control+K opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeHidden();
+
+    await page.keyboard.press("Control+k");
+
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const searchInput = page.locator("[cmdk-input]");
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toBeFocused();
+
+    // Typing immediately should land in the palette input, not the sidebar.
+    await page.keyboard.type("dash");
+    await expect(searchInput).toHaveValue("dash");
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-shortcut-opens-palette.png",
+      fullPage: true,
+    });
+  });
+
+  test("Meta+K (macOS shortcut) also opens the palette", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Meta+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+  });
+
+  test("Escape closes the palette after opening with Ctrl+K", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden({ timeout: 3000 });
+  });
+
+  test("shortcut works while focus is in a text input", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Sidebar inline search input advertises ⌘K next to it; focus it first
+    // to simulate a user already typing in a text field when they invoke the
+    // global shortcut.
+    const sidebarSearch = page
+      .locator('input[placeholder="Search"]')
+      .first();
+    if (await sidebarSearch.count()) {
+      await sidebarSearch.focus();
+      await expect(sidebarSearch).toBeFocused();
+    }
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+  });
+
+  test("Ctrl+K from a non-dashboard route also opens the palette", async ({
+    page,
+  }) => {
+    await page.goto("/devices");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
- Drop the duplicate Cmd+K/Ctrl+K listener in `SidebarSearch` so the global Command Palette is the single source of truth; the sidebar inline search was racing the palette and breaking the shortcut when the sidebar was collapsed.
- Broaden the palette's key match (case-insensitive, ignore Alt+) and `stopPropagation` so the shortcut behaves the same from any focused element, including text inputs.
- Explicitly focus the palette's `Command.Input` on open via a `useRef` + `requestAnimationFrame`, defeating an intermittent Radix focus-trap timing where focus briefly stayed on the dialog root.

Refs #805

## Files
- `web/src/components/CommandPalette.tsx` — single global handler, robust key match, ref-based focus on open.
- `web/src/components/layout/Sidebar.tsx` — remove conflicting `onHotkey` listener (input is still reachable via click/Tab and its inline kbd `⌘K` now correctly advertises *the palette*).
- `web/tests/e2e/command-palette-shortcut.spec.ts` — new spec covering the four user-visible guarantees.

## Test plan
- [x] `bun run build` (web) — passes
- [x] `bun run tsc --noEmit` — passes
- [x] `bun run test` (vitest) — 66/66 pass
- [ ] `bunx playwright test command-palette-shortcut.spec.ts` — added but not executed in worker env (no Rust toolchain available to start `panoptikon-server`; tests will run in CI).

### New E2E coverage (`command-palette-shortcut.spec.ts`)
- Ctrl+K opens the palette and the search input is focused & types straight in.
- Meta+K (macOS) also opens the palette.
- Escape closes the palette.
- Shortcut still opens the palette when focus is in the sidebar search input.
- Shortcut works from non-dashboard routes (`/devices`).

## Why No Live Visual Verification
Worker container lacks `cargo`, so the Rust backend cannot be started locally to run the full Playwright suite. The new spec is wired to the standard `login` fixture and `[cmdk-dialog]`/`[cmdk-input]` selectors used by existing palette specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the Cmd+K / Ctrl+K race condition where the sidebar's `window`-level keydown listener was competing with the global palette handler and breaking the shortcut when the sidebar was focused. The palette handler is hardened with a case-insensitive key match, `stopPropagation` to block any remaining `window`-level listeners, and a `requestAnimationFrame`-based focus fallback that defeats an intermittent Radix focus-trap timing issue.

- `CommandPalette.tsx`: key handler broadened (`!altKey`, case-insensitive), `stopPropagation` added, `useRef` + `requestAnimationFrame` ensures the `Command.Input` reliably receives focus on open.
- `Sidebar.tsx`: duplicate `window` keydown listener removed; sidebar search is still reachable via click and Tab.
- `command-palette-shortcut.spec.ts`: new E2E spec covering four user-visible guarantees (Ctrl+K, Meta+K, Escape, focus-from-input, non-dashboard route), though screenshots are missing on four of five tests and the "focus in a text input" test has a silent conditional that lets it pass trivially when the sidebar is hidden.

<h3>Confidence Score: 4/5</h3>

The production code changes are safe to merge — the sidebar handler removal and palette hardening are clean and correct. The new E2E spec has two weaknesses (missing screenshots and a silently-skippable precondition) but these don't affect runtime behavior.

The `CommandPalette.tsx` and `Sidebar.tsx` changes are straightforward and low-risk. The only concerns are in the new test file: the "shortcut from a text input" test can silently pass without actually exercising its own precondition, and four of the five tests skip the required screenshots. Neither issue affects the fix itself.

web/tests/e2e/command-palette-shortcut.spec.ts — the conditional sidebar-focus guard and missing screenshots.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Adds case-insensitive key match, stopPropagation, and a requestAnimationFrame-based focus fallback via useRef — all look correct and well-reasoned. |
| web/src/components/layout/Sidebar.tsx | Removes the conflicting window-level Cmd+K handler; no other logic changed, clean deletion. |
| web/tests/e2e/command-palette-shortcut.spec.ts | New spec covers the four required scenarios but one test silently skips its precondition when the sidebar is hidden, and 4 of 5 tests are missing the required page.screenshot calls. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/tests/e2e/command-palette-shortcut.spec.ts:79-96
**Silently skips its own precondition when the sidebar is hidden**

The `if (await sidebarSearch.count())` guard means that on any viewport where the sidebar is collapsed or the search input is absent, the test skips focusing a text input and then just presses `Control+k` from no particular element — the same scenario already covered by the first test. The scenario this test is meant to verify (shortcut fires from inside a text input) goes completely untested without any failure signal. Consider using an unconditional approach, e.g., placing focus in a different always-present input, or explicitly expanding the sidebar before asserting `sidebarSearch` is present.

### Issue 2 of 2
web/tests/e2e/command-palette-shortcut.spec.ts:43-110
**Screenshots missing on key assertions in 4 of 5 tests**

`CLAUDE.md` requires `page.screenshot(...)` on key assertions for every E2E test. Only the first test (`Control+K opens…`) calls `page.screenshot`. The remaining four tests — `Meta+K`, `Escape closes`, `shortcut works while focus is in a text input`, and `Ctrl+K from a non-dashboard route` — omit it. This pattern appears across the whole describe block.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): consolidate Cmd+K/Ctrl+K to ope..."](https://github.com/befeast/panoptikon/commit/9487eeb2fe209408539136e539ef0956b2b032e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33331200)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->