### PR TITLE
Cloudflare tunnel route creation verifies DNS

### DIFF
--- a/server/src/api/cloudflare_tunnel.rs
+++ b/server/src/api/cloudflare_tunnel.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use std::env;
 use tracing::{error, info, warn};
 
 use super::{AppError, AppState};
@@ -39,6 +40,20 @@ pub struct TunnelRoute {
     pub hostname: String,
     pub service: String,
     pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dns: Option<TunnelRouteDns>,
+}
+
+/// Cloudflare DNS status for a tunnel route hostname.
+#[derive(Debug, Serialize, Clone)]
+pub struct TunnelRouteDns {
+    pub configured: bool,
+    pub status: String,
+    pub message: String,
+    pub zone_name: Option<String>,
+    pub record_type: Option<String>,
+    pub proxied: Option<bool>,
+    pub target: Option<String>,
 }
 
 /// Response for the routes endpoint.
@@ -121,6 +136,10 @@ fn normalize_path_matcher(path: Option<String>) -> Option<String> {
     }
 }
 
+fn cf_api_base() -> String {
+    env::var("PANOPTIKON_CF_API_BASE").unwrap_or_else(|_| CF_API_BASE.to_string())
+}
+
 // ─── Handlers ───────────────────────────────────────────────
 
 /// GET /api/v1/cloudflare-tunnel/status
@@ -145,8 +164,10 @@ pub async fn status(State(state): State<AppState>) -> Json<TunnelStatus> {
 
     // Fetch tunnel details.
     let tunnel_url = format!(
-        "{CF_API_BASE}/accounts/{}/cfd_tunnel/{}",
-        config.account_id, config.tunnel_id
+        "{}/accounts/{}/cfd_tunnel/{}",
+        cf_api_base(),
+        config.account_id,
+        config.tunnel_id
     );
 
     let tunnel_resp = client
@@ -220,6 +241,7 @@ pub async fn list_routes(
         error!("Failed to fetch tunnel routes: {e}");
         AppError::Internal(e.to_string())
     })?;
+    let routes = annotate_dns_status(&config, routes).await;
 
     Ok(Json(TunnelRoutesResponse { routes }))
 }
@@ -256,11 +278,16 @@ pub async fn add_route(
         ));
     }
 
+    ensure_route_dns(&config, &body.hostname)
+        .await
+        .map_err(DnsEnsureError::into_app_error)?;
+
     // Add new route.
     routes.push(TunnelRoute {
         hostname: body.hostname.clone(),
         service: body.service.clone(),
         path: normalize_path_matcher(body.path.clone()),
+        dns: None,
     });
 
     // Write back to Cloudflare.
@@ -369,11 +396,16 @@ pub async fn update_route(
         }));
     }
 
+    ensure_route_dns(&config, &body.hostname)
+        .await
+        .map_err(DnsEnsureError::into_app_error)?;
+
     // Update the route in place.
     routes[idx] = TunnelRoute {
         hostname: body.hostname.clone(),
         service: body.service.clone(),
         path: normalize_path_matcher(body.path.clone()),
+        dns: None,
     };
 
     // Write back to Cloudflare.
@@ -401,8 +433,10 @@ pub async fn update_route(
 async fn fetch_ingress_routes(config: &CfConfig) -> anyhow::Result<Vec<TunnelRoute>> {
     let client = cf_http_client();
     let url = format!(
-        "{CF_API_BASE}/accounts/{}/cfd_tunnel/{}/configurations",
-        config.account_id, config.tunnel_id
+        "{}/accounts/{}/cfd_tunnel/{}/configurations",
+        cf_api_base(),
+        config.account_id,
+        config.tunnel_id
     );
 
     let resp = client
@@ -434,11 +468,429 @@ async fn fetch_ingress_routes(config: &CfConfig) -> anyhow::Result<Vec<TunnelRou
                 hostname: hostname.to_string(),
                 service,
                 path,
+                dns: None,
             })
         })
         .collect();
 
     Ok(routes)
+}
+
+#[derive(Debug, Deserialize)]
+struct CfListResponse<T> {
+    success: bool,
+    #[serde(default = "empty_cf_result")]
+    result: Vec<T>,
+    #[serde(default)]
+    errors: Vec<CfApiError>,
+}
+
+fn empty_cf_result<T>() -> Vec<T> {
+    Vec::new()
+}
+
+#[derive(Debug, Deserialize)]
+struct CfItemResponse<T> {
+    success: bool,
+    result: Option<T>,
+    #[serde(default)]
+    errors: Vec<CfApiError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CfApiError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CfZone {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CfDnsRecord {
+    id: String,
+    #[serde(rename = "type")]
+    record_type: String,
+    name: String,
+    content: String,
+    proxied: Option<bool>,
+}
+
+#[derive(Debug)]
+enum DnsEnsureError {
+    MissingZone(String),
+    Conflict(String),
+    Upstream(String),
+}
+
+impl DnsEnsureError {
+    fn into_app_error(self) -> AppError {
+        match self {
+            DnsEnsureError::MissingZone(message) => AppError::PreconditionRequired(message),
+            DnsEnsureError::Conflict(message) => AppError::Conflict(message),
+            DnsEnsureError::Upstream(message) => AppError::BadGateway(message),
+        }
+    }
+}
+
+fn tunnel_dns_target(config: &CfConfig) -> String {
+    format!("{}.cfargotunnel.com", config.tunnel_id)
+}
+
+fn normalize_dns_value(value: &str) -> String {
+    value.trim().trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn hostname_zone_candidates(hostname: &str) -> Vec<String> {
+    let labels: Vec<&str> = hostname.trim().trim_end_matches('.').split('.').collect();
+    if labels.len() < 2 {
+        return vec![];
+    }
+    (0..labels.len() - 1)
+        .map(|idx| labels[idx..].join(".").to_ascii_lowercase())
+        .collect()
+}
+
+fn cf_error_message(errors: &[CfApiError], fallback: &str) -> String {
+    errors
+        .first()
+        .map(|e| e.message.clone())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+async fn find_managed_zone(
+    client: &reqwest::Client,
+    config: &CfConfig,
+    hostname: &str,
+) -> Result<Option<CfZone>, DnsEnsureError> {
+    let url = format!("{}/zones", cf_api_base());
+
+    for name in hostname_zone_candidates(hostname) {
+        let resp = client
+            .get(&url)
+            .bearer_auth(&config.api_token)
+            .query(&[("name", name.as_str()), ("status", "active")])
+            .send()
+            .await
+            .map_err(|e| {
+                DnsEnsureError::Upstream(format!(
+                    "Unable to query Cloudflare zones for '{hostname}': {e}"
+                ))
+            })?;
+
+        let status = resp.status();
+        let body: CfListResponse<CfZone> = resp.json().await.map_err(|e| {
+            DnsEnsureError::Upstream(format!(
+                "Unable to parse Cloudflare zone lookup for '{hostname}': {e}"
+            ))
+        })?;
+
+        if !status.is_success() || !body.success {
+            return Err(DnsEnsureError::Upstream(format!(
+                "Cloudflare zone lookup failed for '{hostname}': {}. Ensure the API token has Zone:Read permission.",
+                cf_error_message(&body.errors, &status.to_string())
+            )));
+        }
+
+        if let Some(zone) = body.result.into_iter().find(|zone| zone.name == name) {
+            return Ok(Some(zone));
+        }
+    }
+
+    Ok(None)
+}
+
+async fn fetch_dns_records(
+    client: &reqwest::Client,
+    config: &CfConfig,
+    zone: &CfZone,
+    hostname: &str,
+) -> Result<Vec<CfDnsRecord>, DnsEnsureError> {
+    let url = format!("{}/zones/{}/dns_records", cf_api_base(), zone.id);
+    let resp = client
+        .get(&url)
+        .bearer_auth(&config.api_token)
+        .query(&[("name", hostname), ("per_page", "100")])
+        .send()
+        .await
+        .map_err(|e| {
+            DnsEnsureError::Upstream(format!(
+                "Unable to query Cloudflare DNS records for '{hostname}': {e}"
+            ))
+        })?;
+
+    let status = resp.status();
+    let body: CfListResponse<CfDnsRecord> = resp.json().await.map_err(|e| {
+        DnsEnsureError::Upstream(format!(
+            "Unable to parse Cloudflare DNS records for '{hostname}': {e}"
+        ))
+    })?;
+
+    if !status.is_success() || !body.success {
+        return Err(DnsEnsureError::Upstream(format!(
+            "Cloudflare DNS lookup failed for '{hostname}': {}. Ensure the API token has Zone:Read permission for '{}'.",
+            cf_error_message(&body.errors, &status.to_string()),
+            zone.name
+        )));
+    }
+
+    Ok(body.result)
+}
+
+fn matching_cname<'a>(records: &'a [CfDnsRecord], target: &str) -> Option<&'a CfDnsRecord> {
+    records.iter().find(|record| {
+        record.record_type.eq_ignore_ascii_case("CNAME")
+            && normalize_dns_value(&record.content) == normalize_dns_value(target)
+    })
+}
+
+fn dns_status_from_records(
+    hostname: &str,
+    zone: &CfZone,
+    target: &str,
+    records: &[CfDnsRecord],
+) -> TunnelRouteDns {
+    if records.is_empty() {
+        return TunnelRouteDns {
+            configured: false,
+            status: "missing".to_string(),
+            message: format!("Create a proxied CNAME for {hostname} to {target}."),
+            zone_name: Some(zone.name.clone()),
+            record_type: None,
+            proxied: None,
+            target: Some(target.to_string()),
+        };
+    }
+
+    if let Some(record) = matching_cname(records, target) {
+        let proxied = record.proxied.unwrap_or(false);
+        return TunnelRouteDns {
+            configured: proxied,
+            status: if proxied { "configured" } else { "unproxied" }.to_string(),
+            message: if proxied {
+                format!("{hostname} has a proxied CNAME to {target}.")
+            } else {
+                format!("{hostname} points to {target}, but the CNAME is not proxied.")
+            },
+            zone_name: Some(zone.name.clone()),
+            record_type: Some(record.record_type.clone()),
+            proxied: Some(proxied),
+            target: Some(record.content.clone()),
+        };
+    }
+
+    let record = &records[0];
+    TunnelRouteDns {
+        configured: false,
+        status: "conflict".to_string(),
+        message: format!(
+            "{hostname} has a conflicting {} record pointing to '{}'. Replace it with a proxied CNAME to {target}.",
+            record.record_type, record.content
+        ),
+        zone_name: Some(zone.name.clone()),
+        record_type: Some(record.record_type.clone()),
+        proxied: record.proxied,
+        target: Some(record.content.clone()),
+    }
+}
+
+async fn route_dns_status(
+    client: &reqwest::Client,
+    config: &CfConfig,
+    hostname: &str,
+) -> TunnelRouteDns {
+    let target = tunnel_dns_target(config);
+    let zone = match find_managed_zone(client, config, hostname).await {
+        Ok(Some(zone)) => zone,
+        Ok(None) => {
+            return TunnelRouteDns {
+                configured: false,
+                status: "zone_missing".to_string(),
+                message: format!(
+                    "No managed Cloudflare zone was found for {hostname}. Add the zone to Cloudflare or create a proxied CNAME for {hostname} to {target}."
+                ),
+                zone_name: None,
+                record_type: None,
+                proxied: None,
+                target: Some(target),
+            };
+        }
+        Err(err) => {
+            return TunnelRouteDns {
+                configured: false,
+                status: "unknown".to_string(),
+                message: match err {
+                    DnsEnsureError::MissingZone(message)
+                    | DnsEnsureError::Conflict(message)
+                    | DnsEnsureError::Upstream(message) => message,
+                },
+                zone_name: None,
+                record_type: None,
+                proxied: None,
+                target: Some(target),
+            };
+        }
+    };
+
+    match fetch_dns_records(client, config, &zone, hostname).await {
+        Ok(records) => dns_status_from_records(hostname, &zone, &target, &records),
+        Err(err) => TunnelRouteDns {
+            configured: false,
+            status: "unknown".to_string(),
+            message: match err {
+                DnsEnsureError::MissingZone(message)
+                | DnsEnsureError::Conflict(message)
+                | DnsEnsureError::Upstream(message) => message,
+            },
+            zone_name: Some(zone.name),
+            record_type: None,
+            proxied: None,
+            target: Some(target),
+        },
+    }
+}
+
+async fn annotate_dns_status(config: &CfConfig, routes: Vec<TunnelRoute>) -> Vec<TunnelRoute> {
+    let client = cf_http_client();
+    let mut annotated = Vec::with_capacity(routes.len());
+
+    for mut route in routes {
+        route.dns = Some(route_dns_status(&client, config, &route.hostname).await);
+        annotated.push(route);
+    }
+
+    annotated
+}
+
+async fn create_dns_record(
+    client: &reqwest::Client,
+    config: &CfConfig,
+    zone: &CfZone,
+    hostname: &str,
+    target: &str,
+) -> Result<(), DnsEnsureError> {
+    let url = format!("{}/zones/{}/dns_records", cf_api_base(), zone.id);
+    let body = serde_json::json!({
+        "type": "CNAME",
+        "name": hostname,
+        "content": target,
+        "ttl": 1,
+        "proxied": true,
+    });
+
+    let resp = client
+        .post(&url)
+        .bearer_auth(&config.api_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            DnsEnsureError::Upstream(format!(
+                "Unable to create Cloudflare DNS record for '{hostname}': {e}"
+            ))
+        })?;
+
+    let status = resp.status();
+    let body: CfItemResponse<CfDnsRecord> = resp.json().await.map_err(|e| {
+        DnsEnsureError::Upstream(format!(
+            "Unable to parse Cloudflare DNS create response for '{hostname}': {e}"
+        ))
+    })?;
+
+    if !status.is_success() || !body.success {
+        return Err(DnsEnsureError::Upstream(format!(
+            "Cloudflare could not create the DNS record for '{hostname}': {}. Create a proxied CNAME for {hostname} to {target}.",
+            cf_error_message(&body.errors, &status.to_string())
+        )));
+    }
+
+    let _ = body.result;
+    Ok(())
+}
+
+async fn update_dns_record_to_proxied(
+    client: &reqwest::Client,
+    config: &CfConfig,
+    zone: &CfZone,
+    record: &CfDnsRecord,
+    hostname: &str,
+    target: &str,
+) -> Result<(), DnsEnsureError> {
+    let url = format!(
+        "{}/zones/{}/dns_records/{}",
+        cf_api_base(),
+        zone.id,
+        record.id
+    );
+    let body = serde_json::json!({
+        "type": "CNAME",
+        "name": hostname,
+        "content": target,
+        "ttl": 1,
+        "proxied": true,
+    });
+
+    let resp = client
+        .put(&url)
+        .bearer_auth(&config.api_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            DnsEnsureError::Upstream(format!(
+                "Unable to update Cloudflare DNS record for '{hostname}': {e}"
+            ))
+        })?;
+
+    let status = resp.status();
+    let body: CfItemResponse<CfDnsRecord> = resp.json().await.map_err(|e| {
+        DnsEnsureError::Upstream(format!(
+            "Unable to parse Cloudflare DNS update response for '{hostname}': {e}"
+        ))
+    })?;
+
+    if !status.is_success() || !body.success {
+        return Err(DnsEnsureError::Upstream(format!(
+            "Cloudflare could not update the DNS record for '{hostname}': {}. Ensure the API token has DNS:Edit permission for '{}'.",
+            cf_error_message(&body.errors, &status.to_string()),
+            zone.name
+        )));
+    }
+
+    let _ = body.result;
+    Ok(())
+}
+
+async fn ensure_route_dns(config: &CfConfig, hostname: &str) -> Result<(), DnsEnsureError> {
+    let client = cf_http_client();
+    let target = tunnel_dns_target(config);
+    let zone = find_managed_zone(&client, config, hostname).await?.ok_or_else(|| {
+        DnsEnsureError::MissingZone(format!(
+            "No managed Cloudflare zone was found for {hostname}. Add the zone to Cloudflare or create a proxied CNAME for {hostname} to {target} before creating this tunnel route."
+        ))
+    })?;
+    let records = fetch_dns_records(&client, config, &zone, hostname).await?;
+
+    if records.is_empty() {
+        create_dns_record(&client, config, &zone, hostname, &target).await?;
+        return Ok(());
+    }
+
+    if let Some(record) = matching_cname(&records, &target) {
+        if record.proxied.unwrap_or(false) {
+            return Ok(());
+        }
+        update_dns_record_to_proxied(&client, config, &zone, record, hostname, &target).await?;
+        return Ok(());
+    }
+
+    let record = &records[0];
+    Err(DnsEnsureError::Conflict(format!(
+        "{hostname} already has a conflicting Cloudflare DNS record: {} {} -> '{}'. Replace it with a proxied CNAME to {target}.",
+        record.record_type, record.name, record.content
+    )))
 }
 
 /// Write ingress routes back to the Cloudflare Tunnel configuration.
@@ -448,8 +900,10 @@ async fn fetch_ingress_routes(config: &CfConfig) -> anyhow::Result<Vec<TunnelRou
 async fn write_ingress_routes(config: &CfConfig, routes: &[TunnelRoute]) -> anyhow::Result<()> {
     let client = cf_http_client();
     let url = format!(
-        "{CF_API_BASE}/accounts/{}/cfd_tunnel/{}/configurations",
-        config.account_id, config.tunnel_id
+        "{}/accounts/{}/cfd_tunnel/{}/configurations",
+        cf_api_base(),
+        config.account_id,
+        config.tunnel_id
     );
 
     // Build ingress array: user routes + catch-all.
@@ -496,7 +950,24 @@ async fn write_ingress_routes(config: &CfConfig, routes: &[TunnelRoute]) -> anyh
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_path_matcher;
+    use super::*;
+
+    fn zone() -> CfZone {
+        CfZone {
+            id: "zone-1".to_string(),
+            name: "oklabs.uk".to_string(),
+        }
+    }
+
+    fn record(record_type: &str, content: &str, proxied: Option<bool>) -> CfDnsRecord {
+        CfDnsRecord {
+            id: "record-1".to_string(),
+            record_type: record_type.to_string(),
+            name: "scribe.oklabs.uk".to_string(),
+            content: content.to_string(),
+            proxied,
+        }
+    }
 
     #[test]
     fn normalizes_empty_and_root_path_matchers() {
@@ -517,5 +988,63 @@ mod tests {
             normalize_path_matcher(Some(" ^/api ".to_string())),
             Some("^/api".to_string())
         );
+    }
+
+    #[test]
+    fn cloudflare_tunnel_dns_candidates_include_parent_zones() {
+        assert_eq!(
+            hostname_zone_candidates("scribe.oklabs.uk"),
+            vec!["scribe.oklabs.uk", "oklabs.uk"]
+        );
+    }
+
+    #[test]
+    fn cloudflare_tunnel_dns_accepts_existing_proxied_cname() {
+        let status = dns_status_from_records(
+            "scribe.oklabs.uk",
+            &zone(),
+            "abc.cfargotunnel.com",
+            &[record("CNAME", "abc.cfargotunnel.com.", Some(true))],
+        );
+
+        assert!(status.configured);
+        assert_eq!(status.status, "configured");
+    }
+
+    #[test]
+    fn cloudflare_tunnel_dns_marks_unproxied_cname_not_configured() {
+        let status = dns_status_from_records(
+            "scribe.oklabs.uk",
+            &zone(),
+            "abc.cfargotunnel.com",
+            &[record("CNAME", "abc.cfargotunnel.com", Some(false))],
+        );
+
+        assert!(!status.configured);
+        assert_eq!(status.status, "unproxied");
+    }
+
+    #[test]
+    fn cloudflare_tunnel_dns_reports_conflicting_record() {
+        let status = dns_status_from_records(
+            "scribe.oklabs.uk",
+            &zone(),
+            "abc.cfargotunnel.com",
+            &[record("A", "203.0.113.10", None)],
+        );
+
+        assert!(!status.configured);
+        assert_eq!(status.status, "conflict");
+        assert!(status.message.contains("proxied CNAME"));
+    }
+
+    #[test]
+    fn cloudflare_tunnel_dns_reports_missing_record_action() {
+        let status =
+            dns_status_from_records("scribe.oklabs.uk", &zone(), "abc.cfargotunnel.com", &[]);
+
+        assert!(!status.configured);
+        assert_eq!(status.status, "missing");
+        assert!(status.message.contains("Create a proxied CNAME"));
     }
 }

--- a/web/src/app/(app)/cloudflare-tunnel/page.tsx
+++ b/web/src/app/(app)/cloudflare-tunnel/page.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Cloud,
   ExternalLink,
+  AlertTriangle,
+  CheckCircle2,
   Pencil,
   Plus,
   RefreshCw,
@@ -106,6 +108,29 @@ function normalizePathMatcher(path: string): string | undefined {
     return undefined;
   }
   return trimmed;
+}
+
+function dnsBadgeClass(configured: boolean, status?: string): string {
+  if (configured) return "border-[#4ade80]/30 bg-[#4ade80]/10 text-[#4ade80]";
+  if (status === "conflict") return "border-[#fb7185]/30 bg-[#fb7185]/10 text-[#fb7185]";
+  return "border-[#fbbf24]/30 bg-[#fbbf24]/10 text-[#fbbf24]";
+}
+
+function dnsBadgeLabel(status?: string): string {
+  switch (status) {
+    case "configured":
+      return "DNS ready";
+    case "unproxied":
+      return "Unproxied";
+    case "missing":
+      return "DNS missing";
+    case "zone_missing":
+      return "Zone missing";
+    case "conflict":
+      return "DNS conflict";
+    default:
+      return "DNS unknown";
+  }
 }
 
 export default function CloudflareTunnelPage() {
@@ -479,6 +504,7 @@ export default function CloudflareTunnelPage() {
                         Backend Service
                       </TableHead>
                       <TableHead className="text-mesh-text-dim">Path</TableHead>
+                      <TableHead className="text-mesh-text-dim">DNS</TableHead>
                       <TableHead className="w-[100px] text-mesh-text-dim">
                         Actions
                       </TableHead>
@@ -518,6 +544,31 @@ export default function CloudflareTunnelPage() {
                         </TableCell>
                         <TableCell className="text-mesh-text-dim">
                           {route.path ?? ""}
+                        </TableCell>
+                        <TableCell>
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  variant="outline"
+                                  className={dnsBadgeClass(
+                                    route.dns?.configured ?? false,
+                                    route.dns?.status
+                                  )}
+                                >
+                                  {route.dns?.configured ? (
+                                    <CheckCircle2 className="mr-1 h-3 w-3" />
+                                  ) : (
+                                    <AlertTriangle className="mr-1 h-3 w-3" />
+                                  )}
+                                  {dnsBadgeLabel(route.dns?.status)}
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-xs">
+                                <p>{route.dns?.message || "DNS status unavailable"}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-1">

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2470,6 +2470,17 @@ export interface CloudflareTunnelRoute {
   hostname: string;
   service: string;
   path: string | null;
+  dns?: CloudflareTunnelRouteDns | null;
+}
+
+export interface CloudflareTunnelRouteDns {
+  configured: boolean;
+  status: string;
+  message: string;
+  zone_name: string | null;
+  record_type: string | null;
+  proxied: boolean | null;
+  target: string | null;
 }
 
 export interface CloudflareTunnelRoutesResponse {


### PR DESCRIPTION
## Summary
- ensure Cloudflare tunnel route creation/update verifies DNS before writing ingress config
- create missing proxied CNAMEs and proxy existing matching CNAMEs
- block conflicting records with actionable errors
- show per-route DNS status in the tunnel routes table

Closes #809

## Verification
- cargo test -p panoptikon-server cloudflare_tunnel
- cd web && bun run build

Note: the worker also ran cargo test -p panoptikon-server; it hit the existing unrelated caddy_integration.rs::c12_update_proxy_host_resyncs_caddy failure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds DNS pre-flight verification to Cloudflare tunnel route creation and updates, and displays per-route DNS status in the routes table. Before writing ingress config, the server now looks up the managed Cloudflare zone, then creates a missing proxied CNAME, proxies an unproxied matching CNAME, or blocks with an actionable error on conflicting records.

- `ensure_route_dns` is wired into both `add_route` and `update_route`; `annotate_dns_status` is called on every `list_routes` response and enriches each route with live DNS state from the Cloudflare API.
- `TunnelRouteDns` (Rust) / `CloudflareTunnelRouteDns` (TypeScript) carry the status, message, zone, record type, proxied flag, and target; the frontend renders these as colour-coded badge + tooltip in the routes table.
- A `PANOPTIKON_CF_API_BASE` env-var override is added to make the API base URL injectable for tests.

<h3>Confidence Score: 3/5</h3>

The DNS mutation and annotation logic is correct in the happy path, but sequential per-route Cloudflare lookups in list_routes will degrade noticeably as route count grows.

The core DNS ensure/annotate logic is well-structured and the UI changes are clean. The main concern is that annotate_dns_status runs N × sequential HTTP calls inside the list_routes handler, each backed by a 15-second timeout, blocking the response for every routes-table load.

server/src/api/cloudflare_tunnel.rs — specifically the annotate_dns_status loop and the unconditional DNS call in update_route

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/api/cloudflare_tunnel.rs | Adds DNS verification and annotation logic — ensure_route_dns (create/update routes), annotate_dns_status (list routes). The per-route sequential HTTP calls in annotate_dns_status will make list_routes noticeably slow as route count grows. |
| web/src/app/(app)/cloudflare-tunnel/page.tsx | Adds a DNS status badge column to the tunnel routes table with tooltip, colour-coded by configured/unproxied/conflict/missing states. No issues found. |
| web/src/lib/types.ts | Adds CloudflareTunnelRouteDns interface matching the new Rust struct; field types align correctly with the backend serialisation. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/api/cloudflare_tunnel.rs:757-765
**Sequential DNS annotation blocks list_routes response**

`annotate_dns_status` awaits each route in a loop, issuing at least 2 sequential Cloudflare API calls per route (`find_managed_zone` tries up to D zone-candidate requests, then `fetch_dns_records`). With a 15-second client timeout and N routes, the handler can be blocked for N × 30+ seconds before returning, making the routes table unresponsive under normal load and easily timing out with more than a handful of routes. Using `futures::future::join_all` or `tokio::task::JoinSet` to run the per-route lookups concurrently would bound this to the single-route worst case regardless of N.

### Issue 2 of 4
server/src/api/cloudflare_tunnel.rs:399-401
**`ensure_route_dns` runs even when hostname is unchanged in `update_route`**

`ensure_route_dns` is called unconditionally with `body.hostname` regardless of whether the hostname changed. A user editing only the backend service or path for an existing route triggers zone lookups and potentially silently upgrades an unproxied CNAME to proxied — a DNS mutation the user did not request. It also means the API token now requires `DNS:Edit` permission for any route update, not just hostname changes, which will surface as an opaque `BadGateway` error if the token only has `DNS:Read`.

### Issue 3 of 4
server/src/api/cloudflare_tunnel.rs:809-810
Dead code: `body.result` is deserialized but never used. The `let _ =` suppresses the compiler warning without actually consuming the value. The same pattern appears at line 862 in `update_dns_record_to_proxied`.

```suggestion
    Ok(())
}

async fn update_dns_record_to_proxied(
```

### Issue 4 of 4
server/src/api/cloudflare_tunnel.rs:862-863
Same dead `let _ = body.result;` as in `create_dns_record` — the deserialized field is never consumed.

```suggestion
    Ok(())
}

async fn ensure_route_dns(config: &CfConfig, hostname: &str) -> Result<(), DnsEnsureError> {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: verify cloudflare tunnel route DNS"](https://github.com/befeast/panoptikon/commit/e728a4d76b91002217b87fab02e76bc9dbb0baca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33502951)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->