### PR TITLE
docs: align product docs with Gateway roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,34 @@
 # Panoptikon — Claude Code Guidelines
 
+## Gateway Roadmap Constraints (Mandatory)
+
+The canonical roadmap is
+[`docs/GATEWAY-ARCHITECTURE.md`](docs/GATEWAY-ARCHITECTURE.md), implementing the
+decision in [#834](https://github.com/BeFeast/panoptikon/issues/834). Every worker
+must preserve these boundaries:
+
+- **Current:** Controller mode and supported MikroTik, pfSense, and legacy VyOS
+  integrations remain supported.
+- **Planned:** the primary x86-64 Gateway uses separate unprivileged
+  `panoptikon-core` and privileged `panoptikon-routerd` processes; the isolated
+  Proxmox Gateway VM is mandatory for development/verification; Panoptikon Edge
+  uses OpenWrt `ubus`/UCI with target-specific packaging.
+- **Blocked:** do not claim native forwarding, routerd, OpenWrt firmware, or
+  commit-confirm is shipped until implementation and the documented packet-path,
+  failure, and recovery gates pass.
+- Local Core↔routerd transport is a restricted Unix socket; remote transport is
+  mTLS. Both use the shared capability/desired-state/transaction contract.
+- Commit-confirm and out-of-band recovery are blocking invariants, not optional
+  follow-up work.
+- Never use the working production router or current Controller-mode LXC 115 for
+  Gateway experiments.
+- ER605 V1 is sacrificial HIL/recovery hardware only, never the reference
+  appliance.
+- Do not promise one executable or backend across x86-64 and constrained
+  OpenWrt/MIPS-class targets.
+- When documenting roadmap work, use **current**, **planned**, and **blocked**
+  explicitly and keep shipped behavior separate from accepted direction.
+
 ## E2E Test Requirement (Mandatory)
 
 Every PR that implements a **feature** or **bug fix** MUST include:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ The canonical roadmap is
 decision in [#834](https://github.com/BeFeast/panoptikon/issues/834). Every worker
 must preserve these boundaries:
 
-- **Current:** Controller mode and supported MikroTik, pfSense, and legacy VyOS
-  integrations remain supported.
+- **Current:** Controller mode and supported MikroTik and pfSense integrations
+  remain supported. VyOS was removed by migration 026 and must not be described
+  as shipped or supported.
 - **Planned:** the primary x86-64 Gateway uses separate unprivileged
   `panoptikon-core` and privileged `panoptikon-routerd` processes; the isolated
   Proxmox Gateway VM is mandatory for development/verification; Panoptikon Edge

--- a/README.md
+++ b/README.md
@@ -1,43 +1,49 @@
 # Panoptikon
 
-*The all-seeing eye for your home network.*
+*The all-seeing eye for your network.*
 
-Panoptikon gives your homelab a local-first control surface for discovery, telemetry, and router operations — without shipping your network metadata to someone else's cloud.
+Panoptikon is building a local-first network control platform around a primary
+**x86-64 co-located Gateway**, an isolated **Proxmox Gateway VM** verification
+profile, and an embedded **Panoptikon Edge / OpenWrt** profile.
 
-**Panoptikon** is a self-hosted network operations dashboard that combines discovery, router management, asset intelligence, and lightweight telemetry in one operator-focused interface.
+**Current:** the shipped product is a self-hosted Controller for discovery,
+telemetry, asset intelligence, and managed-router operations through MikroTik,
+pfSense, and legacy VyOS integrations. **Planned:** native Gateway forwarding uses
+separate `panoptikon-core` and privileged `panoptikon-routerd` processes. Native
+forwarding, routerd, OpenWrt firmware, and commit-confirm are not implemented yet.
 
 ---
 
-## Architecture
+## Architecture and product profiles
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                    Browser (User)                   │
-│              Next.js SPA (shadcn/ui, dark)          │
-└────────────┬────────────────────┬───────────────────┘
-             │ REST (CRUD)        │ WebSocket (live)
-             ▼                    ▼
-┌─────────────────────────────────────────────────────┐
-│                Rust API Server (axum)               │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────┐  │
-│  │ REST API │ │ WS Hub   │ │ Scanner  │ │ Router │  │
-│  │          │ │          │ │ (ARP)    │ │ Client │  │
-│  │          │ │          │ │          │ │MT/VyOS │  │
-│  └──────────┘ └──────────┘ └──────────┘ └────────┘  │
-│                     │                               │
-│              ┌──────┴──────┐                        │
-│              │   SQLite    │                        │
-│              └─────────────┘                        │
-└─────────────────────┬───────────────────────────────┘
-                      │ WebSocket (persistent)
-          ┌───────────┼───────────┐
-          ▼           ▼           ▼
-     ┌─────────┐ ┌─────────┐ ┌─────────┐
-     │ Agent   │ │ Agent   │ │ Agent   │
-     └─────────┘ └─────────┘ └─────────┘
+                         Browser / API clients
+                                  |
+                                  v
+                    +---------------------------+
+                    |     panoptikon-core       |
+                    | UI/API, telemetry, policy |
+                    | desired state and history |
+                    +-------------+-------------+
+                                  |
+                  capability / desired-state /
+                      transaction contract
+                                  |
+             +--------------------+--------------------+
+             | local Unix socket                       | remote mTLS
+             v                                         v
+  +---------------------------+             +---------------------------+
+  | panoptikon-routerd        |             | panoptikon-routerd        |
+  | x86 Linux/Netlink adapter |             | OpenWrt ubus/UCI adapter  |
+  +---------------------------+             +---------------------------+
+
+Current Controller path:
+panoptikon-core ---- router APIs ----> MikroTik / pfSense / legacy VyOS
 ```
 
-📋 **[Product Requirements Document (PRD)](docs/PRD.md)** — full feature spec, architecture decisions, and roadmap.
+- [Product Requirements Document](docs/PRD.md)
+- [Canonical Gateway architecture](docs/GATEWAY-ARCHITECTURE.md)
+- [Gateway product decision (#834)](https://github.com/BeFeast/panoptikon/issues/834)
 
 ---
 
@@ -52,7 +58,7 @@ Panoptikon gives your homelab a local-first control surface for discovery, telem
 
 ```bash
 # Clone the repository
-git clone https://github.com/olegkossoy/panoptikon.git
+git clone https://github.com/BeFeast/panoptikon.git
 cd panoptikon
 
 # Build the server
@@ -79,17 +85,21 @@ bun run dev
 
 ```
 panoptikon/
-├── server/     # Rust axum backend (REST API, WebSocket hub, ARP scanner, MikroTik + VyOS router clients)
+├── server/     # Rust axum backend (API, WebSocket hub, discovery, managed-router clients)
 ├── agent/      # Rust lightweight agent (system metrics collector)
 └── web/        # Next.js 15 frontend (shadcn/ui, dark theme)
 ```
 
-## Router Integration
+## Router integration
 
-Panoptikon provides a control plane for two router platforms:
+Current Controller mode remains a supported product profile:
 
 - **MikroTik (primary/default)** — connects via the RouterOS 7+ REST API. Configure in **Settings → Router → MikroTik**.
+- **pfSense** — supported managed-router integration for existing deployments.
 - **VyOS (legacy/optional)** — connects via the VyOS HTTP API. Hidden by default for new users. To expose it, enable **Settings → Advanced → Show legacy routers**, then configure in **Settings → Router → VyOS (Legacy)**.
+
+The planned Gateway and Edge profiles add native data-plane ownership through the
+Core/routerd contract. They do not remove managed-router support.
 
 ## Prometheus Integration
 
@@ -117,7 +127,7 @@ scrape_configs:
       - targets: ['localhost:8080']
 ```
 
-## Docker Deployment
+## Current Controller deployment
 
 Build and run Panoptikon in a container:
 
@@ -129,7 +139,10 @@ docker build -t panoptikon .
 docker-compose up -d
 ```
 
-The multi-stage Dockerfile builds the Rust server and Next.js frontend into a minimal `debian:bookworm-slim` runtime image — self-hosted, single-binary, no external dependencies beyond what ships in the container.
+The multi-stage Dockerfile builds the current Rust Controller and Next.js frontend
+into a minimal `debian:bookworm-slim` runtime image. This packaging describes the
+current x86 Controller; it is not a promise that x86 Gateway and constrained
+OpenWrt Edge targets will share one binary or backend.
 
 **Important notes:**
 
@@ -143,7 +156,8 @@ The multi-stage Dockerfile builds the Rust server and Next.js frontend into a mi
 - **Self-hosted by default** — your network data stays on your network.
 - **Privacy-first and operator-controlled** — no cloud accounts, no phone-home telemetry.
 - **Transparent over magical** — configuration is explicit; behavior is predictable.
-- **Powerful without becoming brittle** — one binary, one database, minimal moving parts.
+- **Powerful without becoming brittle** — explicit contracts, bounded privilege,
+  recoverable changes, and minimal moving parts per deployment profile.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Panoptikon is building a local-first network control platform around a primary
 profile, and an embedded **Panoptikon Edge / OpenWrt** profile.
 
 **Current:** the shipped product is a self-hosted Controller for discovery,
-telemetry, asset intelligence, and managed-router operations through MikroTik,
-pfSense, and legacy VyOS integrations. **Planned:** native Gateway forwarding uses
-separate `panoptikon-core` and privileged `panoptikon-routerd` processes. Native
+telemetry, asset intelligence, and managed-router operations through MikroTik
+and pfSense integrations. **Planned:** native Gateway forwarding uses separate
+`panoptikon-core` and privileged `panoptikon-routerd` processes. Native
 forwarding, routerd, OpenWrt firmware, and commit-confirm are not implemented yet.
+The former VyOS integration was removed by database migration 026 and is retained
+only in explicitly historical design documents.
 
 ---
 
@@ -38,7 +40,7 @@ forwarding, routerd, OpenWrt firmware, and commit-confirm are not implemented ye
   +---------------------------+             +---------------------------+
 
 Current Controller path:
-panoptikon-core ---- router APIs ----> MikroTik / pfSense / legacy VyOS
+panoptikon-server ---- router APIs ----> MikroTik / pfSense
 ```
 
 - [Product Requirements Document](docs/PRD.md)
@@ -96,7 +98,9 @@ Current Controller mode remains a supported product profile:
 
 - **MikroTik (primary/default)** — connects via the RouterOS 7+ REST API. Configure in **Settings → Router → MikroTik**.
 - **pfSense** — supported managed-router integration for existing deployments.
-- **VyOS (legacy/optional)** — connects via the VyOS HTTP API. Hidden by default for new users. To expose it, enable **Settings → Advanced → Show legacy routers**, then configure in **Settings → Router → VyOS (Legacy)**.
+- **VyOS (historical/removed)** — no longer shipped. Migration 026 removes its
+  settings and legacy-router visibility flag; the old design remains in
+  [the archived VyOS PRD](docs/PRD-VyOS-Management.md) for reference only.
 
 The planned Gateway and Edge profiles add native data-plane ownership through the
 Core/routerd contract. They do not remove managed-router support.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,8 +1,19 @@
 # Panoptikon — End-to-End Testing Plan
 
+> **Profile boundary:** This file covers the **current** Controller stack and its
+> managed-router integrations. Native Gateway packet-path testing is **planned**
+> for the isolated Proxmox VM fabric and is currently **blocked**; see
+> [`docs/test-plan.md`](docs/test-plan.md) and the canonical
+> [`docs/GATEWAY-ARCHITECTURE.md`](docs/GATEWAY-ARCHITECTURE.md). The working
+> production router and Controller-mode LXC 115 are never Gateway test targets.
+> ER605 V1 is sacrificial HIL/recovery hardware only.
+
 This document describes how to manually verify each major Panoptikon integration in a real or near-real environment. For the automated integration test suite, see `server/tests/integration.rs`.
 
-> **Prerequisites** — a running Panoptikon stack (`docker compose up`) with the services described in `docker-compose.yml`: Panoptikon (`:8080`), Caddy (`:80/:443`), and Unbound (`:53`). A MikroTik CHR or hardware router on the same network. See `docs/test-environment.md` for the full Proxmox-based lab setup.
+> **Prerequisites** — a running Panoptikon Controller stack (`docker compose up`)
+> with the services described in `docker-compose.yml`: Panoptikon (`:8080`),
+> Caddy (`:80/:443`), and Unbound (`:53`). A MikroTik CHR or hardware router on
+> the same network. See `docs/test-environment.md` for the full current lab setup.
 
 ---
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,5 +1,10 @@
 # Panoptikon — Code Review Report
 
+> **Historical snapshot:** Architecture observations in this review describe the
+> code at review time, primarily the current Controller. They are not a competing
+> roadmap. The canonical planned architecture is
+> [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md).
+
 **Date:** 2026-02-20
 **Reviewer:** Claude Code Review Agent Team
 **Scope:** Full codebase audit — server (Rust/axum), agent (Rust), web (Next.js/React), CI, tests

--- a/docs/FEATURE_GAPS.md
+++ b/docs/FEATURE_GAPS.md
@@ -1,29 +1,34 @@
 # pfSense Feature Parity Analysis — Gap Report
 
-> **Date:** 2026-02-23
+> **Date:** 2026-07-23
 > **Issue:** #245
-> **Scope:** Compare Panoptikon's current feature set against pfSense capabilities.
-> Identify gaps and prioritize missing features for the backlog.
+> **Scope:** Compare Panoptikon's **current Controller** feature set against pfSense
+> capabilities, while identifying which gaps belong to the **planned** native
+> Gateway profile.
+>
+> Roadmap context: [Gateway architecture](./GATEWAY-ARCHITECTURE.md) and
+> [decision #834](https://github.com/BeFeast/panoptikon/issues/834).
 
 ---
 
 ## Methodology
 
-This analysis compares Panoptikon v0.5.0 against pfSense Plus / CE feature set.
-Each pfSense capability is rated:
+This analysis compares the current Panoptikon Controller against the pfSense Plus
+/ CE feature set. Each rating is profile-aware:
 
 | Status | Meaning |
 |--------|---------|
-| **Full** | Feature exists in Panoptikon with equivalent functionality |
-| **Partial** | Feature exists but is incomplete or limited compared to pfSense |
-| **Missing** | Feature does not exist in Panoptikon |
-| **N/A** | Feature is out of scope for Panoptikon's architecture (not a router OS) |
+| **Full** | Feature exists in the current Controller for at least one documented managed-router path; notes identify the path |
+| **Partial** | Current Controller support exists but is incomplete or limited compared to pfSense |
+| **Missing** | Feature is missing from the current Controller; it may still be planned for managed-router or native Gateway work |
+| **N/A — Controller** | The current Controller does not own this packet-path function; this is not a permanent product-wide non-goal |
 
-**Important context:** Panoptikon is a *management and monitoring dashboard*, not a router
-OS. It manages routers (VyOS, MikroTik) via their APIs. Features that require kernel-level
-packet processing (e.g., stateful packet inspection) are inherently handled by the managed
-router, not Panoptikon. The gaps identified here focus on *management plane* parity — can
-a user configure and monitor the equivalent functionality through Panoptikon?
+**Important context:** In the **current** Controller profile, kernel packet
+processing is performed by MikroTik, pfSense, or legacy VyOS, and this report asks
+whether Panoptikon can configure or observe it. In the **planned** x86 Gateway,
+native Linux/Netlink adapters may own an explicitly supported subset through
+privileged routerd. Those features remain **blocked** from shipped status until
+commit-confirm, out-of-band recovery, and isolated Proxmox verification pass.
 
 ---
 
@@ -39,13 +44,13 @@ a user configure and monitor the equivalent functionality through Panoptikon?
 | Address groups (aliases) | **Full** | VyOS address groups with add/remove members |
 | Network groups | **Full** | VyOS network groups (CIDR lists) |
 | Port groups | **Full** | VyOS port groups |
-| Stateful packet inspection config | **N/A** | Handled by router OS, not management plane |
+| Stateful packet inspection config | **N/A — Controller** | Managed router owns enforcement today; native Gateway support is planned and capability-gated |
 | Time-based firewall rules | **Missing** | pfSense supports rules active during specific days/times |
 | Connection limits per rule | **Missing** | pfSense supports per-rule connection count limits |
 | Floating rules (cross-interface) | **Missing** | pfSense floating rules apply across all interfaces |
 | Rule ordering / drag-and-drop | **Missing** | No rule reordering UI; rules identified by number |
 | Rule hit counters / statistics | **Missing** | pfSense shows per-rule match counts |
-| Anti-spoofing configuration | **N/A** | Router-level feature |
+| Anti-spoofing configuration | **N/A — Controller** | Managed router owns enforcement today; evaluate for the planned native Gateway adapter |
 | IP/DNS geoblocking | **Missing** | pfSense supports country-level blocking via pfBlockerNG |
 | Rule import/export | **Missing** | No bulk rule management |
 | Rule search/filter | **Missing** | No search within firewall rules |
@@ -144,7 +149,7 @@ MikroTik WireGuard is read-only (status view only, no management).
 | DHCPv6 server | **Missing** | No IPv6 DHCP management |
 | DHCP failover / HA | **Missing** | No DHCP high-availability configuration |
 | DHCP lease time configuration | **Missing** | No lease duration settings |
-| WINS server option | **N/A** | Legacy, not relevant |
+| WINS server option | **N/A — Controller** | Legacy capability; no current or planned product commitment |
 | TFTP/PXE boot options | **Missing** | pfSense supports network boot configuration |
 | Register DHCP leases in DNS | **Missing** | pfSense auto-registers hostnames in DNS resolver |
 | Per-interface DHCP scopes | **Missing** | No multi-scope management UI |
@@ -169,7 +174,7 @@ up a DHCP server through Panoptikon. Users must configure pools directly on the 
 | DNS block lists | **Missing** | pfSense + pfBlockerNG provides DNS-level ad/malware blocking |
 | Host overrides | **Partial** | Domain overrides exist but limited to A/AAAA |
 | Dynamic DNS (DDNS) client | **Missing** | pfSense supports 20+ DDNS providers |
-| DNS rebinding protection | **N/A** | Router-level feature |
+| DNS rebinding protection | **N/A — Controller** | Managed router/resolver owns enforcement today; future profile support is undecided |
 
 ### Gap Summary — DNS
 Basic DNS forwarding works. Key gaps are **DNS-over-TLS**, **DNSSEC**, **DDNS client
@@ -209,7 +214,7 @@ protocols) is not managed through Panoptikon.
 | Email/Telegram notifications | **Partial** | Telegram supported for alerts; no SMTP email notifications |
 | User privilege levels | **Missing** | Single admin user only; no RBAC |
 | Multi-language support | **Missing** | English only |
-| Serial console access | **N/A** | Not applicable to web dashboard |
+| Serial console access | **N/A — Controller** | Not a dashboard feature; serial remains an out-of-band recovery mechanism for supported HIL |
 | Configuration change audit | **Full** | VyOS command audit log with timestamps |
 
 ### Gap Summary — System
@@ -246,9 +251,9 @@ log parsing** and **SNMP export**.
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| CARP failover | **N/A** | Router-level feature, not management plane |
+| CARP failover | **N/A — Controller** | Not exposed by current managed-router integrations; no native Gateway commitment yet |
 | Config synchronization | **Missing** | No multi-router config sync |
-| State table replication | **N/A** | Router-level feature |
+| State table replication | **N/A — Controller** | Not exposed by current managed-router integrations; no native Gateway commitment yet |
 | Multi-WAN failover | **Missing** | No WAN failover management |
 | Load balancer (HAProxy) | **Missing** | Reverse proxy exists (NPM/Caddy) but no L4/L7 load balancing management |
 

--- a/docs/FEATURE_GAPS.md
+++ b/docs/FEATURE_GAPS.md
@@ -2,29 +2,37 @@
 
 > **Date:** 2026-07-23
 > **Issue:** #245
-> **Scope:** Compare Panoptikon's **current Controller** feature set against pfSense
-> capabilities, while identifying which gaps belong to the **planned** native
-> Gateway profile.
+> **Status:** Historical comparison with a current Gateway-roadmap overlay
+> **Scope:** Preserve the earlier pfSense comparison while identifying which
+> gaps belong to the **planned** native Gateway profile.
 >
 > Roadmap context: [Gateway architecture](./GATEWAY-ARCHITECTURE.md) and
 > [decision #834](https://github.com/BeFeast/panoptikon/issues/834).
+>
+> **Accuracy note:** VyOS was removed from the shipped product by migration 026.
+> Rows whose evidence is only a VyOS path are historical and must not be read as
+> current Controller capability. Until this report is re-baselined against the
+> current MikroTik/pfSense code, the repository PRD and implementation are the
+> authority for shipped status.
 
 ---
 
 ## Methodology
 
-This analysis compares the current Panoptikon Controller against the pfSense Plus
-/ CE feature set. Each rating is profile-aware:
+This analysis preserves a historical Panoptikon Controller comparison against the
+pfSense Plus / CE feature set. Each rating is profile-aware:
 
 | Status | Meaning |
 |--------|---------|
 | **Full** | Feature exists in the current Controller for at least one documented managed-router path; notes identify the path |
 | **Partial** | Current Controller support exists but is incomplete or limited compared to pfSense |
 | **Missing** | Feature is missing from the current Controller; it may still be planned for managed-router or native Gateway work |
+| **Historical** | The row describes removed VyOS behavior and is not current capability |
 | **N/A — Controller** | The current Controller does not own this packet-path function; this is not a permanent product-wide non-goal |
 
 **Important context:** In the **current** Controller profile, kernel packet
-processing is performed by MikroTik, pfSense, or legacy VyOS, and this report asks
+processing is performed by MikroTik or pfSense. Historical VyOS-only rows remain
+visible as provenance but do not establish current support. This report asks
 whether Panoptikon can configure or observe it. In the **planned** x86 Gateway,
 native Linux/Netlink adapters may own an explicitly supported subset through
 privileged routerd. Those features remain **blocked** from shipped status until
@@ -36,14 +44,14 @@ commit-confirm, out-of-band recovery, and isolated Proxmox verification pass.
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| View firewall rules by interface/chain | **Full** | VyOS: inbound/outbound/forward chains. MikroTik: filter rules |
-| Create firewall rules | **Full** | VyOS rule creation with protocol, port, action, source/dest |
-| Edit/update firewall rules | **Full** | VyOS rule modification supported |
-| Delete firewall rules | **Full** | VyOS rule deletion supported |
-| Enable/disable rules (toggle) | **Full** | VyOS rule toggling without deletion |
-| Address groups (aliases) | **Full** | VyOS address groups with add/remove members |
-| Network groups | **Full** | VyOS network groups (CIDR lists) |
-| Port groups | **Full** | VyOS port groups |
+| View firewall rules by interface/chain | **Full** | Current MikroTik filter-rule view |
+| Create firewall rules | **Historical** | Removed VyOS rule creation path |
+| Edit/update firewall rules | **Historical** | Removed VyOS rule modification path |
+| Delete firewall rules | **Historical** | Removed VyOS rule deletion path |
+| Enable/disable rules (toggle) | **Historical** | Removed VyOS rule-toggle path |
+| Address groups (aliases) | **Historical** | Removed VyOS address-group path |
+| Network groups | **Historical** | Removed VyOS network-group path |
+| Port groups | **Historical** | Removed VyOS port-group path |
 | Stateful packet inspection config | **N/A — Controller** | Managed router owns enforcement today; native Gateway support is planned and capability-gated |
 | Time-based firewall rules | **Missing** | pfSense supports rules active during specific days/times |
 | Connection limits per rule | **Missing** | pfSense supports per-rule connection count limits |
@@ -56,7 +64,8 @@ commit-confirm, out-of-band recovery, and isolated Proxmox verification pass.
 | Rule search/filter | **Missing** | No search within firewall rules |
 
 ### Gap Summary — Firewall
-Panoptikon has solid CRUD for VyOS firewall rules and groups. Key gaps are **rule
+The historical snapshot recorded solid CRUD for VyOS firewall rules and groups;
+that removed path is not current capability. The recorded gaps were **rule
 statistics/hit counters**, **time-based rules**, **rule reordering UI**, and
 **geoblocking**. MikroTik firewall management is read-only (view rules only, no CRUD).
 
@@ -101,9 +110,9 @@ a significant gap for users who need fine-grained NAT control.
 ### Gap Summary — Traffic Shaping
 **This is the largest feature gap.** Panoptikon has no traffic shaping or QoS management
 whatsoever. pfSense provides comprehensive QoS with multiple scheduler types, wizards,
-limiters, and real-time queue monitoring. For VyOS (which supports traffic policies) and
-MikroTik (which supports queues), Panoptikon could expose management APIs for these
-router-native QoS features.
+limiters, and real-time queue monitoring. For current MikroTik targets (which
+support queues), Panoptikon could expose additional router-native management;
+native x86 QoS belongs to the planned Gateway capability contract.
 
 ---
 
@@ -111,7 +120,7 @@ router-native QoS features.
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| WireGuard tunnel creation | **Full** | VyOS WireGuard interface CRUD |
+| WireGuard tunnel creation | **Historical** | Removed VyOS WireGuard interface path |
 | WireGuard peer management | **Full** | Add/delete peers, generate keypairs |
 | WireGuard client config generation | **Full** | Generate ready-to-use .conf files |
 | OpenVPN server configuration | **Missing** | No OpenVPN management at all |
@@ -129,7 +138,7 @@ router-native QoS features.
 | VPN user management | **Missing** | No VPN-specific user/client management |
 
 ### Gap Summary — VPN
-WireGuard management on VyOS is well-implemented with full CRUD and client config
+The historical snapshot recorded full VyOS WireGuard CRUD and client config
 generation. However, **OpenVPN management is completely absent**, and there is no IPsec
 support. VPN monitoring (connected clients, tunnel status, traffic stats) is also missing.
 MikroTik WireGuard is read-only (status view only, no management).
@@ -140,9 +149,9 @@ MikroTik WireGuard is read-only (status view only, no management).
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| View DHCP leases | **Full** | Both VyOS and MikroTik lease listing |
-| Static IP mappings (reservations) | **Full** | VyOS static MAC→IP mappings CRUD |
-| Enable/disable DHCP per subnet | **Full** | VyOS subnet toggle |
+| View DHCP leases | **Full** | Current MikroTik lease listing |
+| Static IP mappings (reservations) | **Historical** | Removed VyOS static-mapping path |
+| Enable/disable DHCP per subnet | **Historical** | Removed VyOS subnet-toggle path |
 | DHCP pool range configuration | **Missing** | No pool range (start/end IP) management |
 | DHCP option configuration | **Missing** | No custom DHCP options (gateway, DNS, domain, NTP, etc.) |
 | DHCP relay configuration | **Missing** | No DHCP relay agent setup |
@@ -166,8 +175,8 @@ up a DHCP server through Panoptikon. Users must configure pools directly on the 
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| DNS forwarding configuration | **Full** | VyOS DNS forwarder name servers CRUD |
-| Domain overrides (local DNS) | **Full** | VyOS domain override A/AAAA records |
+| DNS forwarding configuration | **Historical** | Removed VyOS DNS-forwarder path |
+| Domain overrides (local DNS) | **Historical** | Removed VyOS domain-override path |
 | DNS Resolver (Unbound) management | **Missing** | No recursive resolver configuration |
 | DNSSEC configuration | **Missing** | No DNSSEC toggle or trust anchor management |
 | DNS over TLS (DoT) | **Missing** | No encrypted DNS upstream configuration |
@@ -186,8 +195,8 @@ management**, and **DNS block lists** (comparable to pfBlockerNG/Pi-hole).
 
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
-| View routing table | **Full** | VyOS route parsing |
-| Static route creation/deletion | **Full** | VyOS static route CRUD |
+| View routing table | **Full** | Current MikroTik route view |
+| Static route creation/deletion | **Full** | Current MikroTik static-route operations |
 | Policy-based routing | **Missing** | No PBR rule management |
 | Multi-WAN load balancing | **Missing** | No gateway group or load balancing config |
 | Multi-WAN failover | **Missing** | No WAN failover configuration |
@@ -206,16 +215,16 @@ protocols) is not managed through Panoptikon.
 | pfSense Capability | Panoptikon Status | Notes |
 |---|---|---|
 | Web-based management GUI | **Full** | Full web UI for router management |
-| Configuration backup/restore | **Full** | VyOS config backup, diff, restore |
+| Configuration backup/restore | **Historical** | Removed VyOS backup/restore path |
 | Setup wizard | **Partial** | Initial auth setup only; no network setup wizard |
 | Dashboard with widgets | **Full** | Dashboard with device/agent/alert stats |
 | SNMP monitoring | **Missing** | No SNMP agent or trap configuration |
-| Remote syslog | **Partial** | Can view VyOS syslog; no remote syslog target config |
+| Remote syslog | **Historical** | Removed VyOS syslog path |
 | Email/Telegram notifications | **Partial** | Telegram supported for alerts; no SMTP email notifications |
 | User privilege levels | **Missing** | Single admin user only; no RBAC |
 | Multi-language support | **Missing** | English only |
 | Serial console access | **N/A — Controller** | Not a dashboard feature; serial remains an out-of-band recovery mechanism for supported HIL |
-| Configuration change audit | **Full** | VyOS command audit log with timestamps |
+| Configuration change audit | **Partial** | Current generic router/operator audit log; no universal transaction audit |
 
 ### Gap Summary — System
 Panoptikon has strong configuration backup and audit capabilities. Main gaps are **RBAC /
@@ -231,7 +240,7 @@ multi-user**, **SNMP management**, and **email notifications**.
 | Historical traffic data | **Full** | Hourly/daily rollups with configurable retention |
 | Dashboard gauges (CPU, memory) | **Full** | Via agent telemetry |
 | System health monitoring | **Full** | Agent-based CPU/memory/disk monitoring |
-| Firewall log viewing | **Partial** | VyOS syslog access; no structured firewall log parsing |
+| Firewall log viewing | **Historical** | Removed VyOS syslog path; no current structured firewall log parsing |
 | SNMP export | **Missing** | No SNMP daemon management |
 | Prometheus metrics | **Full** | `/metrics` endpoint with device/agent/traffic gauges |
 | Network topology visualization | **Full** | Force-directed graph with DHCP/bridge enrichment |
@@ -318,7 +327,7 @@ Panoptikon is not just playing catch-up — it exceeds pfSense in several areas:
 
 | Capability | Panoptikon | pfSense |
 |---|---|---|
-| Multi-router management | Manages VyOS + MikroTik from one UI | Single device only |
+| Multi-router management | Manages current MikroTik + pfSense integrations from one UI | Single device only |
 | Device discovery (ARP/mDNS/SSDP) | Automatic, multi-protocol | Basic ARP table only |
 | Network topology visualization | Interactive force-directed graph | Not available |
 | Agent-based monitoring | Lightweight agents for deep system metrics | Not available |
@@ -335,10 +344,10 @@ Panoptikon is not just playing catch-up — it exceeds pfSense in several areas:
 
 The following sub-issues should be created for the highest-priority gaps:
 
-1. **feat: standalone port forwarding / NAT management UI** — DNAT CRUD independent of service wizard, with list/create/edit/delete for VyOS and MikroTik
-2. **feat: OpenVPN server and client management** — configure OpenVPN on VyOS/MikroTik, export client configs, view connected clients
-3. **feat: DHCP server pool configuration** — manage pool ranges, lease times, DHCP options (gateway, DNS, domain) on VyOS and MikroTik
+1. **feat: standalone port forwarding / NAT management UI** — current MikroTik operations plus planned native-Gateway capability where safely supported
+2. **feat: OpenVPN server and client management** — evaluate current managed-router adapters and the planned Gateway contract; export client configs and view connected clients
+3. **feat: DHCP server pool configuration** — manage pool ranges, lease times, and DHCP options on current supported adapters or the planned Gateway
 4. **feat: VPN status dashboard — connected clients and tunnel health** — live WireGuard/OpenVPN session monitoring with peer status, handshake times, transfer stats
 5. **feat: MikroTik firewall rule management (CRUD)** — full create/read/update/delete for MikroTik firewall filter and NAT rules
-6. **feat: traffic shaping / QoS queue management** — manage VyOS traffic policies and MikroTik simple queues from the UI
-7. **feat: dynamic DNS client management** — configure DDNS providers on VyOS/MikroTik through Panoptikon
+6. **feat: traffic shaping / QoS queue management** — manage MikroTik queues and planned native-Gateway capabilities from the UI
+7. **feat: dynamic DNS client management** — configure DDNS through current supported adapters or the planned Gateway

--- a/docs/GATEWAY-ARCHITECTURE.md
+++ b/docs/GATEWAY-ARCHITECTURE.md
@@ -18,8 +18,10 @@ and contributor guidance link here instead of defining competing architectures.
   safety or verification dependency is satisfied.
 
 Current Panoptikon is a self-hosted Controller: it discovers devices, collects
-telemetry, and manages supported features through MikroTik, pfSense, and legacy
-VyOS integrations. That mode remains supported. Native packet forwarding,
+telemetry, and manages supported features through MikroTik and pfSense
+integrations. That mode remains supported. The former VyOS integration was
+removed by migration 026 and is historical, not a current compatibility promise.
+Native packet forwarding,
 `panoptikon-routerd`, OpenWrt firmware, and commit-confirm are planned, not current.
 
 ## Deployment profiles
@@ -63,10 +65,11 @@ runtime, storage, and adapter needs.
         x86 packet path                              embedded packet path
 
 Current Controller mode (supported in parallel):
-panoptikon-core ---- router APIs ----> MikroTik / pfSense / legacy VyOS
+panoptikon-server ---- router APIs ----> MikroTik / pfSense
 ```
 
-`panoptikon-core` is the unprivileged control and observation process. It owns the
+The Gateway diagram above the Controller line is **planned**.
+`panoptikon-core` is the planned unprivileged control and observation process. It owns the
 UI/API, identity, inventory, policy intent, desired state, audit history, and
 last-known-good records. It must not gain ambient packet-path privileges merely
 because Core and routerd are co-located.
@@ -114,8 +117,9 @@ unsafe requests before changing the packet path.
 - **OpenWrt Edge:** an OpenWrt adapter integrates with `ubus` and UCI, respecting
   OpenWrt's configuration and service lifecycle. It is separately packaged and
   tested from the x86 build.
-- **Managed routers:** current MikroTik and pfSense integrations, plus legacy VyOS
-  support, continue to use their router-native APIs in Controller mode.
+- **Managed routers:** current MikroTik and pfSense integrations continue to use
+  their router-native APIs in Controller mode. Removed VyOS code and settings are
+  not a supported adapter or Gateway commitment.
 
 ## Offline and last-known-good behavior
 
@@ -155,7 +159,7 @@ the reference appliance and does not define the supported Gateway architecture.
 
 | Phase | Outcome | Gate |
 |---|---|---|
-| **0 — Current Controller** | Preserve and improve current discovery, telemetry, MikroTik/pfSense management, and legacy VyOS support | Existing tests and deployments remain healthy |
+| **0 — Current Controller** | Preserve and improve current discovery, telemetry, and MikroTik/pfSense management | Existing tests and deployments remain healthy |
 | **1 — Contract and simulator** | Version the capability/desired-state/transaction protocol and exercise it with an unprivileged simulator | Deterministic plans, auditability, stale-revision rejection |
 | **2 — Isolated x86 Gateway** | Add split Core/routerd processes and native Linux adapters in the Proxmox VM fabric | Packet-path and failure matrix passes; no production targets used |
 | **3 — Recoverable x86 product** | Deliver commit-confirm, last-known-good reconciliation, upgrade/rollback, and out-of-band recovery | All blocking invariants pass repeatedly |

--- a/docs/GATEWAY-ARCHITECTURE.md
+++ b/docs/GATEWAY-ARCHITECTURE.md
@@ -1,0 +1,174 @@
+# Panoptikon Gateway Architecture
+
+> **Status:** Canonical roadmap contract  
+> **Decision:** [GitHub issue #834](https://github.com/BeFeast/panoptikon/issues/834)  
+> **Updated:** 2026-07-23
+
+This document is the canonical architecture for Panoptikon's Gateway roadmap. The
+[product requirements document](./PRD.md), [README](../README.md), test documents,
+and contributor guidance link here instead of defining competing architectures.
+
+## Status language
+
+- **Current** means behavior shipped in the repository today.
+- **Planned** means accepted roadmap direction that is not yet shipped.
+- **Blocked** means work that must not be presented as complete until its named
+  safety or verification dependency is satisfied.
+
+Current Panoptikon is a self-hosted Controller: it discovers devices, collects
+telemetry, and manages supported features through MikroTik, pfSense, and legacy
+VyOS integrations. That mode remains supported. Native packet forwarding,
+`panoptikon-routerd`, OpenWrt firmware, and commit-confirm are planned, not current.
+
+## Deployment profiles
+
+| Profile | Role | Process placement | Status |
+|---|---|---|---|
+| **x86-64 co-located Gateway** | Primary product build for a dedicated appliance or VM | `panoptikon-core` and `panoptikon-routerd` run as separate local processes; the host owns the packet path | **Planned** |
+| **Proxmox Gateway VM** | Mandatory isolated development and release-verification profile | The same x86 process split runs inside a disposable VM on an isolated virtual fabric | **Planned**; forwarding tests are **blocked** until this fabric exists |
+| **Panoptikon Edge / OpenWrt** | Embedded profile for supported OpenWrt targets | OpenWrt-specific packages use `ubus`/UCI; Core may be remote when the target cannot host the full stack | **Planned** |
+
+The profiles share a contract, not necessarily one executable or one backend.
+x86-64 Linux and constrained OpenWrt/MIPS-class targets have different packaging,
+runtime, storage, and adapter needs.
+
+## Process and privilege boundary
+
+```text
+                         Browser / API clients
+                                  |
+                                  v
+                    +---------------------------+
+                    |     panoptikon-core       |
+                    | UI/API, inventory, policy |
+                    | desired state, history    |
+                    +-------------+-------------+
+                                  |
+                   capability / desired-state /
+                       transaction contract
+                                  |
+             +--------------------+--------------------+
+             | local Unix socket                       | remote mTLS
+             v                                         v
+  +---------------------------+             +---------------------------+
+  |  panoptikon-routerd       |             |  panoptikon-routerd       |
+  | privileged executor       |             | privileged edge executor |
+  +-------------+-------------+             +-------------+-------------+
+                |                                           |
+       Linux / Netlink adapter                     OpenWrt ubus/UCI adapter
+                |                                           |
+                v                                           v
+        x86 packet path                              embedded packet path
+
+Current Controller mode (supported in parallel):
+panoptikon-core ---- router APIs ----> MikroTik / pfSense / legacy VyOS
+```
+
+`panoptikon-core` is the unprivileged control and observation process. It owns the
+UI/API, identity, inventory, policy intent, desired state, audit history, and
+last-known-good records. It must not gain ambient packet-path privileges merely
+because Core and routerd are co-located.
+
+`panoptikon-routerd` is the narrow privileged executor. It advertises capabilities,
+validates transactions against the local platform, applies supported operations,
+reports observed state, and performs rollback/recovery actions. Its API must be
+allow-listed and versioned; it is not a general-purpose root command channel.
+
+## Transport and identity
+
+- **Local:** a permission-restricted Unix domain socket is the default transport
+  between co-located Core and routerd processes. Peer credentials and filesystem
+  ownership provide the first authorization boundary.
+- **Remote:** mutually authenticated TLS is required when Core and routerd run on
+  different hosts. Each endpoint has a rotatable identity, and authorization is
+  bound to the advertised device and capabilities.
+- The transports carry the same versioned contract. Transport selection must not
+  change transaction semantics.
+
+## Shared contract
+
+Every adapter implements the same conceptual contract:
+
+1. **Capabilities:** platform, adapter version, supported resources and operations,
+   constraints, and recovery features.
+2. **Observed state:** normalized state plus freshness and source metadata.
+3. **Desired state:** declarative, versioned intent with explicit preconditions.
+4. **Plan:** deterministic diff, validation result, risk classification, and the
+   recovery mechanism that will protect the apply.
+5. **Transaction:** stable ID, actor, expected revision, ordered operations,
+   timeout, commit-confirm deadline, and audit metadata.
+6. **Result:** applied/failed/rolled-back/unknown state, resulting revision,
+   diagnostics, and refreshed observations.
+
+Capability negotiation is mandatory. Core must not send an operation merely
+because another profile supports it, and routerd must reject unknown, stale, or
+unsafe requests before changing the packet path.
+
+## Platform adapters
+
+- **Native x86 Linux:** a Linux/Netlink adapter owns interfaces, addresses,
+  routes, firewall/NAT, and related host networking through documented kernel
+  APIs. Shelling out is not the primary contract.
+- **OpenWrt Edge:** an OpenWrt adapter integrates with `ubus` and UCI, respecting
+  OpenWrt's configuration and service lifecycle. It is separately packaged and
+  tested from the x86 build.
+- **Managed routers:** current MikroTik and pfSense integrations, plus legacy VyOS
+  support, continue to use their router-native APIs in Controller mode.
+
+## Offline and last-known-good behavior
+
+Core stores observed-state freshness and the last-known-good configuration for
+each routerd. When a remote Edge is offline, the UI may show cached state only if
+it is clearly marked stale; it must not imply that a change was applied. Desired
+state may be queued only with an explicit operator action and must be revalidated
+against capabilities and the current revision after reconnection.
+
+Routerd keeps enough local state to continue the last committed configuration
+without Core. Loss of Core, transport, or UI must not interrupt established
+forwarding. Ambiguous transaction outcomes are reported as `unknown` and require
+reconciliation before a later write.
+
+## Blocking safety invariants
+
+Native Gateway mutation is **blocked** from production claims until all of these
+invariants are implemented and verified:
+
+- **Commit-confirm:** risky packet-path changes automatically roll back unless the
+  operator or an independent reachability check confirms them before a deadline.
+- **Out-of-band recovery:** each supported production target has a documented,
+  tested recovery path that does not depend on the configuration being changed.
+- **Atomicity and reconciliation:** partial or ambiguous applies are detected,
+  audited, and recovered rather than silently accepted.
+- **Privilege containment:** Core compromise does not become unrestricted root
+  command execution through routerd.
+- **Isolated verification:** forwarding, failure, upgrade, and recovery tests run
+  in the Proxmox Gateway VM fabric, never on the working production router or the
+  current Controller-mode LXC 115.
+
+ER605 V1 hardware is sacrificial HIL/recovery equipment only. It may be used to
+exercise flashing, serial recovery, or destructive failure scenarios; it is not
+the reference appliance and does not define the supported Gateway architecture.
+
+## Phased roadmap
+
+| Phase | Outcome | Gate |
+|---|---|---|
+| **0 — Current Controller** | Preserve and improve current discovery, telemetry, MikroTik/pfSense management, and legacy VyOS support | Existing tests and deployments remain healthy |
+| **1 — Contract and simulator** | Version the capability/desired-state/transaction protocol and exercise it with an unprivileged simulator | Deterministic plans, auditability, stale-revision rejection |
+| **2 — Isolated x86 Gateway** | Add split Core/routerd processes and native Linux adapters in the Proxmox VM fabric | Packet-path and failure matrix passes; no production targets used |
+| **3 — Recoverable x86 product** | Deliver commit-confirm, last-known-good reconciliation, upgrade/rollback, and out-of-band recovery | All blocking invariants pass repeatedly |
+| **4 — OpenWrt Edge** | Package the Edge profile and implement the `ubus`/UCI adapter on selected targets | Per-target capabilities, resource limits, upgrade and recovery HIL pass |
+| **5 — Productization** | Installer, lifecycle, observability, documentation, and support boundaries for the primary x86 Gateway | Release criteria and migration path are explicit |
+
+## Explicit non-goals
+
+- Replacing or disrupting supported Controller-mode integrations while Gateway is
+  developed.
+- Experimenting on the working production router or Controller-mode LXC 115.
+- Treating ER605 V1 as the reference appliance.
+- Claiming transparent compatibility between x86 and embedded targets.
+- Exposing arbitrary command execution through routerd.
+- Shipping native forwarding before commit-confirm and out-of-band recovery are
+  proven in the isolated Proxmox profile.
+- Requiring cloud control, cloud identity, or phone-home telemetry.
+

--- a/docs/GATEWAY-ARCHITECTURE.md
+++ b/docs/GATEWAY-ARCHITECTURE.md
@@ -1,7 +1,9 @@
 # Panoptikon Gateway Architecture
 
-> **Status:** Canonical roadmap contract  
-> **Decision:** [GitHub issue #834](https://github.com/BeFeast/panoptikon/issues/834)  
+> **Status:** Canonical roadmap contract
+>
+> **Decision:** [GitHub issue #834](https://github.com/BeFeast/panoptikon/issues/834)
+>
 > **Updated:** 2026-07-23
 
 This document is the canonical architecture for Panoptikon's Gateway roadmap. The
@@ -171,4 +173,3 @@ the reference appliance and does not define the supported Gateway architecture.
 - Shipping native forwarding before commit-confirm and out-of-band recovery are
   proven in the isolated Proxmox profile.
 - Requiring cloud control, cloud identity, or phone-home telemetry.
-

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,5 +1,9 @@
 # Panoptikon — Architecture & Code Improvement Proposals
 
+> **Historical proposals:** Use this document for its original code-improvement
+> context only. Current Gateway roadmap decisions and process boundaries are
+> canonical in [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md).
+
 **Date:** 2026-02-20
 **Author:** Claude Code Review Agent Team
 **Based on:** Full codebase review + PRD analysis

--- a/docs/MIGRATION-pfSense-to-MikroTik.md
+++ b/docs/MIGRATION-pfSense-to-MikroTik.md
@@ -1,5 +1,11 @@
 # Migration Plan: pfSense to MikroTik CHR + Panoptikon
 
+> **Scope note:** This is a managed-router migration plan for the **current**
+> Controller profile, not a native Panoptikon Gateway plan. The **planned**
+> Gateway architecture is documented in
+> [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md). The working production
+> router and Controller-mode LXC 115 must not be used for Gateway experiments.
+
 > **Date:** 2026-02-28
 > **Issue:** #406
 > **Status:** Draft — not urgent, execute when Panoptikon is stable
@@ -303,7 +309,7 @@ After 2 weeks with no issues:
 | Missing firewall rule causes security gap | Low | High | Thorough rule-by-rule comparison in Phase 1; parallel run catches gaps |
 | DHCP issues leave devices without IP | Low | High | Keep pfSense running during Phase 2; rollback in Phase 3 |
 | Performance regression (throughput/latency) | Low | Medium | Speedtest comparison in Phase 2; p10 license for >1 Gbit |
-| Panoptikon MikroTik integration bug | Medium | Low | Panoptikon is monitoring-only; router works independently |
+| Panoptikon MikroTik integration bug | Medium | Low | In this current Controller migration, MikroTik keeps forwarding independently of Panoptikon |
 | Caddy misconfiguration breaks proxy routes | Medium | Medium | Migrate routes one-by-one; keep NPM as fallback |
 
 ---

--- a/docs/PRD-VyOS-Management.md
+++ b/docs/PRD-VyOS-Management.md
@@ -1,5 +1,12 @@
 # Panoptikon — VyOS Management GUI (Legacy PRD Addendum)
 
+> **Architecture note:** This document is legacy Controller-mode integration
+> scope. It does not define the Gateway architecture. See
+> [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md) and
+> [#834](https://github.com/BeFeast/panoptikon/issues/834). Current VyOS support
+> remains available, but new native Gateway/Edge work follows the Core/routerd
+> contract and its blocking recovery invariants.
+
 **Версия:** 0.1.0-draft  
 **Дата:** 2026-02-22  
 **Статус:** Legacy Draft  

--- a/docs/PRD-VyOS-Management.md
+++ b/docs/PRD-VyOS-Management.md
@@ -3,13 +3,16 @@
 > **Architecture note:** This document is legacy Controller-mode integration
 > scope. It does not define the Gateway architecture. See
 > [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md) and
-> [#834](https://github.com/BeFeast/panoptikon/issues/834). Current VyOS support
-> remains available, but new native Gateway/Edge work follows the Core/routerd
-> contract and its blocking recovery invariants.
+> [#834](https://github.com/BeFeast/panoptikon/issues/834). VyOS support was
+> removed from the shipped product by database migration 026, which deletes the
+> `vyos%` settings and `show_legacy_routers`. This file is an archived design
+> record only; it is not a current feature or maintenance promise. New native
+> Gateway/Edge work follows the Core/routerd contract and its blocking recovery
+> invariants.
 
 **Версия:** 0.1.0-draft  
 **Дата:** 2026-02-22  
-**Статус:** Legacy Draft  
+**Статус:** Archived / Removed
 **Родительский документ:** [PRD.md](./PRD.md)
 
 ---
@@ -17,12 +20,13 @@
 ## Legacy Status & Visibility (2026-02-24)
 
 - **MikroTik is the primary/default router path** in Panoptikon product strategy.
-- **VyOS is a legacy integration** and is hidden by default in user-facing navigation for new deployments.
-- **User path:** enable `Settings → Advanced → Show legacy routers`, then configure VyOS in `Settings → Router → VyOS (Legacy)`.
+- **VyOS is a removed historical integration**, not a hidden current feature.
+- **There is no current user path:** migration 026 removes both VyOS settings and
+  the `show_legacy_routers` flag.
 - **Developer contract:**
-  - Keep `show_legacy_routers` default behavior set to `false`.
-  - Keep default router selection on MikroTik (`mikrotik`), not VyOS.
-  - Treat this document as legacy maintenance scope for existing VyOS installs, not as the primary roadmap for new router features.
+  - Do not restore or advertise VyOS without a new accepted product decision and implementation.
+  - Keep default router selection on MikroTik (`mikrotik`).
+  - Treat this document as historical context, not executable backlog or current product scope.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -42,7 +42,8 @@ ceding network metadata or control to a cloud service.
 The product has an intentionally staged identity:
 
 - **Current Controller:** shipped discovery, telemetry, assets, services, and
-  managed-router operations through MikroTik, pfSense, and legacy VyOS APIs.
+  managed-router operations through MikroTik and pfSense APIs. VyOS was removed
+  by migration 026 and remains historical documentation only.
 - **Planned x86-64 Gateway:** the primary product build, with separate
   `panoptikon-core` and privileged `panoptikon-routerd` processes co-located on a
   dedicated Linux appliance or VM.
@@ -85,7 +86,8 @@ fragmented point tools and opaque vendor appliances. Today:
 
 - **MikroTik RouterOS and pfSense** provide strong routing platforms, but their
   native tools do not provide Panoptikon's unified inventory and telemetry model.
-- **VyOS has no built-in web GUI** for day-to-day monitoring. You SSH in, run `show interfaces`, and parse text output.
+- **VyOS has no built-in web GUI** for day-to-day monitoring, but Panoptikon's
+  former integration for that opportunity has been removed and is not current scope.
 - **Network monitoring** requires separate tools: Fing (proprietary, SaaS-leaning), nmap (CLI), Zabbix/LibreNMS (massive overkill for a home network).
 - **Device awareness** is fragmented. You don't know what's on your network without actively scanning. New devices appear silently. Devices go offline without notification.
 - **Agent-based monitoring** (CPU, RAM, traffic per host) typically means deploying Prometheus + node_exporter + Grafana — a stack heavier than the machines being monitored.
@@ -101,7 +103,7 @@ unprivileged control plane and privileged packet-path executor into one process.
 **Primary users:**
 
 - Homelab and small-office operators running the current Controller with
-  MikroTik, pfSense, or an existing VyOS deployment.
+  MikroTik or pfSense.
 - Technical operators who want a dedicated, recoverable x86-64 Gateway they can
   inspect, back up, and operate without vendor cloud control.
 - Developers and maintainers who need an isolated Proxmox fabric for destructive
@@ -124,7 +126,7 @@ unprivileged control plane and privileged packet-path executor into one process.
 
 | # | Goal | Status |
 |---|------|--------|
-| G1 | Preserve the shipped Controller experience for MikroTik, pfSense, and legacy VyOS users | **Current** |
+| G1 | Preserve the shipped Controller experience for MikroTik and pfSense users | **Current** |
 | G2 | Discover devices and unify network, host, service, and asset telemetry locally | **Current** |
 | G3 | Make x86-64 co-located Gateway the primary product build | **Planned** |
 | G4 | Keep Core unprivileged and isolate packet-path execution in routerd | **Planned** |
@@ -173,7 +175,9 @@ unprivileged control plane and privileged packet-path executor into one process.
 #### F3: Router Integration ✅
 - **MikroTik (Primary/Default):** Connect to RouterOS 7+ REST API. Full management: system status (uptime, CPU, memory, board info), interfaces (IPs, MACs, TX/RX, enable/disable), routes (view + create/delete static routes), DHCP leases, VLANs, firewall rules, traffic monitoring, NAT/port forwarding, VPN status, dynamic DNS, QoS, DNS configuration, WireGuard VPN. TTL-based caching for read operations. This is the default router path in onboarding, router pages, and new feature planning.
 - **pfSense (Supported):** Preserve the current pfSense integration and bridge for existing Controller deployments while MikroTik remains the primary/default path.
-- **VyOS (Legacy/Optional):** Connect to VyOS HTTP API. Display: system status, syslog, interfaces, routes, DHCP leases + static mappings, firewall rules (full CRUD + groups), DNS forwarding, WireGuard VPN peers. Configuration backup/restore with diff viewing. Visibility is hidden by default and only exposed when legacy routers are explicitly enabled in Advanced settings.
+- **VyOS (Historical/Removed):** The former HTTP API integration and its settings
+  were removed by migration 026. The archived design addendum is reference
+  material only and is not a shipped Controller capability.
 - Connection test + health indicator in the relevant managed-router UI
 
 #### F4: Authentication ✅
@@ -222,9 +226,8 @@ unprivileged control plane and privileged packet-path executor into one process.
 ### P2 — Nice to Have
 
 #### F10: Router Configuration (Write) — Partial ✅
-- ✅ **VyOS:** Edit firewall rules via GUI (create/modify/delete), firewall groups (address, network, port), interface management, DHCP static mapping management, DNS forwarding configuration, WireGuard VPN peer management
 - ✅ **MikroTik:** Interface enable/disable toggle, static route create/delete, DNS configuration, WireGuard configuration
-- ✅ **Config backup/restore** with unified diff viewing and audit trail (VyOS)
+- Historical VyOS write and config-backup flows are removed and do not count as current capability.
 - [ ] Rollback support
 
 #### F11: Wake-on-LAN ✅
@@ -278,7 +281,8 @@ unprivileged control plane and privileged packet-path executor into one process.
 - Secure external access without port forwarding
 
 #### F16: Services Wizard ✅
-- Unified orchestration for deploying services: NPM proxy host + VyOS firewall rules + DNAT rules
+- Unified service orchestration with per-step status reporting; removed VyOS
+  firewall/DNAT steps are not a current capability.
 - Single API call with per-step status reporting
 
 #### F17: Global Search & Command Palette ✅
@@ -287,7 +291,7 @@ unprivileged control plane and privileged packet-path executor into one process.
 - Unified results with type indicators
 
 #### F18: Audit Log ✅
-- Full router operation audit trail (VyOS)
+- Router and operator action audit trail
 - Action, command, and result tracking
 - Settings page for viewing audit history
 
@@ -375,7 +379,7 @@ Controller implementation only.
 | x86-64 co-located Gateway | Primary product build; separate local Core and routerd processes using a Unix socket | **Planned** |
 | Proxmox Gateway VM | Mandatory isolated development and verification fabric | **Planned**; packet-path work is **blocked** until available |
 | Panoptikon Edge / OpenWrt | Embedded profile with target-specific packaging and `ubus`/UCI adapter | **Planned** |
-| Managed-router Controller | Discovery, telemetry, services, and current MikroTik/pfSense/legacy VyOS integrations | **Current** and supported |
+| Managed-router Controller | Discovery, telemetry, services, and current MikroTik/pfSense integrations | **Current** and supported |
 
 The roadmap does not combine all privilege into the web/API process. Core owns
 intent, history, and operator workflows; routerd owns the minimum privileged
@@ -405,9 +409,9 @@ capability/desired-state/transaction contract.
 ║  │  │ agents,  │ │  to UI)  │ │ SSDP,    │ ││MikroTik││ │  ║
 ║  │  │ assets,  │ │          │ │ NetFlow) │ │├────────┤│ │  ║
 ║  │  │ caddy,   │ │          │ │          │ ││pfSense ││ │  ║
-║  │  │ unbound, │ │          │ │          │ │├────────┤│ │  ║
-║  │  │ cf-tun)  │ │          │ │          │ ││VyOS    ││ │  ║
-║  │  │          │ │          │ │          │ │└────────┘│ │  ║
+║  │  │ unbound, │ │          │ │          │ │└────────┘│ │  ║
+║  │  │ cf-tun)  │ │          │ │          │ │          │ │  ║
+║  │  │          │ │          │ │          │ │          │ │  ║
 ║  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ │  ║
 ║  │                     │                                  │  ║
 ║  │            ┌────────┴────────┐                         │  ║
@@ -434,18 +438,17 @@ capability/desired-state/transaction contract.
 
 Panoptikon currently supports managed-router integrations alongside the Gateway
 roadmap. MikroTik remains the primary/default path, pfSense remains supported for
-existing deployments, and VyOS remains a legacy secondary integration:
+existing deployments. VyOS was removed by migration 026:
 
 | Router | API | Status | Default |
 |--------|-----|--------|---------|
 | **MikroTik** | RouterOS 7+ REST API | ✅ Primary | Default tab and default router type |
 | **pfSense** | pfSense integration/bridge | Supported | Existing deployments |
-| **VyOS** | VyOS HTTP API (1.3+) | ⚠️ Legacy Optional | Hidden by default; shown only when legacy routers are enabled |
+| **VyOS** | Historical HTTP API design | Removed | Not shipped; archived documentation only |
 
-The managed-router integrations retain their current caching and mutation
-behavior. Each router has its own settings path and can be independently
-enabled/disabled. The `show_legacy_routers` setting defaults to `false`, keeping
-VyOS flows out of the primary UI until explicitly enabled.
+The current managed-router integrations retain their caching and mutation
+behavior. Migration 026 deletes `vyos%` settings and `show_legacy_routers`;
+operators must not be directed to a hidden VyOS UI path.
 
 ### Tech Stack Justification
 
@@ -547,10 +550,9 @@ Gateway experiments.
 # cloudflared — Cloudflare Tunnel (optional, enable with --profile tunnel)
 ```
 
-**Optional VyOS** — if running VyOS alongside MikroTik (e.g. as a dedicated firewall VM):
-- VyOS VM: 2 vCPUs, 512 MB RAM, 2 NICs
-- VyOS HTTP API enabled and reachable from LAN
-- Enable in Panoptikon Settings → Advanced → Show legacy routers, then configure in Settings → Router → VyOS (Legacy)
+**Historical VyOS note:** the former optional integration is not part of the
+current deployment model. Its old sizing and API notes remain only in the
+archived VyOS addendum.
 
 ### Current Controller Build Pipeline
 
@@ -1177,7 +1179,8 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 
 - [x] **Authentication:** Password setup, login, session cookies, rate limiting
 - [x] **MikroTik client:** Connect to RouterOS 7+ REST API, fetch system status, interfaces, DHCP leases, routes, firewall, DNS, WireGuard
-- [x] **VyOS client:** Connect, fetch interfaces, DHCP leases, basic stats (legacy optional, lazy-loaded, hidden by default unless legacy routers are enabled)
+- [x] **Historical VyOS client removed:** migration 026 removes its settings and
+  legacy-router visibility flag; it is not current shipped functionality
 - [x] **ARP scanner:** Periodic subnet scan, discover devices (active + passive)
 - [x] **mDNS/SSDP discovery:** Passive device discovery via Bonjour and UPnP
 - [x] **Device management:** List, auto-create on discovery, manual edit (name, icon, notes)
@@ -1188,7 +1191,9 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 - [x] **Online/offline detection:** State change tracking, ping-based uptime monitoring
 - [x] **Alerts:** New device, offline/online state changes, in-app feed with severity filtering
 - [x] **WebSocket:** Live updates to UI when device state changes
-- [x] **Settings page:** MikroTik connection (default), VyOS connection (legacy optional, hidden by default), Caddy connection, Unbound connection, Cloudflare Tunnel, NPM connection, scanner config, webhook, data retention, speedtest, audit log, config backup, password change
+- [x] **Settings page:** MikroTik connection (default), Caddy connection, Unbound
+  connection, Cloudflare Tunnel, NPM connection, scanner config, webhook, data
+  retention, speedtest, audit log, config backup, password change
 
 ### Milestone 2: Agents + Traffic + SSH ✅
 
@@ -1214,10 +1219,10 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 - [x] **Caddy proxy manager:** Admin API integration for reverse proxy management (replaces NPM as primary)
 - [x] **Unbound DNS manager:** Local DNS records, blocklists, query log visualization
 - [x] **Cloudflare Tunnel management:** Tunnel status, ingress rules, optional Docker Compose service
-- [x] **Services wizard:** Unified NPM + VyOS firewall + DNAT deployment
+- [x] **Services wizard:** Service orchestration with per-step status reporting
 - [x] **Speedtest:** Ookla integration with scheduling and history
 - [x] **Audit log:** Router operation tracking
-- [x] **Config backup:** VyOS configuration backup/restore with diff viewing
+- [x] **Historical VyOS config backup removed:** retained only in archived design records
 - [x] **Cmd+K command palette:** Quick navigation and action execution
 - [x] **Framer Motion animations:** Smooth card transitions and micro-interactions
 - [x] **Device type icons:** Visual device identification in lists and topology
@@ -1229,7 +1234,7 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 - [ ] **Docker Compose packaging:** Docker Hub releases, automated image builds
 - [ ] **DNS test setup:** Configure Unbound as the network-wide DNS resolver
 - [ ] **Managed-router support:** keep MikroTik primary while preserving pfSense
-  and legacy VyOS behavior for existing Controller deployments
+  behavior for existing Controller deployments
 - [ ] **UI cleanup:** Polish, consistency, responsive improvements
 
 ### Milestone 5: Gateway Contract and Isolated Fabric (Planned)
@@ -1284,7 +1289,7 @@ Production Gateway claims are **blocked** until every recovery invariant passes.
 | Q3 | **Next.js App Router or Pages Router?** | App Router — stable, Server Components for initial load. |
 | Q4 | **Should the frontend be SSR or static export?** | Static export — embedded in Rust binary, no Node.js runtime at deploy time. |
 | Q5 | **Router API key storage?** | SQLite — stored in settings table. |
-| Q11 | **Should we support multiple routers?** | Yes — MikroTik is primary/default, pfSense remains supported, and VyOS is legacy optional and hidden unless explicitly enabled. |
+| Q11 | **Should we support multiple routers?** | Yes — MikroTik is primary/default and pfSense remains supported. Removed VyOS functionality is not part of the current answer. |
 | Q15 | **Can Panoptikon own the data plane?** | Yes, in the planned Gateway/Edge profiles. Current Controller behavior remains supported. |
 | Q16 | **Where does privileged networking run?** | In a separate `panoptikon-routerd` process; Core remains unprivileged. |
 | Q17 | **How do local and remote deployments communicate?** | Restricted Unix socket locally; mTLS remotely; one versioned semantic contract. |
@@ -1377,8 +1382,8 @@ set service https api
 | Netdata | Agent monitoring | Excellent agent, but no network discovery or router management |
 | The Dude (MikroTik) | Network monitoring | MikroTik-only, desktop app, no modern web UI, no asset management |
 
-The current Controller's unique position is **managed-router operations (MikroTik,
-pfSense, and legacy VyOS) + network discovery + device fingerprinting +
+The current Controller's unique position is **managed-router operations (MikroTik
+and pfSense) + network discovery + device fingerprinting +
 lightweight agents + embedded DNS (Unbound) + reverse proxy (Caddy) + Cloudflare
 Tunnel + IT asset inventory**. The planned Gateway/Edge profiles extend that
 product without pretending their forwarding and recovery features have shipped.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,11 +1,18 @@
-# Panoptikon — Router & Network Monitor
+# Panoptikon — Network Controller, Gateway, and Edge
 
 ## Product Requirements Document
 
-**Version:** 0.7.0
+**Version:** 0.8.0
 **Author:** Oleg Kossoy (concept) / AI-assisted (document)
-**Date:** 2026-02-28
-**Status:** Active
+**Date:** 2026-07-23
+**Status:** Active roadmap
+
+> **Superseding roadmap:** The Gateway decision in
+> [#834](https://github.com/BeFeast/panoptikon/issues/834) supersedes earlier
+> statements that permanently limited Panoptikon to a managed-router dashboard.
+> [`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md) is the canonical system
+> architecture. This PRD defines product outcomes and links to that document
+> instead of creating a second protocol or deployment design.
 
 ---
 
@@ -28,15 +35,36 @@
 
 ## 1. Overview & Vision
 
-**Panoptikon** is a self-hosted web application for managing routers (MikroTik primary/default, VyOS legacy and hidden by default), monitoring all devices on a local network, and maintaining a complete IT asset inventory — without requiring an agent on every host.
+Panoptikon is a self-hosted network control platform for operators who want one
+local system to observe, manage, and eventually route their network without
+ceding network metadata or control to a cloud service.
 
-Think of it as a mashup of **Ubiquiti UniFi's web console** (dark theme, topology map, polished device cards), **Fing** (network scanning, device discovery, online/offline tracking), and **Lansweeper / NetBox** (asset inventory, SSH-based agentless collection, categorization) — but open-source, with multi-router support (MikroTik + VyOS), embedded DNS and reverse proxy management, and deployable as a single Docker Compose stack.
+The product has an intentionally staged identity:
+
+- **Current Controller:** shipped discovery, telemetry, assets, services, and
+  managed-router operations through MikroTik, pfSense, and legacy VyOS APIs.
+- **Planned x86-64 Gateway:** the primary product build, with separate
+  `panoptikon-core` and privileged `panoptikon-routerd` processes co-located on a
+  dedicated Linux appliance or VM.
+- **Planned Proxmox Gateway VM:** the mandatory isolated development and release
+  verification profile for native forwarding and recovery.
+- **Planned Panoptikon Edge / OpenWrt:** an embedded profile using OpenWrt-native
+  `ubus`/UCI integration and target-specific packaging.
+
+Native Gateway forwarding, routerd, OpenWrt firmware, and commit-confirm are not
+shipped. They remain **blocked** from production claims until the safety gates in
+the canonical architecture are implemented and verified.
 
 The name references Bentham's panopticon — the all-seeing observation tower — reimagined as a personal tool: *you* are the observer, your home network is the space. The `k` spelling makes it unique and ownable.
 
-**The one-liner:** The all-seeing eye for your home network. Unified monitoring and management: network devices, routers (MikroTik-first with legacy VyOS support), WiFi mesh (Xiaomi), DNS (Unbound), reverse proxy (Caddy), Cloudflare Tunnel, and IT asset inventory — all in one self-hosted Docker Compose stack.
+**The one-liner:** The all-seeing eye for your network: a local-first Controller
+today, evolving into a recoverable x86 Gateway and embedded Edge platform.
 
-**Vision:** You open a single browser tab and see your entire infrastructure: router health, every device discovered via ARP/DHCP/mDNS/SSDP, full hardware inventory collected via lightweight agents *or* direct SSH, DNS management (Unbound), reverse proxy (Caddy), and secure tunnel (Cloudflare) — all in a dark, information-dense UI that feels like a professional network operations center, not a hobbyist tool.
+**Vision:** You open a single operator console and see the entire infrastructure,
+understand fresh versus stale state, preview intended changes, and apply only the
+operations that the target advertises as safe. In Controller deployments those
+operations are performed through managed-router APIs. In planned Gateway/Edge
+deployments Core expresses desired state and routerd owns privileged execution.
 
 ### Asset Management Vision
 
@@ -52,33 +80,41 @@ The result: a single inventory view of your entire infrastructure, always up to 
 
 ## 2. Problem Statement
 
-Running a home lab or small office network with a dedicated router gives you powerful networking capabilities, but the management experience is fragmented. Meanwhile:
+Running a home lab or small office network gives operators a false choice between
+fragmented point tools and opaque vendor appliances. Today:
 
-- **MikroTik RouterOS** has WinBox and WebFig, but no unified view combining router management with network-wide device awareness and monitoring.
+- **MikroTik RouterOS and pfSense** provide strong routing platforms, but their
+  native tools do not provide Panoptikon's unified inventory and telemetry model.
 - **VyOS has no built-in web GUI** for day-to-day monitoring. You SSH in, run `show interfaces`, and parse text output.
 - **Network monitoring** requires separate tools: Fing (proprietary, SaaS-leaning), nmap (CLI), Zabbix/LibreNMS (massive overkill for a home network).
 - **Device awareness** is fragmented. You don't know what's on your network without actively scanning. New devices appear silently. Devices go offline without notification.
 - **Agent-based monitoring** (CPU, RAM, traffic per host) typically means deploying Prometheus + node_exporter + Grafana — a stack heavier than the machines being monitored.
 
-There is no single, lightweight, self-hosted tool that combines router management + network monitoring + agent telemetry in a polished web UI.
+Current Panoptikon addresses the visibility and managed-router portion. The
+roadmap additionally addresses safe native routing without collapsing the
+unprivileged control plane and privileged packet-path executor into one process.
 
 ---
 
 ## 3. Target User
 
-**Primary persona:** A technical user (developer, sysadmin, homelab enthusiast) who:
+**Primary users:**
 
-- Runs MikroTik (RouterOS 7+) as the primary router, or maintains an existing VyOS deployment that still needs support
-- Has 10–100 devices on the network (servers, workstations, IoT, phones)
-- Wants visibility into their network without deploying a full monitoring stack
-- Values self-hosting, open source, and low resource usage
-- Is comfortable with CLI for initial setup but wants a GUI for day-to-day operations
+- Homelab and small-office operators running the current Controller with
+  MikroTik, pfSense, or an existing VyOS deployment.
+- Technical operators who want a dedicated, recoverable x86-64 Gateway they can
+  inspect, back up, and operate without vendor cloud control.
+- Developers and maintainers who need an isolated Proxmox fabric for destructive
+  packet-path, upgrade, and failure verification.
+- Embedded users who may adopt the planned OpenWrt Edge profile on explicitly
+  supported hardware after its resource and recovery gates pass.
 
 **Not targeting:**
 
-- Enterprise networks (hundreds of switches, SNMP polling at scale)
-- Non-technical users who need a plug-and-play router GUI
-- Multi-site deployments (initially)
+- Enterprise-scale orchestration across hundreds of sites.
+- An unbounded generic Linux root-execution service.
+- Operators unwilling to maintain an out-of-band recovery path for native
+  Gateway experiments.
 
 ---
 
@@ -88,27 +124,27 @@ There is no single, lightweight, self-hosted tool that combines router managemen
 
 | # | Goal | Status |
 |---|------|--------|
-| G1 | Provide a single-pane-of-glass view for a MikroTik or VyOS-based network | ✅ Done |
-| G2 | Auto-discover and track all devices on the local network | ✅ Done |
-| G3 | Offer optional lightweight agents for deep host-level telemetry | ✅ Done |
-| G4 | Deliver a polished, UniFi-quality dark UI | ✅ Done |
-| G5 | Maintain a complete IT asset inventory — hardware, OS, ownership, location — without external tools | ✅ Done |
-| G6 | Support agentless SSH-based monitoring for hosts where installing an agent is not possible or desired | ✅ Done |
-| G7 | Keep resource usage minimal — the server should run on a Raspberry Pi 4 | ✅ Done |
-| G8 | Be easy to deploy: Docker Compose stack with SQLite, minimal external dependencies | ✅ Done |
-| G9 | Open-source (MIT or Apache 2.0) with a clean, contributor-friendly codebase | ✅ Done |
-| G10 | Support multiple router backends (MikroTik primary, VyOS optional) | ✅ Done |
+| G1 | Preserve the shipped Controller experience for MikroTik, pfSense, and legacy VyOS users | **Current** |
+| G2 | Discover devices and unify network, host, service, and asset telemetry locally | **Current** |
+| G3 | Make x86-64 co-located Gateway the primary product build | **Planned** |
+| G4 | Keep Core unprivileged and isolate packet-path execution in routerd | **Planned** |
+| G5 | Use one capability/desired-state/transaction contract over local Unix sockets or remote mTLS | **Planned** |
+| G6 | Continue last-known-good forwarding and show honest stale/offline state when Core or transport is unavailable | **Planned** |
+| G7 | Require commit-confirm, reconciliation, and out-of-band recovery before native forwarding is production-ready | **Blocked** pending implementation and isolated verification |
+| G8 | Verify native Gateway work in a disposable Proxmox VM fabric | **Blocked** until the isolated fabric exists |
+| G9 | Deliver a separately packaged OpenWrt Edge profile using `ubus`/UCI | **Planned** |
+| G10 | Remain self-hosted, open-source, privacy-first, and explicit about target capabilities | **Current and planned** |
 
 ### Non-Goals
 
 | # | Non-Goal | Rationale |
 |---|----------|-----------|
-| NG1 | ~~Support for non-VyOS routers~~ | **Resolved:** MikroTik is now the primary router. Multi-router architecture supports both MikroTik and VyOS. |
-| NG2 | Full configuration management for routers | Read-first approach for MikroTik. VyOS has extended write support (firewall rules, DNS, DHCP, WireGuard). |
-| NG3 | SNMP-based monitoring | Too complex, too legacy. Agents + ARP scanning + router REST APIs cover our use cases. |
-| NG4 | Multi-user / RBAC | Self-hosted, single-user. One admin password is enough. |
-| NG5 | Cloud/SaaS features | No phone-home, no accounts, no telemetry. Fully local. |
-| NG6 | Windows agents in MVP | Linux and macOS first. Windows later if demanded. |
+| NG1 | Removing Controller mode when Gateway ships | Managed-router integrations remain supported. |
+| NG2 | Testing Gateway changes on the working production router or Controller-mode LXC 115 | Experiments require the isolated Proxmox Gateway VM. |
+| NG3 | Treating ER605 V1 as the reference appliance | It is sacrificial HIL/recovery hardware only. |
+| NG4 | One identical binary/backend across x86-64 and constrained OpenWrt targets | Profiles share a contract, not necessarily packaging or implementation. |
+| NG5 | Cloud/SaaS control, required accounts, or phone-home telemetry | The product remains local and operator-controlled. |
+| NG6 | Shipping native forwarding before recovery invariants pass | Commit-confirm and out-of-band recovery are blocking gates. |
 
 ---
 
@@ -136,8 +172,9 @@ There is no single, lightweight, self-hosted tool that combines router managemen
 
 #### F3: Router Integration ✅
 - **MikroTik (Primary/Default):** Connect to RouterOS 7+ REST API. Full management: system status (uptime, CPU, memory, board info), interfaces (IPs, MACs, TX/RX, enable/disable), routes (view + create/delete static routes), DHCP leases, VLANs, firewall rules, traffic monitoring, NAT/port forwarding, VPN status, dynamic DNS, QoS, DNS configuration, WireGuard VPN. TTL-based caching for read operations. This is the default router path in onboarding, router pages, and new feature planning.
+- **pfSense (Supported):** Preserve the current pfSense integration and bridge for existing Controller deployments while MikroTik remains the primary/default path.
 - **VyOS (Legacy/Optional):** Connect to VyOS HTTP API. Display: system status, syslog, interfaces, routes, DHCP leases + static mappings, firewall rules (full CRUD + groups), DNS forwarding, WireGuard VPN peers. Configuration backup/restore with diff viewing. Visibility is hidden by default and only exposed when legacy routers are explicitly enabled in Advanced settings.
-- Connection test + health indicator in UI for both routers
+- Connection test + health indicator in the relevant managed-router UI
 
 #### F4: Authentication ✅
 - Single-user authentication: username + password (bcrypt-hashed, stored in SQLite)
@@ -327,7 +364,26 @@ A structured record for every asset in the infrastructure — servers, VMs, cont
 
 ## 6. Architecture & Tech Stack
 
-### System Architecture
+The normative process boundary, transports, shared contract, adapters, recovery
+rules, and rollout phases live in
+[`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md). The summary below defines
+product placement; the following detailed diagram documents the **current**
+Controller implementation only.
+
+| Deployment profile | Product role | Status |
+|---|---|---|
+| x86-64 co-located Gateway | Primary product build; separate local Core and routerd processes using a Unix socket | **Planned** |
+| Proxmox Gateway VM | Mandatory isolated development and verification fabric | **Planned**; packet-path work is **blocked** until available |
+| Panoptikon Edge / OpenWrt | Embedded profile with target-specific packaging and `ubus`/UCI adapter | **Planned** |
+| Managed-router Controller | Discovery, telemetry, services, and current MikroTik/pfSense/legacy VyOS integrations | **Current** and supported |
+
+The roadmap does not combine all privilege into the web/API process. Core owns
+intent, history, and operator workflows; routerd owns the minimum privileged
+execution surface. Local communication uses a restricted Unix socket. Remote
+Edge communication uses mTLS. Both carry the same versioned
+capability/desired-state/transaction contract.
+
+### Current Controller Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -348,9 +404,10 @@ A structured record for every asset in the infrastructure — servers, VMs, cont
 ║  │  │ alerts,  │ │  updates │ │ mDNS,    │ │┌────────┐│ │  ║
 ║  │  │ agents,  │ │  to UI)  │ │ SSDP,    │ ││MikroTik││ │  ║
 ║  │  │ assets,  │ │          │ │ NetFlow) │ │├────────┤│ │  ║
-║  │  │ caddy,   │ │          │ │          │ ││VyOS    ││ │  ║
-║  │  │ unbound, │ │          │ │          │ │└────────┘│ │  ║
-║  │  │ cf-tun)  │ │          │ │          │ │          │ │  ║
+║  │  │ caddy,   │ │          │ │          │ ││pfSense ││ │  ║
+║  │  │ unbound, │ │          │ │          │ │├────────┤│ │  ║
+║  │  │ cf-tun)  │ │          │ │          │ ││VyOS    ││ │  ║
+║  │  │          │ │          │ │          │ │└────────┘│ │  ║
 ║  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ │  ║
 ║  │                     │                                  │  ║
 ║  │            ┌────────┴────────┐                         │  ║
@@ -373,22 +430,28 @@ A structured record for every asset in the infrastructure — servers, VMs, cont
    └─────────┘ └─────────┘ └─────────┘ └──────────┘
 ```
 
-### Router Integration Architecture
+### Current Managed-Router Integration Architecture
 
-Panoptikon supports a **multi-router architecture** with MikroTik as the primary/default router and VyOS as a legacy secondary integration:
+Panoptikon currently supports managed-router integrations alongside the Gateway
+roadmap. MikroTik remains the primary/default path, pfSense remains supported for
+existing deployments, and VyOS remains a legacy secondary integration:
 
 | Router | API | Status | Default |
 |--------|-----|--------|---------|
 | **MikroTik** | RouterOS 7+ REST API | ✅ Primary | Default tab and default router type |
+| **pfSense** | pfSense integration/bridge | Supported | Existing deployments |
 | **VyOS** | VyOS HTTP API (1.3+) | ⚠️ Legacy Optional | Hidden by default; shown only when legacy routers are enabled |
 
-Both integrations use TTL-based caching for read operations and cache invalidation middleware on mutations. Each router has its own settings page and can be independently enabled/disabled. The `show_legacy_routers` setting defaults to `false`, keeping VyOS flows out of the primary UI until explicitly enabled.
+The managed-router integrations retain their current caching and mutation
+behavior. Each router has its own settings path and can be independently
+enabled/disabled. The `show_legacy_routers` setting defaults to `false`, keeping
+VyOS flows out of the primary UI until explicitly enabled.
 
 ### Tech Stack Justification
 
 | Component | Choice | Why |
 |-----------|--------|-----|
-| **Backend language** | Rust | Performance (handles thousands of agent reports with minimal resources), single static binary deployment, strong type system prevents network-parsing bugs, excellent async ecosystem (tokio). Memory usage stays low even with many concurrent connections. |
+| **Backend language** | Rust | Performance, type safety for network parsing, and the async Tokio ecosystem. The current Controller can ship as one binary; the planned Gateway deliberately separates Core and routerd, and embedded targets may use different packaging. |
 | **Web framework** | axum | Tokio-native, tower middleware ecosystem, first-class WebSocket support, extractors pattern is clean. Most popular Rust web framework as of 2025. |
 | **Database** | SQLite via sqlx | Zero-config, single-file, embedded. Perfect for self-hosted single-server deployment. sqlx gives compile-time query checking. Good enough for 100K+ devices (our ceiling is ~100). |
 | **Frontend framework** | Next.js 14+ (App Router) | React ecosystem, good SSR story for initial load, excellent DX. Massive component ecosystem. |
@@ -403,9 +466,11 @@ Both integrations use TTL-based caching for read operations and cache invalidati
 | **Animations** | Framer Motion | Smooth, declarative animations for React. Card transitions, page enters, and micro-interactions. |
 | **OUI database** | Embedded IEEE MA-L CSV | Compiled into the binary. Updated on release. No runtime download needed. |
 
-### Deployment Model
+### Current Controller Deployment Model
 
-The primary deployment method is **Docker Compose**, packaging Panoptikon with its embedded services:
+The shipped Controller is currently deployed with **Docker Compose**, packaging
+Panoptikon with its companion services. This is not the planned native Gateway
+packaging:
 
 ```yaml
 # docker-compose.yml (simplified)
@@ -448,11 +513,19 @@ docker compose up -d
 # → Open http://localhost:8080
 ```
 
-The Panoptikon binary itself embeds the Next.js frontend (statically exported via `rust-embed`). The binary can also run standalone without Docker, but Docker Compose is the recommended deployment for the full stack (reverse proxy + DNS + tunnel).
+The current x86 Controller binary embeds the Next.js frontend (statically exported
+via `rust-embed`). It can also run standalone without Docker. The planned x86
+Gateway splits Core from privileged routerd, while the OpenWrt Edge profile uses
+separate, target-appropriate packaging; the roadmap does not promise one binary
+or backend across x86 and embedded targets.
 
 **Docker Hub releases** are planned for automated image publishing.
 
-### Reference Deployment: Proxmox + MikroTik + Docker Compose
+### Current Reference Controller Deployment: Proxmox + MikroTik + Docker Compose
+
+This section describes shipped infrastructure, not the planned Proxmox Gateway
+VM. The working production router and Controller-mode LXC 115 must remain outside
+Gateway experiments.
 
 **MikroTik CHR** runs as the primary router (hardware device, CHR VM, or container):
 - RouterOS 7+ with REST API enabled
@@ -479,7 +552,7 @@ The Panoptikon binary itself embeds the Next.js frontend (statically exported vi
 - VyOS HTTP API enabled and reachable from LAN
 - Enable in Panoptikon Settings → Advanced → Show legacy routers, then configure in Settings → Router → VyOS (Legacy)
 
-### Build Pipeline
+### Current Controller Build Pipeline
 
 ```
 Frontend (Next.js):  bun run build → static export → /out/
@@ -1032,9 +1105,22 @@ This keeps the SQLite database small and fast. Target: <100 MB for a network wit
 
 ## 10. Test Environment
 
-A dedicated test environment validates MikroTik integration features before release. The environment runs on Proxmox (Forge/DevBox) using lightweight LXC containers with a MikroTik CHR instance as the gateway.
+Testing has two deliberately separate profiles. The current MikroTik Controller
+lab remains shipped infrastructure. The planned Proxmox Gateway VM fabric is the
+mandatory place for native packet-path and recovery work.
 
-### Topology
+| Profile | Purpose | Status |
+|---|---|---|
+| MikroTik CHR + LXC clients | Validate current managed-router APIs, discovery, DHCP, VLANs, and UI workflows | **Current** |
+| Isolated Proxmox Gateway VM + synthetic WAN/LAN/recovery peers | Validate Linux forwarding, Core/routerd loss, commit-confirm, rollback, upgrade, and last-known-good behavior | **Planned** and currently **blocked** pending fabric setup |
+| ER605 V1 | Destructive flash/serial/recovery exercises only | **Planned** sacrificial HIL; not the reference appliance |
+
+The working production router and current Controller-mode LXC 115 are explicitly
+excluded from Gateway experiments. See
+[`test-environment.md`](./test-environment.md) and
+[`test-plan.md`](./test-plan.md) for the detailed packet-path/failure matrix.
+
+### Current Controller topology
 
 ```
 Proxmox Host
@@ -1047,7 +1133,7 @@ Proxmox Host
 
 All test containers use `10.10.0.125` as their default gateway, placing them behind the MikroTik CHR for realistic routing, DHCP, and firewall testing.
 
-### Automated Setup
+### Current automated setup
 
 ```bash
 # Create test containers (run on Proxmox host)
@@ -1062,7 +1148,7 @@ sudo bash scripts/setup-test-env.sh destroy
 
 The script (`scripts/setup-test-env.sh`) handles container creation, template download, package installation, and cleanup.
 
-### What It Validates
+### What the current lab validates
 
 | Feature              | How It's Tested                                                    |
 |----------------------|--------------------------------------------------------------------|
@@ -1137,15 +1223,47 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 - [x] **Device type icons:** Visual device identification in lists and topology
 - [x] **Dashboard sparklines:** Inline bandwidth charts on dashboard cards
 
-### Milestone 4: Embedded Stack & Integrations (In Progress)
+### Milestone 4: Current Controller Hardening (In Progress)
 
 - [x] **Xiaomi BE3600 mesh integration:** WiFi client list, mesh topology (4 nodes), signal strength monitoring, device list, firmware status, WAN/LAN info, per-band WiFi details
 - [ ] **Docker Compose packaging:** Docker Hub releases, automated image builds
 - [ ] **DNS test setup:** Configure Unbound as the network-wide DNS resolver
-- [ ] **pfSense deprecation:** pfSense is deprecated; MikroTik CHR is the primary router going forward
+- [ ] **Managed-router support:** keep MikroTik primary while preserving pfSense
+  and legacy VyOS behavior for existing Controller deployments
 - [ ] **UI cleanup:** Polish, consistency, responsive improvements
 
-### Milestone 5: Future (Planned)
+### Milestone 5: Gateway Contract and Isolated Fabric (Planned)
+
+- [ ] Version the capability/desired-state/plan/transaction/result contract
+- [ ] Add an unprivileged simulator with stale-revision and failure injection
+- [ ] Build the isolated Proxmox Gateway VM fabric with synthetic WAN, LAN,
+  management, and out-of-band recovery paths
+- [ ] Prove that the working production router and Controller-mode LXC 115 are not
+  reachable from destructive Gateway tests
+
+Native forwarding remains **blocked** until this milestone's isolation gate passes.
+
+### Milestone 6: Recoverable x86-64 Gateway (Planned)
+
+- [ ] Split `panoptikon-core` from privileged `panoptikon-routerd`
+- [ ] Use a restricted Unix socket for co-located communication
+- [ ] Implement native Linux/Netlink adapters for approved capabilities
+- [ ] Preserve forwarding during Core or transport loss
+- [ ] Implement commit-confirm, last-known-good reconciliation, and tested
+  out-of-band recovery
+- [ ] Pass the packet-path and failure matrix repeatedly in the Proxmox fabric
+
+Production Gateway claims are **blocked** until every recovery invariant passes.
+
+### Milestone 7: Panoptikon Edge / OpenWrt (Planned)
+
+- [ ] Select supported targets based on resources and recoverability
+- [ ] Package the Edge runtime separately from the x86 Gateway
+- [ ] Implement the OpenWrt `ubus`/UCI adapter and remote mTLS transport
+- [ ] Validate offline operation, upgrades, rollback, and per-target capabilities
+- [ ] Use ER605 V1 only for sacrificial HIL/recovery testing
+
+### Controller backlog (Planned)
 
 - [ ] **Port scanning:** On-demand port scan with service identification
 - [ ] **LAN speed test:** iperf3 between server and agents
@@ -1166,7 +1284,10 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 | Q3 | **Next.js App Router or Pages Router?** | App Router — stable, Server Components for initial load. |
 | Q4 | **Should the frontend be SSR or static export?** | Static export — embedded in Rust binary, no Node.js runtime at deploy time. |
 | Q5 | **Router API key storage?** | SQLite — stored in settings table. |
-| Q11 | **Should we support multiple routers?** | Yes — MikroTik (primary/default) + VyOS (legacy optional, hidden by default unless explicitly enabled). Multi-router architecture implemented. |
+| Q11 | **Should we support multiple routers?** | Yes — MikroTik is primary/default, pfSense remains supported, and VyOS is legacy optional and hidden unless explicitly enabled. |
+| Q15 | **Can Panoptikon own the data plane?** | Yes, in the planned Gateway/Edge profiles. Current Controller behavior remains supported. |
+| Q16 | **Where does privileged networking run?** | In a separate `panoptikon-routerd` process; Core remains unprivileged. |
+| Q17 | **How do local and remote deployments communicate?** | Restricted Unix socket locally; mTLS remotely; one versioned semantic contract. |
 
 ### Technical Unknowns — Mostly Resolved
 
@@ -1177,6 +1298,9 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 | Q8 | **Agent auto-update mechanism** | Deferred: agents report version, user manually updates. |
 | Q9 | **Time-series database migration** | Resolved: SQLite with aggregation tables works well for <100 devices. |
 | Q10 | **mDNS/DNS-SD for hostname discovery** | Resolved: mDNS passive listener implemented. |
+| Q18 | **Which Linux networking APIs and capability subset ship first?** | Open; validate the smallest Netlink-backed slice in the isolated Proxmox fabric. |
+| Q19 | **What commit-confirm health signal is independent enough?** | Open and **blocking**; it must detect loss of management and packet-path reachability without relying only on Core. |
+| Q20 | **Which OpenWrt targets are supportable?** | Open; decide from storage/RAM, kernel/API availability, upgrade path, and proven recovery. ER605 V1 does not set the product baseline. |
 
 ### Product Questions
 
@@ -1185,6 +1309,8 @@ Full validation procedures with step-by-step commands are documented in [`docs/t
 | Q12 | **Should agents support custom plugins/checks?** | Deferred to post-v1. Keep the agent payload fixed. |
 | Q13 | **Is there value in a mobile companion app?** | No. Responsive web is sufficient. |
 | Q14 | **Community features: device database, shared OUI updates?** | No phone-home. OUI database ships with the binary. |
+| Q21 | **How does a Controller deployment migrate to Gateway?** | Open; migration must be reversible and must not repurpose the production router or LXC 115 as an experiment target. |
+| Q22 | **How are queued desired-state changes presented while Edge is offline?** | Open; the UI must distinguish queued intent, stale observation, unknown outcome, and confirmed apply. |
 
 ---
 
@@ -1251,8 +1377,14 @@ set service https api
 | Netdata | Agent monitoring | Excellent agent, but no network discovery or router management |
 | The Dude (MikroTik) | Network monitoring | MikroTik-only, desktop app, no modern web UI, no asset management |
 
-Panoptikon's unique position: **multi-router management (MikroTik + VyOS) + network discovery + device fingerprinting + lightweight agents + embedded DNS (Unbound) + reverse proxy (Caddy) + Cloudflare Tunnel + IT asset inventory**, all in one polished self-hosted Docker Compose stack.
+The current Controller's unique position is **managed-router operations (MikroTik,
+pfSense, and legacy VyOS) + network discovery + device fingerprinting +
+lightweight agents + embedded DNS (Unbound) + reverse proxy (Caddy) + Cloudflare
+Tunnel + IT asset inventory**. The planned Gateway/Edge profiles extend that
+product without pretending their forwarding and recovery features have shipped.
 
 ---
 
-*This document is actively maintained. Last updated: 2026-02-28 (v0.7.0 — MikroTik primary, Caddy proxy, Xiaomi mesh, Assets inventory, pfSense deprecated).*
+*This document is actively maintained. Last updated: 2026-07-23 (v0.8.0 —
+Gateway roadmap aligned with #834; current Controller behavior separated from
+planned and blocked Gateway/Edge work).*

--- a/docs/test-environment.md
+++ b/docs/test-environment.md
@@ -1,6 +1,70 @@
-# Test Environment — LXC Containers on DevBox Proxmox
+# Test Environments — Controller Lab and Gateway Fabric
 
-Setup guide for the Panoptikon test environment. Uses lightweight LXC containers on Proxmox DevBox as real DHCP clients and mDNS devices for testing device discovery, DHCP lease tracking, and mDNS identification.
+This document separates the **current** MikroTik Controller lab from the
+**planned** isolated Proxmox Gateway fabric. The architecture source of truth is
+[`GATEWAY-ARCHITECTURE.md`](./GATEWAY-ARCHITECTURE.md), based on
+[#834](https://github.com/BeFeast/panoptikon/issues/834).
+
+## Environment roles and safety boundary
+
+| Environment | Role | Status |
+|---|---|---|
+| MikroTik CHR + LXC clients described below | Managed-router API, DHCP, VLAN, discovery, and UI validation | **Current** shipped test infrastructure |
+| Disposable Proxmox Gateway VM fabric | Native x86 forwarding, Core/routerd, transaction, failure, and recovery validation | **Planned** and currently **blocked** pending provisioning |
+| ER605 V1 | Flash, serial, destructive upgrade, and recovery HIL | **Planned** sacrificial hardware only; not the reference appliance |
+
+The working production router and current Controller-mode LXC 115 are protected
+infrastructure. They must not be used as Gateway experiment targets, attached to
+the destructive fabric, or treated as the Gateway under test. Existing scripts
+that deploy or verify LXC 115 describe Controller operations only.
+
+## Planned isolated Proxmox Gateway fabric
+
+The mandatory Gateway development profile uses a disposable VM and synthetic
+packet path. It must be possible to destroy and recreate the entire fabric without
+touching production networking.
+
+```text
+                       Proxmox development host
+  +----------------------------------------------------------------+
+  | isolated management bridge                                     |
+  |   test runner / Core observer ---- mTLS or console ----+        |
+  |                                                        |        |
+  | synthetic WAN bridge       Gateway VM                  | OOB    |
+  | upstream peer -------- WAN [core + separate routerd] LAN ----+  |
+  |                              | Linux/Netlink adapter          |  |
+  |                              +--------------------------+     |  |
+  | synthetic LAN bridge                                   |     |  |
+  | client A / client B / service peer ---------------------+     |  |
+  |                                                              |  |
+  | independent recovery console --------------------------------+  |
+  +----------------------------------------------------------------+
+
+  No bridge or route to the working production router or LXC 115.
+```
+
+Required properties:
+
+- Separate WAN, LAN, management, and out-of-band recovery networks.
+- Synthetic upstream and client peers that can assert packet delivery, loss,
+  NAT/firewall effects, DNS/DHCP behavior, and management reachability.
+- Failure injection for Core, routerd, transport, VM power, interface, and partial
+  transaction loss.
+- Snapshot/rebuild support so every destructive test begins from a known state.
+- Packet capture at both sides of the Gateway, with monotonic timestamps and the
+  transaction ID recorded in test evidence.
+- No route, bridge, credentials, or automated mutation path to production targets.
+
+Provisioning for this fabric is **planned**. Until it exists and the failure matrix
+in [`test-plan.md`](./test-plan.md) passes, native Gateway forwarding and
+commit-confirm remain **blocked** from release claims.
+
+## Current MikroTik Controller lab
+
+The remainder of this guide documents the existing environment. It uses
+lightweight LXC containers on Proxmox DevBox as real DHCP clients and mDNS devices
+for testing device discovery, DHCP lease tracking, and mDNS identification. It
+must continue to work while Gateway development proceeds.
 
 ## Why LXC Containers?
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -13,7 +13,7 @@
 2. [Caddy Reverse Proxy](#2-caddy-reverse-proxy)
 3. [Xiaomi WiFi Mesh](#3-xiaomi-wifi-mesh)
 4. [Assets / Network Inventory](#4-assets--network-inventory)
-5. [Legacy Integrations (VyOS, NPM)](#5-legacy-integrations-vyos-npm)
+5. [Historical and Legacy Integrations (VyOS, NPM)](#5-historical-and-legacy-integrations-vyos-npm)
 
 ---
 
@@ -51,7 +51,7 @@ the synthetic WAN/LAN/management/recovery fabric is provisioned.
 | G-04 | Address/route change | Connectivity probes through old and new path | Change is atomic or rolls back; observed revision advances once | **Planned** |
 | G-05 | DHCP/DNS capability, when advertised | Lease/query transcript and packet capture | Service behavior matches target capabilities; unsupported targets reject the request | **Planned** |
 | G-06 | Capability mismatch | Submit intent available on a different adapter only | Core does not offer/send it; routerd rejects any forged request | **Planned** |
-| G-07 | Controller compatibility | Run current MikroTik/pfSense and legacy VyOS smoke coverage | Existing managed-router behavior remains supported | **Current regression gate** |
+| G-07 | Controller compatibility | Run current MikroTik/pfSense smoke coverage and verify removed VyOS settings/UI stay absent | Existing managed-router behavior remains supported without reviving removed paths | **Current regression gate** |
 
 ### 0.2 Failure and recovery matrix
 
@@ -317,18 +317,17 @@ support matrix.
 
 ---
 
-## 5. Legacy Integrations (VyOS, NPM)
+## 5. Historical and Legacy Integrations (VyOS, NPM)
 
-These integrations are retained for backward compatibility but are not the primary path.
+NPM is retained for backward compatibility. VyOS is a removed historical path.
 
-### 5.1 VyOS (Legacy)
+### 5.1 VyOS (Historical / Removed)
 
 | # | Test Case | Steps | Expected Result |
 |---|-----------|-------|-----------------|
-| L-01 | VyOS hidden by default | Fresh install → check sidebar | VyOS does not appear in default navigation |
-| L-02 | VyOS visible when enabled | Settings → Advanced → Show legacy routers → enable | VyOS tab appears in Router page |
-| L-03 | VyOS connection test | Configure VyOS URL + API key → Test Connection | Connection test works (if VyOS is available) |
-| L-04 | VyOS lazy loading | Load Router page with both routers configured | VyOS data only fetched when VyOS tab is selected |
+| L-01 | Removed settings migrate away | Apply migration 026 to a fixture containing `vyos%` settings and `show_legacy_routers` | Removed keys are deleted; unrelated settings remain |
+| L-02 | No current VyOS navigation | Fresh install → inspect router and Advanced settings navigation | No VyOS tab or legacy-router visibility control is exposed |
+| L-03 | No current VyOS API/client surface | Inspect compiled routes/modules and run current API smoke tests | No VyOS management endpoint or client is advertised as supported |
 
 ### 5.2 NPM (Legacy)
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,13 +1,14 @@
 # Panoptikon — Test Plan
 
-**Version:** 0.7.0
-**Date:** 2026-02-28
+**Version:** 0.8.0
+**Date:** 2026-07-23
 **Status:** Active
 
 ---
 
 ## Table of Contents
 
+0. [Gateway Roadmap Verification](#0-gateway-roadmap-verification)
 1. [MikroTik Router Integration](#1-mikrotik-router-integration)
 2. [Caddy Reverse Proxy](#2-caddy-reverse-proxy)
 3. [Xiaomi WiFi Mesh](#3-xiaomi-wifi-mesh)
@@ -18,12 +19,72 @@
 
 ## Test Environment
 
+The listed LAN systems are the **current** Controller test environment. They are
+not the planned Gateway fabric:
+
 - **MikroTik CHR:** 10.10.0.125 (RouterOS 7+, REST API enabled)
 - **Panoptikon server:** localhost:8080 (or 10.10.0.14:8080 on LAN)
 - **Caddy admin API:** localhost:2019 (Docker container)
 - **Xiaomi mesh main (CAP):** 10.10.0.199
 - **Xiaomi satellites:** 10.10.0.52, 10.10.0.53, 10.10.0.54
 - **Test containers:** See [test-environment.md](./test-environment.md) for Proxmox LXC setup
+
+The working production router and Controller-mode LXC 115 are excluded from all
+Gateway experiments. See [the test-environment guide](./test-environment.md) and
+the [canonical Gateway architecture](./GATEWAY-ARCHITECTURE.md).
+
+---
+
+## 0. Gateway Roadmap Verification
+
+This section is an acceptance matrix for the **planned** isolated Proxmox Gateway
+VM. It does not describe shipped functionality. The cases are **blocked** until
+the synthetic WAN/LAN/management/recovery fabric is provisioned.
+
+### 0.1 Packet-path matrix
+
+| ID | Case | Evidence | Required result | Status |
+|---|---|---|---|---|
+| G-01 | Baseline WAN↔LAN forwarding for an advertised capability | Captures on both sides, route/interface state, transaction ID | Only declared flows pass; counters and observed state agree | **Planned** |
+| G-02 | NAT apply and removal | Pre/post captures and normalized desired/observed state | Translation matches the plan and removal restores baseline | **Planned** |
+| G-03 | Firewall allow/deny ordering | Positive and negative probes with rule counters | Results match deterministic plan order; no undeclared rule is applied | **Planned** |
+| G-04 | Address/route change | Connectivity probes through old and new path | Change is atomic or rolls back; observed revision advances once | **Planned** |
+| G-05 | DHCP/DNS capability, when advertised | Lease/query transcript and packet capture | Service behavior matches target capabilities; unsupported targets reject the request | **Planned** |
+| G-06 | Capability mismatch | Submit intent available on a different adapter only | Core does not offer/send it; routerd rejects any forged request | **Planned** |
+| G-07 | Controller compatibility | Run current MikroTik/pfSense and legacy VyOS smoke coverage | Existing managed-router behavior remains supported | **Current regression gate** |
+
+### 0.2 Failure and recovery matrix
+
+| ID | Failure | Required result | Release gate |
+|---|---|---|---|
+| F-01 | Stop `panoptikon-core` during established traffic | Last committed forwarding continues; UI/API becomes unavailable without data-plane loss | **Blocked** until proven |
+| F-02 | Break the Core↔routerd socket or remote mTLS link | Forwarding continues; observations become stale; new mutations are unavailable or explicitly queued | **Blocked** until proven |
+| F-03 | Kill and restart routerd | Existing kernel state is reconciled before writes resume; no implicit reset | **Blocked** until proven |
+| F-04 | Submit a stale expected revision | Transaction is rejected before mutation and audited | **Blocked** until proven |
+| F-05 | Inject failure midway through a multi-operation apply | Result is rolled back or marked unknown; later writes wait for reconciliation | **Blocked** until proven |
+| F-06 | Commit-confirm acknowledged before deadline | Candidate state becomes the new last-known-good revision | **Blocked** until implemented |
+| F-07 | Commit-confirm deadline expires or reachability fails | Candidate state automatically rolls back without Core assistance | **Blocking invariant** |
+| F-08 | Power-cycle Gateway after confirmed and unconfirmed changes | Confirmed last-known-good state returns; unconfirmed candidate does not persist | **Blocking invariant** |
+| F-09 | Upgrade interruption or incompatible adapter | Previous working version/configuration is recoverable through the documented path | **Blocking invariant** |
+| F-10 | Invalid client certificate or device identity | Remote routerd connection and mutation are rejected and audited | **Blocked** until proven |
+| F-11 | Management path lost by a bad rule | Independent out-of-band access restores last-known-good state | **Blocking invariant** |
+| F-12 | Attempt to address production router or LXC 115 from the fabric | Network policy and credentials make the attempt impossible; test fails closed | **Mandatory isolation gate** |
+
+Every case records the capability set, desired-state revision, transaction ID,
+packet captures, observed-state freshness, result classification, and recovery
+action. A green API health endpoint alone is not Gateway verification.
+
+### 0.3 Embedded Edge and sacrificial HIL
+
+| ID | Target | Case | Required result | Status |
+|---|---|---|---|---|
+| E-01 | Selected OpenWrt target | `ubus`/UCI capability discovery and apply | Only target-supported operations are advertised and applied | **Planned** |
+| E-02 | Selected OpenWrt target | Core offline and reconnect | Last-known-good operation continues; stale state and reconciliation are explicit | **Planned** |
+| E-03 | Selected OpenWrt target | Signed upgrade and rollback | Failed upgrade returns to a reachable supported image | **Blocked** pending target selection |
+| H-01 | ER605 V1 | Interrupted flash / serial recovery | Device is recovered through documented out-of-band steps | **Sacrificial HIL only** |
+
+ER605 V1 results never establish the reference appliance or general OpenWrt
+support matrix.
 
 ---
 
@@ -305,4 +366,5 @@ curl -s http://localhost:8080/api/v1/assets?type=server | jq '.[0].name'
 
 ---
 
-*This document is actively maintained. Last updated: 2026-02-28 (v0.7.0).*
+*This document is actively maintained. Last updated: 2026-07-23 (v0.8.0 —
+current Controller coverage plus planned, blocked Gateway/Edge verification).*

--- a/panoptikon.example.toml
+++ b/panoptikon.example.toml
@@ -1,3 +1,5 @@
+# Current Controller configuration example. This file does not configure the
+# planned Gateway packet path or privileged panoptikon-routerd process.
 listen = "0.0.0.0:8080"
 db_path = "./panoptikon.db"
 

--- a/panoptikon.toml
+++ b/panoptikon.toml
@@ -1,3 +1,5 @@
+# Current Controller configuration example. This file does not configure the
+# planned Gateway packet path or privileged panoptikon-routerd process.
 listen = "0.0.0.0:8080"
 db_path = "./panoptikon.db"
 

--- a/scripts/deploy-lxc.sh
+++ b/scripts/deploy-lxc.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # deploy-lxc.sh — Deploy a pre-built panoptikon binary to LXC 115 via DevBox.
+# LXC 115 is the current Controller deployment, never a Gateway experiment target.
 #
 # This script is now artifact-driven: it receives a pre-built binary and
 # deploys it. Building is handled by CI; orchestration by deploy-worker.sh.

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # setup-test-env.sh — Create LXC test containers on Proxmox for MikroTik integration testing.
+# This current Controller lab must not be reused for native Gateway experiments.
 #
 # Creates 2-3 lightweight LXC containers that use MikroTik CHR (10.10.0.125) as their
 # gateway. These containers simulate a small network for validating:

--- a/scripts/test-env/setup-lxc.sh
+++ b/scripts/test-env/setup-lxc.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # setup-lxc.sh — Create LXC test containers on Proxmox DevBox
+# This is current MikroTik Controller test infrastructure, not the planned
+# isolated Proxmox Gateway fabric.
 #
 # Run this script ON the Proxmox host (10.10.0.11) as root.
 # It creates 3 lightweight containers that act as real DHCP clients

--- a/scripts/test-env/setup-vlan20-lxc.sh
+++ b/scripts/test-env/setup-vlan20-lxc.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # setup-vlan20-lxc.sh — Create LXC test containers on VLAN 20
+# This is current MikroTik Controller test infrastructure, not the planned
+# isolated Proxmox Gateway fabric.
 #
 # Run this script ON the Proxmox host (10.10.0.11) as root.
 # Creates 2 lightweight containers that act as DHCP clients on VLAN 20,

--- a/scripts/test-env/teardown-lxc.sh
+++ b/scripts/test-env/teardown-lxc.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # teardown-lxc.sh — Remove LXC test containers from Proxmox DevBox
+# This only tears down current Controller lab clients; it does not manage the
+# planned isolated Proxmox Gateway fabric.
 #
 # Run this script ON the Proxmox host (10.10.0.11) as root.
 #

--- a/scripts/test-env/verify-lxc.sh
+++ b/scripts/test-env/verify-lxc.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # verify-lxc.sh — Verify LXC test containers are running and discoverable
+# This verifies the current MikroTik Controller lab, not a native Gateway.
 #
 # Run this script ON the Proxmox host (10.10.0.11) as root.
 #


### PR DESCRIPTION
## Summary

- add `docs/GATEWAY-ARCHITECTURE.md` as the canonical Core/routerd roadmap contract
- align README and PRD around the current Controller, planned x86 Gateway/Proxmox/OpenWrt profiles, and blocked recovery gates
- make feature-gap ratings profile-aware and add the isolated packet-path/failure test matrix
- preserve current MikroTik/pfSense Controller support while marking removed VyOS material historical
- exclude LXC 115 and the working production router from Gateway experiments
- add roadmap constraints to contributor guidance and safety labels to current Controller config/script examples

## Review fixes

- use the shipped `panoptikon-server` process name for the current Controller path; reserve `panoptikon-core`/`panoptikon-routerd` for the planned Gateway split
- align current support claims with migration 026: VyOS settings and the old integration are removed, while the archived VyOS PRD and old feature-gap evidence are explicitly historical

## Impact

Documentation now consistently separates shipped Controller behavior from planned Gateway/Edge work. Native forwarding, routerd, OpenWrt firmware, and commit-confirm are not presented as implemented.

No production route or UI changed, so screenshots are not applicable.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n scripts/deploy-lxc.sh scripts/setup-test-env.sh scripts/test-env/setup-lxc.sh scripts/test-env/setup-vlan20-lxc.sh scripts/test-env/teardown-lxc.sh scripts/test-env/verify-lxc.sh`
- targeted Markdown-link validation and roadmap-term coverage checks
- `rg` audit for unqualified “not a router/data plane”, planned-process, and current VyOS support claims

The inherited Rust baseline failure originally recorded here was repaired and merged separately in #889. This branch is rebased onto that fix; current GitHub Actions are the authoritative runtime verification.

## Why No E2E Test

Documentation-only roadmap alignment. No runtime or UI behavior changed, matching issue #883's explicit E2E exemption.

Fixes #883

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the product documentation with the Gateway roadmap. The main changes are:

- Adds a canonical Core and routerd architecture contract.
- Separates current Controller behavior from planned Gateway and Edge profiles.
- Marks removed VyOS features as historical throughout the product docs.
- Adds recovery gates, isolated test requirements, and safety labels.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The removed VyOS integration is consistently described as historical, and current Controller behavior is clearly separated from planned Gateway work.

No blocking issues were found in the changed documentation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Recorded the aggregate log that captures every command, working directory, tested SHAs, statuses, and the rustfmt blocker to establish the execution trace.
- Confirmed that Markdown evidence moved from 17 baseline failures to zero at HEAD.
- Validated configuration evidence showing valid TOML on both revisions and that the new safety labels pass only at HEAD.
- Verified that all six shell scripts are syntactically valid at the tested scope.

<a href="https://app.greptile.com/trex/runs/15582049/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/GATEWAY-ARCHITECTURE.md | Defines the canonical Gateway roadmap, process boundary, shared contract, and blocking safety gates. |
| docs/PRD.md | Updates the product requirements for current Controller and planned Gateway and Edge profiles. |
| docs/FEATURE_GAPS.md | Makes capability ratings profile-aware and labels removed VyOS-only features as historical. |
| docs/PRD-VyOS-Management.md | Marks the former VyOS requirements document as archived and removes the obsolete user path. |
| README.md | Reframes the public overview around current managed-router support and planned native forwarding. |
| CLAUDE.md | Adds mandatory roadmap, recovery, privilege, and test-target constraints for contributors. |

<sub>Reviews (2): Last reviewed commit: ["docs: correct shipped Controller boundar..."](https://github.com/befeast/panoptikon/commit/102b572f4209876899ea1c1b3d6b644ebd8dd55d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46660156)</sub>

<!-- /greptile_comment -->