### PR TITLE
chore: enable Dependabot auto-merge (patch/minor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+# Auto-enable merge for Dependabot patch/minor updates once CI passes. Major
+# updates are left for manual review. Standard GitHub pattern.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fleet-wide rollout: Dependabot auto-merge workflow (auto-merge on green CI for patch/minor; major manual) + Dependabot config for this repo's ecosystems (cargo github-actions). `allow_auto_merge` enabled.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Dependabot updates and auto-merge for safe dependency bumps. The main changes are:

- Weekly Dependabot updates for the root Cargo workspace.
- Weekly Dependabot updates for GitHub Actions.
- Grouped patch/minor update PRs for both ecosystems.
- A Dependabot-only workflow that enables squash auto-merge for patch/minor updates.

<h3>Confidence Score: 4/5</h3>

The automation generally implements the intended Dependabot patch/minor auto-merge behavior, with one workflow reliability edge case around GitHub mergeability timing.

- The Dependabot configuration and workflow scope are small and focused.
- The main behavior is straightforward YAML-based GitHub automation.
- The remaining concern is that the auto-merge command can fail while GitHub is still computing whether a pull request can be merged, causing a transient failed workflow run.

.github/workflows/dependabot-auto-merge.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We ran a PR merge-flow simulation to compare the before and after states.
- The simulation showed that the baseline base commit lacked automation files, so before\_overall\_passes was false.
- In the PR head, after the automation files were present, after\_overall\_passes was true and the simulation indicated that Dependabot patch and minor updates would be merged with gh pr merge --auto --squash, while Dependabot major and renovate/octocat would not trigger a merge.

<a href="https://app.greptile.com/trex/runs/12365908/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/dependabot-auto-merge.yml:22
**Unstable Mergeability Fails Workflow**

When a Dependabot PR is opened, GitHub may still be computing mergeability, and `gh pr merge --auto` can exit non-zero instead of enabling auto-merge. That makes this workflow show a failed check for a patch/minor update even though rerunning it later can succeed, and it can block the PR if this check is required.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enable Dependabot auto-merge for ..."](https://github.com/befeast/panoptikon/commit/301ae43454df50ea29c12317a322409369cdbb2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39975408)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->