### PR TITLE
fix: normalize Cloudflare catch-all tunnel paths

### DIFF
--- a/server/src/api/cloudflare_tunnel.rs
+++ b/server/src/api/cloudflare_tunnel.rs
@@ -112,6 +112,15 @@ fn cf_http_client() -> reqwest::Client {
         .expect("cloudflare HTTP client")
 }
 
+fn normalize_path_matcher(path: Option<String>) -> Option<String> {
+    let path = path?.trim().to_string();
+    if path.is_empty() || path == "/" {
+        None
+    } else {
+        Some(path)
+    }
+}
+
 // ─── Handlers ───────────────────────────────────────────────
 
 /// GET /api/v1/cloudflare-tunnel/status
@@ -251,7 +260,7 @@ pub async fn add_route(
     routes.push(TunnelRoute {
         hostname: body.hostname.clone(),
         service: body.service.clone(),
-        path: body.path.clone(),
+        path: normalize_path_matcher(body.path.clone()),
     });
 
     // Write back to Cloudflare.
@@ -364,7 +373,7 @@ pub async fn update_route(
     routes[idx] = TunnelRoute {
         hostname: body.hostname.clone(),
         service: body.service.clone(),
-        path: body.path.clone(),
+        path: normalize_path_matcher(body.path.clone()),
     };
 
     // Write back to Cloudflare.
@@ -420,7 +429,7 @@ async fn fetch_ingress_routes(config: &CfConfig) -> anyhow::Result<Vec<TunnelRou
             // Skip the catch-all rule (no hostname).
             let hostname = entry["hostname"].as_str()?;
             let service = entry["service"].as_str().unwrap_or("").to_string();
-            let path = entry["path"].as_str().map(|s| s.to_string());
+            let path = normalize_path_matcher(entry["path"].as_str().map(|s| s.to_string()));
             Some(TunnelRoute {
                 hostname: hostname.to_string(),
                 service,
@@ -451,7 +460,7 @@ async fn write_ingress_routes(config: &CfConfig, routes: &[TunnelRoute]) -> anyh
                 "hostname": r.hostname,
                 "service": r.service,
             });
-            if let Some(ref path) = r.path {
+            if let Some(path) = normalize_path_matcher(r.path.clone()) {
                 entry["path"] = serde_json::json!(path);
             }
             entry
@@ -483,4 +492,30 @@ async fn write_ingress_routes(config: &CfConfig, routes: &[TunnelRoute]) -> anyh
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path_matcher;
+
+    #[test]
+    fn normalizes_empty_and_root_path_matchers() {
+        assert_eq!(normalize_path_matcher(None), None);
+        assert_eq!(normalize_path_matcher(Some(String::new())), None);
+        assert_eq!(normalize_path_matcher(Some("   ".to_string())), None);
+        assert_eq!(normalize_path_matcher(Some("/".to_string())), None);
+        assert_eq!(normalize_path_matcher(Some(" / ".to_string())), None);
+    }
+
+    #[test]
+    fn preserves_specific_path_matchers() {
+        assert_eq!(
+            normalize_path_matcher(Some("/api".to_string())),
+            Some("/api".to_string())
+        );
+        assert_eq!(
+            normalize_path_matcher(Some(" ^/api ".to_string())),
+            Some("^/api".to_string())
+        );
+    }
 }

--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -100,6 +100,14 @@ function timeAgo(iso: string | null): string {
   }
 }
 
+function normalizePathMatcher(path: string): string | undefined {
+  const trimmed = path.trim();
+  if (!trimmed || trimmed === "/") {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export default function CloudflareTunnelPage() {
   const [status, setStatus] = useState<CloudflareTunnelStatus | null>(null);
   const [routes, setRoutes] = useState<CloudflareTunnelRoute[]>([]);
@@ -152,7 +160,8 @@ export default function CloudflareTunnelPage() {
         hostname: formHostname,
         service: formService,
       };
-      if (formPath) body.path = formPath;
+      const normalizedPath = normalizePathMatcher(formPath);
+      if (normalizedPath) body.path = normalizedPath;
       const result = await addCloudflareTunnelRoute(body);
       if (result.success) {
         toast.success(result.message);
@@ -207,7 +216,8 @@ export default function CloudflareTunnelPage() {
         hostname: editHostname,
         service: editService,
       };
-      if (editPath) body.path = editPath;
+      const normalizedPath = normalizePathMatcher(editPath);
+      if (normalizedPath) body.path = normalizedPath;
       const result = await updateCloudflareTunnelRoute(
         editOriginalHostname,
         body
@@ -507,7 +517,7 @@ export default function CloudflareTunnelPage() {
                           <span className="block truncate">{route.service}</span>
                         </TableCell>
                         <TableCell className="text-mesh-text-dim">
-                          {route.path || "/"}
+                          {route.path ?? ""}
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-1">
@@ -575,10 +585,13 @@ export default function CloudflareTunnelPage() {
                 </Label>
                 <Input
                   id="path"
-                  placeholder="/"
+                  placeholder="/api"
                   value={formPath}
                   onChange={(e) => setFormPath(e.target.value)}
                 />
+                <p className="text-xs text-mesh-text-dim">
+                  Optional. Leave empty to match the whole hostname.
+                </p>
               </div>
               <div className="flex justify-end gap-2">
                 <Button
@@ -635,10 +648,13 @@ export default function CloudflareTunnelPage() {
                 </Label>
                 <Input
                   id="edit-path"
-                  placeholder="/"
+                  placeholder="/api"
                   value={editPath}
                   onChange={(e) => setEditPath(e.target.value)}
                 />
+                <p className="text-xs text-mesh-text-dim">
+                  Optional. Leave empty to match the whole hostname.
+                </p>
               </div>
               <div className="flex justify-end gap-2">
                 <Button

--- a/web/tests/e2e/cloudflare-tunnel-path-normalization.spec.ts
+++ b/web/tests/e2e/cloudflare-tunnel-path-normalization.spec.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { test, expect, login } from "../../e2e/fixtures";
+
+const status = {
+  configured: true,
+  connected: true,
+  tunnel_id: "tunnel-1",
+  tunnel_name: "panoptikon",
+  created_at: "2026-05-22T00:00:00Z",
+  connections: [
+    {
+      colo_name: "IAD",
+      is_pending_reconnect: false,
+      origin_ip: "10.10.0.13",
+      opened_at: "2026-05-22T00:00:00Z",
+    },
+  ],
+};
+
+async function mockCloudflareTunnelApis(page: Page, requests: unknown[]) {
+  let routes = [
+    {
+      hostname: "scribe.oklabs.uk",
+      service: "http://10.10.0.13:13120",
+      path: null,
+    },
+    {
+      hostname: "api.oklabs.uk",
+      service: "http://10.10.0.13:13120",
+      path: "/api",
+    },
+  ];
+
+  await page.route("**/api/v1/cloudflare-tunnel/status", (route) =>
+    route.fulfill({ status: 200, json: status }),
+  );
+
+  await page.route("**/api/v1/cloudflare-tunnel/routes/*", async (route) => {
+    const request = route.request();
+    const body = request.postDataJSON() as {
+      hostname: string;
+      service: string;
+      path?: string;
+    };
+    requests.push(body);
+    routes = routes.map((item) =>
+      item.hostname === "scribe.oklabs.uk"
+        ? { ...item, ...body, path: body.path ?? null }
+        : item,
+    );
+
+    await route.fulfill({
+      status: 200,
+      json: { success: true, message: "Route updated" },
+    });
+  });
+
+  await page.route("**/api/v1/cloudflare-tunnel/routes", async (route) => {
+    const request = route.request();
+    if (request.method() === "GET") {
+      await route.fulfill({ status: 200, json: { routes } });
+      return;
+    }
+
+    const body = request.postDataJSON() as {
+      hostname: string;
+      service: string;
+      path?: string;
+    };
+    requests.push(body);
+    routes = [...routes, { ...body, path: body.path ?? null }];
+
+    await route.fulfill({
+      status: 201,
+      json: { success: true, message: "Route added" },
+    });
+  });
+}
+
+test.describe("Cloudflare Tunnel path normalization", () => {
+  test("catch-all host routes round-trip as an empty path and omit root path on save", async ({
+    page,
+  }) => {
+    const requests: unknown[] = [];
+    await mockCloudflareTunnelApis(page, requests);
+    await login(page);
+
+    await page.goto("/cloudflare-tunnel/");
+    await expect(
+      page.getByRole("heading", { name: "Cloudflare Tunnel", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const catchAllRow = page
+      .locator("tbody tr")
+      .filter({ hasText: "scribe.oklabs.uk" });
+    await expect(catchAllRow.locator("td").nth(2)).toHaveText("");
+
+    await catchAllRow
+      .locator("button")
+      .filter({ has: page.locator("svg.lucide-pencil") })
+      .click();
+    await expect(page.locator("#edit-path")).toHaveValue("");
+    await expect(
+      page.getByText("Optional. Leave empty to match the whole hostname."),
+    ).toBeVisible();
+
+    await page.locator("#edit-path").fill("/");
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    expect(requests[0]).toEqual({
+      hostname: "scribe.oklabs.uk",
+      service: "http://10.10.0.13:13120",
+    });
+  });
+
+  test("whitespace and root paths are omitted while specific paths are preserved", async ({
+    page,
+  }) => {
+    const requests: unknown[] = [];
+    await mockCloudflareTunnelApis(page, requests);
+    await login(page);
+
+    await page.goto("/cloudflare-tunnel/");
+    await page.getByRole("button", { name: "Add Route" }).click();
+    await page.locator("#hostname").fill("root.oklabs.uk");
+    await page.locator("#service").fill("http://10.10.0.13:13120");
+    await page.locator("#path").fill(" / ");
+    await page.getByRole("button", { name: "Add Route" }).click();
+
+    await page.getByRole("button", { name: "Add Route" }).click();
+    await page.locator("#hostname").fill("api-v2.oklabs.uk");
+    await page.locator("#service").fill("http://10.10.0.13:13120");
+    await page.locator("#path").fill(" ^/api ");
+    await page.getByRole("button", { name: "Add Route" }).click();
+
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests[0]).toEqual({
+      hostname: "root.oklabs.uk",
+      service: "http://10.10.0.13:13120",
+    });
+    expect(requests[1]).toEqual({
+      hostname: "api-v2.oklabs.uk",
+      service: "http://10.10.0.13:13120",
+      path: "^/api",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize Cloudflare tunnel route path matchers so `/`, empty, and whitespace-only values mean hostname-wide matching
- omit the `path` field from API requests and generated Cloudflare ingress rules for catch-all routes
- keep specific matchers such as `/api` and `^/api` intact after trimming
- add focused E2E coverage for add/edit route path normalization

## Why
Issue #802 failed in Maestro after the worker produced local changes but no PR. The route editor treated `/` as a literal path matcher, which can prevent the intended all-paths Cloudflare route behavior.

Closes #802

## Verification
- `cargo fmt --check`
- `cargo test cloudflare_tunnel::tests`
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run test`
- `cd web && bun run build`
- `PANOPTIKON_URL=http://127.0.0.1:18083 bunx playwright test cloudflare-tunnel-path-normalization.spec.ts --workers=1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Cloudflare tunnel route handling so that `/`, empty, and whitespace-only path matchers are treated as catch-all (hostname-wide) routes rather than literal path matchers, both on the server and in the frontend form submission.

- A `normalize_path_matcher` helper is added in Rust and mirrored in TypeScript; it is applied at every path ingestion point — `add_route`, `update_route`, `fetch_ingress_routes`, and `write_ingress_routes` — so normalization is consistent regardless of the call path.
- The frontend path column display changes from `|| "/"` to `?? ""` and the path input placeholder and hint text are updated to reflect the new "empty = catch-all" semantics.
- Two focused E2E tests cover the normalization behavior for both the add and edit flows using mocked API routes.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the normalization logic is correct and consistently applied at every ingress path in both Rust and TypeScript.

The Rust and TypeScript normalization changes are correct and well-covered by unit and E2E tests. The only concern is in the second E2E test where two add-route flows run back-to-back without an intermediate assertion that the first dialog has fully closed, making that test mildly susceptible to timing-related failures in CI.

The second test in `web/tests/e2e/cloudflare-tunnel-path-normalization.spec.ts` could use an explicit dialog-close assertion between its two sequential Add Route submissions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/cloudflare_tunnel.rs | Adds `normalize_path_matcher` helper and applies it at every path ingestion point (add, update, fetch, write); unit tests cover all normalization cases. |
| web/src/app/(app)/cloudflare-tunnel/page.tsx | Mirrors the server-side normalization in the frontend submit handlers; updates path column display from `|| "/"` to `?? ""`; adds hint text to path inputs. |
| web/tests/e2e/cloudflare-tunnel-path-normalization.spec.ts | New E2E tests cover catch-all edit and add-route normalization via mocked APIs; the second test submits two add-route flows back-to-back without an intermediate assertion that the first dialog has closed, which could be flaky. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/tests/e2e/cloudflare-tunnel-path-normalization.spec.ts:120-137
**No intermediate wait between two sequential Add-Route flows**

After the first "Add Route" submit (line 128), the dialog close is triggered by a React state update and may include an animation frame. The very next click on line 130 (`page.getByRole("button", { name: "Add Route" })`) can match either the button inside the still-closing dialog or the one outside it. If both buttons are momentarily visible, Playwright selects the first DOM match, potentially clicking the in-dialog button again instead of the outer one, causing the second hostname to be sent to a stale or wrong handler. Adding `await expect(page.locator("#hostname")).not.toBeVisible()` (or `await expect(page.getByRole("dialog")).not.toBeVisible()`) between the two flow sequences makes the sequencing deterministic.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: normalize Cloudflare catch-all tunn..."](https://github.com/befeast/panoptikon/commit/92b06382d0e8f4db8251359de8edf8a75f31c435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33483852)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->