### PR TITLE
fix(ux): repair Cmd+K command palette shortcut (#805)

### DIFF
--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -44,6 +44,7 @@ import {
   User as UserIcon,
 } from "lucide-react";
 import { PageTransition } from "@/components/PageTransition";
+import { ShortcutKey } from "@/components/ShortcutKey";
 import {
   fetchAlertRules,
   fetchCaddyStatus,
@@ -917,7 +918,7 @@ export default function SettingsPage() {
                 border: "var(--hairline) solid rgba(96,144,212,0.20)",
               }}
             >
-              ⌘K
+              <ShortcutKey actionKey="k" />
             </kbd>
           </div>
           <div
@@ -1012,7 +1013,7 @@ export default function SettingsPage() {
           }}
         >
           <span>
-            Tip · ⌘K from anywhere to search across settings, devices, alerts,
+            Tip · <ShortcutKey actionKey="k" /> from anywhere to search across settings, devices, alerts,
             and runbooks.
           </span>
           <span>

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Command } from 'cmdk'
 import {
@@ -57,13 +57,16 @@ export function CommandPalette() {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS)
   const [scanning, setScanning] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // ── Global Cmd+K / Ctrl+K listener ──
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        if (isEditableShortcutTarget(e.target)) return
         e.preventDefault()
-        setOpen((prev) => !prev)
+        setOpen(true)
+        requestAnimationFrame(() => inputRef.current?.focus())
       }
     }
     document.addEventListener('keydown', handleKeyDown)
@@ -147,6 +150,7 @@ export function CommandPalette() {
       <div className="flex items-center gap-3 border-b border-mesh-border-strong px-4 py-3">
         <Search className="h-5 w-5 shrink-0 text-mesh-text-dim" />
         <Command.Input
+          ref={inputRef}
           value={query}
           onValueChange={setQuery}
           placeholder="Search pages, devices, actions…"
@@ -311,4 +315,17 @@ export function CommandPalette() {
       </Command.List>
     </Command.Dialog>
   )
+}
+
+function isEditableShortcutTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false
+
+  const tagName = target.tagName.toLowerCase()
+  if (target.isContentEditable || tagName === 'textarea') return true
+
+  if (tagName !== 'input') return false
+
+  const input = target as HTMLInputElement
+  const type = input.type.toLowerCase()
+  return !['button', 'checkbox', 'color', 'file', 'radio', 'range', 'reset', 'submit'].includes(type)
 }

--- a/web/src/components/ShortcutKey.tsx
+++ b/web/src/components/ShortcutKey.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function ShortcutKey({ actionKey }: { actionKey: string }) {
+  const [modifier, setModifier] = useState("Ctrl");
+
+  useEffect(() => {
+    if (/(Mac|iPhone|iPad|iPod)/i.test(navigator.platform)) {
+      setModifier("⌘");
+    }
+  }, []);
+
+  return (
+    <>
+      {modifier}
+      {modifier === "⌘" ? "" : "+"}
+      {actionKey.toUpperCase()}
+    </>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { BrandMark } from "@/components/brand/BrandMark";
 import { StatusDot } from "@/components/mesh/StatusDot";
+import { ShortcutKey } from "@/components/ShortcutKey";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -560,17 +561,6 @@ function SidebarSearch() {
     return () => document.removeEventListener("mousedown", onClickOutside);
   }, []);
 
-  useEffect(() => {
-    function onHotkey(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", onHotkey);
-    return () => window.removeEventListener("keydown", onHotkey);
-  }, []);
-
   const flatItems = useMemo(() => {
     if (!results) return [] as Array<{ type: string; id: string; label: string }>;
     const items: Array<{ type: string; id: string; label: string }> = [];
@@ -674,7 +664,7 @@ function SidebarSearch() {
             border: "1px solid rgba(96,144,212,0.20)",
           }}
         >
-          ⌘K
+          <ShortcutKey actionKey="k" />
         </kbd>
       </div>
 

--- a/web/tests/e2e/command-palette-shortcut.spec.ts
+++ b/web/tests/e2e/command-palette-shortcut.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, login } from "../../e2e/fixtures";
+import type { Page } from "@playwright/test";
+
+async function stubShellData(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/auth/status", async (route) => {
+    await route.fulfill({
+      json: { authenticated: false, needs_setup: false, sso_enabled: false, sso_login_url: null },
+    });
+  });
+  await page.route("**/api/v1/auth/login", async (route) => {
+    await route.fulfill({ json: { ok: true } });
+  });
+  await page.route("**/api/v1/version", async (route) => {
+    await route.fulfill({ json: { version: "0.6.103" } });
+  });
+  await page.route("**/api/v1/dashboard/stats", async (route) => {
+    await route.fulfill({
+      json: {
+        router_status: "online",
+        router_type: "mikrotik",
+        devices_online: 3,
+        devices_total: 4,
+        alerts_unread: 0,
+        wan_rx_bps: 0,
+        wan_tx_bps: 0,
+        critical_online: 1,
+        critical_total: 1,
+      },
+    });
+  });
+  await page.route("**/api/v1/dashboard/alerts", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/alerts?limit=5", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dashboard/traffic?*", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dashboard/devices", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dashboard/top-devices", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/topology/graph", async (route) => {
+    await route.fulfill({
+      json: {
+        devices: [],
+        positions: [],
+        router: {
+          router_type: "mikrotik",
+          is_online: true,
+          wan_ip: null,
+          hostname: "core.lan",
+          version: null,
+        },
+      },
+    });
+  });
+  await page.route("**/api/v1/agents", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/v1/dns-queries/stats?*", async (route) => {
+    await route.fulfill({
+      json: {
+        total_queries: 0,
+        blocked_queries: 0,
+        unique_domains: 0,
+        unique_clients: 0,
+        top_queried_domains: [],
+        top_blocked_domains: [],
+        per_device_stats: [],
+        queries_over_time: [],
+      },
+    });
+  });
+}
+
+test.describe("Command palette keyboard shortcut (#805)", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubShellData(page);
+    await login(page);
+  });
+
+  test("Ctrl+K opens the palette and focuses search", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByTestId("dashboard-title")).toBeVisible({ timeout: 10000 });
+
+    await page.keyboard.press("Control+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    const input = page.locator("[cmdk-input]");
+    await expect(input).toBeFocused();
+    await page.keyboard.type("dash");
+    await expect(input).toHaveValue("dash");
+
+    await page.screenshot({
+      path: "tests/screenshots/command-palette-ctrl-k-focused.png",
+      fullPage: true,
+    });
+  });
+
+  test("Meta+K opens the palette and Escape closes it", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByTestId("dashboard-title")).toBeVisible({ timeout: 10000 });
+
+    await page.keyboard.press("Meta+k");
+
+    const dialog = page.locator("[cmdk-dialog]");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[cmdk-input]")).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: 2000 });
+  });
+
+  test("shortcut is ignored inside text inputs", async ({ page }) => {
+    await page.goto("/settings");
+    const settingsSearch = page.getByTestId("settings-search");
+    await expect(settingsSearch).toBeVisible({ timeout: 10000 });
+    await settingsSearch.click();
+    await expect(settingsSearch).toBeFocused();
+
+    await page.keyboard.press("Control+k");
+
+    await expect(page.locator("[cmdk-dialog]")).not.toBeVisible();
+    await expect(settingsSearch).toBeFocused();
+  });
+
+  test("visible shortcut hint matches non-macOS control shortcut", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    await expect(
+      page.locator("kbd").filter({ hasText: "Ctrl+K" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/web/tests/e2e/settings-landing-port.spec.ts
+++ b/web/tests/e2e/settings-landing-port.spec.ts
@@ -68,10 +68,11 @@ test.describe("Settings landing — design-source literal port", () => {
     await expect(search).toBeVisible();
     await expect(search).toHaveAttribute("placeholder", /search settings/i);
 
-    // ⌘K hint inside the settings search card (scoped — TopBar also
-    // renders one ⌘K affordance).
+    // Shortcut hint inside the settings search card (scoped — TopBar also
+    // renders one affordance). The hydrated label is platform-aware: ⌘K on
+    // macOS and Ctrl+K in Linux CI.
     await expect(
-      page.locator('kbd', { hasText: "⌘K" }).first(),
+      page.locator("kbd", { hasText: /(?:⌘K|Ctrl\+K)/ }).first(),
     ).toBeVisible();
 
     // Quick filter labels (settings.jsx L146-150). "Experimental" also
@@ -89,7 +90,7 @@ test.describe("Settings landing — design-source literal port", () => {
     // Footer (settings.jsx L184-196).
     const footer = page.locator('[data-testid="settings-footer"]');
     await expect(footer).toBeVisible();
-    await expect(footer).toContainText("Tip · ⌘K");
+    await expect(footer).toContainText(/Tip · (?:⌘K|Ctrl\+K)/);
     await expect(footer).toContainText("Last config change");
 
     await page.screenshot({


### PR DESCRIPTION
Refs #805

## Summary
- route Cmd+K / Ctrl+K through the shared command palette instead of the sidebar search field
- keep shortcuts from stealing focus inside editable inputs
- render shortcut hints with platform-aware labels
- add focused Playwright coverage for Ctrl+K, Meta+K, Escape close, editable-field behavior, and visible hint text

## Verification
- cd web && bun install --frozen-lockfile
- cd web && bun run test
- cd web && bun run build
- cd web && bun run dev -- -p 8080
- cd web && bun run test:e2e -- tests/e2e/command-palette-shortcut.spec.ts

Note: .maestro/verify.sh hit the known unrelated caddy integration failure, and rerunning the single caddy test passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the broken Cmd+K shortcut by routing it through `CommandPalette` instead of `SidebarSearch`, adds an `isEditableShortcutTarget` guard to prevent focus theft from text inputs, and introduces a `ShortcutKey` component that renders platform-aware labels.

- **`CommandPalette.tsx`**: global `keydown` listener calls `setOpen(true)` with a `requestAnimationFrame` focus fallback; toggle-to-close via the same shortcut is intentionally removed in favour of Escape-only close.
- **`Sidebar.tsx` / `settings/page.tsx`**: old hotkey handler deleted from `SidebarSearch` and hardcoded symbol strings replaced with the new `ShortcutKey` component throughout.
- **Tests**: new Playwright spec covers open/focus, Escape-close, editable-field guard, and hint-text; existing `settings-landing-port` spec updated to accept both platform labels via regex.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are confined to the keyboard shortcut handler and cosmetic label rendering with no impact on data or auth paths.

The core logic change — moving the Cmd+K listener from the sidebar into CommandPalette with an editable-target guard — is straightforward and well-tested. The removed SidebarSearch handler is cleanly replaced, the ShortcutKey component has no side effects, and the updated E2E assertions correctly cover the new behaviour across platforms.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/components/CommandPalette.tsx | Adds global Cmd+K listener with editable-target guard, explicit focus via requestAnimationFrame, and removes toggle-to-close behavior; minor: input[type=image] missing from non-editable exclusion list |
| web/src/components/ShortcutKey.tsx | New component for platform-aware shortcut rendering; uses deprecated navigator.platform (flagged in prior thread) |
| web/src/components/layout/Sidebar.tsx | Removes the old SidebarSearch Cmd+K handler and replaces the hardcoded ⌘K hint with ShortcutKey component; clean removal |
| web/src/app/(app)/settings/page.tsx | Replaces two hardcoded ⌘K strings with ShortcutKey component; no logic changes |
| web/tests/e2e/command-palette-shortcut.spec.ts | New Playwright spec covering Ctrl+K open/focus, Meta+K+Escape close, editable-field guard, and hint text; only one of four tests saves a required screenshot |
| web/tests/e2e/settings-landing-port.spec.ts | Updates existing kbd and footer text assertions to accept both ⌘K and Ctrl+K via regex; correct cross-platform adaptation |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/CommandPalette.tsx:329-330
`input[type=image]` slips through the editable guard. It is a graphical submit button (focusable, receives keyboard events), but because `"image"` is absent from the exclusion list the function returns `true`, so Cmd+K while an image-input is focused silently does nothing instead of opening the palette.

```suggestion
  const type = input.type.toLowerCase()
  return !['button', 'checkbox', 'color', 'file', 'image', 'radio', 'range', 'reset', 'submit'].includes(type)
```

### Issue 2 of 2
web/tests/e2e/command-palette-shortcut.spec.ts:109-143
**Missing screenshots on three of four new tests**

`CLAUDE.md` requires that valid E2E tests "include a screenshot on key assertions." The `Ctrl+K` test saves one, but `Meta+K opens and Escape closes`, `shortcut is ignored inside text inputs`, and `visible shortcut hint matches non-macOS control shortcut` each make visible assertions without calling `page.screenshot(...)`. Adding screenshots would satisfy the project requirement and make CI failures easier to diagnose.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: accept platform shortcut hint in s..."](https://github.com/befeast/panoptikon/commit/a256029a5ea09c60d33a0301d87bd8b4471581c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33345588)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=9f9ff013-13ca-4983-85e1-012d6e91e51a))

<!-- /greptile_comment -->