### PR TITLE
ci: restore Rust baseline and gate Dependabot merges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       cargo-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # These 0.x minor releases contain breaking API changes and need a
+      # dedicated, audited migration instead of grouped auto-merge.
+      - dependency-name: "sqlx"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sha2"
+        update-types: ["version-update:semver-minor"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      # rust-embed requires web/.next/static/ to exist at compile time
+      # rust-embed packages the complete web/out/ static export.
       - name: Setup Bun (for rust-embed assets)
         uses: oven-sh/setup-bun@v2
         with:
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build frontend assets (required by rust-embed)
         working-directory: web
-        run: bun install && bun run build
+        run: bun install --frozen-lockfile && bun run build
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -67,6 +67,8 @@ jobs:
           done
           curl -sf http://localhost:2019/config/ || (echo "Caddy failed to start within 30s" && exit 1)
 
+      # Canonical test split: the Caddy suite mutates shared Caddy state and
+      # must run separately and sequentially.
       - name: Test (unit + other integration)
         run: cargo test --lib --bins --test integration
 
@@ -113,7 +115,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Design tokens guard
         run: bash scripts/check-design-tokens.sh
@@ -151,7 +153,7 @@ jobs:
 
       - name: Build frontend assets
         working-directory: web
-        run: bun install && bun run build
+        run: bun install --frozen-lockfile && bun run build
 
       - name: Build server binary
         run: cargo build --release

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,9 +1,17 @@
 name: Dependabot auto-merge
-# Auto-enable merge for Dependabot patch/minor updates once CI passes. Major
-# updates are left for manual review. Standard GitHub pattern.
-on: pull_request
+# Auto-enable merge for Dependabot patch/minor updates only after the required
+# Rust and frontend checks have completed successfully. Major updates are left
+# for manual review.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
+  checks: read
   contents: write
   pull-requests: write
 
@@ -17,8 +25,65 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for patch and minor updates
+      - name: Wait for required CI checks
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        timeout-minutes: 65
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          required_checks=("Rust Build & Lint" "Frontend Build")
+
+          for attempt in $(seq 1 180); do
+            echo "Required-check poll ${attempt}/180"
+            checks_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?per_page=100")"
+            all_success=true
+
+            for check_name in "${required_checks[@]}"; do
+              state="$(jq -r --arg name "$check_name" '
+                [.check_runs[] | select(.name == $name)]
+                | sort_by(.started_at)
+                | last
+                | if . == null then "missing"
+                  elif .status != "completed" then .status
+                  else .conclusion
+                  end
+              ' <<<"$checks_json")"
+
+              case "$state" in
+                success)
+                  echo "$check_name: success"
+                  ;;
+                missing|queued|in_progress|pending|null)
+                  echo "$check_name: $state"
+                  all_success=false
+                  ;;
+                *)
+                  echo "$check_name: $state"
+                  exit 1
+                  ;;
+              esac
+            done
+
+            if "$all_success"; then
+              exit 0
+            fi
+
+            sleep 20
+          done
+
+          echo "Timed out waiting for required CI checks"
+          exit 1
+      - name: Enable auto-merge for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          current_head="$(gh pr view "${{ github.event.pull_request.html_url }}" --json headRefOid --jq .headRefOid)"
+          if [[ "$current_head" != "$HEAD_SHA" ]]; then
+            echo "PR head changed while checks were running; refusing to enable auto-merge"
+            exit 1
+          fi
+
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,7 +135,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -141,7 +154,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -183,9 +196,21 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
@@ -193,7 +218,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blowfish",
  "getrandom 0.4.2",
  "subtle",
@@ -340,7 +365,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.2",
@@ -351,12 +376,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -375,13 +394,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "const-oid"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -536,15 +552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +571,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,7 +597,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -589,9 +609,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
- "ctutils",
 ]
 
 [[package]]
@@ -666,7 +685,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "memchr",
 ]
 
@@ -694,24 +713,20 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.11.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -724,6 +739,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "flume"
@@ -741,12 +767,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -896,6 +916,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -903,7 +927,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -911,19 +935,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -955,7 +983,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -976,7 +1004,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1003,27 +1031,36 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "hkdf"
-version = "0.13.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.11.3",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1131,7 +1168,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1362,7 +1399,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1414,6 +1451,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1428,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -1437,7 +1477,7 @@ dependencies = [
  "httpdate",
  "idna",
  "mime",
- "nom",
+ "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
  "rustls",
@@ -1455,19 +1495,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1499,6 +1548,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1550,12 +1605,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.11.0"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1565,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18d8ec9d1869796fb2910d95f4d957072df0b6a22e247a1d760d8b4c805e17a"
 dependencies = [
  "fastrand",
- "flume",
+ "flume 0.12.0",
  "if-addrs",
  "log",
  "mio",
@@ -1594,6 +1649,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1632,6 +1693,16 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -1658,10 +1729,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1670,6 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1807,7 +1914,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "similar",
  "sqlx",
  "ssh2",
@@ -1820,12 +1927,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1845,9 +1946,24 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1869,10 +1985,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1964,7 +2107,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1985,7 +2128,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2034,11 +2177,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2055,12 +2209,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2088,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,7 +2277,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2121,7 +2303,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2178,6 +2360,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2428,17 +2643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2699,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,9 +2741,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket-pktinfo"
@@ -2572,10 +2783,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx"
-version = "0.9.0"
+name = "spki"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom 7.1.3",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2586,32 +2817,37 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.9.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
- "base64",
+ "ahash",
+ "atoi",
+ "byteorder",
  "bytes",
- "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
+ "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.16.1",
  "hashlink",
+ "hex",
  "indexmap",
  "log",
  "memchr",
+ "once_cell",
+ "paste",
  "percent-encoding",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror",
+ "sqlformat",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2620,28 +2856,28 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.9.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.9.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
- "cfg-if",
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
+ "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -2649,56 +2885,33 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
- "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
- "thiserror",
+ "syn 1.0.109",
+ "tempfile",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.9.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
+ "atoi",
+ "base64 0.21.7",
  "bitflags",
  "byteorder",
  "bytes",
  "crc",
- "digest 0.11.3",
+ "digest 0.10.7",
  "dotenvy",
  "either",
- "futures-core",
- "futures-util",
- "generic-array",
- "log",
- "percent-encoding",
- "serde",
- "sha1 0.11.0",
- "sha2 0.11.0",
- "sqlx-core",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
-dependencies = [
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "crc",
- "dotenvy",
- "etcetera",
  "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-util",
+ "generic-array",
  "hex",
  "hkdf",
  "hmac",
@@ -2706,27 +2919,67 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.10.1",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.7",
+ "rsa",
  "serde",
- "serde_json",
- "sha2 0.11.0",
+ "sha1",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.9.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
- "flume",
- "form_urlencoded",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2737,9 +2990,9 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2782,6 +3035,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2868,12 +3132,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3224,8 +3521,8 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3268,10 +3565,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -3290,6 +3599,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3374,6 +3689,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3499,9 +3820,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
 
 [[package]]
 name = "widestring"
@@ -3907,7 +4232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3918,7 +4243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",

--- a/agent/src/collectors/cpu.rs
+++ b/agent/src/collectors/cpu.rs
@@ -15,7 +15,7 @@ pub fn collect(sys: &System) -> CpuInfo {
 
     CpuInfo {
         count: sys.cpus().len(),
-        usage_percent: sys.global_cpu_info().cpu_usage(),
+        usage_percent: sys.global_cpu_usage(),
         load_avg: [load.one, load.five, load.fifteen],
     }
 }

--- a/agent/src/collectors/hardware.rs
+++ b/agent/src/collectors/hardware.rs
@@ -42,7 +42,7 @@ pub struct HardwareInfo {
 /// Collect hardware inventory (called once at startup).
 pub fn collect(sys: &System) -> HardwareInfo {
     let cpu_name = sys.cpus().first().map(|c| c.brand().to_string());
-    let cpu_cores = sys.physical_core_count();
+    let cpu_cores = System::physical_core_count();
     let cpu_speed_mhz = sys.cpus().first().map(|c| c.frequency());
     let ram_total_bytes = Some(sys.total_memory());
 

--- a/agent/src/collectors/mod.rs
+++ b/agent/src/collectors/mod.rs
@@ -95,8 +95,8 @@ impl SystemCollector {
 
         // Heavy refresh (disks, networks) only every 5th cycle.
         if self.report_count.is_multiple_of(5) {
-            self.disks.refresh_list();
-            self.networks.refresh_list();
+            self.disks.refresh(true);
+            self.networks.refresh(true);
         }
 
         // Refresh fastfetch info every 10th cycle (~5 min at 30s interval).

--- a/agent/src/ws.rs
+++ b/agent/src/ws.rs
@@ -46,7 +46,7 @@ pub async fn run_session(config: &AgentConfig, collector: &mut SystemCollector) 
         let json = serde_json::to_string(&report)?;
         debug!(bytes = json.len(), "Sending report");
 
-        write.send(Message::Text(json)).await?;
+        write.send(Message::Text(json.into())).await?;
 
         // Wait for ack or timeout before next report.
         let ack = tokio::time::timeout(std::time::Duration::from_secs(5), read.next()).await;

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -2,7 +2,7 @@
 #
 # build-prod.sh — Build Panoptikon production binary with embedded frontend.
 #
-# rust-embed bakes web/.next/static/ into the binary at compile time.
+# rust-embed bakes the complete web/out/ static export into the binary.
 # Order matters: web MUST be built BEFORE cargo build.
 # Running cargo build alone produces a binary with STALE frontend.
 #
@@ -25,5 +25,5 @@ echo "=== Step 2/2: Building Rust server (embeds frontend via rust-embed) ==="
 
 echo ""
 echo "✅ Production binary ready: target/release/panoptikon-server"
-echo "   Frontend embedded from: web/.next/static/"
+echo "   Frontend embedded from: web/out/"
 ls -lh target/release/panoptikon-server

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 axum = { version = "0.8", features = ["ws", "macros"] }
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.9", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
+sqlx = { version = "=0.7.4", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
@@ -35,7 +35,7 @@ rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 mime_guess = "2"
 similar = "2"
 ssh2 = "0.9"
-sha2 = "0.11"
+sha2 = "=0.10.9"
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "builder", "smtp-transport", "tokio1"] }
 
 [dev-dependencies]

--- a/server/src/api/agents.rs
+++ b/server/src/api/agents.rs
@@ -641,7 +641,11 @@ async fn handle_ui_ws(mut socket: WebSocket, state: AppState) {
                             "event": broadcast_msg.event,
                             "data": broadcast_msg.payload,
                         });
-                        if socket.send(Message::Text(payload.to_string())).await.is_err() {
+                        if socket
+                            .send(Message::Text(payload.to_string().into()))
+                            .await
+                            .is_err()
+                        {
                             break;
                         }
                     }
@@ -686,7 +690,9 @@ async fn handle_agent_ws(mut socket: WebSocket, state: AppState, agent_id: Strin
 
     let _ = socket
         .send(Message::Text(
-            json!({"status": "authenticated", "agent_id": &agent_id}).to_string(),
+            json!({"status": "authenticated", "agent_id": &agent_id})
+                .to_string()
+                .into(),
         ))
         .await;
 
@@ -697,7 +703,7 @@ async fn handle_agent_ws(mut socket: WebSocket, state: AppState, agent_id: Strin
             cmd = cmd_rx.recv() => {
                 match cmd {
                     Some(command) => {
-                        if socket.send(Message::Text(command)).await.is_err() {
+                        if socket.send(Message::Text(command.into())).await.is_err() {
                             break;
                         }
                     }
@@ -711,7 +717,13 @@ async fn handle_agent_ws(mut socket: WebSocket, state: AppState, agent_id: Strin
                         if let Err(e) = handle_agent_report(&text, &agent_id, &state).await {
                             warn!(agent_id = %agent_id, "Failed to process agent report: {e}");
                         }
-                        if socket.send(Message::Text(json!({"status":"ok"}).to_string())).await.is_err() {
+                        if socket
+                            .send(Message::Text(
+                                json!({"status":"ok"}).to_string().into(),
+                            ))
+                            .await
+                            .is_err()
+                        {
                             break;
                         }
                     }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -144,39 +144,41 @@ pub fn router(state: AppState) -> Router {
     // Agent WebSocket + install script — authenticated via API key, not session cookie.
     let agent_ws = Router::new()
         .route("/agent/ws", get(agents::ws_handler))
-        .route("/agent/install/:platform", get(agents::install_script))
+        .route("/agent/install/{platform}", get(agents::install_script))
         .route(
-            "/agent/install/:platform/binary",
+            "/agent/install/{platform}/binary",
             get(agents::install_binary),
         );
 
-    // Protected routes — each method registered in its own .route() call to avoid
-    // Axum 0.7 MethodRouter chaining issue where DELETE/PATCH can be dropped
-    // after .layer() + .merge() in certain combinations.
+    // Protected routes — keep each method in its own .route() call so layering
+    // and router merges preserve every registered method.
     let protected_routes = Router::new()
         // Devices
         .route("/devices", get(devices::list))
         .route("/devices", post(devices::create))
-        .route("/devices/:id", get(devices::get_one))
-        .route("/devices/:id", patch(devices::update))
-        .route("/devices/:id/events", get(devices::events))
-        .route("/devices/:id/uptime", get(devices::uptime))
-        .route("/devices/:id/wake", post(devices::wake))
-        .route("/devices/:id/scan", get(devices::get_scan))
-        .route("/devices/:id/scan", post(devices::trigger_scan))
-        .route("/devices/:id/enrichment", patch(devices::update_enrichment))
-        .route("/devices/:id/custom", delete(devices::reset_custom))
-        .route("/devices/:id/sysinfo", get(devices::get_sysinfo))
+        .route("/devices/{id}", get(devices::get_one))
+        .route("/devices/{id}", patch(devices::update))
+        .route("/devices/{id}/events", get(devices::events))
+        .route("/devices/{id}/uptime", get(devices::uptime))
+        .route("/devices/{id}/wake", post(devices::wake))
+        .route("/devices/{id}/scan", get(devices::get_scan))
+        .route("/devices/{id}/scan", post(devices::trigger_scan))
+        .route(
+            "/devices/{id}/enrichment",
+            patch(devices::update_enrichment),
+        )
+        .route("/devices/{id}/custom", delete(devices::reset_custom))
+        .route("/devices/{id}/sysinfo", get(devices::get_sysinfo))
         .route("/devices/identify", post(devices::identify_all))
         .route("/devices/resolve", post(device_resolve::resolve))
         // Agents
         .route("/agents", get(agents::list))
         .route("/agents", post(agents::register))
-        .route("/agents/:id", get(agents::get_one))
-        .route("/agents/:id", patch(agents::update))
-        .route("/agents/:id", delete(agents::delete))
-        .route("/agents/:id/reports", get(agents::list_reports))
-        .route("/agents/:id/fastfetch", get(agents::get_fastfetch))
+        .route("/agents/{id}", get(agents::get_one))
+        .route("/agents/{id}", patch(agents::update))
+        .route("/agents/{id}", delete(agents::delete))
+        .route("/agents/{id}/reports", get(agents::list_reports))
+        .route("/agents/{id}/fastfetch", get(agents::get_fastfetch))
         .route("/agents/bulk-delete", post(agents::bulk_delete))
         // Dashboard
         .route("/dashboard/stats", get(dashboard::stats))
@@ -190,17 +192,17 @@ pub fn router(state: AppState) -> Router {
         .route("/alerts", delete(alerts::delete_all))
         .route("/alerts/mark-all-read", post(alerts::mark_all_read))
         .route("/alerts/read-all", patch(alerts::mark_all_read))
-        .route("/alerts/:id", delete(alerts::delete_one))
-        .route("/alerts/:id/read", post(alerts::mark_read))
-        .route("/alerts/:id/unread", post(alerts::mark_unread))
-        .route("/alerts/:id/acknowledge", post(alerts::acknowledge))
+        .route("/alerts/{id}", delete(alerts::delete_one))
+        .route("/alerts/{id}/read", post(alerts::mark_read))
+        .route("/alerts/{id}/unread", post(alerts::mark_unread))
+        .route("/alerts/{id}/acknowledge", post(alerts::acknowledge))
         // Device mute
-        .route("/devices/:id/mute", post(alerts::mute_device))
+        .route("/devices/{id}/mute", post(alerts::mute_device))
         // Alert rules
         .route("/alert-rules", get(alert_rules::list))
         .route("/alert-rules", post(alert_rules::create))
-        .route("/alert-rules/:id", put(alert_rules::update))
-        .route("/alert-rules/:id", delete(alert_rules::delete))
+        .route("/alert-rules/{id}", put(alert_rules::update))
+        .route("/alert-rules/{id}", delete(alert_rules::delete))
         // Settings
         .route("/settings", get(settings::get_settings))
         .route("/settings", patch(settings::update_settings))
@@ -222,7 +224,7 @@ pub fn router(state: AppState) -> Router {
         .route("/router/speedtest/history", get(speedtest::history))
         // Traffic
         .route("/traffic/history", get(traffic::history))
-        .route("/devices/:id/traffic", get(traffic::device_traffic))
+        .route("/devices/{id}/traffic", get(traffic::device_traffic))
         // Config backups
         .route("/config-backups", get(config_backups::list))
         .route("/config-backups", post(config_backups::create))
@@ -230,25 +232,28 @@ pub fn router(state: AppState) -> Router {
         .route("/config-backups/pending", get(config_backups::pending))
         .route("/config-backups/commit", post(config_backups::commit))
         .route("/config-backups/discard", post(config_backups::discard))
-        .route("/config-backups/:id", get(config_backups::get_one))
-        .route("/config-backups/:id", delete(config_backups::delete))
-        .route("/config-backups/:id/diff", get(config_backups::diff))
-        .route("/config-backups/:id/restore", post(config_backups::restore))
+        .route("/config-backups/{id}", get(config_backups::get_one))
+        .route("/config-backups/{id}", delete(config_backups::delete))
+        .route("/config-backups/{id}/diff", get(config_backups::diff))
+        .route(
+            "/config-backups/{id}/restore",
+            post(config_backups::restore),
+        )
         // Nginx Proxy Manager
         .route("/npm/status", get(npm::status))
         .route("/npm/proxy-hosts", get(npm::proxy_hosts))
         .route("/npm/proxy-hosts", post(npm::create_proxy_host))
-        .route("/npm/proxy-hosts/:id", put(npm::update_proxy_host))
-        .route("/npm/proxy-hosts/:id", delete(npm::delete_proxy_host))
-        .route("/npm/proxy-hosts/:id/toggle", post(npm::toggle_proxy_host))
+        .route("/npm/proxy-hosts/{id}", put(npm::update_proxy_host))
+        .route("/npm/proxy-hosts/{id}", delete(npm::delete_proxy_host))
+        .route("/npm/proxy-hosts/{id}/toggle", post(npm::toggle_proxy_host))
         .route("/npm/redirection-hosts", get(npm::redirection_hosts))
         .route("/npm/redirection-hosts", post(npm::create_redirection_host))
         .route(
-            "/npm/redirection-hosts/:id",
+            "/npm/redirection-hosts/{id}",
             put(npm::update_redirection_host),
         )
         .route(
-            "/npm/redirection-hosts/:id",
+            "/npm/redirection-hosts/{id}",
             delete(npm::delete_redirection_host),
         )
         .route("/npm/certificates", get(npm::list_certificates))
@@ -257,35 +262,35 @@ pub fn router(state: AppState) -> Router {
             post(npm::create_letsencrypt),
         )
         .route("/npm/certificates/custom", post(npm::upload_custom_cert))
-        .route("/npm/certificates/:id/renew", post(npm::renew_certificate))
-        .route("/npm/certificates/:id", delete(npm::delete_certificate))
+        .route("/npm/certificates/{id}/renew", post(npm::renew_certificate))
+        .route("/npm/certificates/{id}", delete(npm::delete_certificate))
         .route("/npm/streams", get(npm::list_streams))
         .route("/npm/streams", post(npm::create_stream))
-        .route("/npm/streams/:id", put(npm::update_stream))
-        .route("/npm/streams/:id", delete(npm::delete_stream))
-        .route("/npm/streams/:id/toggle", post(npm::toggle_stream))
+        .route("/npm/streams/{id}", put(npm::update_stream))
+        .route("/npm/streams/{id}", delete(npm::delete_stream))
+        .route("/npm/streams/{id}/toggle", post(npm::toggle_stream))
         .route("/npm/dead-hosts", get(npm::dead_hosts))
         .route("/npm/dead-hosts", post(npm::create_dead_host))
-        .route("/npm/dead-hosts/:id", delete(npm::delete_dead_host))
+        .route("/npm/dead-hosts/{id}", delete(npm::delete_dead_host))
         .route("/npm/access-lists", get(npm::list_access_lists))
         .route("/npm/access-lists", post(npm::create_access_list))
-        .route("/npm/access-lists/:id", put(npm::update_access_list))
-        .route("/npm/access-lists/:id", delete(npm::delete_access_list))
+        .route("/npm/access-lists/{id}", put(npm::update_access_list))
+        .route("/npm/access-lists/{id}", delete(npm::delete_access_list))
         // Caddy Reverse Proxy
         .route("/caddy/status", get(caddy::status))
         .route("/caddy/proxy-hosts", get(caddy::list))
         .route("/caddy/proxy-hosts", post(caddy::create))
-        .route("/caddy/proxy-hosts/:id", put(caddy::update))
-        .route("/caddy/proxy-hosts/:id", delete(caddy::delete))
-        .route("/caddy/proxy-hosts/:id/toggle", post(caddy::toggle))
+        .route("/caddy/proxy-hosts/{id}", put(caddy::update))
+        .route("/caddy/proxy-hosts/{id}", delete(caddy::delete))
+        .route("/caddy/proxy-hosts/{id}/toggle", post(caddy::toggle))
         .route("/caddy/sync", post(caddy::sync))
         .route("/caddy/test-connection", post(caddy::test_connection))
         // Unbound DNS
         .route("/unbound/dns-records", get(unbound::list))
         .route("/unbound/dns-records", post(unbound::create))
-        .route("/unbound/dns-records/:id", put(unbound::update))
-        .route("/unbound/dns-records/:id", delete(unbound::delete))
-        .route("/unbound/dns-records/:id/toggle", post(unbound::toggle))
+        .route("/unbound/dns-records/{id}", put(unbound::update))
+        .route("/unbound/dns-records/{id}", delete(unbound::delete))
+        .route("/unbound/dns-records/{id}/toggle", post(unbound::toggle))
         .route("/unbound/test-connection", post(unbound::test_connection))
         // Xiaomi Mesh
         .route(
@@ -298,23 +303,23 @@ pub fn router(state: AppState) -> Router {
         // SSH targets (agentless monitoring)
         .route("/ssh-targets", get(ssh_targets::list))
         .route("/ssh-targets", post(ssh_targets::create))
-        .route("/ssh-targets/:id", get(ssh_targets::get_one))
-        .route("/ssh-targets/:id", put(ssh_targets::update))
-        .route("/ssh-targets/:id", delete(ssh_targets::delete))
-        .route("/ssh-targets/:id/reports", get(ssh_targets::list_reports))
-        .route("/ssh-targets/:id/test", post(ssh_targets::test_connection))
+        .route("/ssh-targets/{id}", get(ssh_targets::get_one))
+        .route("/ssh-targets/{id}", put(ssh_targets::update))
+        .route("/ssh-targets/{id}", delete(ssh_targets::delete))
+        .route("/ssh-targets/{id}/reports", get(ssh_targets::list_reports))
+        .route("/ssh-targets/{id}/test", post(ssh_targets::test_connection))
         // MikroTik router proxy
         .route("/mikrotik/status", get(mikrotik::status))
         .route("/mikrotik/test-connection", post(mikrotik::test_connection))
         .route("/mikrotik/interfaces", get(mikrotik::interfaces))
         .route("/mikrotik/vlans", get(mikrotik::vlans))
         .route("/mikrotik/vlans", post(mikrotik::create_vlan))
-        .route("/mikrotik/vlans/:id", put(mikrotik::update_vlan))
-        .route("/mikrotik/vlans/:id", delete(mikrotik::delete_vlan))
+        .route("/mikrotik/vlans/{id}", put(mikrotik::update_vlan))
+        .route("/mikrotik/vlans/{id}", delete(mikrotik::delete_vlan))
         .route("/mikrotik/routes", get(mikrotik::routes))
         .route("/mikrotik/dhcp-leases", get(mikrotik::dhcp_leases))
         .route(
-            "/mikrotik/dhcp-leases/:id",
+            "/mikrotik/dhcp-leases/{id}",
             delete(mikrotik::delete_dhcp_lease),
         )
         .route(
@@ -324,7 +329,7 @@ pub fn router(state: AppState) -> Router {
         // MikroTik DHCP server pool configuration
         .route("/mikrotik/dhcp/servers", get(mikrotik::dhcp_servers))
         .route(
-            "/mikrotik/dhcp/servers/:id",
+            "/mikrotik/dhcp/servers/{id}",
             patch(mikrotik::update_dhcp_server),
         )
         .route("/mikrotik/dhcp/networks", get(mikrotik::dhcp_networks))
@@ -333,18 +338,18 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_dhcp_network),
         )
         .route(
-            "/mikrotik/dhcp/networks/:id",
+            "/mikrotik/dhcp/networks/{id}",
             patch(mikrotik::update_dhcp_network),
         )
         .route(
-            "/mikrotik/dhcp/networks/:id",
+            "/mikrotik/dhcp/networks/{id}",
             delete(mikrotik::delete_dhcp_network),
         )
         .route("/mikrotik/dhcp/pools", get(mikrotik::dhcp_pools))
         .route("/mikrotik/dhcp/pools", post(mikrotik::create_dhcp_pool))
-        .route("/mikrotik/dhcp/pools/:id", put(mikrotik::update_dhcp_pool))
+        .route("/mikrotik/dhcp/pools/{id}", put(mikrotik::update_dhcp_pool))
         .route(
-            "/mikrotik/dhcp/pools/:id",
+            "/mikrotik/dhcp/pools/{id}",
             delete(mikrotik::delete_dhcp_pool),
         )
         .route("/mikrotik/dhcp/logs", get(mikrotik::dhcp_logs))
@@ -354,15 +359,15 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_firewall_filter),
         )
         .route(
-            "/mikrotik/firewall/filter/:id",
+            "/mikrotik/firewall/filter/{id}",
             patch(mikrotik::update_firewall_filter),
         )
         .route(
-            "/mikrotik/firewall/filter/:id",
+            "/mikrotik/firewall/filter/{id}",
             delete(mikrotik::delete_firewall_filter),
         )
         .route(
-            "/mikrotik/firewall/filter/:id/toggle",
+            "/mikrotik/firewall/filter/{id}/toggle",
             post(mikrotik::toggle_firewall_filter),
         )
         .route(
@@ -374,15 +379,15 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_firewall_nat),
         )
         .route(
-            "/mikrotik/firewall/nat/:id",
+            "/mikrotik/firewall/nat/{id}",
             patch(mikrotik::update_firewall_nat),
         )
         .route(
-            "/mikrotik/firewall/nat/:id",
+            "/mikrotik/firewall/nat/{id}",
             delete(mikrotik::delete_firewall_nat),
         )
         .route(
-            "/mikrotik/firewall/nat/:id/toggle",
+            "/mikrotik/firewall/nat/{id}/toggle",
             post(mikrotik::toggle_firewall_nat),
         )
         .route(
@@ -390,15 +395,15 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_address_list),
         )
         .route(
-            "/mikrotik/firewall/address-list/:id",
+            "/mikrotik/firewall/address-list/{id}",
             patch(mikrotik::update_address_list),
         )
         .route(
-            "/mikrotik/firewall/address-list/:id",
+            "/mikrotik/firewall/address-list/{id}",
             delete(mikrotik::delete_address_list),
         )
         .route(
-            "/mikrotik/firewall/address-list/:id/toggle",
+            "/mikrotik/firewall/address-list/{id}/toggle",
             post(mikrotik::toggle_address_list),
         )
         .route("/mikrotik/dns", get(mikrotik::dns))
@@ -407,7 +412,7 @@ pub fn router(state: AppState) -> Router {
         .route("/mikrotik/routing/mangle", get(mikrotik::routing_mangle))
         .route("/mikrotik/routing/mangle", post(mikrotik::create_mangle))
         .route(
-            "/mikrotik/routing/mangle/:id",
+            "/mikrotik/routing/mangle/{id}",
             delete(mikrotik::delete_mangle),
         )
         .route("/mikrotik/routing/rules", get(mikrotik::routing_rules))
@@ -416,7 +421,7 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_routing_rule),
         )
         .route(
-            "/mikrotik/routing/rules/:id",
+            "/mikrotik/routing/rules/{id}",
             delete(mikrotik::delete_routing_rule),
         )
         .route("/mikrotik/routing/tables", get(mikrotik::routing_tables))
@@ -429,7 +434,7 @@ pub fn router(state: AppState) -> Router {
             post(mikrotik::create_netwatch),
         )
         .route(
-            "/mikrotik/routing/netwatch/:id",
+            "/mikrotik/routing/netwatch/{id}",
             delete(mikrotik::delete_netwatch),
         )
         .route("/mikrotik/routing/dynamic", get(mikrotik::routing_dynamic))
@@ -449,13 +454,13 @@ pub fn router(state: AppState) -> Router {
         .route("/pfsense/test-connection", post(pfsense::test_connection))
         .route("/pfsense/interfaces", get(pfsense::interfaces))
         .route(
-            "/pfsense/interfaces/:id/toggle",
+            "/pfsense/interfaces/{id}/toggle",
             post(pfsense::toggle_interface),
         )
         .route("/pfsense/gateways", get(pfsense::gateways))
         .route("/pfsense/routes", get(pfsense::routes))
         .route("/pfsense/routes", post(pfsense::create_route))
-        .route("/pfsense/routes/:id", delete(pfsense::delete_route))
+        .route("/pfsense/routes/{id}", delete(pfsense::delete_route))
         .route("/pfsense/dhcp/leases", get(pfsense::dhcp_leases))
         .route(
             "/pfsense/dhcp/static-mappings",
@@ -466,7 +471,7 @@ pub fn router(state: AppState) -> Router {
             post(pfsense::create_dhcp_static_mapping),
         )
         .route(
-            "/pfsense/dhcp/static-mappings/:id",
+            "/pfsense/dhcp/static-mappings/{id}",
             delete(pfsense::delete_dhcp_static_mapping),
         )
         .route("/pfsense/firewall/rules", get(pfsense::firewall_rules))
@@ -475,30 +480,30 @@ pub fn router(state: AppState) -> Router {
             post(pfsense::create_firewall_rule),
         )
         .route(
-            "/pfsense/firewall/rules/:id",
+            "/pfsense/firewall/rules/{id}",
             put(pfsense::update_firewall_rule),
         )
         .route(
-            "/pfsense/firewall/rules/:id",
+            "/pfsense/firewall/rules/{id}",
             delete(pfsense::delete_firewall_rule),
         )
         .route(
-            "/pfsense/firewall/rules/:id/toggle",
+            "/pfsense/firewall/rules/{id}/toggle",
             post(pfsense::toggle_firewall_rule),
         )
         .route("/pfsense/nat/rules", get(pfsense::nat_rules))
         .route("/pfsense/nat/rules", post(pfsense::create_nat_rule))
-        .route("/pfsense/nat/rules/:id", put(pfsense::update_nat_rule))
-        .route("/pfsense/nat/rules/:id", delete(pfsense::delete_nat_rule))
+        .route("/pfsense/nat/rules/{id}", put(pfsense::update_nat_rule))
+        .route("/pfsense/nat/rules/{id}", delete(pfsense::delete_nat_rule))
         .route("/pfsense/aliases", get(pfsense::aliases))
         .route("/pfsense/aliases", post(pfsense::create_alias))
-        .route("/pfsense/aliases/:id", put(pfsense::update_alias))
-        .route("/pfsense/aliases/:id", delete(pfsense::delete_alias))
+        .route("/pfsense/aliases/{id}", put(pfsense::update_alias))
+        .route("/pfsense/aliases/{id}", delete(pfsense::delete_alias))
         .route("/pfsense/dns/config", get(pfsense::dns_config))
         .route("/pfsense/dns/overrides", get(pfsense::dns_overrides))
         .route("/pfsense/dns/overrides", post(pfsense::create_dns_override))
         .route(
-            "/pfsense/dns/overrides/:id",
+            "/pfsense/dns/overrides/{id}",
             delete(pfsense::delete_dns_override),
         )
         .route("/pfsense/config-backups", get(pfsense::config_backups))
@@ -511,16 +516,16 @@ pub fn router(state: AppState) -> Router {
             get(pfsense::config_current),
         )
         .route(
-            "/pfsense/config-backups/:id/diff",
+            "/pfsense/config-backups/{id}/diff",
             get(pfsense::config_diff),
         )
         .route(
-            "/pfsense/config-backups/:id/restore",
+            "/pfsense/config-backups/{id}/restore",
             post(pfsense::restore_config_backup),
         )
         .route("/pfsense/services", get(pfsense::services))
         .route(
-            "/pfsense/services/:name/action",
+            "/pfsense/services/{name}/action",
             post(pfsense::service_action),
         )
         .route("/pfsense/audit", get(pfsense::audit_log))
@@ -535,11 +540,11 @@ pub fn router(state: AppState) -> Router {
             post(qos::create_mikrotik_simple_queue),
         )
         .route(
-            "/qos/mikrotik/simple-queues/:id",
+            "/qos/mikrotik/simple-queues/{id}",
             put(qos::update_mikrotik_simple_queue),
         )
         .route(
-            "/qos/mikrotik/simple-queues/:id",
+            "/qos/mikrotik/simple-queues/{id}",
             delete(qos::delete_mikrotik_simple_queue),
         )
         .route("/qos/mikrotik/queue-tree", get(qos::mikrotik_queue_tree))
@@ -548,11 +553,11 @@ pub fn router(state: AppState) -> Router {
             post(qos::create_mikrotik_queue_tree),
         )
         .route(
-            "/qos/mikrotik/queue-tree/:id",
+            "/qos/mikrotik/queue-tree/{id}",
             put(qos::update_mikrotik_queue_tree),
         )
         .route(
-            "/qos/mikrotik/queue-tree/:id",
+            "/qos/mikrotik/queue-tree/{id}",
             delete(qos::delete_mikrotik_queue_tree),
         )
         // VPN Status Dashboard
@@ -569,17 +574,17 @@ pub fn router(state: AppState) -> Router {
         .route("/nat/summary", get(nat::summary))
         .route("/nat/mikrotik/rules", get(nat::mikrotik_list))
         .route("/nat/mikrotik/rules", post(nat::mikrotik_create))
-        .route("/nat/mikrotik/rules/:id", put(nat::mikrotik_update))
-        .route("/nat/mikrotik/rules/:id", delete(nat::mikrotik_delete))
+        .route("/nat/mikrotik/rules/{id}", put(nat::mikrotik_update))
+        .route("/nat/mikrotik/rules/{id}", delete(nat::mikrotik_delete))
         // Assets (IT inventory)
         .route("/assets", get(assets::list))
         .route("/assets", post(assets::create))
         .route("/assets/import", post(assets::import))
         .route("/assets/auto-link", post(assets::auto_link))
         .route("/assets/sync-from-devices", post(assets::sync_from_devices))
-        .route("/assets/:id", get(assets::get_one))
-        .route("/assets/:id", put(assets::update))
-        .route("/assets/:id", delete(assets::delete))
+        .route("/assets/{id}", get(assets::get_one))
+        .route("/assets/{id}", put(assets::update))
+        .route("/assets/{id}", delete(assets::delete))
         // DNS Blocklists
         .route("/dns-blocklists", get(dns_blocklists::list))
         .route("/dns-blocklists", post(dns_blocklists::create))
@@ -597,14 +602,14 @@ pub fn router(state: AppState) -> Router {
             post(dns_blocklists::create_override),
         )
         .route(
-            "/dns-blocklists/overrides/:id",
+            "/dns-blocklists/overrides/{id}",
             delete(dns_blocklists::delete_override),
         )
-        .route("/dns-blocklists/:id", put(dns_blocklists::update))
-        .route("/dns-blocklists/:id", delete(dns_blocklists::delete))
-        .route("/dns-blocklists/:id/toggle", post(dns_blocklists::toggle))
+        .route("/dns-blocklists/{id}", put(dns_blocklists::update))
+        .route("/dns-blocklists/{id}", delete(dns_blocklists::delete))
+        .route("/dns-blocklists/{id}/toggle", post(dns_blocklists::toggle))
         .route(
-            "/dns-blocklists/:id/download",
+            "/dns-blocklists/{id}/download",
             post(dns_blocklists::download),
         )
         // DNS Security (DoT + DNSSEC)
@@ -625,20 +630,20 @@ pub fn router(state: AppState) -> Router {
             post(cloudflare_tunnel::add_route),
         )
         .route(
-            "/cloudflare-tunnel/routes/:hostname",
+            "/cloudflare-tunnel/routes/{hostname}",
             delete(cloudflare_tunnel::delete_route),
         )
         .route(
-            "/cloudflare-tunnel/routes/:hostname",
+            "/cloudflare-tunnel/routes/{hostname}",
             put(cloudflare_tunnel::update_route),
         )
         // Dynamic DNS (DDNS) client management
         .route("/ddns", get(ddns::list))
         .route("/ddns", post(ddns::create))
         .route("/ddns/status", get(ddns::status))
-        .route("/ddns/:id", put(ddns::update))
-        .route("/ddns/:id", delete(ddns::delete))
-        .route("/ddns/:id/toggle", post(ddns::toggle))
+        .route("/ddns/{id}", put(ddns::update))
+        .route("/ddns/{id}", delete(ddns::delete))
+        .route("/ddns/{id}/toggle", post(ddns::toggle))
         // Audit log
         .route("/audit-log", get(audit::list))
         .route("/audit-log/actions", get(audit::actions))
@@ -650,8 +655,8 @@ pub fn router(state: AppState) -> Router {
         // Users (RBAC)
         .route("/users", get(users::list))
         .route("/users", post(users::create))
-        .route("/users/:id", put(users::update))
-        .route("/users/:id", delete(users::delete))
+        .route("/users/{id}", put(users::update))
+        .route("/users/{id}", delete(users::delete))
         // SNMP management
         .route("/snmp/config", get(snmp_management::get_config))
         .route("/snmp/config", patch(snmp_management::update_config))

--- a/server/src/scanner/mod.rs
+++ b/server/src/scanner/mod.rs
@@ -8,7 +8,7 @@ pub mod snmp;
 
 use anyhow::Result;
 use chrono::Utc;
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::TokioResolver;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::SqlitePool;
@@ -128,7 +128,7 @@ pub fn start_scanner_task(db: SqlitePool, config: ScannerConfig, ws_hub: Arc<WsH
 /// Uses a 2-second timeout. The underlying lookup is fully async via
 /// `hickory-resolver`, so dropping the future on timeout actually cancels
 /// the in-flight DNS query (no lingering background threads).
-async fn reverse_dns_lookup(resolver: &TokioAsyncResolver, ip: &str) -> Option<String> {
+async fn reverse_dns_lookup(resolver: &TokioResolver, ip: &str) -> Option<String> {
     let addr: IpAddr = match ip.parse() {
         Ok(a) => a,
         Err(_) => return None,
@@ -138,7 +138,7 @@ async fn reverse_dns_lookup(resolver: &TokioAsyncResolver, ip: &str) -> Option<S
 
     match result {
         Ok(Ok(lookup)) => {
-            let hostname = lookup.iter().next()?.to_string();
+            let hostname = lookup.answers().first()?.data.to_string();
             // Strip trailing dot from FQDN (e.g. "router.local." → "router.local").
             let hostname = hostname.trim_end_matches('.').to_string();
             // Skip if the hostname is just the IP address repeated back.
@@ -577,7 +577,7 @@ pub async fn process_scan_results(
 
     // If the system resolver config cannot be loaded, skip DNS entirely — the default
     // resolver (8.8.8.8 / 1.1.1.1) will not resolve local PTR records anyway.
-    let dns_resolver = match TokioAsyncResolver::tokio_from_system_conf() {
+    let dns_resolver = match TokioResolver::builder_tokio().and_then(|builder| builder.build()) {
         Ok(r) => Some(r),
         Err(e) => {
             warn!(error = %e, "Failed to load system DNS config; skipping reverse DNS for this scan cycle");


### PR DESCRIPTION
## Summary

- update agent, WebSocket, sysinfo, Hickory resolver, and Axum route APIs for the versions currently selected by the workspace
- roll SQLx back to 0.7.4 and the direct SHA-2 dependency back to 0.10.9; exclude those breaking 0.x minor upgrades from grouped Dependabot updates until they receive dedicated migrations
- make CI frontend installs reproducible and document/enforce the canonical split for the stateful Caddy test suite
- prevent Dependabot auto-merge from racing CI by waiting for both `Rust Build & Lint` and `Frontend Build`, cancelling stale per-PR waiters, and verifying the PR head SHA before enabling merge

## Baseline conflict discovered

The issue evidence listed compiler/API failures. Once those compiled, the integration suite exposed an additional inherited Axum 0.8 failure: every router construction panicked on legacy `/:id` captures. This PR converts the production API router to Axum 0.8 `/{id}` captures; the standard integration suite then passes 20/20.

## Verification

- `CC=/usr/bin/cc CXX=/usr/bin/c++ cargo check --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `CC=/usr/bin/cc CXX=/usr/bin/c++ RUSTFLAGS='-Dwarnings' cargo clippy --all-targets --all-features`
- `CC=/usr/bin/cc CXX=/usr/bin/c++ cargo test --lib --bins --test integration` — 11 agent unit tests, 393 server unit tests, and 20 integration tests passed
- `CC=/usr/bin/cc CXX=/usr/bin/c++ cargo test --test caddy_integration -- --test-threads=1` with a disposable `caddy:2-alpine` container — 13 passed
- `CC=/usr/bin/cc CXX=/usr/bin/c++ RUST_TEST_THREADS=1 cargo test` with Caddy running — full Rust suite passed
- `CC=/usr/bin/cc CXX=/usr/bin/c++ RUSTFLAGS='-Dwarnings' cargo build --release --all-targets`
- `cd web && bun install --frozen-lockfile && bun run test && bun run build` — 90 frontend unit tests passed and static export completed
- `actionlint .github/workflows/dependabot-auto-merge.yml`
- `shellcheck scripts/build-prod.sh`

The generated `.maestro/verify.sh` was also run. Its initial full Rust suite passed, then the generated script exited with `make: *** No rule to make target 'test'. Stop.` because this repository's Makefile has no `test` target. The generated Maestro file was not modified.

## Why No E2E Test

This is a CI/dependency-baseline repair with no frontend behavior change. The runtime route compatibility fix is covered by the existing Rust integration suite, which failed before the Axum capture migration and passes afterward.

Fixes #888

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the compatible Rust baseline and tightens CI automation. The main changes are:

- Pins SQLx and SHA-2 to compatible versions.
- Updates Axum, WebSocket, sysinfo, and Hickory APIs.
- Uses frozen frontend installs in CI.
- Waits for Rust and frontend checks before Dependabot auto-merge.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The API migrations and dependency lockfile are internally consistent. GitHub still enforces repository merge requirements after auto-merge is enabled.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex determined that the previous HEAD^ state could not compile the integration target and exited with code 101 due to a dependency/API incompatibility.
- T-Rex re-ran the integration tests with CC=/usr/bin/cc and CXX=/usr/bin/c++ and executed cargo test -j 2 --test integration to address the incompatibility.
- T-Rex confirmed the integration tests finished successfully with exit code 0 and all 20 tests passed.
- T-Rex captured and uploaded the full command outputs as logs for review.

<a href="https://app.greptile.com/trex/runs/15578755/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/dependabot-auto-merge.yml | Adds per-PR cancellation, head-specific check polling, and a final head SHA check before enabling auto-merge. |
| .github/workflows/ci.yml | Makes Bun installs reproducible and documents the isolated sequential Caddy test suite. |
| .github/dependabot.yml | Excludes breaking SQLx and SHA-2 minor updates from grouped dependency updates. |
| server/Cargo.toml | Pins SQLx 0.7.4 and SHA-2 0.10.9 to restore the compatible dependency baseline. |
| server/src/api/mod.rs | Migrates dynamic route captures to Axum 0.8 brace syntax without changing handlers or HTTP methods. |
| server/src/scanner/mod.rs | Updates resolver construction, types, and reverse-DNS answer extraction for Hickory 0.26. |
| agent/src/collectors/mod.rs | Updates disk and network refresh calls for the selected sysinfo API. |

<sub>Reviews (1): Last reviewed commit: ["ci: restore Rust baseline and gate Depen..."](https://github.com/befeast/panoptikon/commit/861799630e69d991c022f109877d716d52d4a0ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46671464)</sub>

<!-- /greptile_comment -->