### PR TITLE
fix(ux): render real Wi-Fi mesh names + SVG topology map (#807)

### DIFF
--- a/server/src/api/mesh.rs
+++ b/server/src/api/mesh.rs
@@ -110,6 +110,30 @@ fn parse_onlines(v: &serde_json::Value) -> i32 {
     }
 }
 
+/// True for the Xiaomi locale placeholders (`default`, `node`, …) that the
+/// firmware ships before the user gives a mesh node a real label — they
+/// must not be treated as a display name.
+fn is_placeholder_label(s: &str) -> bool {
+    matches!(
+        s.trim().to_ascii_lowercase().as_str(),
+        "" | "default" | "node" | "router" | "mesh" | "unknown"
+    )
+}
+
+/// Pick the best human-readable label for a mesh node. Prefer `name` (what the
+/// user typed in the MiWiFi app for the device), fall back to `locale` only
+/// when it's not a Xiaomi placeholder like `default`. Returns the first
+/// non-placeholder candidate, or an empty string when neither qualifies.
+fn pick_mesh_label(name: &str, locale: &str) -> String {
+    if !is_placeholder_label(name) {
+        return name.to_string();
+    }
+    if !is_placeholder_label(locale) {
+        return locale.to_string();
+    }
+    String::new()
+}
+
 // ── API response types ──────────────────────────────────────
 
 /// A mesh node returned to the frontend.
@@ -212,11 +236,7 @@ pub async fn topology(
     nodes.push(MeshNode {
         ip: graph.ip.clone(),
         mac: main_mac.clone(),
-        name: if graph.name.is_empty() {
-            graph.locale.clone()
-        } else {
-            graph.name
-        },
+        name: pick_mesh_label(&graph.name, &graph.locale),
         model: String::new(),
         hardware: graph.hardware,
         is_main: true,
@@ -246,11 +266,7 @@ pub async fn topology(
         nodes.push(MeshNode {
             ip: leaf.ip.clone(),
             mac: leaf_mac,
-            name: if leaf.name.is_empty() {
-                leaf.locale.clone()
-            } else {
-                leaf.name
-            },
+            name: pick_mesh_label(&leaf.name, &leaf.locale),
             model: String::new(),
             hardware: leaf.hardware,
             is_main: false,
@@ -267,4 +283,51 @@ pub async fn topology(
         total_devices,
         nodes,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn placeholder_label_detected_case_insensitively() {
+        assert!(is_placeholder_label(""));
+        assert!(is_placeholder_label("default"));
+        assert!(is_placeholder_label("DEFAULT"));
+        assert!(is_placeholder_label("  Default  "));
+        assert!(is_placeholder_label("node"));
+        assert!(is_placeholder_label("router"));
+        assert!(is_placeholder_label("mesh"));
+        assert!(is_placeholder_label("unknown"));
+
+        assert!(!is_placeholder_label("Live Studio"));
+        assert!(!is_placeholder_label("Basement"));
+        assert!(!is_placeholder_label("master"));
+        assert!(!is_placeholder_label("slave"));
+    }
+
+    #[test]
+    fn pick_mesh_label_prefers_real_name_over_default_locale() {
+        // The screenshot bug: BE3600 firmware returns locale="default" for
+        // satellite nodes while the actual node label lives in `name`.
+        // Picking the locale first collapses every node to "default".
+        assert_eq!(pick_mesh_label("Live Studio", "default"), "Live Studio");
+        assert_eq!(pick_mesh_label("Basement", "default"), "Basement");
+        assert_eq!(pick_mesh_label("Floor 2", "default"), "Floor 2");
+    }
+
+    #[test]
+    fn pick_mesh_label_falls_back_to_locale_when_name_is_placeholder() {
+        // Older firmwares put the user-set label in `locale` (e.g. "master").
+        assert_eq!(pick_mesh_label("", "master"), "master");
+        assert_eq!(pick_mesh_label("default", "slave"), "slave");
+        assert_eq!(pick_mesh_label("router", "OK Home"), "OK Home");
+    }
+
+    #[test]
+    fn pick_mesh_label_returns_empty_when_both_are_placeholders() {
+        assert_eq!(pick_mesh_label("default", "default"), "");
+        assert_eq!(pick_mesh_label("", ""), "");
+        assert_eq!(pick_mesh_label("router", "node"), "");
+    }
 }

--- a/web/src/components/XiaomiMeshTopology.tsx
+++ b/web/src/components/XiaomiMeshTopology.tsx
@@ -17,6 +17,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchXiaomiTopology } from "@/lib/api";
+import { meshLeafLabel, meshNodeLabel } from "@/lib/mesh-labels";
 import type { XiaomiTopology, XiaomiTopoNode, XiaomiTopoLeaf } from "@/lib/types";
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -28,6 +29,300 @@ function leafsForNode(
 ): XiaomiTopoLeaf[] {
   if (!nodeMac) return [];
   return leafs.filter((l) => l.parent_id === nodeMac);
+}
+
+// ─── SVG topology view ──────────────────────────────────
+//
+// Restores the SVG topology semantics that the cards-only redesign
+// regressed (#807). Mirrors the topology.jsx geometry: main router center,
+// satellite mesh nodes radially placed, leaf devices on a ring around their
+// parent. Uses the mesh design tokens (--accent-cyan, --surface-*) so it
+// reads as a cohesive operator-console screen.
+
+const SVG_W = 900;
+const SVG_H = 420;
+const SVG_CX = SVG_W / 2;
+const SVG_CY = SVG_H / 2;
+const SATELLITE_RADIUS = 170;
+const LEAF_RING_RADIUS = 56;
+
+interface PlacedNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  isMain: boolean;
+  online: number;
+  ip: string;
+  hardware: string;
+  model: string;
+}
+
+interface PlacedLeaf {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  parentId: string;
+  ip: string;
+}
+
+interface PlacedTopology {
+  mainId: string | null;
+  nodes: PlacedNode[];
+  leafs: PlacedLeaf[];
+}
+
+function placeTopology(data: XiaomiTopology): PlacedTopology {
+  const main = data.nodes[0] ?? null;
+  const mainId = main ? main.mac || main.ip || "main" : null;
+  const placed: PlacedNode[] = [];
+
+  if (main) {
+    placed.push({
+      id: mainId as string,
+      label: meshNodeLabel(main),
+      x: SVG_CX,
+      y: SVG_CY,
+      isMain: true,
+      online: main.online ?? 0,
+      ip: main.ip ?? "",
+      hardware: main.hardware ?? "",
+      model: main.model ?? "",
+    });
+  }
+
+  const satellites = data.nodes.slice(1);
+  satellites.forEach((node, i) => {
+    const id = node.mac || node.ip || `sat-${i}`;
+    const angle = (i / Math.max(satellites.length, 1)) * Math.PI * 2 - Math.PI / 2;
+    placed.push({
+      id,
+      label: meshNodeLabel(node),
+      x: SVG_CX + Math.cos(angle) * SATELLITE_RADIUS,
+      y: SVG_CY + Math.sin(angle) * SATELLITE_RADIUS,
+      isMain: false,
+      online: node.online ?? 0,
+      ip: node.ip ?? "",
+      hardware: node.hardware ?? "",
+      model: node.model ?? "",
+    });
+  });
+
+  // Place leafs on a tight ring around their parent (or the main router if
+  // unparented). Skip orphan leafs without a placed parent so the layout
+  // doesn't drift.
+  const nodeById = new Map(placed.map((n) => [n.id, n]));
+  const leafsByParent = new Map<string, XiaomiTopoLeaf[]>();
+  for (const leaf of data.leafs) {
+    const parentId = leaf.parent_id ?? mainId ?? "main";
+    const list = leafsByParent.get(parentId) ?? [];
+    list.push(leaf);
+    leafsByParent.set(parentId, list);
+  }
+
+  const placedLeafs: PlacedLeaf[] = [];
+  for (const [parentId, leafList] of leafsByParent.entries()) {
+    const parent = nodeById.get(parentId);
+    if (!parent) continue;
+    leafList.forEach((leaf, i) => {
+      const angle = (i / leafList.length) * Math.PI * 2;
+      placedLeafs.push({
+        id: leaf.mac || leaf.ip || `leaf-${parentId}-${i}`,
+        label: meshLeafLabel(leaf),
+        x: parent.x + Math.cos(angle) * LEAF_RING_RADIUS,
+        y: parent.y + Math.sin(angle) * LEAF_RING_RADIUS,
+        parentId,
+        ip: leaf.ip ?? "",
+      });
+    });
+  }
+
+  return { mainId, nodes: placed, leafs: placedLeafs };
+}
+
+function MeshTopologySvg({ data }: { data: XiaomiTopology }) {
+  const placed = useMemo(() => placeTopology(data), [data]);
+
+  if (placed.nodes.length === 0) {
+    return null;
+  }
+
+  const mainNode = placed.nodes.find((n) => n.isMain);
+
+  return (
+    <div
+      className="mesh-card relative overflow-hidden"
+      data-testid="mesh-topology-svg"
+      style={{ padding: 0 }}
+    >
+      {/* Blueprint grid background */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "linear-gradient(rgba(96,144,212,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(96,144,212,0.08) 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+        }}
+      />
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "radial-gradient(circle at 50% 50%, rgba(56,189,248,0.05), transparent 60%)",
+        }}
+      />
+
+      {/* Corner tick — node count */}
+      <div
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 10,
+          font: "400 10px var(--font-mono)",
+          color: "var(--text-faint)",
+          zIndex: 1,
+        }}
+      >
+        mesh · {placed.nodes.length} node
+        {placed.nodes.length === 1 ? "" : "s"} · {placed.leafs.length} leaf
+        {placed.leafs.length === 1 ? "" : "s"}
+      </div>
+
+      <svg
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ width: "100%", height: "100%", minHeight: 320, display: "block" }}
+      >
+        <defs>
+          <radialGradient id="mesh-node-glow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stopColor="#fbbf24" stopOpacity="0.45" />
+            <stop offset="1" stopColor="#fbbf24" stopOpacity="0" />
+          </radialGradient>
+          <radialGradient id="mesh-sat-glow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stopColor="#38bdf8" stopOpacity="0.30" />
+            <stop offset="1" stopColor="#38bdf8" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        {/* Backhaul links: satellites → main */}
+        {mainNode &&
+          placed.nodes
+            .filter((n) => !n.isMain)
+            .map((sat) => (
+              <line
+                key={`backhaul-${sat.id}`}
+                x1={mainNode.x}
+                y1={mainNode.y}
+                x2={sat.x}
+                y2={sat.y}
+                stroke="var(--accent-cyan)"
+                strokeWidth={1.4}
+                strokeDasharray="6 4"
+                opacity={0.7}
+              />
+            ))}
+
+        {/* Leaf links: leaf → parent */}
+        {placed.leafs.map((leaf) => {
+          const parent = placed.nodes.find((n) => n.id === leaf.parentId);
+          if (!parent) return null;
+          return (
+            <line
+              key={`leaf-link-${leaf.id}`}
+              x1={parent.x}
+              y1={parent.y}
+              x2={leaf.x}
+              y2={leaf.y}
+              stroke="rgba(96,144,212,0.30)"
+              strokeWidth={0.7}
+              strokeDasharray="2 4"
+              opacity={0.55}
+            />
+          );
+        })}
+
+        {/* Mesh nodes */}
+        {placed.nodes.map((n) => {
+          const r = n.isMain ? 22 : 16;
+          return (
+            <g
+              key={`node-${n.id}`}
+              transform={`translate(${n.x},${n.y})`}
+              data-testid={`mesh-svg-node-${n.id}`}
+            >
+              <circle
+                r={r + 10}
+                fill={`url(#${n.isMain ? "mesh-node-glow" : "mesh-sat-glow"})`}
+              />
+              <rect
+                x={-r}
+                y={-r}
+                width={r * 2}
+                height={r * 2}
+                rx={3}
+                fill={n.isMain ? "#fbbf24" : "#2563eb"}
+                stroke="var(--accent-cyan)"
+                strokeWidth={1.5}
+              />
+              <text
+                y={r + 14}
+                textAnchor="middle"
+                fontSize="11"
+                fill="var(--text)"
+                fontFamily="var(--font-sans)"
+                fontWeight={600}
+              >
+                {n.label}
+              </text>
+              <text
+                y={r + 26}
+                textAnchor="middle"
+                fontSize="9"
+                fill="var(--text-mute)"
+                fontFamily="var(--font-mono)"
+              >
+                {n.ip}
+              </text>
+              {n.isMain && (
+                <text
+                  y={-r - 8}
+                  textAnchor="middle"
+                  fontSize="8.5"
+                  fill="#fbbf24"
+                  fontFamily="var(--font-mono)"
+                  letterSpacing="0.05em"
+                  style={{ textTransform: "uppercase" }}
+                >
+                  Main
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Leaf glyphs */}
+        {placed.leafs.map((leaf) => (
+          <g
+            key={`leaf-${leaf.id}`}
+            transform={`translate(${leaf.x},${leaf.y})`}
+            data-testid={`mesh-svg-leaf-${leaf.id}`}
+          >
+            <circle
+              r={3.5}
+              fill="var(--surface-2)"
+              stroke="var(--accent-cyan)"
+              strokeWidth={1}
+            />
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
 }
 
 // ─── Node Card ───────────────────────────────────────────
@@ -43,6 +338,7 @@ function NodeCard({
 }) {
   const connectedLeafs = leafsForNode(node.mac, leafs);
   const onlineDevices = node.online ?? 0;
+  const label = meshNodeLabel(node);
 
   return (
     <Card className={isMain ? "ring-1 ring-[#fbbf24]/30" : undefined}>
@@ -61,7 +357,7 @@ function NodeCard({
           </div>
           <div className="min-w-0 flex-1">
             <CardTitle className="truncate text-sm font-semibold text-mesh-text">
-              {node.locale || node.name || "Mesh Node"}
+              {label}
             </CardTitle>
             <p className="truncate font-mono text-xs text-mesh-text-dim">
               {node.ip || "No IP"}
@@ -136,7 +432,7 @@ function NodeCard({
                   className="flex items-center justify-between rounded px-1.5 py-0.5 text-[11px] hover:bg-mesh-surface-2"
                 >
                   <span className="truncate text-mesh-text">
-                    {leaf.name || leaf.mac || "Unknown"}
+                    {meshLeafLabel(leaf)}
                   </span>
                   <span className="shrink-0 font-mono text-mesh-text-mute">
                     {leaf.ip || "—"}
@@ -238,7 +534,7 @@ export default function XiaomiMeshTopology() {
   }, [data]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="xiaomi-mesh-topology">
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -297,6 +593,11 @@ export default function XiaomiMeshTopology() {
             </CardContent>
           </Card>
         </div>
+      )}
+
+      {/* SVG topology — restored from the previous correct semantics (#807) */}
+      {!loading && data && sortedNodes.length > 0 && (
+        <MeshTopologySvg data={data} />
       )}
 
       {/* Error state */}

--- a/web/src/components/router/XiaomiRouterDesign.tsx
+++ b/web/src/components/router/XiaomiRouterDesign.tsx
@@ -19,6 +19,7 @@ import {
   fetchXiaomiWanInfo,
   fetchXiaomiLanInfo,
 } from "@/lib/api";
+import { meshNodeLabel } from "@/lib/mesh-labels";
 import {
   RouterPage,
   type RouterInterfaceRow,
@@ -163,7 +164,7 @@ export default function XiaomiRouterDesign({
     }
     for (const node of topology.data?.nodes ?? []) {
       rows.push({
-        name: node.name ?? node.mac ?? "node",
+        name: meshNodeLabel(node),
         type: "bridge",
         running: !!node.online,
         ip: node.ip ?? "—",

--- a/web/src/lib/mesh-labels.ts
+++ b/web/src/lib/mesh-labels.ts
@@ -1,0 +1,39 @@
+import type { XiaomiTopoLeaf, XiaomiTopoNode } from "@/lib/types";
+
+/**
+ * Xiaomi MiWiFi firmware reports placeholder strings (`default`, `node`, ...)
+ * for the locale of mesh satellites that the user has not relabelled in the
+ * app. Treat those as "no label" so the real `name` wins. See #807.
+ */
+const PLACEHOLDER_LABELS = new Set([
+  "",
+  "default",
+  "node",
+  "router",
+  "mesh",
+  "unknown",
+]);
+
+export function isPlaceholderMeshLabel(
+  value: string | null | undefined,
+): boolean {
+  if (value == null) return true;
+  return PLACEHOLDER_LABELS.has(value.trim().toLowerCase());
+}
+
+/** Pick the best human-readable label for a mesh node. */
+export function meshNodeLabel(node: XiaomiTopoNode): string {
+  if (!isPlaceholderMeshLabel(node.name)) return node.name as string;
+  if (!isPlaceholderMeshLabel(node.locale)) return node.locale as string;
+  if (node.ip) return node.ip;
+  if (node.mac) return node.mac;
+  return "Mesh Node";
+}
+
+/** Pick the best human-readable label for a connected leaf device. */
+export function meshLeafLabel(leaf: XiaomiTopoLeaf): string {
+  if (!isPlaceholderMeshLabel(leaf.name)) return leaf.name as string;
+  if (leaf.ip) return leaf.ip;
+  if (leaf.mac) return leaf.mac;
+  return "Device";
+}

--- a/web/tests/e2e/mesh-topology-names.spec.ts
+++ b/web/tests/e2e/mesh-topology-names.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * Regression tests for #807 — Mesh topology should render correct Wi-Fi
+ * names/roles.
+ *
+ * The bug: Xiaomi BE3600 firmware reports `locale: "default"` for satellite
+ * mesh nodes whose label hasn't been customised in the MiWiFi app. The
+ * cards-only redesign collapsed every such node to "default", losing the
+ * real per-node `name` (e.g. `Live Studio`, `Basement`, `Floor 2`). After
+ * the fix, the topology must render the real `name` and an SVG mesh map
+ * (not just generic repeated cards).
+ */
+
+const XIAOMI_TOPOLOGY_WITH_DEFAULT_LOCALE = {
+  // Mirrors the screenshot from the issue: one user-labelled satellite
+  // ("Live Studio") plus several whose locale is the firmware placeholder
+  // "default" but whose `name` is actually set.
+  nodes: [
+    {
+      mac: "AA:BB:CC:00:00:01",
+      name: "OK Home",
+      locale: "default",
+      ip: "10.10.0.199",
+      online: 8,
+      hardware: "RD15",
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:00:00:02",
+      name: "Live Studio",
+      locale: "Live Studio",
+      ip: "10.10.0.52",
+      online: 5,
+      hardware: "RD03",
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:00:00:03",
+      name: "Basement",
+      locale: "default",
+      ip: "10.10.0.53",
+      online: 4,
+      hardware: "RD03",
+      model: null,
+    },
+    {
+      mac: "AA:BB:CC:00:00:04",
+      name: "Floor 2",
+      locale: "default",
+      ip: "10.10.0.54",
+      online: 6,
+      hardware: "RD03",
+      model: null,
+    },
+  ],
+  leafs: [
+    {
+      mac: "DE:AD:BE:EF:00:01",
+      ip: "10.10.0.100",
+      name: "iPhone",
+      online: 1,
+      parent_id: "AA:BB:CC:00:00:02",
+    },
+    {
+      mac: "DE:AD:BE:EF:00:02",
+      ip: "10.10.0.101",
+      name: "Laptop",
+      online: 1,
+      parent_id: "AA:BB:CC:00:00:01",
+    },
+  ],
+};
+
+async function mockXiaomiTopology(page: Page, data: unknown) {
+  await page.route("**/api/v1/xiaomi/topology", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(data),
+    }),
+  );
+}
+
+/**
+ * The /topology Mesh tab renders the XiaomiMeshTopology component when
+ * settings have xiaomi_mesh_enabled true. We patch settings to make sure
+ * the Mesh tab is reachable regardless of the local DB state.
+ */
+async function mockXiaomiEnabled(page: Page) {
+  await page.route("**/api/v1/settings", async (route) => {
+    try {
+      const response = await route.fetch();
+      const json = await response.json();
+      json.xiaomi_mesh_enabled = true;
+      await route.fulfill({ response, json });
+    } catch {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ xiaomi_mesh_enabled: true }),
+      });
+    }
+  });
+}
+
+test.describe("Mesh topology — name resolution & SVG map (#807)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockXiaomiEnabled(page);
+    await mockXiaomiTopology(page, XIAOMI_TOPOLOGY_WITH_DEFAULT_LOCALE);
+    await login(page);
+  });
+
+  test("topology Mesh tab renders real names, not the locale placeholder", async ({
+    page,
+  }) => {
+    await page.goto("/topology/");
+
+    await expect(page.getByTestId("topology-root")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Switch to the Mesh tab — verify the component mounts.
+    await page.getByTestId("topology-tab-mesh").click();
+    const meshPane = page.getByTestId("topology-mesh-pane");
+    await expect(meshPane).toBeVisible({ timeout: 10000 });
+    await expect(
+      meshPane.getByTestId("xiaomi-mesh-topology"),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Each user-set node label must render — none should collapse to
+    // "default". Use the SVG topology surface (which is dedicated to #807)
+    // so the assertion is unambiguous.
+    const svg = meshPane.getByTestId("mesh-topology-svg");
+    await expect(svg).toBeVisible();
+    await expect(svg.getByText("OK Home")).toBeVisible();
+    await expect(svg.getByText("Live Studio")).toBeVisible();
+    await expect(svg.getByText("Basement")).toBeVisible();
+    await expect(svg.getByText("Floor 2")).toBeVisible();
+
+    // The literal placeholder string must not appear as a node label.
+    await expect(svg.getByText("default", { exact: true })).toHaveCount(0);
+
+    await page.screenshot({
+      path: "tests/screenshots/mesh-topology-names-807.png",
+      fullPage: true,
+    });
+  });
+
+  test("topology Mesh tab includes an SVG topology map, not only cards", async ({
+    page,
+  }) => {
+    await page.goto("/topology/");
+    await page.getByTestId("topology-tab-mesh").click();
+
+    const meshPane = page.getByTestId("topology-mesh-pane");
+    await expect(meshPane.getByTestId("mesh-topology-svg")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // SVG element must be present inside the map container — this is the
+    // concrete "visual SVG/topology map" acceptance criterion.
+    const svgEl = meshPane
+      .getByTestId("mesh-topology-svg")
+      .locator("svg")
+      .first();
+    await expect(svgEl).toBeVisible();
+
+    // The main router is the first node — assert its SVG group exists with
+    // the user-set label.
+    await expect(
+      meshPane.getByTestId("mesh-svg-node-AA:BB:CC:00:00:01"),
+    ).toBeAttached();
+    await expect(
+      meshPane.getByTestId("mesh-svg-node-AA:BB:CC:00:00:02"),
+    ).toBeAttached();
+  });
+
+  test("router/xiaomi legacy Mesh Topology tab also renders real names", async ({
+    page,
+  }) => {
+    // The same XiaomiMeshTopology component is embedded in
+    // /router/xiaomi when the `?legacy=1` flag is set. Same fix must apply
+    // there — regression coverage for the second mount point.
+    await page.goto("/router/xiaomi/?legacy=1");
+    await page.getByTestId("router-tab-mesh").click();
+
+    const svg = page.getByTestId("mesh-topology-svg");
+    await expect(svg).toBeVisible({ timeout: 15000 });
+    await expect(svg.getByText("Live Studio")).toBeVisible();
+    await expect(svg.getByText("Basement")).toBeVisible();
+    await expect(svg.getByText("default", { exact: true })).toHaveCount(0);
+
+    await page.screenshot({
+      path: "tests/screenshots/router-xiaomi-mesh-names-807.png",
+      fullPage: true,
+    });
+  });
+});

--- a/web/tests/unit/mesh-labels.test.ts
+++ b/web/tests/unit/mesh-labels.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPlaceholderMeshLabel,
+  meshLeafLabel,
+  meshNodeLabel,
+} from "@/lib/mesh-labels";
+import type { XiaomiTopoLeaf, XiaomiTopoNode } from "@/lib/types";
+
+const baseNode: XiaomiTopoNode = {
+  mac: "AA:BB:CC:00:00:01",
+  name: null,
+  locale: null,
+  ip: "10.10.0.199",
+  online: 0,
+  hardware: null,
+  model: null,
+};
+
+const baseLeaf: XiaomiTopoLeaf = {
+  mac: "DE:AD:BE:EF:00:01",
+  ip: "10.10.0.100",
+  name: null,
+  online: 1,
+  parent_id: "AA:BB:CC:00:00:01",
+};
+
+describe("mesh label resolution (#807)", () => {
+  describe("isPlaceholderMeshLabel", () => {
+    it.each([
+      [null],
+      [undefined],
+      [""],
+      ["default"],
+      ["DEFAULT"],
+      ["  Default  "],
+      ["node"],
+      ["router"],
+      ["mesh"],
+      ["unknown"],
+    ])("treats %p as a placeholder", (value) => {
+      expect(isPlaceholderMeshLabel(value)).toBe(true);
+    });
+
+    it.each([["Live Studio"], ["Basement"], ["Floor 2"], ["master"], ["slave"]])(
+      "treats %p as a real label",
+      (value) => {
+        expect(isPlaceholderMeshLabel(value)).toBe(false);
+      },
+    );
+  });
+
+  describe("meshNodeLabel", () => {
+    it("prefers the real name over a `default` locale (#807 regression)", () => {
+      // BE3600 firmware sends locale=default for unlabelled satellites.
+      // The old code chose locale first and collapsed every node to "default".
+      expect(
+        meshNodeLabel({ ...baseNode, name: "Live Studio", locale: "default" }),
+      ).toBe("Live Studio");
+      expect(
+        meshNodeLabel({ ...baseNode, name: "Basement", locale: "default" }),
+      ).toBe("Basement");
+      expect(
+        meshNodeLabel({ ...baseNode, name: "Floor 2", locale: "default" }),
+      ).toBe("Floor 2");
+    });
+
+    it("falls back to locale when name is a placeholder", () => {
+      expect(
+        meshNodeLabel({ ...baseNode, name: null, locale: "master" }),
+      ).toBe("master");
+      expect(
+        meshNodeLabel({ ...baseNode, name: "default", locale: "OK Home" }),
+      ).toBe("OK Home");
+    });
+
+    it("falls back to ip then mac when both labels are placeholders", () => {
+      expect(
+        meshNodeLabel({
+          ...baseNode,
+          name: "default",
+          locale: "default",
+          ip: "10.10.0.199",
+        }),
+      ).toBe("10.10.0.199");
+
+      expect(
+        meshNodeLabel({
+          ...baseNode,
+          name: "default",
+          locale: "default",
+          ip: null,
+        }),
+      ).toBe("AA:BB:CC:00:00:01");
+    });
+
+    it("returns the generic 'Mesh Node' fallback when no identifier is present", () => {
+      expect(
+        meshNodeLabel({
+          ...baseNode,
+          name: "default",
+          locale: "default",
+          ip: null,
+          mac: null,
+        }),
+      ).toBe("Mesh Node");
+    });
+  });
+
+  describe("meshLeafLabel", () => {
+    it("uses the real device name when present", () => {
+      expect(meshLeafLabel({ ...baseLeaf, name: "iPhone" })).toBe("iPhone");
+    });
+
+    it("filters placeholder names and falls back to ip / mac", () => {
+      expect(
+        meshLeafLabel({ ...baseLeaf, name: "default", ip: "10.10.0.100" }),
+      ).toBe("10.10.0.100");
+      expect(
+        meshLeafLabel({ ...baseLeaf, name: "default", ip: null }),
+      ).toBe("DE:AD:BE:EF:00:01");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Xiaomi BE3600 firmware reports `locale: "default"` for satellite mesh nodes the user hasn't relabelled in the MiWiFi app. The cards-only redesign chose `locale` before `name` and collapsed every such node to the placeholder "default" — only `Live Studio` (which had a user-set locale) survived. This PR resolves labels through a placeholder-aware helper on **both** sides of the API so every mesh node renders its real `name` (`Live Studio`, `Basement`, `Floor 2`, …).
- Restores the SVG topology map that the cards-only sweep removed. The new pane renders the main router center, satellites radially placed, and leaf devices on a tight ring around their parent — using the mesh design tokens so it reads as a coherent operator-console surface. Cards remain below for detail.
- Same fix applies to both mount points of `XiaomiMeshTopology`: `/topology` Mesh tab and the legacy `/router/xiaomi?legacy=1` Mesh Topology tab.

## Changes
- `server/src/api/mesh.rs` — new `pick_mesh_label()` + `is_placeholder_label()` helpers filter Xiaomi placeholders (`default`, `node`, `router`, `mesh`, `unknown`) when constructing `MeshNode.name`.
- `web/src/lib/mesh-labels.ts` — shared `meshNodeLabel` / `meshLeafLabel` / `isPlaceholderMeshLabel` helpers.
- `web/src/components/XiaomiMeshTopology.tsx` — inline `<MeshTopologySvg>` view (main + satellites + leafs) + labels routed through the helper.
- `web/src/components/router/XiaomiRouterDesign.tsx` — interface-table row names also routed through the helper.

## Tests
- **Rust** (`cargo test -p panoptikon-server --lib api::mesh::tests`): 4 new tests cover placeholder detection (case-insensitive) and name selection precedence (`name` wins over `locale: "default"`, locale fallback when name is a placeholder, both-placeholder returns empty).
- **Vitest** (`bun run test`): 21 new unit tests in `web/tests/unit/mesh-labels.test.ts` for the same matrix at the frontend boundary.
- **Playwright** (`web/tests/e2e/mesh-topology-names.spec.ts`): 3 specs
  1. Topology → Mesh tab — verifies `Live Studio`, `Basement`, `Floor 2`, `OK Home` all render and no `default` label appears in the SVG.
  2. Topology → Mesh tab — verifies the SVG topology map mounts (acceptance criterion).
  3. `/router/xiaomi?legacy=1` Mesh Topology tab — same name-resolution regression at the second mount point.

## Commands Run
```
# Backend
cargo fmt --all
cargo check -p panoptikon-server
cargo clippy -p panoptikon-server --lib --no-deps
cargo test -p panoptikon-server --lib        # 386 passed (incl. 4 new)

# Frontend
cd web
bun install --frozen-lockfile
bun run test                                  # 87 passed (incl. 21 new)
bun run build                                 # ✓
bunx tsc --noEmit                             # ✓
node_modules/.bin/playwright test --list      # 3 new specs discovered
```

## Test plan
- [ ] Merge & deploy to `https://net.oklabs.uk`.
- [ ] Live visual QA at `/topology` Mesh tab: SVG topology map visible, every satellite node shows its real Wi-Fi name (no `default`).
- [ ] Live visual QA at `/mesh`: existing ReactFlow view also benefits from the backend fix.
- [ ] Spot-check at `/router/xiaomi` interfaces table — node rows show real names.

## Why No Browser-Side QA Here
The worktree has no running panoptikon server, so I could not exercise the Playwright suite against a live UI. All three specs parse and list via `playwright test --list`, and the helper logic is exhaustively covered by the unit tests.

Refs #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Xiaomi BE3600 firmware's `locale: "default"` placeholder collapsing every unlabelled satellite mesh node to the string "default", and restores the SVG topology map that an earlier cards-only redesign removed.

- **Backend (`mesh.rs`)**: `pick_mesh_label` / `is_placeholder_label` helpers filter known Xiaomi placeholder strings (`default`, `node`, `router`, `mesh`, `unknown`) and prefer `name` over `locale` when resolving the display label for both the main router and satellite nodes.
- **Frontend (`mesh-labels.ts`, `XiaomiMeshTopology.tsx`, `XiaomiRouterDesign.tsx`)**: Shared TypeScript helpers mirror the Rust logic; all three label sites (SVG topology, node cards, router interface table) are updated to use the placeholder-aware resolution path.
- **Tests**: 4 Rust unit tests, 21 Vitest unit tests, and 3 Playwright E2E specs cover the full placeholder-detection matrix and both mount points of `XiaomiMeshTopology`.

<h3>Confidence Score: 4/5</h3>

The core label-resolution logic is correct on both the Rust and TypeScript sides, and the fix is well-tested. The main area to revisit before merging is the SVG geometry in MeshTopologySvg.

The placeholder-aware helpers and their integration across the three label sites are sound. The restored SVG topology map has two geometry issues: leaf nodes and per-node IP text can overflow the 420 px viewBox when satellites land near the top or bottom of the canvas, and the hardcoded gradient IDs will collide if two MeshTopologySvg instances share the DOM at the same time.

web/src/components/XiaomiMeshTopology.tsx — SVG viewBox height and gradient ID uniqueness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/mesh.rs | Adds `is_placeholder_label` and `pick_mesh_label` helpers; replaces the old empty-string check with placeholder-aware label selection for both the main router and satellite nodes. Logic is sound, tests cover the key cases. |
| web/src/lib/mesh-labels.ts | New shared label-resolution helpers; placeholder set mirrors the Rust side, null/undefined are handled correctly via `== null`, and the `as string` casts after the placeholder guards are type-safe. |
| web/src/components/XiaomiMeshTopology.tsx | Restores the SVG topology map and routes card/leaf labels through the placeholder-aware helper. Two visual issues: leaf nodes and IP labels clip outside the 420 px viewBox for top/bottom satellites, and hardcoded SVG gradient IDs will collide when two instances are in the DOM simultaneously. |
| web/src/components/router/XiaomiRouterDesign.tsx | Minimal one-liner change routing the interface-table node name through `meshNodeLabel`; correct and consistent with the rest of the fix. |
| web/tests/unit/mesh-labels.test.ts | 21 unit tests covering placeholder detection, name/locale precedence, and all fallback tiers; good matrix coverage of the helper logic. |
| web/tests/e2e/mesh-topology-names.spec.ts | Three Playwright specs covering both mount points; mocking pattern is correct, assertions target the SVG surface, and screenshots are captured on key assertions as required by CLAUDE.md. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/XiaomiMeshTopology.tsx:148-160
**SVG leaf nodes and label text clip at viewBox edges**

With `SATELLITE_RADIUS = 170`, `SVG_H = 420`, and nodes centred at `SVG_CY = 210`, a bottom satellite lands at y = 380. Its leaf-ring nodes then reach y = 380 + 56 = 436 — 16 px outside the `0 0 900 420` viewBox — and are silently clipped. The IP-address label rendered at `y + r + 26` for that same satellite resolves to ≈ 422 px, also clipped. A symmetric problem occurs at the top (y ≈ 40, leafs reach y = −16). Increasing `SVG_H` to at least 540 (adding one `LEAF_RING_RADIUS` of headroom above and below `SATELLITE_RADIUS`), or reducing `SATELLITE_RADIUS` to ≤ 150, would keep all geometry within the viewBox.

### Issue 2 of 2
web/src/components/XiaomiMeshTopology.tsx:202-209
**Hardcoded SVG gradient IDs collide when two instances exist in the DOM**

SVG `id` values are scoped to the HTML document, not the `<svg>` element. If `MeshTopologySvg` is mounted twice simultaneously — for example, during React Strict Mode's double-invoke in development, or during an animated route transition where both the `/topology` and `/router/xiaomi` pages are briefly live — both `<defs>` blocks will define `id="mesh-node-glow"` and `id="mesh-sat-glow"` in the same document. The `fill="url(#mesh-node-glow)"` references on circles will resolve to whichever definition the browser encounters first, so the second instance's glows may render incorrectly. Deriving the ID from a stable unique identifier (e.g. `React.useId()`) makes each instance self-contained.

```suggestion
          <radialGradient id={`${uid}-mesh-node-glow`} cx="0.5" cy="0.5" r="0.5">
            <stop offset="0" stopColor="#fbbf24" stopOpacity="0.45" />
            <stop offset="1" stopColor="#fbbf24" stopOpacity="0" />
          </radialGradient>
          <radialGradient id={`${uid}-mesh-sat-glow`} cx="0.5" cy="0.5" r="0.5">
            <stop offset="0" stopColor="#38bdf8" stopOpacity="0.30" />
            <stop offset="1" stopColor="#38bdf8" stopOpacity="0" />
          </radialGradient>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): render real Wi-Fi mesh names + ..."](https://github.com/befeast/panoptikon/commit/a3ac0a0a967a9e694e7ab34bea3e036dcb1d6e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33336969)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->