### PR TITLE
fix: make auto-version bump idempotent

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,8 +11,14 @@ permissions:
 jobs:
   bump-version:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    concurrency:
+      group: auto-version-bump-${{ github.ref }}
+      cancel-in-progress: false
 
-    # Skip if commit message contains [skip-bump] or starts with "chore: bump version"
+    # Skip semantics for the head commit on main:
+    # - [skip-bump] anywhere in the message skips the bump.
+    # - A message starting with "chore: bump version" skips the bump.
+    # Generated bump commits use both markers so their push does not recurse.
     if: |
       !contains(github.event.head_commit.message, '[skip-bump]') &&
       !startsWith(github.event.head_commit.message, 'chore: bump version')
@@ -21,33 +27,65 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Read and bump patch version
+      - name: Choose next available patch version
         id: bump
         run: |
-          CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          set -euo pipefail
+
+          # fetch-depth: 0 normally includes tags, but refresh immediately before
+          # selection so a queued or retried run sees the current repository state.
+          git fetch --force --tags origin
+
+          CURRENT=$(awk -F'"' '/^version = "/ { print $2; exit }' Cargo.toml)
           echo "Current version: $CURRENT"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          PATCH=$((PATCH + 1))
+
+          if [[ ! "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Invalid workspace version: $CURRENT" >&2
+            exit 1
+          fi
+
+          MAJOR=${BASH_REMATCH[1]}
+          MINOR=${BASH_REMATCH[2]}
+          PATCH=$((10#${BASH_REMATCH[3]} + 1))
+
+          while git show-ref --verify --quiet "refs/tags/v${MAJOR}.${MINOR}.${PATCH}"; do
+            echo "Tag v${MAJOR}.${MINOR}.${PATCH} already exists; trying the next patch."
+            PATCH=$((PATCH + 1))
+          done
+
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "New version: $NEW_VERSION"
+
           # Update Cargo.toml (first occurrence of version = "...")
           sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"${NEW_VERSION}\"/}" Cargo.toml
-          # Regenerate Cargo.lock
-          cargo generate-lockfile
+          # Update only the workspace packages in Cargo.lock. Regenerating the
+          # lockfile would also pull unrelated compatible dependency updates.
+          cargo update --workspace
+
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Commit, tag, and publish atomically
         run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.bump.outputs.new_version }}"
+          TAG="v${VERSION}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip-bump]"
-          git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin main
-          git push origin "v${{ steps.bump.outputs.new_version }}"
+          git commit -m "chore: bump version to ${VERSION} [skip-bump]"
+          git tag "$TAG"
+
+          # Publishing both refs atomically makes any failed attempt harmless:
+          # either main and the tag advance together, or neither remote ref does.
+          git push --atomic origin \
+            HEAD:refs/heads/main \
+            "refs/tags/${TAG}:refs/tags/${TAG}"


### PR DESCRIPTION
## Summary

- refresh tags and choose the first unused patch version after the workspace version
- serialize qualifying bump jobs and check out current `main` before selecting a version
- update only workspace package entries in `Cargo.lock`, avoiding unrelated dependency re-resolution
- publish the version commit and tag in one atomic push
- document `[skip-bump]` and generated bump-commit skip semantics in the workflow

## Verification

Commands run:

```bash
cargo fmt --all
actionlint -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/version-bump.yml
git diff --check
```

Repository collision check:

```bash
CURRENT=$(awk -F'"' '/^version = "/ { print $2; exit }' Cargo.toml)
if [[ ! "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then exit 1; fi
MAJOR=${BASH_REMATCH[1]}
MINOR=${BASH_REMATCH[2]}
PATCH=$((10#${BASH_REMATCH[3]} + 1))
while git show-ref --verify --quiet "refs/tags/v${MAJOR}.${MINOR}.${PATCH}"; do PATCH=$((PATCH + 1)); done
SELECTED="${MAJOR}.${MINOR}.${PATCH}"
test "$SELECTED" = "0.6.105"
```

Result: workspace `0.6.103` plus existing `v0.6.104` selected `0.6.105`.

In an isolated clone, this command updated only the two workspace package versions in `Cargo.lock`:

```bash
cargo update --workspace
git diff --stat
git diff -- Cargo.toml Cargo.lock
```

In a temporary bare-repository integration fixture, these publication commands and ref assertions were run for success, collision, and retry cases:

```bash
git push --atomic origin HEAD:refs/heads/main refs/tags/v0.6.105:refs/tags/v0.6.105
test "$(git --git-dir="$REMOTE" rev-parse refs/heads/main)" = "$(git --git-dir="$REMOTE" rev-parse refs/tags/v0.6.105)"

git push --atomic origin HEAD:refs/heads/main refs/tags/v0.6.106:refs/tags/v0.6.106
test "$(git --git-dir="$REMOTE" rev-parse refs/heads/main)" = "$REMOTE_BEFORE"

git push --atomic origin HEAD:refs/heads/main refs/tags/v0.6.107:refs/tags/v0.6.107
test "$(git --git-dir="$REMOTE" rev-parse refs/heads/main)" = "$(git --git-dir="$REMOTE" rev-parse refs/tags/v0.6.107)"
```

Observed behavior: the occupied `v0.6.106` rejected the atomic push without advancing `main`; a fresh retry skipped that tag, selected `0.6.107`, and advanced the branch and tag together.

## Why No E2E Test

This is release automation with no UI surface. Playwright cannot exercise GitHub ref publication; the issue-defined acceptance gate is the reproducible version-selection and atomic Git workflow simulation above.

Implements #891

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes automatic version bumps tag-aware and publishes them atomically. The main changes are:

- Serializes qualifying bump jobs for the pushed ref.
- Selects the first unused patch version after refreshing tags.
- Updates workspace package entries without regenerating the full lockfile.
- Pushes the version commit and tag in one atomic operation.

<h3>Confidence Score: 4/5</h3>

Queued runs can create duplicate version bumps and should be corrected before merging.

Run eligibility comes from the triggering commit, while checkout uses the current branch tip. A queued qualifying run can therefore operate on a bump commit created by an earlier run and increment the version again.

.github/workflows/version-bump.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The queued run was reproduced, showing two sequential runs that produced two consecutive bump commits and two version tags in the final remote history.
- The tag-selection workflow was exercised, demonstrating an initial occupied tag, a collision on the push attempt, and a retry that succeeded with a newer tag, with ALL\_ASSERTIONS\_PASSED at completion.

<a href="https://app.greptile.com/trex/runs/15587963/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/version-bump.yml | Adds serialized, tag-aware version selection and atomic publication, but queued runs can bump an already-bumped branch tip again. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/version-bump.yml:30
**Queued Run Bumps Newer State Again**

The job condition is evaluated from the push that created the run, but `ref: main` checks out the branch tip when a queued run starts. If two qualifying pushes arrive before the first run publishes, the first run can check out and bump a tip containing both pushes; the second run then checks out that generated bump commit but still qualifies from its older event, producing an unnecessary second version bump.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make auto version bump tag-aware"](https://github.com/befeast/panoptikon/commit/59b3239890ed64dd05688bb2bb8cfc1435801531) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46690010)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->