### PR TITLE
ci: gate macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v1.0.0"
+        required: true
+        type: string
+      include_macos:
+        description: "Build expensive macOS server and agent artifacts"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -17,6 +27,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -48,6 +60,8 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -79,6 +93,7 @@ jobs:
   build-macos:
     name: macOS (${{ matrix.arch }})
     needs: frontend
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.include_macos) || (github.event_name == 'push' && endsWith(github.ref_name, '.0.0')) }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -91,6 +106,8 @@ jobs:
             runner: blacksmith-6vcpu-macos-15
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -122,9 +139,12 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build-linux, build-macos]
+    if: ${{ always() && needs.build-linux.result == 'success' && (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -143,6 +163,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           generate_release_notes: true
           body: |
             ## Quick Install


### PR DESCRIPTION
## Summary

- Add manual `workflow_dispatch` release inputs for an explicit release tag and macOS artifact opt-in.
- Skip expensive macOS release builders for normal patch/minor tag releases.
- Keep macOS artifacts for manual releases with `include_macos=true` and automatic major tags ending in `.0.0`.
- Ensure manual release jobs checkout the requested tag before building artifacts.

## Verification

- `git diff --check`
- `uvx --from yq yq . .github/workflows/release.yml >/dev/null`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore "label .+ is unknown" .github/workflows/release.yml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the expensive macOS release builders behind an explicit `include_macos` flag for `workflow_dispatch` runs and behind an `endsWith(github.ref_name, '.0.0')` heuristic for push-triggered runs, reducing CI cost for routine patch/minor releases. The `release` job is updated to use `always()` combined with explicit result checks so it still executes when `build-macos` is skipped.

- All four `actions/checkout` steps now override `ref` to use `inputs.tag` under `workflow_dispatch`, ensuring builds reflect the intended tag rather than the default branch.
- A `tag_name` override is added to `softprops/action-gh-release` so manual dispatches publish against the supplied tag rather than `github.ref_name` (which would be the branch name during a dispatch).
- The `release` job `if` condition correctly allows `build-macos.result == 'skipped'` so Linux-only releases proceed without requiring macOS success.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the conditional logic and always() pattern are correct for all described scenarios, and the two observations are minor operational footguns rather than functional breakage.

The core workflow logic is correct: the build-macos gating, the release job's always()+skipped guard, and the ref overrides all work as intended. The two observations are about missing input validation and a non-obvious manual-dispatch default — neither causes incorrect releases on the normal push path, but both could trip up a committer triggering the workflow manually.

.github/workflows/release.yml — specifically the workflow_dispatch input handling and how include_macos interacts with major version tags dispatched manually.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds workflow_dispatch trigger with tag/include_macos inputs, gates build-macos on major tags (.0.0) or explicit opt-in, and guards the release job with always()+skipped logic so Linux-only releases proceed correctly when macOS is skipped. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/release.yml:9-12
**No format guard on `inputs.tag`**

The `tag` input accepts any string and is passed directly into `actions/checkout` `ref:` and `softprops/action-gh-release` `tag_name:`. If a dispatcher accidentally passes a branch name (e.g. `main`) or a bare SHA, the checkout succeeds (HEAD of that ref is checked out) but the release action then creates — or re-tags — a GitHub Release under that arbitrary name. A lightweight pattern guard (e.g. `startsWith(inputs.tag, 'v')` in each job's `if`) would prevent silent misfires without adding much ceremony.

### Issue 2 of 2
.github/workflows/release.yml:96
**`include_macos` defaults to `false` for all manual dispatches, including major releases**

When a committer dispatches the workflow manually for a `vX.0.0` tag, the `build-macos` `if` condition evaluates `github.event_name == 'push'` to `false`, so the push-path `.0.0` heuristic never fires. A release for `v2.0.0` dispatched manually without checking `include_macos` will publish with Linux artifacts only — identical to a minor patch release — with no warning. At minimum the input description could call this out (e.g. "required for major version releases dispatched manually"), so the dispatcher knows to opt in.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: gate macOS release artifacts"](https://github.com/befeast/panoptikon/commit/41204b883c99be32dc0d93014426b17f0bf6376c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33451456)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->