### PR TITLE
fix(pfsense): switch panels for each hash subroute (#806)

### DIFF
--- a/web/src/components/pfsense/tabs/DnsTab.tsx
+++ b/web/src/components/pfsense/tabs/DnsTab.tsx
@@ -40,6 +40,8 @@ export function DnsTab() {
   const overridesFetcher = useCallback(() => fetchPfsenseDnsOverrides(), []);
   const { data: config, loading: configLoading } = useData(configFetcher);
   const { data: overrides, loading: overridesLoading, reload: reloadOverrides } = useData(overridesFetcher);
+  const resolverEnabled = config?.resolver_enabled ?? false;
+  const servers = config?.servers ?? [];
 
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<PfsenseDnsOverride | null>(null);
@@ -93,19 +95,19 @@ export function DnsTab() {
                 <Badge
                   variant="outline"
                   className={
-                    config.resolver_enabled
+                    resolverEnabled
                       ? "border-[#4ade80]/30 bg-[#4ade80]/10 text-[#4ade80]"
                       : "border-mesh-text-mute/30 bg-mesh-text-mute/10 text-mesh-text-mute"
                   }
                 >
-                  {config.resolver_enabled ? "Enabled" : "Disabled"}
+                  {resolverEnabled ? "Enabled" : "Disabled"}
                 </Badge>
               </div>
-              {config.servers.length > 0 && (
+              {servers.length > 0 && (
                 <div>
                   <span className="text-sm text-mesh-text-dim">Upstream DNS Servers:</span>
                   <div className="mt-1 flex flex-wrap gap-2">
-                    {config.servers.map((s) => (
+                    {servers.map((s) => (
                       <Badge key={s} variant="outline" className="border-mesh-border-strong font-mono text-mesh-text">
                         {s}
                       </Badge>

--- a/web/src/components/router/PfSenseRouterDesign.tsx
+++ b/web/src/components/router/PfSenseRouterDesign.tsx
@@ -2,11 +2,11 @@
 
 /**
  * PfSenseRouterDesign — pfSense vendor wrapper for the literal-port
- * RouterPage. Same recipe as MikrotikRouterDesign, with pfSense-specific
- * data hooks. The design source only ships a MikroTik artboard, so the
- * tab set is adapted to pfSense's surfaces (Status / Interfaces / Firewall
- * / NAT / DHCP / DNS / Routing / Config / Services) but the chrome,
- * spacing and recipes are byte-exact from router-page.jsx.
+ * RouterPage. The page header, stats grid, tab strip and footer come from
+ * the literal design recipe, while each tab's panel content is provided by
+ * the dedicated `pfsense/tabs/*` components so hash sub-routes (`#system`,
+ * `#interfaces`, `#firewall`, `#dhcp`, `#dns`, `#services`, `#routing`,
+ * `#config`) render the matching pfSense section in place.
  */
 
 import { useCallback, useMemo } from "react";
@@ -20,8 +20,6 @@ import {
 } from "@/lib/api";
 import {
   RouterPage,
-  type RouterFirewallRow,
-  type RouterDhcpRow,
   type RouterInterfaceRow,
   type RouterStatRow,
   gen,
@@ -29,6 +27,14 @@ import {
 } from "@/components/router/RouterPage";
 import type { RouterTab } from "@/components/router/RouterTabs";
 import type { RouterHeaderMeta } from "@/components/router/RouterHeader";
+import { SystemTab } from "@/components/pfsense/tabs/SystemTab";
+import { InterfacesTab } from "@/components/pfsense/tabs/InterfacesTab";
+import { FirewallTab } from "@/components/pfsense/tabs/FirewallTab";
+import { DhcpTab } from "@/components/pfsense/tabs/DhcpTab";
+import { DnsTab } from "@/components/pfsense/tabs/DnsTab";
+import { ServicesTab } from "@/components/pfsense/tabs/ServicesTab";
+import { RoutingTab } from "@/components/pfsense/tabs/RoutingTab";
+import { ConfigTab } from "@/components/pfsense/tabs/ConfigTab";
 
 const PFSENSE_TABS: RouterTab[] = [
   { id: "system", label: "System" },
@@ -149,40 +155,32 @@ export default function PfSenseRouterDesign({
     }));
   }, [interfaces.data]);
 
-  const fwRows: RouterFirewallRow[] = useMemo(() => {
-    return (rules.data ?? []).map((r, idx) => ({
-      idx,
-      chain: r.interface,
-      action: r.action,
-      src: r.source,
-      dst: r.destination,
-      comment: r.description ?? "",
-      hits: r.tracker ?? "—",
-      enabled: !r.disabled,
-    }));
-  }, [rules.data]);
-
-  const dhcpRows: RouterDhcpRow[] = useMemo(() => {
-    return (leases.data ?? []).map((l) => ({
-      ip: l.ip,
-      mac: l.mac,
-      name: l.hostname ?? "(unknown)",
-      exp: l.end ?? "—",
-      server: l.interface,
-      static: l.status === "static",
-    }));
-  }, [leases.data]);
-
   const totalIfaces = ifaceRows.length;
   const runningIfaces = ifaceRows.filter((r) => r.running).length;
   const downIfaces = totalIfaces - runningIfaces;
-  const staticLeases = dhcpRows.filter((r) => r.static).length;
-  const disabledRules = fwRows.filter((r) => !r.enabled).length;
 
   const connected = !!status.data?.reachable;
   const title = status.data?.hostname
     ? `pfSense · ${status.data.hostname}`
     : "pfSense Firewall";
+
+  // Per-tab content. Each hash subroute (`#system`, `#interfaces`, etc.) maps
+  // to one of these nodes. RouterPage renders only the entry matching
+  // `activeTab` below the tabs strip, so direct URL load + tab clicks +
+  // browser back/forward all swap the panel in place.
+  const tabContent = useMemo(
+    () => ({
+      system: status.data ? <SystemTab status={status.data} /> : null,
+      interfaces: <InterfacesTab />,
+      firewall: <FirewallTab />,
+      dhcp: <DhcpTab />,
+      dns: <DnsTab />,
+      services: <ServicesTab />,
+      routing: <RoutingTab />,
+      config: <ConfigTab />,
+    }),
+    [status.data],
+  );
 
   return (
     <RouterPage
@@ -204,24 +202,7 @@ export default function PfSenseRouterDesign({
             ? "loading…"
             : "no data"
       }
-      firewall={{
-        rules: fwRows,
-        label:
-          fwRows.length > 0
-            ? `${fwRows.length} rules · ${disabledRules} disabled`
-            : rules.loading
-              ? "loading…"
-              : "no rules",
-      }}
-      dhcp={{
-        leases: dhcpRows,
-        label:
-          dhcpRows.length > 0
-            ? `${dhcpRows.length} · ${staticLeases} static`
-            : leases.loading
-              ? "loading…"
-              : "no leases",
-      }}
+      tabContent={tabContent}
       footer={{
         snapshotLabel: "Live pfSense state",
         driftLabel: status.data?.domain

--- a/web/src/components/router/RouterPage.tsx
+++ b/web/src/components/router/RouterPage.tsx
@@ -16,6 +16,10 @@
  *     fetch hooks (fetchMikrotikStatus / fetchPfsenseStatus / ...).
  *   - `gen()` sparkline RNG retained as the design's data fallback when
  *     a vendor API does not expose history yet — clearly marked.
+ *   - Optional `tabContent` prop enables per-tab routing (one panel at a
+ *     time) so callers like pfSense can wire hash subroutes to discrete
+ *     sections. When omitted, all three panels render stacked as in the
+ *     design source.
  *
  * Token substitutions (per task brief):
  *   var(--border)         → rgba(96,144,212,0.20)
@@ -205,6 +209,17 @@ export type RouterPageProps = {
     driftLabel?: string; // "drift since last apply · 1 rule"
     actions?: RouterHeaderAction[];
   };
+
+  // Optional per-tab content map. When provided, RouterPage renders only the
+  // panel matching `activeTab` below the tabs strip:
+  //   - if `tabContent[activeTab]` is defined → renders that custom node
+  //   - else if activeTab is "interfaces"/"firewall"/"dhcp" and the matching
+  //     prop is provided → renders the built-in panel
+  //   - else renders nothing
+  // When omitted, falls back to the original stacked layout (interfaces +
+  // firewall + dhcp panels rendered together), preserving callers that have
+  // not opted into tabbed routing.
+  tabContent?: Partial<Record<string, ReactNode>>;
 };
 
 // ── Layout ────────────────────────────────────────────────────────────────
@@ -262,7 +277,502 @@ export function RouterPage(props: RouterPageProps) {
     firewall,
     dhcp,
     footer,
+    tabContent,
   } = props;
+
+  // ── Panel JSX, extracted so we can either stack them (legacy stacked
+  //    layout) or render only the panel matching `activeTab` in tabbed
+  //    mode (when `tabContent` is supplied). ──────────────────────────────
+  const interfacesPanel = (
+    <div
+      className="card"
+      style={{ padding: 0 }}
+      data-testid="router-panel-interfaces"
+    >
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">Interfaces</h3>
+          {interfacesTotalsLabel && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {interfacesTotalsLabel}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={onFilterInterface}
+          >
+            <Filter size={11} />
+            <span>Type · all</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            onClick={onAddInterface}
+          >
+            <Plus size={11} />
+            <span>Add</span>
+          </button>
+        </div>
+      </div>
+      <div style={IFACE_HEADER_STYLE}>
+        <span>State</span>
+        <span>Interface</span>
+        <span>Type</span>
+        <span>IP / role</span>
+        <span>MAC</span>
+        <span>MTU</span>
+        <span style={{ textAlign: "right" }}>RX GB</span>
+        <span style={{ textAlign: "right" }}>TX GB</span>
+        <span>24h</span>
+        <span />
+      </div>
+      {interfaces.map((it, i) => (
+        <div
+          key={it.name}
+          style={{
+            display: "grid",
+            gridTemplateColumns: IFACE_GRID,
+            padding: "8px 14px",
+            alignItems: "center",
+            borderBottom:
+              i < interfaces.length - 1
+                ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                : "none",
+            background: !it.running
+              ? "rgba(251,113,133,0.03)"
+              : "transparent",
+            font: "400 12.5px var(--font-sans)",
+          }}
+        >
+          <span>
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 5,
+                font: "600 9px var(--font-sans)",
+                letterSpacing: "0.06em",
+                padding: "1px 6px",
+                borderRadius: 2,
+                background: it.running
+                  ? "rgba(74,222,128,0.10)"
+                  : "var(--surface-2)",
+                color: it.running ? "#4ade80" : "var(--text-mute)",
+                border: `var(--hairline) solid ${
+                  it.running
+                    ? "rgba(74,222,128,0.30)"
+                    : "rgba(96,144,212,0.20)"
+                }`,
+              }}
+            >
+              <span
+                style={{
+                  width: 4,
+                  height: 4,
+                  borderRadius: 2,
+                  background: it.running ? "#4ade80" : "#fb7185",
+                }}
+              />
+              {it.running ? "UP" : "DOWN"}
+            </span>
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text)", fontWeight: 500 }}
+          >
+            {it.name}
+          </span>
+          <span>{ifaceTypeBadge(it.type)}</span>
+          <span style={{ minWidth: 0 }}>
+            <div
+              className="mono"
+              style={{ color: "var(--text-dim)", fontSize: 11.5 }}
+            >
+              {it.ip}
+            </div>
+            {it.role !== "—" && it.role !== "" && (
+              <div
+                style={{
+                  font: "500 10px var(--font-sans)",
+                  color: "var(--accent-cyan)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                {it.role}
+              </div>
+            )}
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text-mute)", fontSize: 11 }}
+          >
+            {it.mac}
+          </span>
+          <span
+            className="mono"
+            style={{ color: "var(--text-mute)", fontSize: 11 }}
+          >
+            {it.mtu}
+          </span>
+          <span
+            className="mono"
+            style={{ textAlign: "right", color: "var(--text)" }}
+          >
+            {it.rx.toFixed(1)}
+          </span>
+          <span
+            className="mono"
+            style={{ textAlign: "right", color: "var(--text-dim)" }}
+          >
+            {it.tx.toFixed(1)}
+          </span>
+          <span>
+            <Spark
+              data={gen(20, 30 + it.rx / 5, 18)}
+              width={70}
+              height={20}
+              color={it.running ? "#38bdf8" : "var(--text-mute)"}
+            />
+          </span>
+          <span
+            style={{
+              color: "var(--text-mute)",
+              display: "flex",
+              justifyContent: "flex-end",
+            }}
+          >
+            <ChevronRight size={12} />
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+
+  const firewallPanel = firewall ? (
+    <div
+      className="card"
+      style={{ padding: 0 }}
+      data-testid="router-panel-firewall"
+    >
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">Firewall rules</h3>
+          {firewall.label && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {firewall.label}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-primary"
+          onClick={firewall.onAdd}
+        >
+          <Plus size={11} />
+          <span>New rule</span>
+        </button>
+      </div>
+      <div
+        style={{
+          borderTop: "var(--hairline) solid rgba(96,144,212,0.20)",
+        }}
+      >
+        {firewall.rules.map((r, i) => (
+          <div
+            key={`${r.idx}-${r.chain}-${r.src}-${r.dst}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: FW_GRID,
+              padding: "7px 14px",
+              alignItems: "center",
+              gap: 8,
+              borderBottom:
+                i < firewall.rules.length - 1
+                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                  : "none",
+              font: "400 12px var(--font-sans)",
+              opacity: r.enabled ? 1 : 0.55,
+            }}
+          >
+            <span
+              style={{
+                color: "var(--text-faint)",
+                cursor: "grab",
+              }}
+            >
+              ⋮⋮
+            </span>
+            <span
+              className="mono"
+              style={{
+                color: "var(--text-mute)",
+                fontSize: 11,
+              }}
+            >
+              {r.idx}
+            </span>
+            <span
+              style={{
+                font: "500 10.5px var(--font-mono)",
+                color: "var(--text-dim)",
+              }}
+            >
+              {r.chain}
+            </span>
+            <span>{actionBadge(r.action)}</span>
+            <span
+              className="mono"
+              style={{
+                color: "var(--text-dim)",
+                fontSize: 11,
+              }}
+            >
+              {r.src}
+            </span>
+            <span
+              className="mono"
+              style={{
+                color: "var(--text-dim)",
+                fontSize: 11,
+              }}
+            >
+              {r.dst}
+            </span>
+            <span
+              style={{
+                color: "var(--text-mute)",
+                fontSize: 11.5,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {r.comment}
+            </span>
+            <span
+              className="mono"
+              style={{
+                textAlign: "right",
+                color:
+                  r.action === "fasttrack" || r.action === "accept"
+                    ? "var(--text)"
+                    : "#fbbf24",
+                fontSize: 11,
+              }}
+            >
+              {r.hits}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+  const dhcpPanel = dhcp ? (
+    <div
+      className="card"
+      style={{ padding: 0 }}
+      data-testid="router-panel-dhcp"
+    >
+      <div
+        style={{
+          padding: "10px 14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <h3 className="t-h3">DHCP leases</h3>
+          {dhcp.label && (
+            <span
+              className="mono"
+              style={{
+                font: "500 11px var(--font-mono)",
+                color: "var(--text-mute)",
+              }}
+            >
+              {dhcp.label}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn btn-sm btn-ghost"
+          onClick={dhcp.onFilter}
+        >
+          <Filter size={11} />
+        </button>
+      </div>
+      <div
+        style={{
+          borderTop: "var(--hairline) solid rgba(96,144,212,0.20)",
+        }}
+      >
+        {dhcp.leases.map((l, i) => (
+          <div
+            key={`${l.ip}-${l.mac}`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: DHCP_GRID,
+              padding: "8px 14px",
+              alignItems: "center",
+              gap: 6,
+              borderBottom:
+                i < dhcp.leases.length - 1
+                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
+                  : "none",
+              font: "400 12px var(--font-sans)",
+            }}
+          >
+            <span
+              className="mono"
+              style={{
+                color: "var(--text)",
+                fontSize: 11.5,
+              }}
+            >
+              {l.ip}
+            </span>
+            <span style={{ minWidth: 0 }}>
+              <div
+                style={{
+                  color: "var(--text)",
+                  fontWeight: 500,
+                  fontSize: 12,
+                }}
+              >
+                {l.name}
+              </div>
+              <div
+                className="mono"
+                style={{
+                  color: "var(--text-mute)",
+                  fontSize: 10,
+                }}
+              >
+                {l.mac} · {l.server}
+              </div>
+            </span>
+            <span
+              className="mono"
+              style={{
+                color: l.static
+                  ? "var(--accent-cyan)"
+                  : "var(--text-mute)",
+                fontSize: 11,
+                textAlign: "right",
+              }}
+            >
+              {l.static ? "static" : l.exp}
+            </span>
+            <span style={{ color: "var(--text-mute)" }}>
+              {l.static ? <Pin size={11} /> : <Plus size={11} />}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+  const stackedPanels = (
+    <>
+      {interfacesPanel}
+      {(firewallPanel || dhcpPanel) && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              firewallPanel && dhcpPanel ? "1.4fr 1fr" : "1fr",
+            gap: 12,
+          }}
+        >
+          {firewallPanel}
+          {dhcpPanel}
+        </div>
+      )}
+    </>
+  );
+
+  // Resolve which panel(s) to render below the tabs strip. When `tabContent`
+  // is undefined the page keeps the original stacked layout (Mikrotik). When
+  // supplied, only the panel matching the active tab is rendered, falling
+  // back to the built-in interfaces/firewall/dhcp panels for those three tab
+  // ids when no custom node was provided for them.
+  let panelArea: ReactNode;
+  if (tabContent !== undefined) {
+    const customNode = tabContent[activeTab];
+    if (customNode !== undefined) {
+      panelArea = customNode;
+    } else if (activeTab === "interfaces") {
+      panelArea = interfacesPanel;
+    } else if (activeTab === "firewall") {
+      panelArea = firewallPanel;
+    } else if (activeTab === "dhcp") {
+      panelArea = dhcpPanel;
+    } else {
+      panelArea = null;
+    }
+  } else {
+    panelArea = stackedPanels;
+  }
 
   return (
     <div style={PAGE_STYLE} data-testid="router-page">
@@ -320,454 +830,15 @@ export function RouterPage(props: RouterPageProps) {
 
       <RouterTabs tabs={tabs} active={activeTab} onChange={onTabChange} />
 
-      {/* Interfaces table — router-page.jsx lines 73-141 */}
-      <div className="card" style={{ padding: 0 }}>
-        <div
-          style={{
-            padding: "10px 14px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "baseline",
-              gap: 8,
-              flexWrap: "wrap",
-            }}
-          >
-            <h3 className="t-h3">Interfaces</h3>
-            {interfacesTotalsLabel && (
-              <span
-                className="mono"
-                style={{
-                  font: "500 11px var(--font-mono)",
-                  color: "var(--text-mute)",
-                }}
-              >
-                {interfacesTotalsLabel}
-              </span>
-            )}
-          </div>
-          <div style={{ display: "flex", gap: 6 }}>
-            <button
-              type="button"
-              className="btn btn-sm"
-              onClick={onFilterInterface}
-            >
-              <Filter size={11} />
-              <span>Type · all</span>
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-primary"
-              onClick={onAddInterface}
-            >
-              <Plus size={11} />
-              <span>Add</span>
-            </button>
-          </div>
-        </div>
-        <div style={IFACE_HEADER_STYLE}>
-          <span>State</span>
-          <span>Interface</span>
-          <span>Type</span>
-          <span>IP / role</span>
-          <span>MAC</span>
-          <span>MTU</span>
-          <span style={{ textAlign: "right" }}>RX GB</span>
-          <span style={{ textAlign: "right" }}>TX GB</span>
-          <span>24h</span>
-          <span />
-        </div>
-        {interfaces.map((it, i) => (
-          <div
-            key={it.name}
-            style={{
-              display: "grid",
-              gridTemplateColumns: IFACE_GRID,
-              padding: "8px 14px",
-              alignItems: "center",
-              borderBottom:
-                i < interfaces.length - 1
-                  ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                  : "none",
-              background: !it.running
-                ? "rgba(251,113,133,0.03)"
-                : "transparent",
-              font: "400 12.5px var(--font-sans)",
-            }}
-          >
-            <span>
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 5,
-                  font: "600 9px var(--font-sans)",
-                  letterSpacing: "0.06em",
-                  padding: "1px 6px",
-                  borderRadius: 2,
-                  background: it.running
-                    ? "rgba(74,222,128,0.10)"
-                    : "var(--surface-2)",
-                  color: it.running ? "#4ade80" : "var(--text-mute)",
-                  border: `var(--hairline) solid ${
-                    it.running
-                      ? "rgba(74,222,128,0.30)"
-                      : "rgba(96,144,212,0.20)"
-                  }`,
-                }}
-              >
-                <span
-                  style={{
-                    width: 4,
-                    height: 4,
-                    borderRadius: 2,
-                    background: it.running ? "#4ade80" : "#fb7185",
-                  }}
-                />
-                {it.running ? "UP" : "DOWN"}
-              </span>
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text)", fontWeight: 500 }}
-            >
-              {it.name}
-            </span>
-            <span>{ifaceTypeBadge(it.type)}</span>
-            <span style={{ minWidth: 0 }}>
-              <div
-                className="mono"
-                style={{ color: "var(--text-dim)", fontSize: 11.5 }}
-              >
-                {it.ip}
-              </div>
-              {it.role !== "—" && it.role !== "" && (
-                <div
-                  style={{
-                    font: "500 10px var(--font-sans)",
-                    color: "var(--accent-cyan)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.06em",
-                  }}
-                >
-                  {it.role}
-                </div>
-              )}
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text-mute)", fontSize: 11 }}
-            >
-              {it.mac}
-            </span>
-            <span
-              className="mono"
-              style={{ color: "var(--text-mute)", fontSize: 11 }}
-            >
-              {it.mtu}
-            </span>
-            <span
-              className="mono"
-              style={{ textAlign: "right", color: "var(--text)" }}
-            >
-              {it.rx.toFixed(1)}
-            </span>
-            <span
-              className="mono"
-              style={{ textAlign: "right", color: "var(--text-dim)" }}
-            >
-              {it.tx.toFixed(1)}
-            </span>
-            <span>
-              <Spark
-                data={gen(20, 30 + it.rx / 5, 18)}
-                width={70}
-                height={20}
-                color={it.running ? "#38bdf8" : "var(--text-mute)"}
-              />
-            </span>
-            <span
-              style={{
-                color: "var(--text-mute)",
-                display: "flex",
-                justifyContent: "flex-end",
-              }}
-            >
-              <ChevronRight size={12} />
-            </span>
-          </div>
-        ))}
+      {/* Tab panel area — stacked layout (Mikrotik legacy) or single active
+          panel (pfSense / any caller that supplies `tabContent`). */}
+      <div
+        role="tabpanel"
+        data-testid={`router-tabpanel-${activeTab}`}
+        style={{ display: "flex", flexDirection: "column", gap: 12 }}
+      >
+        {panelArea}
       </div>
-
-      {/* Two-pane — Firewall + DHCP — router-page.jsx lines 143-200 */}
-      {(firewall || dhcp) && (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: firewall && dhcp ? "1.4fr 1fr" : "1fr",
-            gap: 12,
-          }}
-        >
-          {firewall && (
-            <div className="card" style={{ padding: 0 }}>
-              <div
-                style={{
-                  padding: "10px 14px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  flexWrap: "wrap",
-                  gap: 8,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: 8,
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <h3 className="t-h3">Firewall rules</h3>
-                  {firewall.label && (
-                    <span
-                      className="mono"
-                      style={{
-                        font: "500 11px var(--font-mono)",
-                        color: "var(--text-mute)",
-                      }}
-                    >
-                      {firewall.label}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-primary"
-                  onClick={firewall.onAdd}
-                >
-                  <Plus size={11} />
-                  <span>New rule</span>
-                </button>
-              </div>
-              <div
-                style={{
-                  borderTop:
-                    "var(--hairline) solid rgba(96,144,212,0.20)",
-                }}
-              >
-                {firewall.rules.map((r, i) => (
-                  <div
-                    key={`${r.idx}-${r.chain}-${r.src}-${r.dst}`}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: FW_GRID,
-                      padding: "7px 14px",
-                      alignItems: "center",
-                      gap: 8,
-                      borderBottom:
-                        i < firewall.rules.length - 1
-                          ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                          : "none",
-                      font: "400 12px var(--font-sans)",
-                      opacity: r.enabled ? 1 : 0.55,
-                    }}
-                  >
-                    <span
-                      style={{
-                        color: "var(--text-faint)",
-                        cursor: "grab",
-                      }}
-                    >
-                      ⋮⋮
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-mute)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.idx}
-                    </span>
-                    <span
-                      style={{
-                        font: "500 10.5px var(--font-mono)",
-                        color: "var(--text-dim)",
-                      }}
-                    >
-                      {r.chain}
-                    </span>
-                    <span>{actionBadge(r.action)}</span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-dim)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.src}
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text-dim)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.dst}
-                    </span>
-                    <span
-                      style={{
-                        color: "var(--text-mute)",
-                        fontSize: 11.5,
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
-                    >
-                      {r.comment}
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        textAlign: "right",
-                        color:
-                          r.action === "fasttrack" || r.action === "accept"
-                            ? "var(--text)"
-                            : "#fbbf24",
-                        fontSize: 11,
-                      }}
-                    >
-                      {r.hits}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {dhcp && (
-            <div className="card" style={{ padding: 0 }}>
-              <div
-                style={{
-                  padding: "10px 14px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  flexWrap: "wrap",
-                  gap: 8,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: 8,
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <h3 className="t-h3">DHCP leases</h3>
-                  {dhcp.label && (
-                    <span
-                      className="mono"
-                      style={{
-                        font: "500 11px var(--font-mono)",
-                        color: "var(--text-mute)",
-                      }}
-                    >
-                      {dhcp.label}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-ghost"
-                  onClick={dhcp.onFilter}
-                >
-                  <Filter size={11} />
-                </button>
-              </div>
-              <div
-                style={{
-                  borderTop:
-                    "var(--hairline) solid rgba(96,144,212,0.20)",
-                }}
-              >
-                {dhcp.leases.map((l, i) => (
-                  <div
-                    key={`${l.ip}-${l.mac}`}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: DHCP_GRID,
-                      padding: "8px 14px",
-                      alignItems: "center",
-                      gap: 6,
-                      borderBottom:
-                        i < dhcp.leases.length - 1
-                          ? "var(--hairline) solid rgba(96,144,212,0.20)"
-                          : "none",
-                      font: "400 12px var(--font-sans)",
-                    }}
-                  >
-                    <span
-                      className="mono"
-                      style={{
-                        color: "var(--text)",
-                        fontSize: 11.5,
-                      }}
-                    >
-                      {l.ip}
-                    </span>
-                    <span style={{ minWidth: 0 }}>
-                      <div
-                        style={{
-                          color: "var(--text)",
-                          fontWeight: 500,
-                          fontSize: 12,
-                        }}
-                      >
-                        {l.name}
-                      </div>
-                      <div
-                        className="mono"
-                        style={{
-                          color: "var(--text-mute)",
-                          fontSize: 10,
-                        }}
-                      >
-                        {l.mac} · {l.server}
-                      </div>
-                    </span>
-                    <span
-                      className="mono"
-                      style={{
-                        color: l.static
-                          ? "var(--accent-cyan)"
-                          : "var(--text-mute)",
-                        fontSize: 11,
-                        textAlign: "right",
-                      }}
-                    >
-                      {l.static ? "static" : l.exp}
-                    </span>
-                    <span style={{ color: "var(--text-mute)" }}>
-                      {l.static ? <Pin size={11} /> : <Plus size={11} />}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
 
       {/* Quick actions footer — router-page.jsx lines 203-216 */}
       {footer && (

--- a/web/src/hooks/useHashTab.ts
+++ b/web/src/hooks/useHashTab.ts
@@ -23,7 +23,14 @@ export function useHashTab<T extends string>(
 
   const setTab = useCallback((value: string) => {
     setTabState(value as T);
-    window.history.replaceState(null, "", `#${value}`);
+    const next = `#${value}`;
+    // Use pushState so browser back/forward steps between tab selections
+    // (acceptance for #806). When the URL is already at `next` — e.g. the
+    // hashchange listener fired on a back/forward event and we are syncing
+    // local state — skip the push to avoid duplicate history entries.
+    if (window.location.hash !== next) {
+      window.history.pushState(null, "", next);
+    }
   }, []);
 
   // Listen for hash changes (browser back/forward)

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2257,8 +2257,8 @@ export interface PfsenseRoute {
 }
 
 export interface PfsenseDnsConfig {
-  resolver_enabled: boolean;
-  servers: string[];
+  resolver_enabled: boolean | null;
+  servers: string[] | null;
 }
 
 export interface PfsenseDnsOverride {

--- a/web/tests/e2e/pfsense-hash-routes.spec.ts
+++ b/web/tests/e2e/pfsense-hash-routes.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+type Page = import("@playwright/test").Page;
+
+/**
+ * Regression for #806 — pfSense router page hash sub-routes did not switch
+ * panels. Each tab id (system, interfaces, firewall, dhcp, dns, services,
+ * routing, config) is also a hash sub-route on /router/pfsense; loading
+ * #<tab> directly, clicking the tab, or navigating browser back/forward
+ * must render the matching panel below the tabs strip.
+ */
+
+const TAB_IDS = [
+  "system",
+  "interfaces",
+  "firewall",
+  "dhcp",
+  "dns",
+  "services",
+  "routing",
+  "config",
+] as const;
+
+/**
+ * Mock all pfSense endpoints so the page renders fully in CI without a real
+ * firewall reachable.
+ */
+async function mockPfsenseApis(page: Page) {
+  // Generic catch-all for unspecified endpoints returns []. Playwright
+  // evaluates routes in reverse registration order, so the specific mocks
+  // below win.
+  await page.route("**/api/v1/pfsense/**", (route) =>
+    route.fulfill({ json: [] }),
+  );
+
+  await page.route("**/api/v1/settings", (route) =>
+    route.fulfill({
+      json: {
+        mikrotik_enabled: false,
+        pfsense_enabled: true,
+        xiaomi_mesh_enabled: false,
+        default_router: "pfsense",
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/status", (route) =>
+    route.fulfill({
+      json: {
+        configured: true,
+        reachable: true,
+        hostname: "pfSense-test",
+        domain: "localdomain",
+        version: "2.7.0",
+        uptime: "1 day",
+        cpu_usage: 5,
+        memory_total: 8192 * 1024 * 1024,
+        memory_used: 2048 * 1024 * 1024,
+        platform: "pfSense",
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/interfaces", (route) =>
+    route.fulfill({
+      json: [
+        {
+          name: "lan",
+          descr: "LAN",
+          iface_type: "ethernet",
+          status: "up",
+          ip_address: "192.168.1.1",
+          subnet: "24",
+          mac: "00:11:22:33:44:55",
+          mtu: 1500,
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/firewall/rules", (route) =>
+    route.fulfill({ json: [] }),
+  );
+
+  await page.route("**/api/v1/pfsense/dhcp/leases", (route) =>
+    route.fulfill({ json: [] }),
+  );
+}
+
+async function gotoPfsense(page: Page, hash = "") {
+  await login(page);
+  await mockPfsenseApis(page);
+  await page.goto(`/router/pfsense${hash}`);
+  // Wait for the tabs strip to be present — proves pfSense was enabled and
+  // the design wrapper mounted.
+  await expect(page.getByTestId("router-tabs")).toBeVisible({
+    timeout: 15000,
+  });
+}
+
+test.describe("pfSense router — hash sub-routes (#806)", () => {
+  for (const tab of TAB_IDS) {
+    test(`direct navigation to #${tab} renders the matching panel`, async ({
+      page,
+    }) => {
+      await gotoPfsense(page, `#${tab}`);
+
+      await expect(page.getByTestId(`router-tabpanel-${tab}`)).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByTestId(`router-tab-${tab}`)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      await page.screenshot({
+        path: `tests/screenshots/pfsense-hash-${tab}.png`,
+      });
+    });
+  }
+
+  test("clicking each tab updates URL hash and panel content", async ({
+    page,
+  }) => {
+    await gotoPfsense(page);
+
+    for (const tab of TAB_IDS) {
+      await page.getByTestId(`router-tab-${tab}`).click();
+
+      await expect.poll(() => new URL(page.url()).hash).toBe(`#${tab}`);
+      await expect(page.getByTestId(`router-tabpanel-${tab}`)).toBeVisible();
+      await expect(page.getByTestId(`router-tab-${tab}`)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    }
+  });
+
+  test("browser back/forward navigates between panels", async ({ page }) => {
+    await gotoPfsense(page);
+
+    // Default tab is "system" — each click pushes a history entry via
+    // useHashTab → window.history.pushState.
+    await page.getByTestId("router-tab-interfaces").click();
+    await expect(page.getByTestId("router-tabpanel-interfaces")).toBeVisible();
+    await page.getByTestId("router-tab-firewall").click();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible();
+    await page.getByTestId("router-tab-dhcp").click();
+    await expect(page.getByTestId("router-tabpanel-dhcp")).toBeVisible();
+
+    // Back twice → interfaces; forward → firewall.
+    await page.goBack();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect.poll(() => new URL(page.url()).hash).toBe("#firewall");
+
+    await page.goBack();
+    await expect(page.getByTestId("router-tabpanel-interfaces")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect.poll(() => new URL(page.url()).hash).toBe("#interfaces");
+
+    await page.goForward();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect.poll(() => new URL(page.url()).hash).toBe("#firewall");
+  });
+
+  test("invalid hash falls back to default panel without breaking state", async ({
+    page,
+  }) => {
+    await gotoPfsense(page, "#totally-not-a-tab");
+
+    // Default tab is "system" — the page should mount that panel rather than
+    // erroring out or rendering nothing.
+    await expect(page.getByTestId("router-tabpanel-system")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId("router-tab-system")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    // The tabs strip is still interactive after the invalid hash.
+    await page.getByTestId("router-tab-firewall").click();
+    await expect(page.getByTestId("router-tabpanel-firewall")).toBeVisible();
+  });
+});

--- a/web/tests/e2e/pfsense-hash-routes.spec.ts
+++ b/web/tests/e2e/pfsense-hash-routes.spec.ts
@@ -85,6 +85,19 @@ async function mockPfsenseApis(page: Page) {
   await page.route("**/api/v1/pfsense/dhcp/leases", (route) =>
     route.fulfill({ json: [] }),
   );
+
+  await page.route("**/api/v1/pfsense/dns/config", (route) =>
+    route.fulfill({
+      json: {
+        resolver_enabled: true,
+        servers: ["1.1.1.1", "9.9.9.9"],
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pfsense/dns/overrides", (route) =>
+    route.fulfill({ json: [] }),
+  );
 }
 
 async function gotoPfsense(page: Page, hash = "") {


### PR DESCRIPTION
## Summary

- pfSense router page (`/router/pfsense#<tab>`) now renders the panel matching the active hash subroute instead of always stacking Interfaces + Firewall + DHCP.
- `RouterPage` gains an optional `tabContent` prop; when supplied, only the active tab's panel renders below the tabs strip. MikroTik keeps its existing stacked layout.
- `useHashTab` now uses `pushState` (with a no-op when the URL hash already matches), so browser back/forward steps through tab selections.
- `PfSenseRouterDesign` wires all eight subroutes (system, interfaces, firewall, dhcp, dns, services, routing, config) to the existing `pfsense/tabs/*` components.

## Why no production-route demo

This is a bug fix on the production `/router/pfsense` route — no parallel design demo route was added. The legacy `?legacy=1` view was left untouched.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run test` (66 tests, all pass)
- [x] `bun run build` — `/router/pfsense` route compiles (14.4 kB)
- [x] `bunx tsc --noEmit` — clean
- [ ] `bunx playwright test pfsense-hash-routes` — covered by:
  - `web/tests/e2e/pfsense-hash-routes.spec.ts`
  - direct navigation to each of the 8 hash subroutes
  - tab clicks update URL hash and panel content
  - browser back/forward navigates between panels
  - invalid hash falls back to the default `#system` panel

Refs #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the pfSense router page (`/router/pfsense#<tab>`) so each hash subroute renders its matching panel instead of always stacking all three panels. It introduces an optional `tabContent` prop on `RouterPage`, wires all eight pfSense subroutes to their dedicated tab components, and switches `useHashTab` from `replaceState` to `pushState` to enable browser back/forward between tab selections.

- `RouterPage` gains a `tabContent?: Partial<Record<string, ReactNode>>` prop; when supplied, only the active tab's panel renders below the tabs strip, with a no-op guard to avoid duplicate history entries on back/forward.
- `PfsenseDnsConfig` in `types.ts` relaxes `resolver_enabled` and `servers` to nullable; `DnsTab.tsx` guards both fields with null-coalescing defaults.
- A new Playwright E2E suite (`pfsense-hash-routes.spec.ts`) covers direct navigation, tab clicks, back/forward, and invalid-hash fallback.

<h3>Confidence Score: 4/5</h3>

Safe to merge for pfSense; the pushState change in useHashTab affects all tab-based pages across the app and is not yet covered by tests for those other routes.

The pfSense panel-switching logic itself is correct and well-tested. The main concern is the useHashTab change: switching from replaceState to pushState now adds a browser history entry on every tab click across all 10+ pages that share this hook (MikroTik, NAT, QoS, VPN Status, DNS Logs, npm, settings pages, etc.). On stacked-layout pages like MikroTik where visible content doesn't change on tab click, users pressing Back will step through previously-highlighted tabs rather than leaving the page. The new E2E suite covers only the pfSense route — none of the other affected pages are exercised.

web/src/hooks/useHashTab.ts — the pushState change ripples across every page that calls this hook, and those pages have no updated tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/hooks/useHashTab.ts | Switches from replaceState to pushState; adds a duplicate-entry guard. The change is app-wide, affecting all 10+ pages that use this hook. |
| web/src/components/router/RouterPage.tsx | Extracts panels into variables and adds tabContent routing logic; stacked layout (MikroTik) is fully preserved when tabContent is omitted. |
| web/src/components/router/PfSenseRouterDesign.tsx | Removes inline firewall/DHCP row mapping and replaces it with a tabContent map; all 8 subroutes wired correctly. Memo dependency on status.data re-creates all 8 JSX descriptors on every poll. |
| web/src/components/pfsense/tabs/DnsTab.tsx | Adds null-coalescing guards for resolver_enabled and servers; existing config ? guard prevents unsafe access. Change is correct. |
| web/src/lib/types.ts | Relaxes PfsenseDnsConfig.resolver_enabled and servers to nullable; only consumer (DnsTab) already handles the null case. |
| web/tests/e2e/pfsense-hash-routes.spec.ts | Covers direct navigation, tab-click URL sync, back/forward, and invalid-hash fallback. The back/forward test starts from a no-hash URL, leaving the navigate-back-to-no-hash edge case untested. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/tests/e2e/pfsense-hash-routes.spec.ts`, line 1327-1357 ([link](https://github.com/befeast/panoptikon/blob/8a7fdf4d1027af8dcf4850b7629bce3ec2b7b9d3/web/tests/e2e/pfsense-hash-routes.spec.ts#L1327-L1357)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Back/forward test starts from a no-hash URL, leaving an untested edge**

   The helper `gotoPfsense(page)` lands on `/router/pfsense` with no fragment. The first tab click pushes `#interfaces`, so the history stack is `["/router/pfsense", "#interfaces", "#firewall", "#dhcp"]`. The test steps back to `#firewall` and `#interfaces`, never reaching the initial no-hash entry. `useHashTab`'s `hashchange` handler has `if (hash && ...)` so navigating back to the hash-less URL silently leaves the tab in its previous state while the URL shows no hash — a divergence between URL and component state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/tests/e2e/pfsense-hash-routes.spec.ts
   Line: 1327-1357

   Comment:
   **Back/forward test starts from a no-hash URL, leaving an untested edge**

   The helper `gotoPfsense(page)` lands on `/router/pfsense` with no fragment. The first tab click pushes `#interfaces`, so the history stack is `["/router/pfsense", "#interfaces", "#firewall", "#dhcp"]`. The test steps back to `#firewall` and `#interfaces`, never reaching the initial no-hash entry. `useHashTab`'s `hashchange` handler has `if (hash && ...)` so navigating back to the hash-less URL silently leaves the tab in its previous state while the URL shows no hash — a divergence between URL and component state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: keep pfSense DNS tab routable"](https://github.com/befeast/panoptikon/commit/3d4d7d44e2fdc3367011f5975792ac95b7694c8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33335013)</sub>

<!-- /greptile_comment -->