### PR TITLE
chore: run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       cargo-minor-patch:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       github-actions-minor-patch:


### PR DESCRIPTION
Switch Dependabot schedule weekly→daily across this repo's ecosystems. Patch/minor auto-merge; major stays manual. Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Dependabot to check for updates every day.

- Cargo update checks move from weekly to daily.
- GitHub Actions update checks move from weekly to daily.
- Existing grouping and pull request limits stay unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the change is limited to Dependabot scheduling configuration.

Only .github/dependabot.yml changes, and the update frequency change is straightforward with existing grouping and pull request limits preserved.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I inspected the pre-change run and confirmed cargo and github-actions schedule.interval values were weekly with minor/patch-only groups.
- I inspected the post-change run and confirmed both schedule.interval values are now daily with the same minor/patch-only groups, and include-major=false to exclude major updates.
- I captured artifacts for review, including two log artifacts and one Python source artifact.

<a href="https://app.greptile.com/trex/runs/12386307/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: run Dependabot daily instead of w..."](https://github.com/befeast/panoptikon/commit/cf7ee1a65866996d2b4795294bd548735e60aaf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40018989)</sub>

<!-- /greptile_comment -->