### PR TITLE
fix(ux): make Cmd+K / Ctrl+K consistently open command palette

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -59,15 +59,20 @@ export function CommandPalette() {
   const [scanning, setScanning] = useState(false)
 
   // ── Global Cmd+K / Ctrl+K listener ──
+  // Captures the shortcut at the window level so it fires consistently
+  // regardless of where focus is (sidebar search, settings page input, etc.).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault()
-        setOpen((prev) => !prev)
-      }
+      if (e.key.toLowerCase() !== 'k') return
+      if (!(e.metaKey || e.ctrlKey)) return
+      // Ignore Cmd+Shift+K / Cmd+Alt+K — those are reserved for browser tools.
+      if (e.shiftKey || e.altKey) return
+      e.preventDefault()
+      e.stopPropagation()
+      setOpen((prev) => !prev)
     }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
 
   // ── Reset state when closed ──

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -560,17 +560,6 @@ function SidebarSearch() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  useEffect(() => {
-    function onHotkey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onHotkey);
-    return () => window.removeEventListener("keydown", onHotkey);
-  }, []);
-
   const flatItems = useMemo(() => {
     if (!results) return [] as Array<{ type: string; id: string; label: string }>;
     const items: Array<{ type: string; id: string; label: string }> = [];

--- a/web/tests/e2e/cmdk-global-shortcut.spec.ts
+++ b/web/tests/e2e/cmdk-global-shortcut.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect, login } from "../../e2e/fixtures";
+
+/**
+ * E2E coverage for issue #805 — Cmd+K / Ctrl+K must focus/open the global
+ * command + search palette consistently from any authenticated route, even
+ * when focus is inside a text input. Escape must close the palette and
+ * restore focus to the page.
+ */
+test.describe("Global Cmd+K / Ctrl+K shortcut (#805)", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Ctrl+K opens the palette and focuses the search input", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Sanity — the palette is not visible at rest.
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeHidden();
+
+    await page.keyboard.press("Control+k");
+
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+
+    // The placeholder hints at the palette's purpose.
+    const placeholder = await input.getAttribute("placeholder");
+    expect(placeholder).toMatch(/search/i);
+
+    // Typing reaches the palette input (not the page underneath).
+    await page.keyboard.type("dash");
+    await expect(input).toHaveValue("dash");
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-global-open.png",
+      fullPage: true,
+    });
+  });
+
+  test("Escape closes the palette", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const dialog = page.locator("[cmdk-dialog]");
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden({ timeout: 3000 });
+  });
+
+  test("Ctrl+K toggles the palette closed when pressed again", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const dialog = page.locator("[cmdk-dialog]");
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await page.keyboard.press("Control+k");
+    await expect(dialog).toBeHidden({ timeout: 3000 });
+  });
+
+  test("Ctrl+K opens the palette even when a page input has focus", async ({
+    page,
+  }) => {
+    // Settings has an inline search input that advertises ⌘K. Pressing the
+    // shortcut while typing there must still open the global palette.
+    await page.goto("/settings");
+    await expect(
+      page.getByRole("heading", { name: "Settings", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const settingsSearch = page.locator('[data-testid="settings-search"]');
+    await expect(settingsSearch).toBeVisible();
+    await settingsSearch.click();
+    await expect(settingsSearch).toBeFocused();
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+
+    // The settings input should not have received the "k" keystroke because
+    // the global handler preventDefault'd it.
+    await expect(settingsSearch).toHaveValue("");
+
+    await page.screenshot({
+      path: "tests/screenshots/cmdk-global-open-from-input.png",
+      fullPage: true,
+    });
+  });
+
+  test("Ctrl+K works from a route other than dashboard", async ({ page }) => {
+    await page.goto("/devices");
+    await expect(
+      page.getByRole("heading", { name: "Devices", level: 1 }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
- Drop the duplicate Cmd+K/Ctrl+K listener that lived inside `SidebarSearch`. It raced the global `CommandPalette` listener (both called `preventDefault` and ran in the same tick), so Cmd+K stole focus into the sidebar input *and* opened the dialog. Behavior was inconsistent depending on whether the sidebar was collapsed.
- Promote the `CommandPalette` listener to `window`-level, ignore `Cmd+Shift+K` / `Cmd+Alt+K` (reserved for browser/devtools), and `stopPropagation` so we have a single source of truth for the shortcut.
- Add focused e2e coverage in `web/tests/e2e/cmdk-global-shortcut.spec.ts`: open from `/dashboard`, open from `/settings` while another text input is focused, open from `/devices`, Escape closes, and second Cmd+K toggles closed.

## Why
The topbar/sidebar advertise `⌘K` via the placeholder + kbd hint, but pressing Cmd+K only inconsistently surfaced the global search. With both listeners racing, the dialog opened but focus could end up split between two inputs depending on event order.

## Implementation Notes
- `CommandPalette.tsx`: tighten the keydown guard — modifier required, ignore Shift/Alt, normalize key case, `stopPropagation` so nested input handlers (e.g. settings page search) never see the `k`.
- `Sidebar.tsx` (`SidebarSearch`): remove the now-redundant `useEffect` that focused the sidebar input on Cmd+K. The sidebar input still keeps its own Escape/blur behavior; only the duplicate hotkey is gone.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run build` — passes
- [x] `bunx tsc --noEmit` — passes
- [x] `bun run test` (vitest) — 66/66 pass
- [ ] `bun run test:e2e -- cmdk-global-shortcut` — requires the panoptikon backend; not runnable in this worktree. The new spec is not `.skip()`-marked and is wired into the same fixtures used by `cmdk-device-deeplink.spec.ts`.

## Why No Live Visual Check
This is a behavioral fix scoped to a global keyboard handler; the visual surface is the already-renewed `cmdk` dialog and the unchanged sidebar input. No CSS/markup changes were made to the production routes.

Refs #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the Cmd+K / Ctrl+K race between the global `CommandPalette` listener and the now-removed `SidebarSearch` listener, so the shortcut reliably opens the command palette from any route and focus state.

- **`CommandPalette.tsx`**: moves the `keydown` listener to `window`, adds `.toLowerCase()` normalization, filters out Shift/Alt combos, and calls `stopPropagation` to block any remaining window-level competitors.
- **`Sidebar.tsx`**: deletes the duplicate `useEffect` in `SidebarSearch` that previously raced the palette listener and stole focus into the sidebar input.
- **`cmdk-global-shortcut.spec.ts`**: adds five Playwright scenarios covering open, Escape-close, toggle-close, cross-route, and from-focused-input; all use `Control+k` only — `Meta+k` (macOS Cmd+K) is not covered in the new suite.

<h3>Confidence Score: 4/5</h3>

The fix is safe to merge — it removes a clearly duplicate listener and tightens the remaining one; no logic regressions were identified in the changed code.

The production-side changes are minimal and well-scoped: one listener removed, one tightened. The only gap is that the new e2e spec exercises `Control+k` exclusively, leaving the `metaKey` path (macOS Cmd+K) without automated coverage.

web/tests/e2e/cmdk-global-shortcut.spec.ts — worth adding a `Meta+k` variant to cover the macOS modifier path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Promotes Cmd+K listener from `document` to `window`, adds `.toLowerCase()` normalization, Shift/Alt guard, and `stopPropagation` — cleanly eliminates the race with the removed Sidebar listener |
| web/src/components/layout/Sidebar.tsx | Removes the duplicate `useEffect` that focused the sidebar input on Cmd+K — the source of the race condition; remaining Escape/blur behavior is untouched |
| web/tests/e2e/cmdk-global-shortcut.spec.ts | New Playwright spec covering open/close/toggle/cross-route/input-focus scenarios; all five tests use `Control+k` only — `Meta+k` (macOS Cmd+K) is not exercised |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/cmdk-global-shortcut.spec.ts:26
**macOS `Meta+k` untested** — every assertion in this spec presses `Control+k`, but the fix and the PR title both advertise Cmd+K (macOS `Meta+k`) as well. On macOS Playwright runs, `Control+k` does not fire a `metaKey` event, so the `e.metaKey` branch of the guard in `CommandPalette.tsx` is never exercised by CI. A parallel `Meta+k` variant of at least the "opens palette and focuses input" test would confirm both modifier paths work correctly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): make Cmd+K / Ctrl+K consistentl..."](https://github.com/befeast/panoptikon/commit/6c1d19587f3c0404b0bee25a8aff847e49b8c8f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33336098)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->